### PR TITLE
Add asynchronous value read/write capability on server side

### DIFF
--- a/bin/simple_server.js
+++ b/bin/simple_server.js
@@ -119,6 +119,11 @@ server.on("post_initialize", function () {
                 get: function () {
                     var pump_speed = 200 + 100*Math.sin(Date.now()/10000);
                     return new Variant({dataType: DataType.Double, value: pump_speed});
+                },
+                getAsync: function(callback){
+                    var pump_speed = 200 + 100*Math.sin(Date.now()/10000);
+                    var test = new Variant({dataType: DataType.Double, value: pump_speed});
+                    callback(test);
                 }
             }
         });

--- a/lib/address_space/address_space.js
+++ b/lib/address_space/address_space.js
@@ -62,7 +62,7 @@ View.prototype.nodeClass = NodeClass.View;
  * @param attributeId
  * @return {DataValue}
  */
-View.prototype.readAttribute = function (attributeId) {
+View.prototype.readAttribute = function (attributeId, callback) {
 
     var options = {};
 
@@ -70,15 +70,16 @@ View.prototype.readAttribute = function (attributeId) {
         case AttributeIds.EventNotifier:
             options.value = { dataType: DataType.UInt32, value: this.eventNotifier };
             options.statusCode = StatusCodes.Good;
+            callback(new DataValue(options));
             break;
         case AttributeIds.ContainsNoLoops:
             options.value = { dataType: DataType.Boolean, value: this.containsNoLoops };
             options.statusCode = StatusCodes.Good;
+            callback(new DataValue(options));
             break;
         default:
-            return BaseNode.prototype.readAttribute.call(this,attributeId);
+            BaseNode.prototype.readAttribute.call(this,attributeId, callback);
     }
-    return new DataValue(options);
 };
 
 

--- a/lib/address_space/baseObject.js
+++ b/lib/address_space/baseObject.js
@@ -44,7 +44,7 @@ util.inherits(BaseObject, BaseNode);
 BaseObject.prototype.nodeClass = NodeClass.Object;
 BaseObject.typeDefinition = resolveNodeId("BaseObjectType");
 
-BaseObject.prototype.readAttribute = function (attributeId) {
+BaseObject.prototype.readAttribute = function (attributeId, callback) {
     var options = {};
     switch (attributeId) {
         case AttributeIds.EventNotifier:
@@ -52,9 +52,10 @@ BaseObject.prototype.readAttribute = function (attributeId) {
             options.statusCode = StatusCodes.Good;
             break;
         default:
-            return BaseNode.prototype.readAttribute.call(this,attributeId);
+            BaseNode.prototype.readAttribute.call(this,attributeId, callback);
+            return;
     }
-    return new DataValue(options);
+    callback(new DataValue(options));
 };
 
 exports.BaseObject= BaseObject;

--- a/lib/address_space/basenode.js
+++ b/lib/address_space/basenode.js
@@ -344,7 +344,7 @@ BaseNode.prototype.propagate_back_references = function (address_space) {
  * @param attributeId {AttributeId}
  * @return {DataValue}
  */
-BaseNode.prototype.readAttribute = function (attributeId) {
+BaseNode.prototype.readAttribute = function (attributeId, callback) {
 
     var options = {};
     options.statusCode = StatusCodes.Good;
@@ -381,7 +381,7 @@ BaseNode.prototype.readAttribute = function (attributeId) {
             options.statusCode = StatusCodes.BadAttributeIdInvalid;
             break;
     }
-    return new DataValue(options);
+    callback(new DataValue(options));
 };
 
 /**
@@ -390,10 +390,10 @@ BaseNode.prototype.readAttribute = function (attributeId) {
  * @param dataValue {DataValue}
  * @return {StatusCodes}
  */
-BaseNode.prototype.writeAttribute = function (attributeId, dataValue) {
+BaseNode.prototype.writeAttribute = function (attributeId, dataValue, callback) {
     // by default Node is read-only,
     // this method needs to be overridden to change the behavior
-    return StatusCodes.BadNotWritable;
+    callback(StatusCodes.BadNotWritable);
 };
 
 /**

--- a/lib/address_space/method.js
+++ b/lib/address_space/method.js
@@ -40,7 +40,7 @@ function Method(options) {
 util.inherits(Method, BaseNode);
 Method.prototype.nodeClass = NodeClass.Method;
 
-Method.prototype.readAttribute = function (attributeId) {
+Method.prototype.readAttribute = function (attributeId, callback) {
 
     var options = {};
     switch (attributeId) {
@@ -55,9 +55,10 @@ Method.prototype.readAttribute = function (attributeId) {
             options.statusCode = StatusCodes.BadAttributeIdInvalid;
             break;
         default:
-            return BaseNode.prototype.readAttribute.call(this,attributeId);
+            BaseNode.prototype.readAttribute.call(this,attributeId, callback);
+            return;
     }
-    return new DataValue(options);
+    callback(new DataValue(options));
 };
 
 exports.Method = Method;

--- a/lib/address_space/objectType.js
+++ b/lib/address_space/objectType.js
@@ -41,17 +41,17 @@ function ObjectType(options) {
 util.inherits(ObjectType, BaseNode);
 ObjectType.prototype.nodeClass = NodeClass.ObjectType;
 
-ObjectType.prototype.readAttribute = function (attributeId) {
+ObjectType.prototype.readAttribute = function (attributeId, callback) {
     var options = {};
     switch (attributeId) {
         case AttributeIds.IsAbstract:
             options.value = { dataType: DataType.Boolean, value: this.isAbstract ? true : false };
             options.statusCode = StatusCodes.Good;
+            callback(new DataValue(options));
             break;
         default:
-            return BaseNode.prototype.readAttribute.call(this,attributeId);
+            BaseNode.prototype.readAttribute.call(this,attributeId, callback);
     }
-    return new DataValue(options);
 };
 
 exports.ObjectType = ObjectType;

--- a/lib/address_space/referenceType.js
+++ b/lib/address_space/referenceType.js
@@ -43,7 +43,7 @@ ReferenceType.prototype.nodeClass = NodeClass.ReferenceType;
  * @param attributeId {AttributeIds}
  * @return {DataValue}
  */
-ReferenceType.prototype.readAttribute = function (attributeId) {
+ReferenceType.prototype.readAttribute = function (attributeId, callback) {
 
     var options = {};
     switch (attributeId) {
@@ -60,9 +60,10 @@ ReferenceType.prototype.readAttribute = function (attributeId) {
             options.statusCode = StatusCodes.Good;
             break;
         default:
-            return BaseNode.prototype.readAttribute.call(this,attributeId);
+            BaseNode.prototype.readAttribute.call(this,attributeId, callback);
+            return;
     }
-    return new DataValue(options);
+    callback(new DataValue(options));
 };
 exports.ReferenceType = ReferenceType;
 

--- a/lib/address_space/variable.js
+++ b/lib/address_space/variable.js
@@ -165,7 +165,7 @@ function is_Variant_or_StatusCode(v) {
  * @method readValue
  * @param indexRange  {NumericRange||null}
  * @param dataEncoding
- * @return {DataValue}
+ * @param callback
  *
  *
  * from OPC.UA.Spec 1.2 part 4
@@ -193,49 +193,52 @@ function is_Variant_or_StatusCode(v) {
  *  Bad_UserAccessDenied        User does not have permission to perform the requested operation. (table 165)
  */
 
-Variable.prototype.readValue = function (indexRange, dataEncoding) {
+Variable.prototype.readValue = function (indexRange, dataEncoding, callback) {
 
     var options = {};
     if (!is_valid_dataEncoding(dataEncoding)) {
         options.statusCode = StatusCodes.BadDataEncodingInvalid;
-        return new DataValue(options);
+        callback(new DataValue(options));
+        return;
     }
     try {
+        // make sure we only read value once
+        this._timestamped_get_func(function(timestamped_value){
+            if (timestamped_value) {
+                options.sourceTimestamp   = timestamped_value.sourceTimestamp;
+                options.sourcePicoseconds = timestamped_value.sourcePicoseconds || 0;
+                options.value             = timestamped_value.value;
+                assert(is_Variant(options.value), "expecting value to be a variant");
+                assert(options.sourceTimestamp instanceof Date, "expecting timestamp to be a Date");
 
-        if (this.timestamped_value) {
-            var timestamped_value = this.timestamped_value;
+            } else {
+                options.value             = this.get_variant();
 
-            options.sourceTimestamp   = timestamped_value.sourceTimestamp;
-            options.sourcePicoseconds = timestamped_value.sourcePicoseconds || 0;
-            options.value             = timestamped_value.value;
-            assert(is_Variant(options.value), "expecting value to be a variant");
-
-        } else {
-            options.value             = this.get_variant();
-
-        }
-
-        if (options.value === null) {
-
-            options.statusCode = StatusCodes.UncertainInitialValue;
-
-        } else if (is_StatusCode(options.value) ) {
-
-            options.statusCode = options.value;
-            options.value = null;
-
-        } else {
-
-            options.statusCode = StatusCodes.Good;
-
-            var variant = options.value;
-            if (indexRange && options.value.arrayType !== VariantArrayType.Scalar && _.isArray(variant.value)) {
-
-                var result = indexRange.extract_values(variant.value);
-                variant.value = result.array;
-                options.statusCode = result.statusCode;
             }
-        }
+
+            if (options.value === null) {
+
+                options.statusCode = StatusCodes.UncertainInitialValue;
+
+            } else if (is_StatusCode(options.value) ) {
+
+                options.statusCode = options.value;
+                options.value = null;
+
+            } else {
+
+                options.statusCode = StatusCodes.Good;
+
+                var variant = options.value;
+                if (indexRange && options.value.arrayType !== VariantArrayType.Scalar && _.isArray(variant.value)) {
+
+                    var result = indexRange.extract_values(variant.value);
+                    variant.value = result.array;
+                    options.statusCode = result.statusCode;
+                }
+            }
+            callback(options);
+        });
     } catch (err) {
         console.log(" exception raised while extracting variant from variable");
         console.log(" browseName ", this.browseName);
@@ -244,75 +247,79 @@ Variable.prototype.readValue = function (indexRange, dataEncoding) {
         console.log(err.stack);
         options.value = null;
         options.statusCode = StatusCodes.BadInternalError;
+        callback(options);
     }
-    return options;
 };
 
 
 /**
  * @method readAttribute
  * @param attributeId {AttributeIds} the attributeId to read
+ * @param callback
  * @param indexRange
  * @param dataEncoding
- * @return {DataValue}
  */
-Variable.prototype.readAttribute = function (attributeId, indexRange, dataEncoding) {
-
+Variable.prototype.readAttribute = function (attributeId, callback, indexRange, dataEncoding) {
     var options = {};
 
     if (attributeId !== AttributeIds.Value) {
         if (indexRange && indexRange.isDefined()) {
             options.statusCode = StatusCodes.BadIndexRangeNoData;
-            return new DataValue(options);
+            callback(new DataValue(options));
         }
         if (is_dataEncoding(dataEncoding)) {
             options.statusCode = StatusCodes.BadDataEncodingInvalid;
-            return new DataValue(options);
+            callback(new DataValue(options));
         }
     }
-
-    switch (attributeId) {
-    case AttributeIds.Value:
-        options = this.readValue(indexRange, dataEncoding);
-        break;
-    case AttributeIds.DataType:
-        options.value = { dataType: DataType.NodeId, value: this.dataType};
-        options.statusCode = StatusCodes.Good;
-        break;
-    case AttributeIds.ValueRank:
-        assert(typeof(this.valueRank) === "number");
-        options.value = { dataType: DataType.Int32, value: this.valueRank };
-        options.statusCode = StatusCodes.Good;
-        break;
-    case AttributeIds.ArrayDimensions:
-        options.value = { dataType: DataType.UInt32, value: this.arrayDimensions };
-        options.statusCode = StatusCodes.Good;
-        break;
-    case AttributeIds.AccessLevel:
-        options.value = { dataType: DataType.Byte, value: this.accessLevel.value };
-        options.statusCode = StatusCodes.Good;
-        break;
-    case AttributeIds.UserAccessLevel:
-        options.value = { dataType: DataType.Byte, value: this.userAccessLevel.value };
-        options.statusCode = StatusCodes.Good;
-        break;
-    case AttributeIds.MinimumSamplingInterval:
-        if (this.minimumSamplingInterval === undefined) {
-            options.statusCode = StatusCodes.BadAttributeIdInvalid;
-        } else {
-            options.value = { dataType: DataType.UInt32, value: this.minimumSamplingInterval };
+    
+    else if (attributeId == AttributeIds.Value){
+        this.readValue(indexRange, dataEncoding, function(options){
+            callback(new DataValue(options));
+        });    
+    }
+    else {
+        switch (attributeId) {
+        case AttributeIds.DataType:
+            options.value = { dataType: DataType.NodeId, value: this.dataType};
             options.statusCode = StatusCodes.Good;
+            break;
+        case AttributeIds.ValueRank:
+            assert(typeof(this.valueRank) === "number");
+            options.value = { dataType: DataType.Int32, value: this.valueRank };
+            options.statusCode = StatusCodes.Good;
+            break;
+        case AttributeIds.ArrayDimensions:
+            options.value = { dataType: DataType.UInt32, value: this.arrayDimensions };
+            options.statusCode = StatusCodes.Good;
+            break;
+        case AttributeIds.AccessLevel:
+            options.value = { dataType: DataType.Byte, value: this.accessLevel.value };
+            options.statusCode = StatusCodes.Good;
+            break;
+        case AttributeIds.UserAccessLevel:
+            options.value = { dataType: DataType.Byte, value: this.userAccessLevel.value };
+            options.statusCode = StatusCodes.Good;
+            break;
+        case AttributeIds.MinimumSamplingInterval:
+            if (this.minimumSamplingInterval === undefined) {
+                options.statusCode = StatusCodes.BadAttributeIdInvalid;
+            } else {
+                options.value = { dataType: DataType.UInt32, value: this.minimumSamplingInterval };
+                options.statusCode = StatusCodes.Good;
+            }
+            break;
+        case AttributeIds.Historizing:
+            options.value = { dataType: DataType.Boolean, value: this.historizing };
+            options.statusCode = StatusCodes.Good;
+            break;
+        default:
+            BaseNode.prototype.readAttribute.call(this, attributeId, callback, indexRange, dataEncoding);
+            return;
         }
-        break;
-    case AttributeIds.Historizing:
-        options.value = { dataType: DataType.Boolean, value: this.historizing };
-        options.statusCode = StatusCodes.Good;
-        break;
-    default:
-        return BaseNode.prototype.readAttribute.call(this, attributeId);
+        //xx console.log("attributeId = ",attributeId); console.log((new Variant(options.value)).isValid());
+        callback(new DataValue(options));
     }
-    //xx console.log("attributeId = ",attributeId); console.log((new Variant(options.value)).isValid());
-    return new DataValue(options);
 };
 
 /**
@@ -321,32 +328,35 @@ Variable.prototype.readAttribute = function (attributeId, indexRange, dataEncodi
  * @param writeValue.value.value {Variant}
  * @return {StatusCode}
  */
-Variable.prototype.writeValue = function (variant) {
+Variable.prototype.writeValue = function (variant, callback) {
 
     var statusCode = StatusCodes.BadNotWritable;
     if (this._set_func) {
-        statusCode = this._set_func(variant) || StatusCodes.BadNotWritable;
+        if(this._set_func){
+            this._set_func(variant,callback);
+        }
+        else{
+            callback(StatusCodes.BadNotWritable);
+        }
     } else {
-
         this.value = variant.value;
+        callback(statusCode);
     }
-    return statusCode;
 };
 
 /**
  * @method writeAttribute
  * @param attributeId
  * @param dataValue {DataValue}
- * @return {StatusCode}
+ * @param callback {function}
  */
-Variable.prototype.writeAttribute = function (attributeId, dataValue) {
-
+Variable.prototype.writeAttribute = function (attributeId, dataValue, callback) {
     assert(dataValue instanceof DataValue);
     switch (attributeId) {
         case AttributeIds.Value:
-            return this.writeValue(dataValue.value);
+            this.writeValue(dataValue.value, callback);
         default:
-            return BaseNode.prototype.writeAttribute.call(this, attributeId, dataValue);
+            BaseNode.prototype.writeAttribute.call(this, attributeId, dataValue, callback);
     }
 };
 
@@ -357,45 +367,78 @@ function _not_writtable_set_func(){
  * bind a variable with a get and set functions
  * @method bindVariable
  * @param options
- * @param [options.set] {Function} the variable setter function
+ * @param options.set {Function} the variable setter function
+ * @param options.setAsync {Function} the variable setter function
  * @param options.get {Function} the variable getter function. the function must return a Variant
+ * @param options.getAsnyc {Function} the variable getter function. the function must return a Variant
  * @param options.dataType {NodeId} [optional] default: null the nodeId of the dataType
  * @param options.accessLevel  {AccessLevelFlagItem} [optional]
  * @param options.userAccessLevel  {AccessLevelFlagItem} [optional]
  */
 Variable.prototype.bindVariable = function (options) {
-
     var self = this;
     options = options || {};
-
-
+    if (options.getAsync){
+        //throw new Error("test"+options.timestamped_get);
+    }
     if (!options.timestamped_get) {
-
         assert(_.isFunction(options.get), "should  specify get function");
-        self._get_func = options.get;
-        self._set_func = options.set || _not_writtable_set_func;
+        self._get_func = function(callback){
+            //console.log("test:"+options.getAsync+".."+callback);
+            if (options.getAsync){
+                options.getAsync(callback);
+            }
+            else {
+                var value = options.get();
+                //console.log("val:"+value);
+                callback(value);
+            }
+        };
+        self._set_func = function(variant,callback){
+            if (options.setAsync){
+                options.setAsync(variant, callback);
+            }
+            else if (options.set){
+                options.set(variant);
+                callback();
+            }
+            else {
+                _not_writtable_set_func();
+                callback();
+            }
+        };
 
-        self._timestamped_get_func = function() {
-            var value = {
-                value: self._get_func(),
-                sourceTimestamp: new Date(),
-                sourcePicoseconds: 0
-            };
-            assert(is_Variant_or_StatusCode(value.value));
+        self._timestamped_get_func = function(callback) {
+            self._get_func(function(r){
+                var value = {
+                    value: r,
+                    sourceTimestamp: new Date(),
+                    sourcePicoseconds: 0
+                };
+                assert(is_Variant_or_StatusCode(value.value));
+                callback(value);
+            });
         }
-        self._timestamped_set_func = function(timestamped_value) {
-            self._set_func(timestamped_value.value);
+        self._timestamped_set_func = function(timestamped_value, callback) {
+            self._set_func(timestamped_value.value,callback);
         }
     } else {
         assert(_.isFunction(options.timestamped_get), "");
         assert(!_.isFunction(options.get), "should not specify get when timestamped_get exists ");
-        self._timestamped_get_func = options.timestamped_get;
-        self._timestamped_set_func = options.timestamped_set || function(){};
+        self._timestamped_get_func = function(callback) {
+            callback(options.timestamped_get());
+        };
+        self._timestamped_set_func = function(variant,callback) {
+            callback(options.timestamped_set(variant));
+        };
 
-        self._get_func = function() {
-            return self._timestamped_get_func().value;
+        self._get_func = function(callback) {
+            callback(self._timestamped_get_func().value);
         }
-        self._set_func = _not_writtable_set_func;
+        self._set_func = function(variant,callback){
+            _not_writtable_set_func();
+            callback();
+        }
     }
 
     assert(_.isFunction(self._get_func));
@@ -403,6 +446,7 @@ Variable.prototype.bindVariable = function (options) {
     assert(_.isFunction(self._timestamped_get_func));
     assert(_.isFunction(self._timestamped_set_func));
 
+    /*
     Object.defineProperty(self, "timestamped_value", {
         get: self._timestamped_get_func,
         set: self._timestamped_set_func,
@@ -414,6 +458,7 @@ Variable.prototype.bindVariable = function (options) {
         set: self._set_func,
         enumerable: true
     });
+    */
 
     if (options.dataType) {
         options.dataType = resolveNodeId(options.dataType);
@@ -429,6 +474,7 @@ Variable.prototype.bindVariable = function (options) {
     }
 
     // check that the function returns a variant
+    /*
     var value_check = self.value;
 
     if (!is_Variant_or_StatusCode(value_check)) {
@@ -436,7 +482,7 @@ Variable.prototype.bindVariable = function (options) {
         console.log("value_check.constructor.name ",value_check.constructor.name );
         throw new Error(" bindVariable : the value getter function returns a invalid result ( expecting a Variant or a StatusCode !!!") ;
     }
-
+	*/
 
 };
 

--- a/lib/address_space/variable.js
+++ b/lib/address_space/variable.js
@@ -368,9 +368,9 @@ function _not_writtable_set_func(){
  * @method bindVariable
  * @param options
  * @param options.set {Function} the variable setter function
- * @param options.setAsync {Function} the variable setter function
+ * @param options.setAsync {Function} asynchronous write function
  * @param options.get {Function} the variable getter function. the function must return a Variant
- * @param options.getAsnyc {Function} the variable getter function. the function must return a Variant
+ * @param options.getAsync {Function} asynchronous read function
  * @param options.dataType {NodeId} [optional] default: null the nodeId of the dataType
  * @param options.accessLevel  {AccessLevelFlagItem} [optional]
  * @param options.userAccessLevel  {AccessLevelFlagItem} [optional]
@@ -382,7 +382,8 @@ Variable.prototype.bindVariable = function (options) {
         //throw new Error("test"+options.timestamped_get);
     }
     if (!options.timestamped_get) {
-        assert(_.isFunction(options.get), "should  specify get function");
+        assert(_.isFunction(options.get) || _.isFunction(options.getAsync),
+            "should specify get function");
         self._get_func = function(callback){
             //console.log("test:"+options.getAsync+".."+callback);
             if (options.getAsync){

--- a/lib/address_space/variableType.js
+++ b/lib/address_space/variableType.js
@@ -51,7 +51,7 @@ function VariableType(options) {
 util.inherits(VariableType, BaseNode);
 VariableType.prototype.nodeClass = NodeClass.VariableType;
 
-VariableType.prototype.readAttribute = function (attributeId) {
+VariableType.prototype.readAttribute = function (attributeId, callback){
     var options = {};
     switch (attributeId) {
         case AttributeIds.IsAbstract:
@@ -82,9 +82,10 @@ VariableType.prototype.readAttribute = function (attributeId) {
             options.statusCode = StatusCodes.Good;
             break;
         default:
-            return BaseNode.prototype.readAttribute.call(this,attributeId);
+            BaseNode.prototype.readAttribute.call(this,attributeId,callback);
+            return;
     }
-    return new DataValue(options);
+    callback(new DataValue(options));
 };
 
 exports.VariableType = VariableType;

--- a/lib/server/base_server.js
+++ b/lib/server/base_server.js
@@ -158,6 +158,7 @@ OPCUABaseServer.prototype.on_request = function(message,channel) {
         }
 
     } catch(err) {
+        console.log(err.stack);
 
         errMessage = "EXCEPTION CAUGHT WHILE PROCESSING REQUEST !! " + request._schema.name;
         console.log(errMessage.red.bold);

--- a/lib/server/opcua_server.js
+++ b/lib/server/opcua_server.js
@@ -341,7 +341,7 @@ OPCUAServer.prototype._on_CreateSessionRequest = function (message, channel) {
 
         serverNonce: session.nonce,
 
-        // serverCertificate: type ApplicationServerCertificate
+        // serverCertificate: type AppplicationServerCertificate
         // The application instance Certificate issued to the Server.
         // A Server shall prove possession by using the private key to sign the Nonce provided
         // by the Client in the request. The Client shall verify that this Certificate is the same as
@@ -576,16 +576,19 @@ OPCUAServer.prototype._on_ReadRequest = function (message, channel) {
         assert(request.nodesToRead[0]._schema.name === "ReadValueId");
         assert(request.timestampsToReturn);
 
-        results = engine.read(request);
-        assert(results[0]._schema.name === "DataValue");
-        assert(results.length === request.nodesToRead.length);
+        engine.read(request,function(results){
+            assert(results[0]._schema.name === "DataValue");
+            assert(results.length === request.nodesToRead.length);
 
-        //xx dumpDataValues(results, request.nodesToRead);
+            //xx dumpDataValues(results, request.nodesToRead);
 
-        response = new read_service.ReadResponse({
-            results: results,
-            diagnosticInfos: null
+            response = new read_service.ReadResponse({
+                results: results,
+                diagnosticInfos: null
+            });
+            channel.send_response("MSG", response, message);
         });
+        return;
 
     } else {
         // ! BadNothingToDo
@@ -612,17 +615,19 @@ OPCUAServer.prototype._on_WriteRequest = function (message, channel) {
     if (request.nodesToWrite.length > 0) {
 
         assert(request.nodesToWrite[0]._schema.name === "WriteValue");
-        results = engine.write(request.nodesToWrite);
+    }
+    
+    engine.write(request.nodesToWrite,function(results){
+    
         assert(_.isArray(results));
         assert(results.length === request.nodesToWrite.length);
+        var response = new write_service.WriteResponse({
+            results: results,
+            diagnosticInfos: null
+        });
+        channel.send_response("MSG", response, message);
 
-    }
-
-    var response = new write_service.WriteResponse({
-        results: results,
-        diagnosticInfos: null
     });
-    channel.send_response("MSG", response, message);
 };
 
 
@@ -668,8 +673,12 @@ function readValue2(self, oldValue, node, itemToMonitor) {
 
     assert(self instanceof MonitoredItem);
 
-    var dataValue = node.readAttribute(itemToMonitor.attributeId);
+    var dataValue = node.readAttribute(itemToMonitor.attributeId, function(dataValue){
+        readValue2Next(self, oldValue, node, itemToMonitor, dataValue);
+    });
+}
 
+function readValue2Next(self, oldValue, node, itemToMonitor, dataValue) {
     if (dataValue.statusCode === StatusCodes.Good) {
         if (!_.isEqual(dataValue.value, oldValue)) {
             self.recordValue(dataValue.value);

--- a/lib/server/server_engine.js
+++ b/lib/server/server_engine.js
@@ -861,16 +861,16 @@ function apply_timestamps(dataValue, timestampsToReturn, attributeId) {
  * @param [timestampsToReturn=TimestampsToReturn.Neither]
  * @return {DataValue}
  */
-ServerEngine.prototype.readSingleNode = function (nodeId, attributeId, timestampsToReturn) {
+ServerEngine.prototype.readSingleNode = function (nodeId, attributeId, timestampsToReturn, callback) {
 
 
-    return this._readSingleNode({
+    this._readSingleNode({
         nodeId: nodeId,
         attributeId: attributeId
-    }, timestampsToReturn);
+    }, timestampsToReturn, callback);
 };
 
-ServerEngine.prototype._readSingleNode = function (nodeToRead, timestampsToReturn) {
+ServerEngine.prototype._readSingleNode = function (nodeToRead, timestampsToReturn, callback) {
 
     var nodeId = nodeToRead.nodeId;
     var attributeId = nodeToRead.attributeId;
@@ -880,7 +880,8 @@ ServerEngine.prototype._readSingleNode = function (nodeToRead, timestampsToRetur
     assert(self.address_space instanceof AddressSpace); // initialize not called
 
     if (timestampsToReturn === TimestampsToReturn.Invalid) {
-        return new DataValue({ statusCode: StatusCodes.BadTimestampsToReturnInvalid });
+        callback(new DataValue({ statusCode: StatusCodes.BadTimestampsToReturnInvalid }));
+        return;
     }
 
     timestampsToReturn = (timestampsToReturn !== null) ? timestampsToReturn : TimestampsToReturn.Neither;
@@ -890,21 +891,21 @@ ServerEngine.prototype._readSingleNode = function (nodeToRead, timestampsToRetur
     if (!obj) {
         // may be return BadNodeIdUnknown in dataValue instead ?
         // Object Not Found
-        return new DataValue({ statusCode: StatusCodes.BadNodeIdUnknown });
+        callback(new DataValue({ statusCode: StatusCodes.BadNodeIdUnknown }));
+        return;
     } else {
         // check access
         //    BadUserAccessDenied
         //    BadNotReadable
         //    invalid attributes : BadNodeAttributesInvalid
         //    invalid range      : BadIndexRangeInvalid
-        var dataValue = obj.readAttribute(attributeId, indexRange, dataEncoding);
+        obj.readAttribute(attributeId, function(dataValue){
+            assert(dataValue.statusCode instanceof StatusCode);
+            assert(dataValue.isValid());
 
-        assert(dataValue.statusCode instanceof StatusCode);
-        assert(dataValue.isValid());
-
-        apply_timestamps(dataValue, timestampsToReturn, attributeId);
-
-        return dataValue;
+            apply_timestamps(dataValue, timestampsToReturn, attributeId);
+            callback(dataValue);
+        }, indexRange, dataEncoding);
     }
 };
 
@@ -914,8 +915,10 @@ ServerEngine.prototype._readSingleNode = function (nodeToRead, timestampsToRetur
  * @param readRequest {ReadRequest}
  * @return {DataValue[]}
  */
-ServerEngine.prototype.read = function (readRequest) {
-
+ServerEngine.prototype.read = function (readRequest, callback) {
+    if (callback == null){
+        throw new Error("Callback not defined");
+    }
     assert(readRequest instanceof ReadRequest);
     assert(readRequest.maxAge >= 0);
     var self = this;
@@ -926,22 +929,33 @@ ServerEngine.prototype.read = function (readRequest) {
     assert(self.address_space instanceof AddressSpace); // initialize not called
     assert(_.isArray(nodesToRead));
 
-    var dataValues = nodesToRead.map(function (readValueId) {
-        assert(readValueId.indexRange instanceof NumericRange);
-        return self._readSingleNode(readValueId, timestampsToReturn);
+    var results = [];
+    this.readSupport(0,nodesToRead,timestampsToReturn,results,function(){
+        callback(results);
     });
-
-    assert(dataValues.length === readRequest.nodesToRead.length);
-    return dataValues;
 };
+
+ServerEngine.prototype.readSupport = function (index, list, timestampsToReturn, results, callback){
+    if (index >= list.length){
+        callback();
+        return;
+    }
+    var self = this;
+    var readValueId = list[index];
+    assert(readValueId.indexRange instanceof NumericRange);
+    self._readSingleNode(readValueId, timestampsToReturn, function(data){
+        results.push(data);
+        self.readSupport(index+1,list,timestampsToReturn,results,callback);
+    });
+}
 
 /**
  *
  * @method writeSingleNode
  * @param writeValue {DataValue}
- * @return {StatusCodes}
+ * @param callback {function}
  */
-ServerEngine.prototype.writeSingleNode = function (writeValue) {
+ServerEngine.prototype.writeSingleNode = function (writeValue, callback) {
 
     assert(writeValue._schema.name === "WriteValue");
     assert(writeValue.value instanceof DataValue);
@@ -953,9 +967,9 @@ ServerEngine.prototype.writeSingleNode = function (writeValue) {
 
     var obj = this.__findObject(nodeId);
     if (!obj) {
-        return StatusCodes.BadNodeIdUnknown;
+        callback(StatusCodes.BadNodeIdUnknown);
     } else {
-        return obj.writeAttribute(writeValue.attributeId, writeValue.value);
+        obj.writeAttribute(writeValue.attributeId, writeValue.value, callback);
     }
 };
 
@@ -965,19 +979,33 @@ var WriteValue = require("../services/write_service").WriteValue;
  *
  * @method writeSingleNode
  * @param nodesToWrite {Object[]}
- * @return {StatusCode[]}
+ * @param callback {function}
  */
-ServerEngine.prototype.write = function (nodesToWrite) {
+ServerEngine.prototype.write = function (nodesToWrite, callback) {
     var self = this;
     assert(self.address_space instanceof AddressSpace); // initialize not called
 
-    var statusCodes = nodesToWrite.map(function (writeValue) {
-        assert(writeValue instanceof WriteValue);
-        return self.writeSingleNode(writeValue);
+    var statusCodes = [];
+    this.writeSupport(0,nodesToWrite,statusCodes,function(){
+        assert(_.isArray(statusCodes));
+        callback(statusCodes);
     });
-    assert(_.isArray(statusCodes));
-    return statusCodes;
 };
+
+ServerEngine.prototype.writeSupport = function (index, list, statusCodes, callback){
+    if (index >= list.length){
+        callback();
+        return;
+    }
+    var self = this;
+    var writeValue = list[index];
+    
+    assert(writeValue instanceof WriteValue);
+    self.writeSingleNode(writeValue,function(statusCode){
+        statusCodes.push(statusCode);
+        self.writeSupport(index+1,list,statusCodes,callback);
+    });
+}
 
 /**
  *

--- a/test/address_space/test_variable.js
+++ b/test/address_space/test_variable.js
@@ -23,42 +23,49 @@ describe("testing Variables ",function(){
 
         var value ;
 
-        value = v.readAttribute(AttributeIds.AccessLevel);
-        value.value.dataType.should.eql(DataType.Byte);
-        value.statusCode.should.eql(StatusCodes.Good);
+        v.readAttribute(AttributeIds.AccessLevel,function(value){
+            value.value.dataType.should.eql(DataType.Byte);
+            value.statusCode.should.eql(StatusCodes.Good);
+        });
 
-        value = v.readAttribute(AttributeIds.UserAccessLevel);
-        value.value.dataType.should.eql(DataType.Byte);
-        value.statusCode.should.eql(StatusCodes.Good);
+        v.readAttribute(AttributeIds.UserAccessLevel,function(value){
+            value.value.dataType.should.eql(DataType.Byte);
+            value.statusCode.should.eql(StatusCodes.Good);
+        });
 
-        value = v.readAttribute(AttributeIds.ValueRank);
-        value.value.dataType.should.eql(DataType.Int32);
-        value.statusCode.should.eql(StatusCodes.Good);
+        v.readAttribute(AttributeIds.ValueRank,function(value){
+            value.value.dataType.should.eql(DataType.Int32);
+            value.statusCode.should.eql(StatusCodes.Good);
+        });
 
-        value = v.readAttribute(AttributeIds.Historizing);
-        value.value.dataType.should.eql(DataType.Boolean);
-        value.statusCode.should.eql(StatusCodes.Good);
+        v.readAttribute(AttributeIds.Historizing,function(value){
+            value.value.dataType.should.eql(DataType.Boolean);
+            value.statusCode.should.eql(StatusCodes.Good);
+        });
 
-        value = v.readAttribute(AttributeIds.BrowseName);
-        value.value.dataType.should.eql(DataType.QualifiedName);
-        value.statusCode.should.eql(StatusCodes.Good);
+        v.readAttribute(AttributeIds.BrowseName,function(value){
+            value.value.dataType.should.eql(DataType.QualifiedName);
+            value.statusCode.should.eql(StatusCodes.Good);
+        });
 
-        value = v.readAttribute(AttributeIds.DisplayName);
-        value.value.dataType.should.eql(DataType.LocalizedText);
-        value.statusCode.should.eql(StatusCodes.Good);
+        v.readAttribute(AttributeIds.DisplayName,function(value){
+            value.value.dataType.should.eql(DataType.LocalizedText);
+            value.statusCode.should.eql(StatusCodes.Good);
+        });
 
-        value = v.readAttribute(AttributeIds.MinimumSamplingInterval);
-        value.value.dataType.should.eql(DataType.UInt32);
-        value.statusCode.should.eql(StatusCodes.Good);
+        v.readAttribute(AttributeIds.MinimumSamplingInterval,function(value){
+            value.value.dataType.should.eql(DataType.UInt32);
+            value.statusCode.should.eql(StatusCodes.Good);
+        });
 
-        value = v.readAttribute(AttributeIds.IsAbstract);
-        value.statusCode.name.should.eql("BadAttributeIdInvalid");
+        v.readAttribute(AttributeIds.IsAbstract,function(value){
+            value.statusCode.name.should.eql("BadAttributeIdInvalid");
+        });
 
-        value = v.readAttribute(AttributeIds.NodeClass);
-        value.value.dataType.should.eql(DataType.Int32);
-        value.value.value.should.eql(NodeClass.Variable.value);
-        value.statusCode.should.eql(StatusCodes.Good);
-
+        v.readAttribute(AttributeIds.NodeClass,function(value){
+            value.value.dataType.should.eql(DataType.Int32);
+            value.value.value.should.eql(NodeClass.Variable.value);
+            value.statusCode.should.eql(StatusCodes.Good);
+        });
     });
-
 });

--- a/test/server/test_server_engine.js
+++ b/test/server/test_server_engine.js
@@ -278,8 +278,10 @@ describe("testing ServerEngine", function () {
 
             });
 
-        newVariable.value.should.be.instanceOf(Variant);
-        newVariable.value.value.should.equal(10.0);
+        newVariable.readAttribute(AttributeIds.Value,function(dataValue){
+            dataValue.value.should.be.instanceOf(Variant);
+            dataValue.value.value.should.equal(10.0);
+        });
 
         newVariable.hasTypeDefinition.should.equal(BaseDataVariableTypeId);
         newVariable.parent.should.equal(newFolder.nodeId);
@@ -335,11 +337,12 @@ describe("testing ServerEngine", function () {
             });
 
 
-        var dataValue = newVariable.readAttribute(AttributeIds.Value,undefined,undefined);
-        dataValue.should.be.instanceOf(DataValue);
+        newVariable.readAttribute(AttributeIds.Value,function(dataValue){
+            dataValue.should.be.instanceOf(DataValue);
 
-        dataValue.sourceTimestamp.should.eql(new Date(Date.UTC(1999,9,9)));
-        dataValue.sourcePicoseconds.should.eql(10);
+            dataValue.sourceTimestamp.should.eql(new Date(Date.UTC(1999,9,9)));
+            dataValue.sourcePicoseconds.should.eql(10);
+        });
 
     });
 
@@ -550,74 +553,83 @@ describe("testing ServerEngine", function () {
 
         it("should handle a readSingleNode - BrowseName",function() {
 
-            var readResult = engine.readSingleNode("RootFolder",AttributeIds.BrowseName);
+            engine.readSingleNode("RootFolder",AttributeIds.BrowseName,null,function(readResult){
 
-            readResult.statusCode.should.eql( StatusCodes.Good);
-            readResult.value.dataType.should.eql(DataType.QualifiedName);
-            readResult.value.value.name.should.equal("Root");
+                readResult.statusCode.should.eql( StatusCodes.Good);
+                readResult.value.dataType.should.eql(DataType.QualifiedName);
+                readResult.value.value.name.should.equal("Root");
+            });
         });
 
         it("should handle a readSingleNode - NodeClass",function() {
 
-            var readResult = engine.readSingleNode("RootFolder",AttributeIds.NodeClass);
+            engine.readSingleNode("RootFolder",AttributeIds.NodeClass,null,function(readResult){
 
-            readResult.statusCode.should.eql( StatusCodes.Good);
-            readResult.value.dataType.should.eql(DataType.Int32);
-            readResult.value.value.should.equal(NodeClass.Object.value);
+                readResult.statusCode.should.eql( StatusCodes.Good);
+                readResult.value.dataType.should.eql(DataType.Int32);
+                readResult.value.value.should.equal(NodeClass.Object.value);
+            });
         });
 
         it("should handle a readSingleNode - NodeId",function() {
 
-            var readResult = engine.readSingleNode("RootFolder",AttributeIds.NodeId);
+            engine.readSingleNode("RootFolder",AttributeIds.NodeId,null,function(readResult){
 
-            readResult.statusCode.should.eql( StatusCodes.Good);
-            readResult.value.dataType.should.eql(DataType.NodeId);
-            readResult.value.value.toString().should.equal("ns=0;i=84");
+                readResult.statusCode.should.eql( StatusCodes.Good);
+                readResult.value.dataType.should.eql(DataType.NodeId);
+                readResult.value.value.toString().should.equal("ns=0;i=84");
+            });
         });
 
         it("should handle a readSingleNode - DisplayName",function() {
 
-            var readResult = engine.readSingleNode("RootFolder",AttributeIds.DisplayName);
+            engine.readSingleNode("RootFolder",AttributeIds.DisplayName,null,function(readResult){
 
-            readResult.statusCode.should.eql( StatusCodes.Good);
-            readResult.value.dataType.should.eql(DataType.LocalizedText);
-            readResult.value.value.text.toString().should.equal("Root");
+                readResult.statusCode.should.eql( StatusCodes.Good);
+                readResult.value.dataType.should.eql(DataType.LocalizedText);
+                readResult.value.value.text.toString().should.equal("Root");
+            });
         });
 
         it("should handle a readSingleNode - Description",function() {
 
-            var readResult = engine.readSingleNode("RootFolder",AttributeIds.Description);
-            readResult.statusCode.should.eql( StatusCodes.Good);
-            readResult.value.dataType.should.eql(DataType.LocalizedText);
-            readResult.value.value.text.toString().should.equal("");
+            engine.readSingleNode("RootFolder",AttributeIds.Description,null,function(readResult){
+                readResult.statusCode.should.eql( StatusCodes.Good);
+                readResult.value.dataType.should.eql(DataType.LocalizedText);
+                readResult.value.value.text.toString().should.equal("");
+            });
         });
 
         it("should handle a readSingleNode - WriteMask",function() {
 
-            var readResult = engine.readSingleNode("RootFolder",AttributeIds.WriteMask);
-            readResult.statusCode.should.eql( StatusCodes.Good);
-            readResult.value.dataType.should.eql(DataType.UInt32);
-            readResult.value.value.should.equal(0);
+            engine.readSingleNode("RootFolder",AttributeIds.WriteMask,null,function(readResult){
+                readResult.statusCode.should.eql( StatusCodes.Good);
+                readResult.value.dataType.should.eql(DataType.UInt32);
+                readResult.value.value.should.equal(0);
+            });
         });
 
         it("should handle a readSingleNode - UserWriteMask",function() {
 
-            var readResult = engine.readSingleNode("RootFolder",AttributeIds.UserWriteMask);
-            readResult.value.dataType.should.eql(DataType.UInt32);
-            readResult.value.value.should.equal(0);
+            engine.readSingleNode("RootFolder",AttributeIds.UserWriteMask,null,function(readResult){
+                readResult.value.dataType.should.eql(DataType.UInt32);
+                readResult.value.value.should.equal(0);
+            });
         });
         it("should handle a readSingleNode - EventNotifier",function() {
 
-            var readResult = engine.readSingleNode("RootFolder",AttributeIds.EventNotifier);
-            readResult.value.dataType.should.eql(DataType.Byte);
-            readResult.value.value.should.equal(0   );
+            engine.readSingleNode("RootFolder",AttributeIds.EventNotifier,null,function(readResult){
+                readResult.value.dataType.should.eql(DataType.Byte);
+                readResult.value.value.should.equal(0   );
+            });
         });
 
         it("should return BadAttributeIdInvalid  - readSingleNode - for bad attribute    ",function() {
 
-            var readResult = engine.readSingleNode("RootFolder",AttributeIds.ContainsNoLoops);
-            readResult.statusCode.should.eql(StatusCodes.BadAttributeIdInvalid);
-            assert(readResult.value === null);
+            engine.readSingleNode("RootFolder",AttributeIds.ContainsNoLoops,null,function(readResult){
+                readResult.statusCode.should.eql(StatusCodes.BadAttributeIdInvalid);
+                assert(readResult.value === null);
+            });
         });
     });
 
@@ -631,41 +643,46 @@ describe("testing ServerEngine", function () {
         //  --- on reference Type ....
         it("should handle a readSingleNode - IsAbstract",function() {
 
-            var readResult = engine.readSingleNode(ref_Organizes_nodeId,AttributeIds.IsAbstract);
-            readResult.value.dataType.should.eql(DataType.Boolean);
-            readResult.value.value.should.equal(false);
-            readResult.statusCode.should.eql(StatusCodes.Good);
+            engine.readSingleNode(ref_Organizes_nodeId,AttributeIds.IsAbstract,null,function(readResult){
+                readResult.value.dataType.should.eql(DataType.Boolean);
+                readResult.value.value.should.equal(false);
+                readResult.statusCode.should.eql(StatusCodes.Good);
+            });
         });
 
         it("should handle a readSingleNode - Symmetric",function() {
 
-            var readResult = engine.readSingleNode(ref_Organizes_nodeId,AttributeIds.Symmetric);
-            readResult.statusCode.should.eql(StatusCodes.Good);
-            readResult.value.dataType.should.eql(DataType.Boolean);
-            readResult.value.value.should.equal(false);
+            engine.readSingleNode(ref_Organizes_nodeId,AttributeIds.Symmetric,null,function(readResult){
+                readResult.statusCode.should.eql(StatusCodes.Good);
+                readResult.value.dataType.should.eql(DataType.Boolean);
+                readResult.value.value.should.equal(false);
+            });
         });
 
         it("should handle a readSingleNode - InverseName",function() {
 
-            var readResult = engine.readSingleNode(ref_Organizes_nodeId,AttributeIds.InverseName);
-            readResult.statusCode.should.eql(StatusCodes.Good);
-            readResult.value.dataType.should.eql(DataType.LocalizedText);
-            //xx readResult.value.value.should.equal(false);
+            engine.readSingleNode(ref_Organizes_nodeId,AttributeIds.InverseName,null,function(readResult){
+                readResult.statusCode.should.eql(StatusCodes.Good);
+                readResult.value.dataType.should.eql(DataType.LocalizedText);
+                //xx readResult.value.value.should.equal(false);
+            });
         });
 
         it("should handle a readSingleNode - BrowseName",function() {
 
-            var readResult = engine.readSingleNode(ref_Organizes_nodeId,AttributeIds.BrowseName);
-            readResult.statusCode.should.eql(StatusCodes.Good);
-            readResult.value.dataType.should.eql(DataType.QualifiedName);
-            readResult.value.value.name.should.eql("Organizes");
-            //xx readResult.value.value.should.equal(false);
+            engine.readSingleNode(ref_Organizes_nodeId,AttributeIds.BrowseName,null,function(readResult){
+                readResult.statusCode.should.eql(StatusCodes.Good);
+                readResult.value.dataType.should.eql(DataType.QualifiedName);
+                readResult.value.value.name.should.eql("Organizes");
+                //xx readResult.value.value.should.equal(false);
+            });
         });
         it("should return BadAttributeIdInvalid on EventNotifier",function() {
 
-            var readResult = engine.readSingleNode(ref_Organizes_nodeId,AttributeIds.EventNotifier);
-            readResult.statusCode.should.eql(StatusCodes.BadAttributeIdInvalid);
-            assert(readResult.value === null);
+            engine.readSingleNode(ref_Organizes_nodeId,AttributeIds.EventNotifier,null,function(readResult){
+                readResult.statusCode.should.eql(StatusCodes.BadAttributeIdInvalid);
+                assert(readResult.value === null);
+            });
         });
     });
 
@@ -673,37 +690,43 @@ describe("testing ServerEngine", function () {
         //
         it("should handle a readSingleNode - BrowseName",function() {
 
-            var readResult = engine.readSingleNode("DataTypeDescriptionType",AttributeIds.BrowseName);
-            readResult.statusCode.should.eql( StatusCodes.Good);
+            engine.readSingleNode("DataTypeDescriptionType",AttributeIds.BrowseName,null,function(readResult){
+                readResult.statusCode.should.eql( StatusCodes.Good);
+            });
         });
         it("should handle a readSingleNode - IsAbstract",function() {
 
-            var readResult = engine.readSingleNode("DataTypeDescriptionType",AttributeIds.IsAbstract);
+            engine.readSingleNode("DataTypeDescriptionType",AttributeIds.IsAbstract,null,function(readResult){
 
-            readResult.statusCode.should.eql( StatusCodes.Good);
-            readResult.value.dataType.should.eql(DataType.Boolean);
-            readResult.value.value.should.equal(false);
+                readResult.statusCode.should.eql( StatusCodes.Good);
+                readResult.value.dataType.should.eql(DataType.Boolean);
+                readResult.value.value.should.equal(false);
+            });
         });
         it("should handle a readSingleNode - Value",function() {
 
-            var readResult = engine.readSingleNode("DataTypeDescriptionType",AttributeIds.Value);
-            readResult.statusCode.should.eql( StatusCodes.BadAttributeIdInvalid);
+            engine.readSingleNode("DataTypeDescriptionType",AttributeIds.Value,null,function(readResult){
+                readResult.statusCode.should.eql( StatusCodes.BadAttributeIdInvalid);
+            });
         });
 
         it("should handle a readSingleNode - DataType",function() {
 
-            var readResult = engine.readSingleNode("DataTypeDescriptionType",AttributeIds.DataType);
-            readResult.statusCode.should.eql( StatusCodes.Good);
+            engine.readSingleNode("DataTypeDescriptionType",AttributeIds.DataType,null,function(readResult){
+                readResult.statusCode.should.eql( StatusCodes.Good);
+            });
         });
         it("should handle a readSingleNode - ValueRank",function() {
 
-            var readResult = engine.readSingleNode("DataTypeDescriptionType",AttributeIds.ValueRank);
-            readResult.statusCode.should.eql( StatusCodes.Good);
+            engine.readSingleNode("DataTypeDescriptionType",AttributeIds.ValueRank,null,function(readResult){
+                readResult.statusCode.should.eql( StatusCodes.Good);
+            });
         });
         it("should handle a readSingleNode - ArrayDimensions",function() {
 
-            var readResult = engine.readSingleNode("DataTypeDescriptionType",AttributeIds.ArrayDimensions);
-            readResult.statusCode.should.eql( StatusCodes.Good);
+            engine.readSingleNode("DataTypeDescriptionType",AttributeIds.ArrayDimensions,null,function(readResult){
+                readResult.statusCode.should.eql( StatusCodes.Good);
+            });
         });
     });
 
@@ -711,35 +734,41 @@ describe("testing ServerEngine", function () {
         var productUri_id = makeNodeId(2262,0);
         it("should handle a readSingleNode - BrowseName",function() {
 
-            var readResult = engine.readSingleNode(productUri_id,AttributeIds.BrowseName);
-            readResult.statusCode.should.eql( StatusCodes.Good);
+            engine.readSingleNode(productUri_id,AttributeIds.BrowseName,null,function(readResult){
+                readResult.statusCode.should.eql( StatusCodes.Good);
+            });
         });
         it("should handle a readSingleNode - ArrayDimensions",function() {
 
-            var readResult = engine.readSingleNode(productUri_id,AttributeIds.ArrayDimensions);
-            readResult.statusCode.should.eql( StatusCodes.Good);
+            engine.readSingleNode(productUri_id,AttributeIds.ArrayDimensions,null,function(readResult){
+                readResult.statusCode.should.eql( StatusCodes.Good);
+            });
         });
         it("should handle a readSingleNode - AccessLevel",function() {
 
-            var readResult = engine.readSingleNode(productUri_id,AttributeIds.AccessLevel);
-            readResult.statusCode.should.eql( StatusCodes.Good);
+            engine.readSingleNode(productUri_id,AttributeIds.AccessLevel,null,function(readResult){
+                readResult.statusCode.should.eql( StatusCodes.Good);
+            });
         });
         it("should handle a readSingleNode - UserAccessLevel",function() {
 
-            var readResult = engine.readSingleNode(productUri_id,AttributeIds.UserAccessLevel);
-            readResult.statusCode.should.eql( StatusCodes.Good);
+            engine.readSingleNode(productUri_id,AttributeIds.UserAccessLevel,null,function(readResult){
+                readResult.statusCode.should.eql( StatusCodes.Good);
+            });
         });
         it("should handle a readSingleNode - MinimumSamplingInterval",function() {
 
-            var readResult = engine.readSingleNode(productUri_id,AttributeIds.MinimumSamplingInterval);
-            readResult.statusCode.should.eql( StatusCodes.Good);
-            readResult.value.value.should.eql(1000);
+            engine.readSingleNode(productUri_id,AttributeIds.MinimumSamplingInterval,null,function(readResult){
+                readResult.statusCode.should.eql( StatusCodes.Good);
+                readResult.value.value.should.eql(1000);
+            });
         });
         it("should handle a readSingleNode - Historizing",function() {
 
-            var readResult = engine.readSingleNode(productUri_id,AttributeIds.Historizing);
-            readResult.statusCode.should.eql( StatusCodes.Good);
-            readResult.value.value.should.eql(false);
+            engine.readSingleNode(productUri_id,AttributeIds.Historizing,null,function(readResult){
+                readResult.statusCode.should.eql( StatusCodes.Good);
+                readResult.value.value.should.eql(false);
+            });
         });
     });
 
@@ -748,9 +777,10 @@ describe("testing ServerEngine", function () {
         // for views
         xit("should handle a readSingleNode - ContainsNoLoops",function() {
 
-            var readResult = engine.readSingleNode("RootFolder",AttributeIds.ContainsNoLoops);
-            readResult.value.dataType.should.eql(DataType.Boolean);
-            readResult.value.value.should.equal(true);
+            engine.readSingleNode("RootFolder",AttributeIds.ContainsNoLoops,null,function(readResult){
+                readResult.value.dataType.should.eql(DataType.Boolean);
+                readResult.value.value.should.equal(true);
+            });
         });
     });
 
@@ -765,16 +795,18 @@ describe("testing ServerEngine", function () {
 
             var obj =engine.address_space.findDataType("ServerStatusDataType");
             var serverStatusDataType_id = obj.nodeId;
-            var readResult = engine.readSingleNode(serverStatusDataType_id,AttributeIds.BrowseName);
-            readResult.value.dataType.should.eql(DataType.QualifiedName);
-            readResult.value.value.name.should.equal("ServerStatusDataType");
+            engine.readSingleNode(serverStatusDataType_id,AttributeIds.BrowseName,null,function(readResult){
+                readResult.value.dataType.should.eql(DataType.QualifiedName);
+                readResult.value.value.name.should.equal("ServerStatusDataType");
+            });
         });
     });
 
     it("should return BadNodeIdUnknown  - readSingleNode - with unknown object",function() {
 
-        var readResult = engine.readSingleNode("**UNKNOWN**",AttributeIds.DisplayName);
-        readResult.statusCode.should.eql(StatusCodes.BadNodeIdUnknown);
+        engine.readSingleNode("**UNKNOWN**",AttributeIds.DisplayName,null,function(readResult){
+            readResult.statusCode.should.eql(StatusCodes.BadNodeIdUnknown);
+        });
     });
 
     it("should read the display name of RootFolder",function() {
@@ -791,8 +823,9 @@ describe("testing ServerEngine", function () {
                 }
             ]
         });
-        var dataValues = engine.read(readRequest);
-        dataValues.length.should.equal(1);
+        engine.read(readRequest,function(dataValues){
+            dataValues.length.should.equal(1);
+        });
 
     });
 
@@ -839,10 +872,11 @@ describe("testing ServerEngine", function () {
                     }
                 ]
             });
-            var dataValues = engine.read(readRequest);
-            dataValues.length.should.eql(1);
-            dataValues[0].statusCode.should.eql(StatusCodes.BadIndexRangeNoData);
-            done();
+            engine.read(readRequest,function(dataValues){
+                dataValues.length.should.eql(1);
+                dataValues[0].statusCode.should.eql(StatusCodes.BadIndexRangeNoData);
+                done();
+            });
         }
         var attributes = ["AccessLevel", "BrowseName", "DataType", "DisplayName", "Historizing", "NodeClass", "NodeId", "UserAccessLevel", "ValueRank"];
         attributes.forEach(function(attribute) {
@@ -866,9 +900,10 @@ describe("testing ServerEngine", function () {
                     }
                 ]
             });
-            var dataValues = engine.read(readRequest);
-            dataValues.length.should.eql(1);
-            dataValues[0].statusCode.should.eql(StatusCodes.BadDataEncodingInvalid);
+            engine.read(readRequest,function(dataValues){
+                dataValues.length.should.eql(1);
+                dataValues[0].statusCode.should.eql(StatusCodes.BadDataEncodingInvalid);
+            });
         });
     });
 
@@ -903,19 +938,20 @@ describe("testing ServerEngine", function () {
                 timestampsToReturn: TimestampsToReturn.Neither,
                 nodesToRead: nodesToRead
             });
-            var dataValues = engine.read(readRequest);
-            dataValues.length.should.equal(3);
-            dataValues[0].should.be.instanceOf(DataValue);
-            dataValues[1].should.be.instanceOf(DataValue);
-            dataValues[2].should.be.instanceOf(DataValue);
-            should(dataValues[0].serverTimeStamp).eql(undefined);
-            should(dataValues[0].sourceTimeStamp).eql(undefined);
-            should(dataValues[0].serverPicoseconds).eql(0);
-            should(dataValues[0].sourcePicoseconds).eql(0);
-            should(dataValues[1].serverTimeStamp).eql(undefined);
-            should(dataValues[1].sourceTimeStamp).eql(undefined);
-            should(dataValues[1].serverPicoseconds).eql(0);
-            should(dataValues[1].sourcePicoseconds).eql(0);
+            engine.read(readRequest,function(dataValues){
+                dataValues.length.should.equal(3);
+                dataValues[0].should.be.instanceOf(DataValue);
+                dataValues[1].should.be.instanceOf(DataValue);
+                dataValues[2].should.be.instanceOf(DataValue);
+                should(dataValues[0].serverTimeStamp).eql(undefined);
+                should(dataValues[0].sourceTimeStamp).eql(undefined);
+                should(dataValues[0].serverPicoseconds).eql(0);
+                should(dataValues[0].sourcePicoseconds).eql(0);
+                should(dataValues[1].serverTimeStamp).eql(undefined);
+                should(dataValues[1].sourceTimeStamp).eql(undefined);
+                should(dataValues[1].serverPicoseconds).eql(0);
+                should(dataValues[1].sourcePicoseconds).eql(0);
+            });
 
         });
 
@@ -927,20 +963,21 @@ describe("testing ServerEngine", function () {
                 timestampsToReturn: TimestampsToReturn.Server,
                 nodesToRead: nodesToRead
             });
-            var dataValues = engine.read(readRequest);
-            dataValues.length.should.equal(3);
-            dataValues[0].should.be.instanceOf(DataValue);
-            dataValues[1].should.be.instanceOf(DataValue);
-            dataValues[2].should.be.instanceOf(DataValue);
+            engine.read(readRequest,function(dataValues){
+                dataValues.length.should.equal(3);
+                dataValues[0].should.be.instanceOf(DataValue);
+                dataValues[1].should.be.instanceOf(DataValue);
+                dataValues[2].should.be.instanceOf(DataValue);
 
-            should(dataValues[0].serverTimestamp).be.instanceOf(Date);
-            should(dataValues[0].sourceTimestamp).be.eql(null);
-            should(dataValues[0].serverPicoseconds).be.eql(0);
-            should(dataValues[0].sourcePicoseconds).be.eql(0);
-            should(dataValues[1].serverTimestamp).be.instanceOf(Date);
-            should(dataValues[1].sourceTimestamp).be.eql(null);
-            should(dataValues[1].serverPicoseconds).be.eql(0);
-            should(dataValues[1].sourcePicoseconds).be.eql(0);
+                should(dataValues[0].serverTimestamp).be.instanceOf(Date);
+                should(dataValues[0].sourceTimestamp).be.eql(null);
+                should(dataValues[0].serverPicoseconds).be.eql(0);
+                should(dataValues[0].sourcePicoseconds).be.eql(0);
+                should(dataValues[1].serverTimestamp).be.instanceOf(Date);
+                should(dataValues[1].sourceTimestamp).be.eql(null);
+                should(dataValues[1].serverPicoseconds).be.eql(0);
+                should(dataValues[1].sourcePicoseconds).be.eql(0);
+            });
 
         });
 
@@ -953,24 +990,25 @@ describe("testing ServerEngine", function () {
                 nodesToRead: nodesToRead
             });
 
-            var dataValues = engine.read(readRequest);
+            engine.read(readRequest,function(dataValues){
 
-            dataValues.length.should.equal(3);
-            dataValues[0].should.be.instanceOf(DataValue);
-            dataValues[1].should.be.instanceOf(DataValue);
-            dataValues[2].should.be.instanceOf(DataValue);
+                dataValues.length.should.equal(3);
+                dataValues[0].should.be.instanceOf(DataValue);
+                dataValues[1].should.be.instanceOf(DataValue);
+                dataValues[2].should.be.instanceOf(DataValue);
 
-            should(dataValues[0].serverTimestamp).be.eql(null);
-            should(dataValues[0].sourceTimestamp).be.null; /// SourceTimestamp only for AttributeIds.Value
-            should(dataValues[0].serverPicoseconds).be.eql(0);
-            should(dataValues[0].sourcePicoseconds).be.eql(0);
+                should(dataValues[0].serverTimestamp).be.eql(null);
+                should(dataValues[0].sourceTimestamp).be.null; /// SourceTimestamp only for AttributeIds.Value
+                should(dataValues[0].serverPicoseconds).be.eql(0);
+                should(dataValues[0].sourcePicoseconds).be.eql(0);
 
-            should(dataValues[1].serverTimestamp).be.eql(null);
-            should(dataValues[1].sourceTimestamp).be.null; /// SourceTimestamp only for AttributeIds.Value
-            should(dataValues[1].serverPicoseconds).be.eql(0);
-            should(dataValues[1].sourcePicoseconds).be.eql(0);
+                should(dataValues[1].serverTimestamp).be.eql(null);
+                should(dataValues[1].sourceTimestamp).be.null; /// SourceTimestamp only for AttributeIds.Value
+                should(dataValues[1].serverPicoseconds).be.eql(0);
+                should(dataValues[1].sourcePicoseconds).be.eql(0);
 
-            should(dataValues[2].sourceTimestamp).be.instanceOf(Date);
+                should(dataValues[2].sourceTimestamp).be.instanceOf(Date);
+            });
 
         });
 
@@ -982,24 +1020,25 @@ describe("testing ServerEngine", function () {
                 timestampsToReturn: TimestampsToReturn.Both,
                 nodesToRead: nodesToRead
             });
-            var dataValues = engine.read(readRequest);
+            engine.read(readRequest,function(dataValues){
 
-            dataValues.length.should.equal(3);
-            dataValues[0].should.be.instanceOf(DataValue);
-            dataValues[1].should.be.instanceOf(DataValue);
-            dataValues[2].should.be.instanceOf(DataValue);
+                dataValues.length.should.equal(3);
+                dataValues[0].should.be.instanceOf(DataValue);
+                dataValues[1].should.be.instanceOf(DataValue);
+                dataValues[2].should.be.instanceOf(DataValue);
 
-            should(dataValues[0].serverTimestamp).be.instanceOf(Date);
-            should(dataValues[0].sourceTimestamp).be.eql(null); /// SourceTimestamp only for AttributeIds.Value
-            should(dataValues[0].serverPicoseconds).be.eql(0);
-            should(dataValues[0].sourcePicoseconds).be.eql(0);
+                should(dataValues[0].serverTimestamp).be.instanceOf(Date);
+                should(dataValues[0].sourceTimestamp).be.eql(null); /// SourceTimestamp only for AttributeIds.Value
+                should(dataValues[0].serverPicoseconds).be.eql(0);
+                should(dataValues[0].sourcePicoseconds).be.eql(0);
 
-            should(dataValues[1].serverTimestamp).be.instanceOf(Date);
-            should(dataValues[1].sourceTimestamp).be.eql(null); /// SourceTimestamp only for AttributeIds.Value
-            should(dataValues[1].serverPicoseconds).be.eql(0);
-            should(dataValues[1].sourcePicoseconds).be.eql(0);
+                should(dataValues[1].serverTimestamp).be.instanceOf(Date);
+                should(dataValues[1].sourceTimestamp).be.eql(null); /// SourceTimestamp only for AttributeIds.Value
+                should(dataValues[1].serverPicoseconds).be.eql(0);
+                should(dataValues[1].sourcePicoseconds).be.eql(0);
 
-            should(dataValues[2].sourceTimestamp).be.instanceOf(Date);
+                should(dataValues[2].sourceTimestamp).be.instanceOf(Date);
+            });
 
         });
 
@@ -1024,11 +1063,12 @@ describe("testing ServerEngine", function () {
                 }
             ]
         });
-        var dataValues = engine.read(readRequest);
-        dataValues.length.should.equal(2);
-        dataValues[0].value.value.text.should.eql("NamespaceArray");
-        dataValues[1].value.value.should.be.instanceOf(Array);
-        dataValues[1].value.value.length.should.be.eql(2);
+        engine.read(readRequest,function(dataValues){
+            dataValues.length.should.equal(2);
+            dataValues[0].value.value.text.should.eql("NamespaceArray");
+            dataValues[1].value.value.should.be.instanceOf(Array);
+            dataValues[1].value.value.length.should.be.eql(2);
+        });
     });
 
     it("should handle indexRange with individual value",function() {
@@ -1045,13 +1085,14 @@ describe("testing ServerEngine", function () {
                 }
             ]
         });
-        var dataValues = engine.read(readRequest);
-        dataValues.length.should.equal(1);
-        dataValues[0].statusCode.should.eql(StatusCodes.Good);
+        engine.read(readRequest,function(dataValues){
+            dataValues.length.should.equal(1);
+            dataValues[0].statusCode.should.eql(StatusCodes.Good);
 
-        dataValues[0].value.value.should.be.instanceOf(Array);
-        dataValues[0].value.value.length.should.be.eql(1);
-        dataValues[0].value.value[0].should.be.eql(2.0);
+            dataValues[0].value.value.should.be.instanceOf(Array);
+            dataValues[0].value.value.length.should.be.eql(1);
+            dataValues[0].value.value[0].should.be.eql(2.0);
+        });
 
     });
 
@@ -1069,12 +1110,13 @@ describe("testing ServerEngine", function () {
                 }
             ]
         });
-        var dataValues = engine.read(readRequest);
-        dataValues.length.should.equal(1);
-        dataValues[0].statusCode.should.eql(StatusCodes.Good);
-        dataValues[0].value.value.should.be.instanceOf(Array);
-        dataValues[0].value.value.length.should.be.eql(4);
-        dataValues[0].value.value.should.be.eql([ 2.0 , 3.0 , 4.0, 5.0]);
+        engine.read(readRequest,function(dataValues){
+            dataValues.length.should.equal(1);
+            dataValues[0].statusCode.should.eql(StatusCodes.Good);
+            dataValues[0].value.value.should.be.instanceOf(Array);
+            dataValues[0].value.value.length.should.be.eql(4);
+            dataValues[0].value.value.should.be.eql([ 2.0 , 3.0 , 4.0, 5.0]);
+        });
 
     });
     it("should receive BadIndexRangeNoData when indexRange try to access outside boundary",function() {
@@ -1091,9 +1133,10 @@ describe("testing ServerEngine", function () {
                 }
             ]
         });
-        var dataValues = engine.read(readRequest);
-        dataValues.length.should.equal(1);
-        dataValues[0].statusCode.should.eql(StatusCodes.BadIndexRangeNoData);
+        engine.read(readRequest,function(dataValues){
+            dataValues.length.should.equal(1);
+            dataValues[0].statusCode.should.eql(StatusCodes.BadIndexRangeNoData);
+        });
 
     });
 
@@ -1110,10 +1153,11 @@ describe("testing ServerEngine", function () {
                 }
             ]
         });
-        var dataValues = engine.read(readRequest);
-        dataValues.length.should.equal(1);
-        dataValues[0].value.dataType.should.eql(DataType.NodeId);
-        dataValues[0].value.value.toString().should.eql("ns=0;i=12"); // String
+        engine.read(readRequest,function(dataValues){
+            dataValues.length.should.equal(1);
+            dataValues[0].value.dataType.should.eql(DataType.NodeId);
+            dataValues[0].value.value.toString().should.eql("ns=0;i=12"); // String
+        });
     });
 
     it("should read Server_NamespaceArray ValueRank",function() {
@@ -1131,12 +1175,13 @@ describe("testing ServerEngine", function () {
             ]
         });
 
-        var dataValues = engine.read(readRequest);
-        dataValues.length.should.equal(1);
-        dataValues[0].statusCode.should.eql(StatusCodes.Good);
+        engine.read(readRequest,function(dataValues){
+            dataValues.length.should.equal(1);
+            dataValues[0].statusCode.should.eql(StatusCodes.Good);
 
-       //xx console.log("xxxxxxxxx =  dataValues[0].value.value",typeof( dataValues[0].value.value), dataValues[0].value.value);
-        dataValues[0].value.value.should.eql(VariantArrayType.Array.value);
+           //xx console.log("xxxxxxxxx =  dataValues[0].value.value",typeof( dataValues[0].value.value), dataValues[0].value.value);
+            dataValues[0].value.value.should.eql(VariantArrayType.Array.value);
+        });
 
     });
 
@@ -1244,11 +1289,11 @@ describe("testing ServerEngine", function () {
                 }]
             });
 
-            var dataValues = engine.read(readRequest);
-            dataValues.length.should.equal(1);
-            dataValues[0].statusCode.should.eql(StatusCodes.Good);
-            dataValues[0].value.dataType.should.eql(DataType.DateTime);
-            dataValues[0].value.value.should.be.instanceOf(Date);
+            engine.read(readRequest,function(dataValues){
+                dataValues[0].statusCode.should.eql(StatusCodes.Good);
+                dataValues[0].value.dataType.should.eql(DataType.DateTime);
+                dataValues[0].value.value.should.be.instanceOf(Date);
+            });
 
         });
 
@@ -1262,11 +1307,12 @@ describe("testing ServerEngine", function () {
                 }]
             });
 
-            var dataValues = engine.read(readRequest);
-            dataValues.length.should.equal(1);
-            dataValues[0].statusCode.should.eql(StatusCodes.Good);
-            dataValues[0].value.dataType.should.eql(DataType.DateTime);
-            dataValues[0].value.value.should.be.instanceOf(Date);
+            engine.read(readRequest,function(dataValues){
+                dataValues.length.should.equal(1);
+                dataValues[0].statusCode.should.eql(StatusCodes.Good);
+                dataValues[0].value.dataType.should.eql(DataType.DateTime);
+                dataValues[0].value.value.should.be.instanceOf(Date);
+            });
 
         });
 
@@ -1282,11 +1328,12 @@ describe("testing ServerEngine", function () {
                 }]
             });
 
-            var dataValues = engine.read(readRequest);
-            dataValues.length.should.equal(1);
-            dataValues[0].statusCode.should.eql(StatusCodes.Good);
-            dataValues[0].value.dataType.should.eql(DataType.String);
-            dataValues[0].value.value.should.eql("1234")
+            engine.read(readRequest,function(dataValues){
+                dataValues.length.should.equal(1);
+                dataValues[0].statusCode.should.eql(StatusCodes.Good);
+                dataValues[0].value.dataType.should.eql(DataType.String);
+                dataValues[0].value.value.should.eql("1234");
+            });
 
         });
 
@@ -1298,11 +1345,11 @@ describe("testing ServerEngine", function () {
             var node = engine.findObject(nodeid);
             should(node).not.equal(null);
 
-            var dataValue = node.readAttribute(13);
-
-            dataValue.statusCode.should.eql(StatusCodes.Good);
-            dataValue.value.dataType.should.eql(DataType.String);
-            dataValue.value.value.should.eql("1234");
+            node.readAttribute(13,function(dataValue){
+                dataValue.statusCode.should.eql(StatusCodes.Good);
+                dataValue.value.dataType.should.eql(DataType.String);
+                dataValue.value.value.should.eql("1234");
+            });
 
         });
 
@@ -1314,11 +1361,12 @@ describe("testing ServerEngine", function () {
             assert(node!=null);
             should(node).not.eql(null);
 
-            var dataValue = node.readAttribute(13);
+            node.readAttribute(13,function(dataValue){
 
-            dataValue.statusCode.should.eql(StatusCodes.Good);
-            dataValue.value.dataType.should.eql(DataType.UInt32);
-            dataValue.value.value.should.eql(0);
+                dataValue.statusCode.should.eql(StatusCodes.Good);
+                dataValue.value.dataType.should.eql(DataType.UInt32);
+                dataValue.value.value.should.eql(0);
+            });
 
         });
 
@@ -1334,11 +1382,12 @@ describe("testing ServerEngine", function () {
                 })
             });
 
-            var dataValues = engine.read(readRequest);
-            dataValues.length.should.equal(15);
-            dataValues[7].statusCode.should.eql(StatusCodes.Good);
-            dataValues[7].value.dataType.should.eql(DataType.DateTime);
-            dataValues[7].value.value.should.be.instanceOf(Date);
+            engine.read(readRequest,function(dataValues){
+                dataValues.length.should.equal(15);
+                dataValues[7].statusCode.should.eql(StatusCodes.Good);
+                dataValues[7].value.dataType.should.eql(DataType.DateTime);
+                dataValues[7].value.value.should.be.instanceOf(Date);
+            });
 
         });
     });
@@ -1355,24 +1404,25 @@ describe("testing ServerEngine", function () {
                 }]
             });
 
-            var dataValues = engine.read(readRequest);
-            dataValues.length.should.equal(1);
-            dataValues[0].statusCode.should.eql(StatusCodes.Good);
-            dataValues[0].value.dataType.should.eql(DataType.ExtensionObject);
+            engine.read(readRequest,function(dataValues){
+                dataValues.length.should.equal(1);
+                dataValues[0].statusCode.should.eql(StatusCodes.Good);
+                dataValues[0].value.dataType.should.eql(DataType.ExtensionObject);
 
 
-            dataValues[0].value.value.should.be.instanceOf(Object);
+                dataValues[0].value.value.should.be.instanceOf(Object);
 
-            var serverStatus =  dataValues[0].value.value;
+                var serverStatus =  dataValues[0].value.value;
 
-            serverStatus.state.key.should.eql("Running");
-            serverStatus.state.value.should.eql(0);
-            serverStatus.shutdownReason.text.should.eql("");
+                serverStatus.state.key.should.eql("Running");
+                serverStatus.state.value.should.eql(0);
+                serverStatus.shutdownReason.text.should.eql("");
 
-            serverStatus.buildInfo.productName.should.equal("NODEOPCUA-SERVER");
-            serverStatus.buildInfo.softwareVersion.should.equal("1.0");
-            serverStatus.buildInfo.manufacturerName.should.equal("<Manufacturer>");
-            serverStatus.buildInfo.productUri.should.equal("URI:NODEOPCUA-SERVER");
+                serverStatus.buildInfo.productName.should.equal("NODEOPCUA-SERVER");
+                serverStatus.buildInfo.softwareVersion.should.equal("1.0");
+                serverStatus.buildInfo.manufacturerName.should.equal("<Manufacturer>");
+                serverStatus.buildInfo.productUri.should.equal("URI:NODEOPCUA-SERVER");
+            });
 
         });
     });
@@ -1390,21 +1440,21 @@ describe("testing ServerEngine", function () {
                 }]
             });
 
-            var dataValues = engine.read(readRequest);
-            dataValues.length.should.equal(1);
-            dataValues[0].statusCode.should.eql(StatusCodes.Good);
-            dataValues[0].value.dataType.should.eql(DataType.ExtensionObject);
+            engine.read(readRequest,function(dataValues){
+                dataValues.length.should.equal(1);
+                dataValues[0].statusCode.should.eql(StatusCodes.Good);
+                dataValues[0].value.dataType.should.eql(DataType.ExtensionObject);
 
-            console.log('buildInfo',dataValues[0].value.value);
-            dataValues[0].value.value.should.be.instanceOf(Object);
+                console.log('buildInfo',dataValues[0].value.value);
+                dataValues[0].value.value.should.be.instanceOf(Object);
 
-            var buildInfo= dataValues[0].value.value;
+                var buildInfo= dataValues[0].value.value;
 
-            buildInfo.productName.should.equal("NODEOPCUA-SERVER");
-            buildInfo.softwareVersion.should.equal("1.0");
-            buildInfo.manufacturerName.should.equal("<Manufacturer>");
-            buildInfo.productUri.should.equal("URI:NODEOPCUA-SERVER");
-
+                buildInfo.productName.should.equal("NODEOPCUA-SERVER");
+                buildInfo.softwareVersion.should.equal("1.0");
+                buildInfo.manufacturerName.should.equal("<Manufacturer>");
+                buildInfo.productUri.should.equal("URI:NODEOPCUA-SERVER");
+            });
 
         });
     });
@@ -1427,8 +1477,9 @@ describe("testing ServerEngine", function () {
                     }
                 }
             });
-            engine.writeSingleNode(nodeToWrite);
-            done();
+            engine.writeSingleNode(nodeToWrite,function(){
+                done();
+            });
         });
 
         it("should return BadNotWritable when trying to write a Executable attribute",function(done){
@@ -1443,9 +1494,10 @@ describe("testing ServerEngine", function () {
                     }
                 }
             });
-            var result = engine.writeSingleNode(nodeToWrite);
-            assert(result.should.eql(StatusCodes.BadNotWritable));
-            done();
+            engine.writeSingleNode(nodeToWrite,function(result){
+                assert(result.should.eql(StatusCodes.BadNotWritable));
+                done();
+            });
 
         });
 
@@ -1475,8 +1527,9 @@ describe("testing ServerEngine", function () {
                     }
                 })
             ];
-            engine.write(nodesToWrite);
-            done();
+            engine.write(nodesToWrite,function(){
+                done();
+            });
 
         });
     });
@@ -1508,9 +1561,9 @@ describe("testing ServerEngine", function () {
         });
         it("should have statusCode=BadResourceUnavailable when trying to read the FailingPLCValue variable",function() {
 
-            var readResult = engine.readSingleNode("ns=1;s=FailingPLCValue",AttributeIds.Value);
-
-            readResult.statusCode.should.eql(StatusCodes.BadResourceUnavailable);
+            engine.readSingleNode("ns=1;s=FailingPLCValue",function(readResult){
+                readResult.statusCode.should.eql(StatusCodes.BadResourceUnavailable);
+            },AttributeIds.Value);
 
         });
     });

--- a/test/simulation/test_simulation_address_space.js
+++ b/test/simulation/test_simulation_address_space.js
@@ -53,9 +53,7 @@ describe("testing address space for conformance testing",function() {
                         value: 1000
                     }
                 }
-            }));
-
-
+            }),function(){});
 
 
             // address space variable change for conformance testing are changing randomly
@@ -86,7 +84,7 @@ describe("testing address space for conformance testing",function() {
                        value: 250
                    }
                 }
-            }));
+            }),function(){});
             // set enable to true
             var enabledNodeId = makeNodeId("Scalar_Simulation_Enabled", namespaceIndex);
             engine.writeSingleNode(new WriteValue({
@@ -98,7 +96,7 @@ describe("testing address space for conformance testing",function() {
                         value: true
                     }
                 }
-            }));
+            }),function(){});
 
             // address space variable change for conformance testing are changing randomly
             // let wait a little bit to make sure variables have changed at least once


### PR DESCRIPTION
Asynchronous value reading/writing is required for our potential use of the node-opcua library, so this pull request is to add that functionality.  Variables can now optionally have a getAsync and setAsync function in order to asynchronously process requests.

However, this change required changes to a significant number of files, as the current architecture relied on "returns" and "getters/setters" which are all synchronous by nature.  This change affects the api for several calls, especially on the server side.  For example, server.write, server.writeSingleNode, server.readSingleNode, etc...all now require a callback instead of a synchronous return value.

All existing tests were updated to pass using the new API, and several new tests were added to test the functionality.