### PR TITLE
Fix historical_data store on sourceTimestamp==null

### DIFF
--- a/lib/address_space/historical_access/address_space_historical_data_node.js
+++ b/lib/address_space/historical_access/address_space_historical_data_node.js
@@ -148,12 +148,14 @@ exports.install = function (AddressSpace) {
         node.on("value_changed", function (newDataValue) {
             node._timeline.push(newDataValue);
 
+            var sourceTime = newDataValue.sourceTimestamp ||  new Date(); 
+            
             // ensure that values are set with date increasing
-            if (newDataValue.sourceTimestamp.getTime() <= lastDate.getTime()) {
-                console.log("Warning date not increasing ".red,newDataValue.toString()," last known date = ",lastDate);
+            if (sourceTime.getTime() <= lastDate.getTime()) {
+                console.log("Warning date not increasing ".red, newDataValue.toString(), " last known date = ", lastDate);
             }
 
-            lastDate = newDataValue.sourceTimestamp;
+            lastDate = sourceTime;
 
             // we keep only a limited amount in main memory
             if (node._timeline.length > node._maxOnlineValues) {


### PR DESCRIPTION
Fix a null pointer exeption if sourceTimestamp is NULL on "value_changed" event in historical_data store