### PR TITLE
If used timestamped_set, no context is set

### DIFF
--- a/lib/address_space/ua_variable.js
+++ b/lib/address_space/ua_variable.js
@@ -996,7 +996,7 @@ function _Variable_bind_with_timestamped_set(options) {
     assert(!options.set, "should not specify set when timestamped_set_func exists ");
     self._timestamped_set_func = function (dataValue, indexRange, callback) {
         //xx assert(!indexRange,"indexRange Not Implemented");
-        return options.timestamped_set(dataValue, callback);
+        return options.timestamped_set.call(self, dataValue, callback);
     };
 }
 


### PR DESCRIPTION
Bind to variable if timestamped_set used to determine context