### PR TITLE
Add/Fix validateDataType() for EnumType

### DIFF
--- a/lib/address_space/ua_variable.js
+++ b/lib/address_space/ua_variable.js
@@ -123,7 +123,11 @@ function validateDataType(addressSpace, dataTypeNodeId, variantDataType, nodeId)
 
     if (destUADataType.isAbstract) {
         builtInUADataType = destUADataType;
-    } else {
+    } else if (destUADataType.enumValues) {
+        // in case of an enum
+        builtInUADataType = addressSpace.findDataType("Int32");
+        // todo: handle (destUADataType.enumStrings)
+    } else {        
         builtInType = findBuiltInType(destUADataType.browseName).name;
         builtInUADataType = addressSpace.findDataType(builtInType);
     }


### PR DESCRIPTION
If the value of an EnumType is written by the UA Client the Server raises: 
EXCEPTION CAUGHT WHILE PROCESSING REQUEST !!! WriteRequest datatype 2:MyEnumeration must be registered
Error: datatype 2:MyEnumeration must be registered