### PR TITLE
Events

### DIFF
--- a/bin/crypto_create_CA.js
+++ b/bin/crypto_create_CA.js
@@ -658,7 +658,7 @@ function create_default_certificates(done) {
 
 function __create_default_certificates(base_name,prefix,application_URI,done) {
 
-    // Fugl hack
+    // Bad hack that ensures that paths with spaces are correctly interpreted.
     base_name = "\"" + base_name + "\"";
 
     assert(_.isFunction(done));

--- a/bin/generate_opcua_classes.js
+++ b/bin/generate_opcua_classes.js
@@ -242,9 +242,9 @@ registerObject("ReadProcessedDetails");
 registerObject("ReadAtTimeDetails");
 
 // Event results
-registerObject("ContentFilterElementResult", undefined, true);
-registerObject("ContentFilterResult", undefined, true);
-registerObject("EventFilterResult", undefined, true);
+registerObject("ContentFilterElementResult");
+registerObject("ContentFilterResult");
+registerObject("EventFilterResult");
 
 // Call service
 registerObject("CallMethodRequest");

--- a/bin/generate_opcua_classes.js
+++ b/bin/generate_opcua_classes.js
@@ -241,6 +241,11 @@ registerObject("ReadRawModifiedDetails");
 registerObject("ReadProcessedDetails");
 registerObject("ReadAtTimeDetails");
 
+// Event results
+registerObject("ContentFilterElementResult", undefined, true);
+registerObject("ContentFilterResult", undefined, true);
+registerObject("EventFilterResult", undefined, true);
+
 // Call service
 registerObject("CallMethodRequest");
 registerObject("CallMethodResult");

--- a/lib/client/client_monitored_item.js
+++ b/lib/client/client_monitored_item.js
@@ -119,22 +119,23 @@ ClientMonitoredItem.prototype._monitor = function (done) {
     // todo can be done in another way?
     // todo implement AggregateFilter
     // todo support DataChangeFilter
-    // todo support where clause
+    // todo support whereClause
     if(self.itemToMonitor.attributeId === AttributeIds.EventNotifier) {
         var filter = self.monitoringParameters.filter;
         assert(filter);
 
         if(filter.extensionType === 'EventFilter' ) {
-            assert(filter.data);
-            // todo Where clause not supported yet
-            assert(filter.data.whereClause.length === 0);
+            if (filter.data.whereClause.length === 0){
+                throw new Error ('whereClause is not yet implemented in node-opcua.')
+            }
 
             filter.data.selectClauses = filter.data.selectClauses.map(function(selectClause){
 
                 assert(selectClause.browsePath);
 
                 var browsePath = _.isArray(selectClause.browsePath)
-                    ? selectClause.browsePath : [selectClause.browsePath];
+                    ? selectClause.browsePath
+                    : [selectClause.browsePath];
 
                 // Create SimpleAttributeOperand based on the browsePath array
                 browsePath = browsePath.map(function(bp){
@@ -156,10 +157,10 @@ ClientMonitoredItem.prototype._monitor = function (done) {
             // Instantiate the EventFilter
             self.monitoringParameters.filter = new subscription_service.EventFilter(filter.data);
 
-        } else if (filter.extensionType === 'DataChangeFilter') {
-            throw new Error({ message: 'DataChangeFilter not implemented'});
+        } else if (['DataChangeFilter', 'AggregateFilter'].indexOf(filter.extensionType) > -1) {
+            throw new Error('filter type is not yet implemented in node-opcua');
         } else {
-            throw new Error({ message: 'Mismatch between attributeId and filter in monitoring parameters'});
+            throw new Error('Mismatch between attributeId and filter in monitoring parameters');
         }
 
     } else {
@@ -168,7 +169,6 @@ ClientMonitoredItem.prototype._monitor = function (done) {
 
     var createMonitorItemsRequest = new subscription_service.CreateMonitoredItemsRequest({
         subscriptionId: self.subscription.subscriptionId,
-        // timestampsToReturn:
         timestampsToReturn: self.timestampsToReturn,
         itemsToCreate: [
             {

--- a/lib/client/client_monitored_item.js
+++ b/lib/client/client_monitored_item.js
@@ -12,6 +12,8 @@ var StatusCodes = require("lib/datamodel/opcua_status_code").StatusCodes;
 var assert = require("better-assert");
 var TimestampsToReturn = read_service.TimestampsToReturn;
 
+var AttributeIds = read_service.AttributeIds;
+
 var _ = require("underscore");
 
 /**
@@ -86,6 +88,19 @@ ClientMonitoredItem.prototype._monitor = function (done) {
 
     self.monitoringParameters.clientHandle = self.subscription.nextClientHandle();
     assert(self.monitoringParameters.clientHandle > 0);
+
+    // If attributeId is EventNotifier then monitoring parameters need a filter.
+    // The filter must then either be DataChangeFilter, EventFilter or AggregateFilter.
+    // todo can be done in another way?
+    // todo implement AggregateFilter
+    if (!((self.itemToMonitor.attributeId === AttributeIds.EventNotifier
+            && self.monitoringParameters.filter
+            && (self.monitoringParameters.filter instanceof subscription_service.EventFilter
+                || self.monitoringParameters.filter instanceof subscription_service.DataChangeFilter))
+        || self.itemToMonitor.attributeId !== AttributeIds.EventNotifier
+            && !self.monitoringParameters.filter)) {
+        throw new Error({ message: 'Mismatch between attributeId and filter in monitoring parameters'});
+    }
 
     var createMonitorItemsRequest = new subscription_service.CreateMonitoredItemsRequest({
         subscriptionId: self.subscription.subscriptionId,

--- a/lib/client/client_monitored_item.js
+++ b/lib/client/client_monitored_item.js
@@ -14,6 +14,9 @@ var TimestampsToReturn = read_service.TimestampsToReturn;
 
 var AttributeIds = read_service.AttributeIds;
 
+var resolveNodeId = require("lib/datamodel/nodeid").resolveNodeId;
+var ObjectTypeIds = require("lib/opcua_node_ids").ObjectTypeIds;
+
 var _ = require("underscore");
 
 /**
@@ -78,6 +81,28 @@ ClientMonitoredItem.prototype._notify_value_change = function (value) {
     self.emit("changed", value);
 };
 
+
+/**
+ *
+ * Creates the monitor.
+ *
+ * If the monitor attributeId is EventNotifer then the filter must be
+ * spcified in this data format:
+ *
+ * filter: {
+ *   extensionType: 'EventFilter',
+ *   data: {
+ *       selectClauses: [
+ *           {browsePath: [{name: 'ActiveState'}, {name: 'id'} ]},
+ *           {browsePath: {name: 'ConditionName'} }
+ *       ],
+ *       whereClause: []
+ *   }
+ *
+ *
+ * @param done
+ * @private
+ */
 ClientMonitoredItem.prototype._monitor = function (done) {
 
     assert(done === undefined || _.isFunction(done));
@@ -93,13 +118,52 @@ ClientMonitoredItem.prototype._monitor = function (done) {
     // The filter must then either be DataChangeFilter, EventFilter or AggregateFilter.
     // todo can be done in another way?
     // todo implement AggregateFilter
-    if (!((self.itemToMonitor.attributeId === AttributeIds.EventNotifier
-            && self.monitoringParameters.filter
-            && (self.monitoringParameters.filter instanceof subscription_service.EventFilter
-                || self.monitoringParameters.filter instanceof subscription_service.DataChangeFilter))
-        || self.itemToMonitor.attributeId !== AttributeIds.EventNotifier
-            && !self.monitoringParameters.filter)) {
-        throw new Error({ message: 'Mismatch between attributeId and filter in monitoring parameters'});
+    // todo support DataChangeFilter
+    // todo support where clause
+    if(self.itemToMonitor.attributeId === AttributeIds.EventNotifier) {
+        var filter = self.monitoringParameters.filter;
+        assert(filter);
+
+        if(filter.extensionType === 'EventFilter' ) {
+            assert(filter.data);
+            // todo Where clause not supported yet
+            assert(filter.data.whereClause.length === 0);
+
+            filter.data.selectClauses = filter.data.selectClauses.map(function(selectClause){
+
+                assert(selectClause.browsePath);
+
+                var browsePath = _.isArray(selectClause.browsePath)
+                    ? selectClause.browsePath : [selectClause.browsePath];
+
+                // Create SimpleAttributeOperand based on the browsePath array
+                browsePath = browsePath.map(function(bp){
+                    assert(bp.name);
+                    return {
+                        namespaceIndex: bp.namespaceIndex || 0,
+                        name: bp.name
+                    }
+                });
+
+                return {
+                    typeId: selectClause.typeId || resolveNodeId(ObjectTypeIds.BaseEventType),
+                    browsePath: browsePath,
+                    attributeId: selectClause.attributeId || AttributeIds.Value,
+                    indexRange: selectClause.indexRange || null
+                }
+            });
+
+            // Instantiate the EventFilter
+            self.monitoringParameters.filter = new subscription_service.EventFilter(filter.data);
+
+        } else if (filter.extensionType === 'DataChangeFilter') {
+            throw new Error({ message: 'DataChangeFilter not implemented'});
+        } else {
+            throw new Error({ message: 'Mismatch between attributeId and filter in monitoring parameters'});
+        }
+
+    } else {
+        assert(!self.monitoringParameters.filter);
     }
 
     var createMonitorItemsRequest = new subscription_service.CreateMonitoredItemsRequest({

--- a/lib/client/client_subscription.js
+++ b/lib/client/client_subscription.js
@@ -162,9 +162,7 @@ ClientSubscription.prototype.__on_publish_response_EventNotificationList = funct
 
     var self = this;
 
-    var events = notification.events;
-
-    events.forEach(function(event){
+    notification.events.forEach(function(event){
         var monitorItemObj = self.monitoredItems[event.clientHandle];
 
         assert(monitorItemObj, "Expecting a monitored item");

--- a/lib/client/client_subscription.js
+++ b/lib/client/client_subscription.js
@@ -158,8 +158,19 @@ ClientSubscription.prototype.__on_publish_response_StatusChangeNotification = fu
 };
 
 ClientSubscription.prototype.__on_publish_response_EventNotificationList = function (notification) {
-    // todo implement
-    console.log('__on_publish_response_EventNotificationList', JSON.stringify(notification, null, 4));
+    assert(notification._schema.name === "EventNotificationList");
+
+    var self = this;
+
+    var events = notification.events;
+
+    events.forEach(function(event){
+        var monitorItemObj = self.monitoredItems[event.clientHandle];
+
+        assert(monitorItemObj, "Expecting a monitored item");
+
+        monitorItemObj._notify_value_change(event.eventFields);
+    });
 };
 
 

--- a/lib/client/client_subscription.js
+++ b/lib/client/client_subscription.js
@@ -157,6 +157,11 @@ ClientSubscription.prototype.__on_publish_response_StatusChangeNotification = fu
 
 };
 
+ClientSubscription.prototype.__on_publish_response_EventNotificationList = function (notification) {
+    // todo implement
+    console.log('__on_publish_response_EventNotificationList', JSON.stringify(notification, null, 4));
+};
+
 
 ClientSubscription.prototype.__on_publish_response = function (notificationData) {
 

--- a/lib/services/subscription_service.js
+++ b/lib/services/subscription_service.js
@@ -46,6 +46,11 @@ exports.ModifyMonitoredItemsResponse = require("_generated_/_auto_generated_Modi
 exports.SetMonitoringModeRequest = require("_generated_/_auto_generated_SetMonitoringModeRequest").SetMonitoringModeRequest;
 exports.SetMonitoringModeResponse = require("_generated_/_auto_generated_SetMonitoringModeResponse").SetMonitoringModeResponse;
 
+// Event results
+exports.EventFilterResult = require("_generated_/_auto_generated_EventFilterResult").EventFilterResult;
+exports.ContentFilterResult = require("_generated_/_auto_generated_ContentFilterResult").ContentFilterResult;
+exports.ContentFilterElementResult = require("_generated_/_auto_generated_ContentFilterElementResult").ContentFilterElementResult;
+
 // ContentFilters
 exports.FilterOperator = require("schemas/FilterOperator_enum").FilterOperator;
 exports.SimpleAttributeOperand = require("_generated_/_auto_generated_SimpleAttributeOperand").SimpleAttributeOperand;

--- a/schemas/ContentFilterElementResult_schema.js
+++ b/schemas/ContentFilterElementResult_schema.js
@@ -1,0 +1,12 @@
+
+var ContentFilterElementResult_Schema = {
+    name: "ContentFilterElementResult",
+    //baseType: "MonitoringFilter",
+    fields: [
+        { name: "statusCode", fieldType: "StatusCode" },
+        { name: "operandStatusCodes", isArrays: true, fieldType: "StatusCode"},
+        { name: "operandGiagnosticInfos", isArrays: true, fieldType: "DiagnosticInfo" },
+    ]
+};
+
+exports.ContentFilterElementResult_Schema = ContentFilterElementResult_Schema;

--- a/schemas/ContentFilterResult_schema.js
+++ b/schemas/ContentFilterResult_schema.js
@@ -1,0 +1,8 @@
+var ContentFilterResult_Schema = {
+    name: "ContentFilterResult",
+    fields: [
+        { name: "elementResults", isArray: true, fieldType: "ContentFilterElementResult" },
+        { name: "elementDiagnosticInfos", isArray: true, fieldType: "DiagnosticInfo" }
+    ]
+};
+exports.ContentFilterResult_Schema = ContentFilterResult_Schema;

--- a/schemas/EventFilterResult_schema.js
+++ b/schemas/EventFilterResult_schema.js
@@ -1,0 +1,10 @@
+var EventFilterResult_Schema = {
+    name: "EventFilterResult",
+    baseType: "MonitoringFilter", // todo Correct to use?
+    fields: [
+        { name: "selectClauseResults", isArray: true, fieldType: "StatusCode" },
+        { name: "selectClauseDiagnosticInfos", isArray: true, fieldType: "DiagnosticInfo" },
+        { name: "whereClauseResult",   fieldType: "ContentFilterResult"}
+    ]
+};
+exports.EventFilterResult_Schema = EventFilterResult_Schema;


### PR DESCRIPTION
Hello,

This PR implements basic event support on the client. If EventNotifier is specified for monitoring, then it will instantiate the correct filter classes. It will throw an error if filter is in the object when not needed. The filter supported is EventFilter without a whereClause.

Correct schemas for ```createMonitoredItemResponse``` are implemented. 

Monitoring parameters needed to create a monitor is on the following format:
````
monitoringParameters: {
    samplingInterval: 0, 
    discardOldest: true,
    queueSize: 10,
    filter: {
        extensionType: 'EventFilter',
        data: {
            selectClauses: [
                [{namespaceIndex:0, name: "NodeId"}]
            ],
            whereClause: []
        }
    }
}
````

As you know, the filter is an extension type, so we have created a data format to specify what filter type it is. Do you think this is a good idea or should it only accept correctly instantiated filters?

We are also missing tests at the moment. For that we need a basic server implementation for event monitoring.

We are at the moment unsure whether we should indicate an error with the event emitter, or by throwing exceptions. The important thing is that monitor creation is stopped, as certain servers will crash if the parameters are not correct. 