### PR TITLE
Add Callback for every object created by instantiate

### DIFF
--- a/lib/address_space/base_node.js
+++ b/lib/address_space/base_node.js
@@ -1617,7 +1617,8 @@ BaseNode.prototype.install_extra_properties = function () {
 
 };
 
-function _clone_collection_new(newParent,collectionRef,optionalFilter, extraInfo) {
+
+function _clone_collection_new(newParent, collectionRef, optionalFilter, extraInfo, callBackPerNode) {
 
     var addressSpace = newParent.addressSpace;
     assert(!optionalFilter || (_.isFunction(optionalFilter.shouldKeep) && _.isFunction(optionalFilter.filterFor)) );
@@ -1635,23 +1636,33 @@ function _clone_collection_new(newParent,collectionRef,optionalFilter, extraInfo
             return;
         }
 
-        if (optionalFilter && !optionalFilter.shouldKeep(node)) {
-            return ; // skip this node
+        var dontCreate = (optionalFilter && !optionalFilter.shouldKeep(node));
+
+        var clone = null;
+
+        if (!dontCreate) {
+            // only nodes needed to create
+
+            var options = {
+                references: [
+                    { referenceType: reference.referenceType, isForward: false, nodeId: newParent.nodeId }
+                ]
+            };
+
+            var clone = node.clone(options, optionalFilter, extraInfo, callBackPerNode);
+
+            clone.propagate_back_references();
+
+            if (extraInfo) {
+                extraInfo.registerClonedObject(node, clone);
+            }
         }
 
-        var options = {
-            references: [
-                {referenceType: reference.referenceType, isForward: false, nodeId: newParent.nodeId}
-            ]
-        };
-
-        var clone = node.clone(options,optionalFilter,extraInfo);
-
-        clone.propagate_back_references();
-
-        if (extraInfo) {
-            extraInfo.registerClonedObject(node,clone);
+        // callback 
+        if (callBackPerNode) {
+            callBackPerNode(newParent, node, clone);
         }
+
     });
 }
 
@@ -1664,13 +1675,13 @@ function _clone_collection_new(newParent,collectionRef,optionalFilter, extraInfo
  * @return {Array}
  * @private
  */
-BaseNode.prototype._clone_children_references = function (newParent,optionalFilter, extraInfo) {
+BaseNode.prototype._clone_children_references = function (newParent, optionalFilter, extraInfo, callBackPerNode) {
 
     var self = this;
     assert(newParent instanceof BaseNode);
     // find all reference that derives from the HasChild
     var aggregatesRef = self.findReferencesEx("Aggregates", BrowseDirection.Forward);
-    _clone_collection_new(newParent,aggregatesRef, optionalFilter, extraInfo);
+    _clone_collection_new(newParent, aggregatesRef, optionalFilter, extraInfo, callBackPerNode);
 
 };
 
@@ -1682,7 +1693,7 @@ BaseNode.prototype._clone_children_references = function (newParent,optionalFilt
  * @return {*}
  * @private
  */
-BaseNode.prototype._clone = function (Constructor, options,optionalfilter, extraInfo) {
+BaseNode.prototype._clone = function (Constructor, options, optionalfilter, extraInfo, callBackPerNode) {
 
     var self = this;
 
@@ -1718,7 +1729,7 @@ BaseNode.prototype._clone = function (Constructor, options,optionalfilter, extra
     self.addressSpace._register(cloneObj);
 
     var newFilter = optionalfilter? optionalfilter.filterFor(cloneObj) :null;
-    self._clone_children_references(cloneObj,newFilter,extraInfo);
+    self._clone_children_references(cloneObj, newFilter, extraInfo, callBackPerNode);
 
     cloneObj.install_extra_properties();
 

--- a/lib/address_space/ua_object.js
+++ b/lib/address_space/ua_object.js
@@ -55,14 +55,14 @@ UAObject.prototype.readAttribute = function (attributeId) {
 };
 
 
-UAObject.prototype.clone = function (options,optionalfilter,extraInfo) {
+UAObject.prototype.clone = function (options, optionalfilter, extraInfo, callBackPerNode) {
     var self = this;
     options = options || {};
     options = _.extend(_.clone(options),{
         eventNotifier: self.eventNotifier,
         symbolicName: self.symbolicName
     });
-    return self._clone(UAObject,options, optionalfilter, extraInfo);
+    return self._clone(UAObject, options, optionalfilter, extraInfo, callBackPerNode);
 };
 
 exports.UAObject = UAObject;

--- a/lib/address_space/ua_object_type.js
+++ b/lib/address_space/ua_object_type.js
@@ -78,7 +78,7 @@ var assertUnusedChildBrowseName = require("./ua_variable_type").assertUnusedChil
  *  DataVariable      | Variable
  *  DataVariableType  |
  */
-UAObjectType.prototype.instantiate = function (options) {
+UAObjectType.prototype.instantiate = function (options, callBackPerNode) {
 
 
     var self = this;
@@ -116,7 +116,7 @@ UAObjectType.prototype.instantiate = function (options) {
 
     var instance = addressSpace.addObject(opts);
 
-    initialize_properties_and_components(instance, baseObjectType,self, options.optionals);
+    initialize_properties_and_components(instance, baseObjectType, self, options.optionals, callBackPerNode);
 
     assert(instance.typeDefinition.toString()=== self.nodeId.toString());
 

--- a/lib/address_space/ua_variable.js
+++ b/lib/address_space/ua_variable.js
@@ -1288,7 +1288,7 @@ UAVariable.prototype.getUserWriteMask = function () {
 };
 
 
-UAVariable.prototype.clone = function (options, optionalfilter,extraInfo) {
+UAVariable.prototype.clone = function (options, optionalfilter, extraInfo, callBackPerNode) {
 
     var self = this;
     options = options || {};
@@ -1304,7 +1304,7 @@ UAVariable.prototype.clone = function (options, optionalfilter,extraInfo) {
         minimumSamplingInterval: self.minimumSamplingInterval,
         historizing:             self.historizing
     });
-    var newVariable = self._clone(UAVariable, options, optionalfilter, extraInfo);
+    var newVariable = self._clone(UAVariable, options, optionalfilter, extraInfo, callBackPerNode);
 
     newVariable.bindVariable();
     assert(_.isFunction(newVariable._timestamped_set_func));

--- a/lib/address_space/ua_variable_type.js
+++ b/lib/address_space/ua_variable_type.js
@@ -273,7 +273,7 @@ CloneHelper.prototype.registerClonedObject = function(objInType,clonedObj) {
 //  => OptionalPlaceHolder       => Not Installed
 //  => null (no modelling rule ) => Not Installed
 //
-function _initialize_properties_and_components(instance,topMostType,typeNode,optionalsMap, extraInfo) {
+function _initialize_properties_and_components(instance, topMostType, typeNode, optionalsMap, extraInfo, callBackPerNode) {
 
     optionalsMap = optionalsMap || {};
 
@@ -293,10 +293,10 @@ function _initialize_properties_and_components(instance,topMostType,typeNode,opt
     var filter = new MandatoryChildOrRequestedOptionalFilter(instance,optionalsMap);
 
 
-    typeNode._clone_children_references(instance,filter,extraInfo);
+    typeNode._clone_children_references(instance, filter, extraInfo, callBackPerNode);
 
     // get properties and components from base class
-    _initialize_properties_and_components(instance,topMostType,baseType,optionalsMap , extraInfo);
+    _initialize_properties_and_components(instance, topMostType, baseType, optionalsMap, extraInfo, callBackPerNode);
 
 }
 
@@ -529,7 +529,7 @@ function reconstructFunctionalGroupType(extraInfo)
 
 var makeOptionalsMap = require("lib/address_space/make_optionals_map").makeOptionalsMap;
 
-function initialize_properties_and_components(instance,topMostType,nodeType,optionals) {
+function initialize_properties_and_components(instance, topMostType, nodeType, optionals, callBackPerNode) {
 
     var extraInfo = new CloneHelper();
 
@@ -538,7 +538,7 @@ function initialize_properties_and_components(instance,topMostType,nodeType,opti
 
     var optionalsMap = makeOptionalsMap(optionals);
     
-    _initialize_properties_and_components(instance,topMostType,nodeType,optionalsMap,extraInfo);
+    _initialize_properties_and_components(instance, topMostType, nodeType, optionalsMap, extraInfo, callBackPerNode);
 
     reconstructFunctionalGroupType(extraInfo);
 


### PR DESCRIPTION
Problem: for using custom Nodesets with opcua.OPCUAServer to load a .xml models it is not possible to manage the behavior for modellingRule="OptionalPlaceholder" when creating a inctance of the model.

Solution: add Callback that is triggered on create new node:

e.g.

    server = new opcua.OPCUAServer({
        port: 26543, // the port of the listening socket of the server
        resourcePath: "UA/"+ serverName, // this path will be added to the endpoint resource name
        nodeset_filename: additionalNodeset
    });
  
    function onAddNode(parent, node, instance) {
        console.log(" new Object: " + node.browseName + " : " + node.modellingRule);
        
        if (node.modellingRule.indexOf("Placeholder") >= 0) {
            /// Add "NewObject" Methode for every modellingRule=="OptionalPlaceholder"
            addMethodNew(parent, node);    
        }
    }

    OpcUaObject.instantiate(object, onAddNode ).

