### PR TITLE
Implement NodeClass for NodeCrawler

### DIFF
--- a/lib/client/node_crawler.js
+++ b/lib/client/node_crawler.js
@@ -351,7 +351,7 @@ NodeCrawler.prototype._process_browse_response = function (task, callback) {
 };
 
 //                         "ReferenceType | IsForward | BrowseName | NodeClass | DisplayName | TypeDefinition"
-var resultMask = opcua.browse_service.makeResultMask("ReferenceType | IsForward | BrowseName | TypeDefinition");
+var resultMask = opcua.browse_service.makeResultMask("ReferenceType | IsForward | BrowseName | NodeClass | TypeDefinition");
 
 NodeCrawler.prototype._resolve_deferred_browseNode = function (callback) {
 
@@ -645,6 +645,12 @@ NodeCrawler.prototype.read = function (nodeId, callback) {
                 browseName: object.browseName.name,
                 nodeId: object.nodeId.toString()
             };
+
+            // Append nodeClass
+            if (object.nodeClass) {
+                obj.nodeClass = object.nodeClass.toString();
+            }
+
             objMap[index] = obj;
 
             var referenceMap = obj;
@@ -663,6 +669,9 @@ NodeCrawler.prototype.read = function (nodeId, callback) {
                     console.log(util.inspect(object, {colorize: true, depth: 10}));
                 }
                 var reference = self._objectCache[ref.nodeId.toString()];
+
+                // Extract nodeClass so it can be appended
+                reference.nodeClass = ref.$nodeClass;
 
                 var refName = lowerize(referenceType.browseName.name);
 


### PR DESCRIPTION
Hi Etienne,

This PR adds `NodeClass` to the resultmask. We saw a need for this information to be returned to be able to fully separate different node types in our program. We add the nodeclass to the `obj`-object that is passed to the callback.

It might be an idea to have the user specify what is needed in the resultmask, and pass it to the function as an argument. If you think that this is a better way, then we could refactor it to do this. 

Regards,
@perok and @hanskhe