### PR TITLE
Error Handling for Socket Error EPIPE added

### DIFF
--- a/lib/transport/client_tcp_transport.js
+++ b/lib/transport/client_tcp_transport.js
@@ -168,7 +168,7 @@ ClientTCP_transport.prototype.connect = function (endpoint_url, callback, option
 
     function _on_socket_error_after_connection(err) {
         console.log(" ClientTCP_transport Socket Error",err.message);
-        if (err.message.match(/ECONNRESET/)) {
+        if (err.message.match(/ECONNRESET|EPIPE/)) {
             /**
              * @event connection_break
              *


### PR DESCRIPTION
I discovered an non deterministic behavior using this module as a client & server in my middleware.

The following test case brought up this behavior:

1. init client (--> client.pending)
2. client connected (--> client.connected)
3. stop server (--> client.start_reconnection)
4. start server (--> client.connection_reestablished)

When the server is stopped the client connection terminates in most cases with socket error ECONNRESET which causes connection_break event. This event initiates the reconnection process.
However, in some cases the client connection terminates with socket error EPIPE which led to a timeout.

EPIPE  The local end has been shut down on a connection oriented socket.  In this case, the process will also receive a SIGPIPE unless MSG_NOSIGNAL is set.

From my point of view the EPIPE socket error should initiate the reconnection process, too.

The reason for these two different socket errors might be related to way node-opcua uses the network layer. Just a guess.

I added a test and updated the existing tests, which were effected by my test changes.
This solution works for me.
Nevertheless other suggestions are welcome.