### PR TITLE
Update opcua_client.js to document closeSession param

### DIFF
--- a/lib/client/opcua_client.js
+++ b/lib/client/opcua_client.js
@@ -621,7 +621,8 @@ OPCUAClient.prototype._closeSession = function (session, deleteSubscriptions,cal
  *
  * @method closeSession
  * @async
- * @param session  {ClientSession} -
+ * @param session  {ClientSession} - the created client session
+ * @param deleteSubscriptions  {Boolean} - whether to delete subscriptions or not
  * @param callback {Function} - the callback
  * @param callback.err {Error|null}   - the Error if the async method has failed
  */


### PR DESCRIPTION
The documentation suggests that the `closeSession` method would take only 2 parameters: `session` and `callback`. Nevertheless, when reviewing the source code reality is different. It takes 3 params. A brief description of this missing parameter (`deleteSubscriptions` - Boolean) is proposed with this commit.