### PR TITLE
Resolve nodeIds early when monitoring to propagate errors faster.

### DIFF
--- a/lib/client/client_subscription.js
+++ b/lib/client/client_subscription.js
@@ -20,6 +20,8 @@ var ClientMonitoredItem = require("lib/client/client_monitored_item").ClientMoni
 
 var StatusCodes = require("lib/datamodel/opcua_status_code").StatusCodes;
 
+var NodeId = require("lib/datamodel/nodeid.js");
+
 var debugLog = require("lib/misc/utils").make_debugLog(__filename);
 //xx var debugLog = console.log;
 
@@ -319,6 +321,8 @@ ClientSubscription.prototype.monitor = function (itemToMonitor, requestedParamet
     assert(itemToMonitor.attributeId);
     assert(done === undefined || _.isFunction(done));
 
+    // Try to resolve the nodeId and fail fast if we can't.
+    NodeId.resolveNodeId(itemToMonitor.nodeId);
 
     timestampsToReturn = timestampsToReturn || TimestampsToReturn.Neither;
 


### PR DESCRIPTION
This simple commit tries to resolve/coerce a NodeId early when initiating a monitor.

Before, the coercion happens within a setImmediate, which mean that errors can't be caught in try/catch and the stack trace goes missing.

I got a bit lost tracing the details, but the result of resolution could be cached to eliminate some reworking?