### PR TITLE
Fix missing applicationUri in findServers response

### DIFF
--- a/lib/server/opcua_discovery_server.js
+++ b/lib/server/opcua_discovery_server.js
@@ -143,7 +143,7 @@ OPCUADiscoveryServer.prototype._on_RegisterServerRequest = function (message, ch
 
         // prepare serverInfo which will be used by FindServers
         var serverInfo = {};
-        serverInfo.applicationUri = serverInfo.serverUri;
+        serverInfo.applicationUri = request.server.serverUri;
         serverInfo.applicationType = request.server.serverType;
         serverInfo.productUri = request.server.productUri;
         serverInfo.applicationName = request.server.serverNames[0]; // which one shall we use ?

--- a/test/discovery/test_discovery_server.js
+++ b/test/discovery/test_discovery_server.js
@@ -201,6 +201,7 @@ if (!crypto_utils.isFullySupported()) {
                     perform_findServersRequest(discovery_server_endpointUrl, function (err, servers) {
                         console.log(servers[0].toString());
                         servers.length.should.eql(initialServerCount + 1);
+                        assert(servers[1].applicationUri === "urn:NodeOPCUA-Server-default");
                         callback(err);
                     });
                 },

--- a/test/discovery/test_discovery_server.js
+++ b/test/discovery/test_discovery_server.js
@@ -201,7 +201,7 @@ if (!crypto_utils.isFullySupported()) {
                     perform_findServersRequest(discovery_server_endpointUrl, function (err, servers) {
                         console.log(servers[0].toString());
                         servers.length.should.eql(initialServerCount + 1);
-                        assert(servers[1].applicationUri === "urn:NodeOPCUA-Server-default");
+                        servers[1].applicationUri.should.eql("urn:NodeOPCUA-Server-default");
                         callback(err);
                     });
                 },


### PR DESCRIPTION
I was trying out OPCUADiscoveryServer and I noticed that the response did not include `applicationUri` which is crucial to identify a specific server from the list.

In the source code comment:
```
            // The globally unique identifier for the application instance. This URI is used as
            // ServerUri in Services if the application is a Server.
```

So, I would assume applicationUri was intended to be used by applications to identify registered servers.

 