### PR TITLE
Added nodeId to object returned from NodeCrawler.read.

### DIFF
--- a/lib/client/node_crawler.js
+++ b/lib/client/node_crawler.js
@@ -578,7 +578,8 @@ NodeCrawler.prototype.read = function (nodeId, callback) {
              * }
              */
             var obj = {
-                browseName: object.browseName.name
+                browseName: object.browseName.name,
+                nodeId: object.nodeId
             };
             objMap[index] = obj;
 


### PR DESCRIPTION
This is for convenience to be able to later access the referenced nodes.