### PR TITLE
Add OPCUADiscoveryServer to index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ module.exports.ClientSession      = require("lib/client/opcua_client").ClientSes
 
 // Server services
 module.exports.OPCUAServer        = require("lib/server/opcua_server").OPCUAServer;
+module.exports.OPCUADiscoveryServer = require("lib/server/opcua_discovery_server").OPCUADiscoveryServer;
 module.exports.ServerEngine       = require("lib/server/server_engine").ServerEngine;
 module.exports.generate_address_space = require("lib/address_space/load_nodeset2").generate_address_space;
 module.exports.AddressSpace       = require("lib/address_space/address_space").AddressSpace;


### PR DESCRIPTION
There's an undocumented function for creating a discovery server. There's even a test so I figured maybe the missing module in index.js was not intentional.