### PR TITLE
opcua_client.js - createUserNameIdentityToken

### DIFF
--- a/lib/client/opcua_client.js
+++ b/lib/client/opcua_client.js
@@ -306,12 +306,25 @@ function createUserNameIdentityToken(session, userName, password) {
     }
 
     var serverCertificate = session.serverCertificate;
+    // if server does not provide certificate use unencrypted password
+    if (serverCertificate == null) {
+        var userIdentityToken = new UserNameIdentityToken({
+	        userName: userName,
+            password: new Buffer(password, "utf-8"),
+            encryptionAlgorithm: null,
+            policyId: userTokenPolicy.policyId
+	    });
+       return userIdentityToken; 
+    }
+    
     assert(serverCertificate instanceof Buffer);
 
     serverCertificate = crypto_utils.toPem(serverCertificate, "CERTIFICATE");
     var publicKey = crypto_utils.extractPublicKeyFromCertificateSync(serverCertificate);
 
     var serverNonce = session.serverNonce;
+    // if serverNonce not specified by server
+	if (serverNonce == null) serverNonce = new Buffer(0);
     assert(serverNonce instanceof Buffer);
 
 


### PR DESCRIPTION
Enhances opcua_client.js - createUserNameIdentityToken method
+ allows username/password authentication with servers without certificate
+ allows username/password authentication with servers not providing serverNonce - resolves #196 
