### PR TITLE
Read predefined string values for variables from nodeset xml

### DIFF
--- a/lib/address_space/load_nodeset2.js
+++ b/lib/address_space/load_nodeset2.js
@@ -534,6 +534,14 @@ function generate_address_space(addressSpace, xmlFiles, callback) {
             "References": references_parser,
             "Value": {
                 parser: {
+                    "String": {
+                        finish: function () {
+                            this.parent.parent.obj.value = {
+                                dataType: DataType.String,
+                                value: this.text
+                            }
+                        }
+                    },
                     "ByteString": {
                         init: function () {
                             this.byteString = null;

--- a/test/address_space/test_load_nodeset2.js
+++ b/test/address_space/test_load_nodeset2.js
@@ -125,4 +125,29 @@ describe("testing NodeSet XML file loading", function () {
             done(err);
         });
     });
+
+    it.only("should read predefined string values for variables", function(done) {
+
+        this.timeout(Math.max(400000,this._timeout));
+
+        var xml_file = path.join(__dirname,"../fixtures/fixture_node_with_predefined_string_variable.xml");
+
+        var xml_files = [
+            path.join(__dirname ,"../../nodesets/Opc.Ua.NodeSet2.xml"),
+            xml_file
+        ];
+
+        require("fs").existsSync(xml_files[0]).should.be.eql(true);
+        require("fs").existsSync(xml_files[1]).should.be.eql(true);
+
+        generate_address_space(addressSpace, xml_files, function (err) {
+            var someVariable = addressSpace.findNode("ns=1;i=2");
+
+            someVariable.browseName.toString().should.eql("1:SomeVariable");
+            someVariable.readValue().value.dataType.key.should.be.type('string');
+            someVariable.readValue().value.value.should.eql("any predefined string value");
+
+            done(err);
+        });
+    });
 });

--- a/test/fixtures/fixture_node_with_predefined_string_variable.xml
+++ b/test/fixtures/fixture_node_with_predefined_string_variable.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UANodeSet
+        Version="1.02" LastModified="2013-03-06T05:36:44.0862658Z"
+        xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd"
+        xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd">
+    <NamespaceUris>
+        <Uri>http://nodeopcua.org/UA/CUSTOM_NAMESPACE1/</Uri>
+     </NamespaceUris>
+    <Aliases>
+        <Alias Alias="Boolean">i=1</Alias>
+        <Alias Alias="NodeId">i=17</Alias>
+        <Alias Alias="HasTypeDefinition">i=40</Alias>
+        <Alias Alias="HasSubtype">i=45</Alias>
+        <Alias Alias="Organizes">i=35</Alias>
+    </Aliases>
+    <UAObject NodeId="ns=1;i=1" BrowseName="1:MyObject">
+        <DisplayName>MyObject</DisplayName>
+        <References>
+            <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=58</Reference>
+            <Reference ReferenceType="HasComponent">ns=1;i=2</Reference>
+        </References>
+    </UAObject>
+    <UAVariable NodeId="ns=1;i=2" BrowseName="1:SomeVariable" DataType="String">
+        <DisplayName>SomeVariable</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=58</Reference>
+        </References>
+        <Value>
+            <uax:String>any predefined string value</uax:String>
+        </Value>
+    </UAVariable>
+</UANodeSet>


### PR DESCRIPTION
When modelling the address space, I defined some variables for server side configuration routines. Unfortunately, the value was not part of the runtime space. I extended the loading routine parser to recognize string values from xml models.