### PR TITLE
some performance tuning

### DIFF
--- a/lib/datamodel/access_level.js
+++ b/lib/datamodel/access_level.js
@@ -4,7 +4,7 @@
  */
 require("requirish")._(module);
 
-var Enum = require("enum");
+var Enum = require("lib/misc/enum");
 var assert = require("better-assert");
 
 var registerBasicType = require("lib/misc/factories_basic_type").registerBasicType;

--- a/lib/datamodel/nodeid.js
+++ b/lib/datamodel/nodeid.js
@@ -4,7 +4,7 @@
  * @module opcua.datamodel
  */
 require("requirish")._(module);
-var Enum = require("enum");
+var Enum = require("lib/misc/enum");
 var assert = require("better-assert");
 var isValidGuid = require("lib/datamodel/guid").isValidGuid;
 

--- a/lib/datamodel/numeric_range.js
+++ b/lib/datamodel/numeric_range.js
@@ -9,7 +9,7 @@ var StatusCodes = require("lib/datamodel/opcua_status_code").StatusCodes;
 
 var ec = require("lib/misc/encode_decode");
 var _ = require("underscore");
-var Enum = require("enum");
+var Enum = require("lib/misc/enum");
 var assert = require("better-assert");
 
 // OPC.UA Part 4 7.21 Numerical Range

--- a/lib/misc/encode_decode.js
+++ b/lib/misc/encode_decode.js
@@ -7,7 +7,7 @@
 require("requirish")._(module);
 
 var assert = require("better-assert");
-var Enum = require("enum");
+var Enum = require("lib/misc/enum");
 
 var ec = exports;
 var _ = require("underscore");

--- a/lib/misc/enum.js
+++ b/lib/misc/enum.js
@@ -179,3 +179,4 @@ Enum.prototype._get_by_num = function(key) {
 }
 
 module.exports = Enum;
+

--- a/lib/misc/enum.js
+++ b/lib/misc/enum.js
@@ -1,0 +1,181 @@
+"use strict";
+
+/**
+ * Represents an Item of an Enum.
+ * @param {String} key  The Enum key.
+ * @param {Number} value The Enum value.
+ */
+var EnumItem = function(key, value) {
+    this.key = key;
+    this.value = value;
+}
+
+/**
+ * Checks if the EnumItem is the same as the passing object.
+ * @param  {EnumItem || String || Number} item The object to check with.
+ * @return {Boolean}                          The check result.
+ */
+EnumItem.prototype.is = function(item) {
+    if(item instanceof EnumItem) {
+        return this.value === item.value;
+    } else if (typeof item === 'string') {
+        return this.key === item;
+    } else {
+        return this.value === item;
+    }
+}
+
+/**
+ * Checks if the flagged EnumItem has the passing object.
+ * @param  {EnumItem || String || Number} value The object to check with.
+ * @return {Boolean}                            The check result.
+ */
+EnumItem.prototype.has = function(value) {
+    if(value instanceof EnumItem) {
+        return (value.value&this.value) !== 0;
+    } else if(typeof value === 'string') {
+        return this.key.indexOf(value)>=0;
+    } else {
+        return (value&this.value) !== 0;
+    }
+}
+
+/**
+ * Returns String representation of this EnumItem.
+ * @return {String} String representation of this EnumItem.
+ */
+
+EnumItem.prototype.toString = function toString() {
+    return this.key;
+};
+
+/**
+ * Returns JSON object representation of this EnumItem.
+ * @return {String} JSON object representation of this EnumItem.
+ */
+
+EnumItem.prototype.toJSON = function toJSON() {
+    return this.key;
+};
+
+/**
+ * Returns the value to compare with.
+ * @return {String} The value to compare with.
+ */
+
+EnumItem.prototype.valueOf = function valueOf() {
+    return this.value;
+};
+
+/**
+ * Represents an Enum with enum items.
+ * @param {Array || Object}  map     This are the enum items.
+ */
+var Enum = function(map){
+    var self = this;
+    self.enums = [];
+    var mm = null;
+    if(Array.isArray(map)) {
+    	// create map as flaggable enum
+        mm = {};
+        for(var i in map) {
+            mm[map[i]] = 1<<i;
+        }
+    } else {
+        mm = map;
+    }
+    for(var key in mm) {
+        if(!mm.hasOwnProperty(key)) continue;
+        var val = mm[key];
+        var kv = new EnumItem(key,val);
+        self[key] = kv;
+        self[val] = kv;
+        self.enums.push(kv);
+    }
+
+    // check if enum is flaggable
+    var is_flaggable = function () {
+	    for(var i in self.enums) {
+	    	var e = self.enums[i];
+	        if (!(e.value !== 0 && !(e.value & e.value - 1))) {
+	          return false;
+	        }
+	    }
+	    return true;
+    }
+
+    this._is_flaggable = is_flaggable();
+}
+
+/**
+ * Returns the appropriate EnumItem.
+ * @param  {EnumItem || String || Number} key The object to get with.
+ * @return {EnumItem}                         The get result.
+ */
+Enum.prototype.get = function(key){
+    if(key===null||key===undefined) {
+        return;
+    }
+    if(key instanceof EnumItem) {
+        key = key.key;
+    }
+
+    if(this.hasOwnProperty(key)) {
+        return this[key];
+    } else if(this._is_flaggable) {
+	    if(typeof key === "string") {
+	        return this._get_by_str(key);
+	    } else if(typeof key === "number") {
+	        return this._get_by_num(key);
+	    }
+    }
+    return;
+}
+
+Enum.prototype._get_by_str = function(key) {
+    if(key.indexOf(' | ')>-1) {
+        var val = 0;
+        var keys = key.split(' | ');
+        for(var i in keys) {
+        	if(!this.hasOwnProperty(keys[i])) {
+        		return;
+        	}
+            val = val | this[keys[i]].value;
+        }
+        var kv = new EnumItem(key,val);
+        if(this.hasOwnProperty(val)) {
+        	this[kv.key] = kv;
+        } else {
+	        // cache val->kv item through _get_by_num
+	        var kv2 = this._get_by_num(val);
+	        if( kv2.key !== kv.key ) {
+	            // keys are not in the same order, cache it
+	            this[kv.key] = kv;
+	        }
+
+        }
+        return kv;
+    }
+}
+
+Enum.prototype._get_by_num = function(key) {
+	if(key===0) return;
+    var names = [];
+    for(var i=0; key>>i !== 0; i++) {
+    	var val = 1<<i;
+        if(key&val){
+            if( this.hasOwnProperty(val) ) {
+                names.push(this[val].key);
+            } else {
+                return;
+            }
+        }
+    }
+    var name = names.join(' | ');
+    var kv = new EnumItem(name,key);
+    this[name] = kv;
+    this[key] = kv;
+    return kv;
+}
+
+module.exports = Enum;

