### PR TITLE
fix, for some reason status was good however dataValue.value was null

### DIFF
--- a/lib/client/node_crawler.js
+++ b/lib/client/node_crawler.js
@@ -238,7 +238,12 @@ NodeCrawler.prototype._resolve_deferred_readNode = function (callback) {
                 var dataValue = pair[1];
                 assert(dataValue.hasOwnProperty("statusCode"));
                 if (dataValue.statusCode === StatusCodes.Good) {
-                    _nodeToReadEx.callback(dataValue.value.value);
+                    if (dataValue.value === null) {
+                        _nodeToReadEx.callback(null);
+                    }
+                    else {
+                        _nodeToReadEx.callback(dataValue.value.value);
+                    }
                 } else {
                     _nodeToReadEx.callback({name: dataValue.statusCode.key});
                 }


### PR DESCRIPTION
It was observed repeatedly on an OPC server in production. This permits the crawler to continue. I haven't got any clue on how this can actually happen but it did :-)
If it is not ok just to return null, then what should the error strategy then be in the crawler?