### PR TITLE
Fix for ServerStatus not updating #233

### DIFF
--- a/lib/server/server_engine.js
+++ b/lib/server/server_engine.js
@@ -589,7 +589,18 @@ ServerEngine.prototype.initialize = function (options, callback) {
 
             bindVariableIfPresent(makeNodeId(VariableIds.Server_ServerStatus), {
                 get: function() {
-                    return serverStatus_var;
+                    var clone= new ServerStatus({
+                        startTime: self.serverStatus.startTime,
+                        currentTime: new Date(),
+                        state: self.serverStatus.state,
+                        buildInfo: self.serverStatus.buildInfo,
+                        secondsTillShutdown: self.serverStatus.secondsTillShutdown,
+                        shutdownReason: self.serverStatus.shutdownReason
+                    });
+                    return new Variant({
+                        dataType: DataType.ExtensionObject,
+                        value: clone
+                    });
                 },
                 set: null
             });


### PR DESCRIPTION
The fix for #221 causes a client that is monitoring ServerStatus to not receive published updates.