--- a/lib/misc/factories_enumerations.js
+++ b/lib/misc/factories_enumerations.js
@@ -7,7 +7,7 @@ require("requirish")._(module);
 var assert = require("better-assert");
 var _ = require("underscore");
 
-var Enum = require("enum");
+var Enum = require("lib/misc/enum");
 
 var _enumerations = {};
 

--- a/lib/misc/factory_code_generator.js
+++ b/lib/misc/factory_code_generator.js
@@ -70,6 +70,39 @@
     var RUNTIME_GENERATED_ID = -1;
 
 
+    function write_enumeration_define(f, schema, field, member, i) {
+
+        assert(f instanceof LineFile);
+        function write() {
+            f.write.apply(f, arguments);
+        }
+
+        var __member = "__" + member;
+
+        assert(!field.isArray); // would not work in this case
+
+        write("    \"" + member + "\": {");
+        write("        hidden: false,");
+        write("        enumerable: true,");
+        write("        configurable: true,");
+        write("            get: function () {");
+        write("                return this." + __member + ";");
+        write("            },");
+        write("            set: function (value) {");
+        write("                var coercedValue = _enumerations." + field.fieldType + ".typedEnum.get(value);");
+        write("                if ( coercedValue === undefined || coercedValue === null) {");
+        write("                      throw new Error(\"value cannot be coerced to " + field.fieldType + ": \" + value);");
+        write("                }");
+        write("                this." + __member + " = coercedValue;");
+        write("            }");
+        write("    },");
+        write("    \"" + __member + "\": {");
+        write("         hidden: true,");
+        write("         writable: true,");
+        write("         enumerable: false");
+        write("    },");
+    }
+
     function write_enumeration(f, schema, field, member, i) {
 
         assert(f instanceof LineFile);
@@ -81,29 +114,6 @@
 
         assert(!field.isArray); // would not work in this case
 
-        write("    //## Define special behavior for Enumeration");
-        write("    Object.defineProperties(this,{");
-        write("        \"" + member + "\": {");
-        write("            hidden: false,");
-        write("            enumerable: true,");
-        write("            configurable: true,");
-        write("                get: function () {");
-        write("                    return this." + __member + ";");
-        write("                },");
-        write("                set: function (value) {");
-        write("                    var coercedValue = _enumerations." + field.fieldType + ".typedEnum.get(value);");
-        write("                    if ( coercedValue === undefined || coercedValue === null) {");
-        write("                          throw new Error(\"value cannot be coerced to " + field.fieldType + ": \" + value);");
-        write("                    }");
-        write("                    this." + __member + " = coercedValue;");
-        write("                }");
-        write("        },");
-        write("        \"" + __member + "\": {");
-        write("             hidden: true,");
-        write("             writable: true,");
-        write("             enumerable: false");
-        write("        }");
-        write("    });");
         write("    self." + member + " = initialize_field(schema.fields[" + i + "]" + ", options." + field.name + ");");
 
     }
@@ -280,6 +290,35 @@
         function makeFieldType(field) {
            return "{" +  field.fieldType + (field.isArray ? "[" : "") + (field.isArray ? "]" : "") + "}"
         }
+
+// -------------------------------------------------------------------------
+// - insert class enumeration propeties
+// -------------------------------------------------------------------------
+        var has_enumeration = false;
+        var n = schema.fields.length;
+        for (i = 0; i < n; i++) {
+            if(schema.fields[i].category === "enumeration") {
+                has_enumeration = true;
+                break;
+            }
+        }
+        if(has_enumeration){
+            write("");
+            write("//## Define special behavior for Enumeration");
+            write("var _enum_properties = {");
+
+            for (i = 0; i < n; i++) {
+                field = schema.fields[i];
+                member = field.name;
+                if (field.category === "enumeration") {
+                    write_enumeration_define(f, schema, field, member, i);
+                }
+            }
+
+            write("};");
+            write("");
+        }
+
 // -------------------------------------------------------------------------
 // - insert class constructor
 // -------------------------------------------------------------------------
@@ -296,7 +335,6 @@
         // dump parameters
 
         write(" * @param  options {Object}");
-        var n = schema.fields.length;
         var def ="";
         for (i = 0; i < n; i++) {
             field = schema.fields[i];
@@ -333,6 +371,12 @@
         }
         if (baseclass) {
             write("    " + baseclass + ".call(this,options);");
+        }
+
+        if (has_enumeration) {
+            write("");
+            write("    //define enumeration properties");
+            write("    Object.defineProperties(this,_enum_properties);");
         }
 
         for (i = 0; i < n; i++) {

--- a/lib/misc/packet_analyzer.js
+++ b/lib/misc/packet_analyzer.js
@@ -13,7 +13,7 @@ var hexDump = require("lib/misc/utils").hexDump;
 var assert = require("better-assert");
 var util = require("util");
 var _ = require("underscore");
-var Enum = require("enum");
+var Enum = require("lib/misc/enum");
 
 var spaces = "                                                                                                                                                                             ";
 

--- a/lib/misc/security_policy.js
+++ b/lib/misc/security_policy.js
@@ -3,7 +3,7 @@
  * @module opcua.miscellaneous
  */
 require("requirish")._(module);
-var Enum = require("enum");
+var Enum = require("lib/misc/enum");
 var assert = require("better-assert");
 var _ = require("underscore");
 

--- a/lib/server/subscription.js
+++ b/lib/server/subscription.js
@@ -8,7 +8,7 @@ var NotificationMessage = subscription_service.NotificationMessage;
 var StatusChangeNotification =subscription_service.StatusChangeNotification;
 
 var StatusCodes = require("lib/datamodel/opcua_status_code").StatusCodes;
-var Enum = require("enum");
+var Enum = require("lib/misc/enum");
 var assert = require("better-assert");
 var _ = require("underscore");
 

--- a/lib/services/browse_service.js
+++ b/lib/services/browse_service.js
@@ -3,7 +3,7 @@
  * @module services.browse
  */
 require("requirish")._(module);
-var Enum = require("enum");
+var Enum = require("lib/misc/enum");
 
 // Specifies the NodeClasses of the TargetNodes. Only TargetNodes with the
 // selected NodeClasses are returned. The NodeClasses are assigned the

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "byline": "4.2.1",
     "colors": "1.0.3",
     "easy-table": "0.3.0",
-    "enum": "2.0.2",
     "ersatz-node-expat": "0.1.2",
     "exit": "^0.1.2",
     "fqdn": "0.0.3",

--- a/test/misc/test_enum.js
+++ b/test/misc/test_enum.js
@@ -1,0 +1,81 @@
+require("requirish")._(module);
+var Enum = require("lib/misc/enum");
+var should = require("should");
+
+describe("Test Enum", function () {
+
+    it("should create flaggable enum from string array", function () {
+        var e = new Enum(['e1','e2','e3']);
+        e.get('e1').value.should.equal(1);
+        e.get('e2').value.should.equal(2);
+        e.get('e3').value.should.equal(4);
+        e.get('e3 | e1').value.should.equal(5);
+        e.get(3).key.should.equal('e1 | e2');
+        e.get(3).value.should.equal(3);
+        should(e.get(9)).equal(undefined);
+        should(e.get(0)).equal(undefined);
+    });
+
+    it("should create flaggable enum from flaggable map", function () {
+        var e = new Enum({'e1':1,'e2':2,'e3':4});
+        e.get('e1').value.should.equal(1);
+        e.get('e2').value.should.equal(2);
+        e.get('e3').value.should.equal(4);
+        e.get('e3 | e1').value.should.equal(5);
+        e.get(3).key.should.equal('e1 | e2');
+        e.get(3).value.should.equal(3);
+        should(e.get(9)).equal(undefined);
+        should(e.get(0)).equal(undefined);
+    });
+
+    it("should create non-flaggable enum from non-flaggable map", function () {
+        var e = new Enum({'e1':1,'e2':2,'e3':3});
+        e.get('e1').value.should.equal(1);
+        e.get('e2').value.should.equal(2);
+        e.get('e3').value.should.equal(3);
+        should(e.get(5)).equal(undefined);
+        should(e.get('e0')).equal(undefined);
+        should(e.get('e3 | e1')).equal(undefined);
+        e.get(3).key.should.equal('e3');
+        e.get(3).value.should.equal(3);
+        e.enums[0].key.should.equal('e1');
+    });
+
+    it("should access enum from enum item name", function () {
+        var e = new Enum({'e1':1,'e2':2,'e3':4});
+        e.e1.value.should.equal(1);
+        e.e1.key.should.equal('e1');
+        e.e2.value.should.equal(2);
+        e.e2.key.should.equal('e2');
+        e.e3.value.should.equal(4);
+        e.e3.key.should.equal('e3');
+    });
+
+    it("EnumItem should function properly", function () {
+        var e = new Enum({'e1':1,'e2':2,'e3':4});
+        var e1ore2 = e.get('e2 | e1');
+        e1ore2.value.should.equal(3);
+        e1ore2.is(e.get(3)).should.equal(true);
+        e1ore2.is(3).should.equal(true);
+        e1ore2.is('e2 | e1').should.equal(true);
+        e1ore2.is(e.get(5)).should.equal(false);
+        e1ore2.is(5).should.equal(false);
+        e1ore2.is('e1 | e3').should.equal(false);
+        e1ore2.has('e1').should.equal(true);
+        e1ore2.has('e2').should.equal(true);
+        e1ore2.has('e3').should.equal(false);
+        e1ore2.has(1).should.equal(true);
+        e1ore2.has(2).should.equal(true);
+        e1ore2.has(4).should.equal(false);
+        e1ore2.has(e.e1).should.equal(true);
+        e1ore2.has(e.e2).should.equal(true);
+        e1ore2.has(e.e3).should.equal(false);
+        e1ore2.toString().should.equal('e2 | e1');
+        e1ore2.valueOf().should.equal(3);
+        e1ore2.toJSON().should.equal('e2 | e1');
+        e.e1.toString().should.equal('e1');
+        e.e1.valueOf().should.equal(1);
+        e.e1.toJSON().should.equal('e1');
+    });
+
+});

--- a/test/misc/test_enum.js
+++ b/test/misc/test_enum.js
@@ -79,3 +79,4 @@ describe("Test Enum", function () {
     });
 
 });
+


### PR DESCRIPTION
Hi.

I want to use node-opcua to operate with some plc devices in low power computer. The functionality is well, but performance does not come up to expectation. So I fired up profiling and discovered that new Variant and Enum.get use too much cpu. These commits are based on the profiling.
The performance test I did is monitoring 1000 double variables with sampling interval 100ms and publishing interval 100ms. The original node-opcua ate up all cpu ( AMD E-450 1.6G Hz), but can not catch up the publishing interval ( got 90 publishing in 30s). After these fixes, the cpu usage is about 60% after JIT warm up, and no publishing is missing. It's about 4-5 times performance enhancement in pure monitoring application.
Hope these changes could be merged. All tests are passed on node v0.12.2.