### PR TITLE
fixed #386 client crash on terminating monitored item before initialization

### DIFF
--- a/packages/node-opcua-client/src/client_subscription.js
+++ b/packages/node-opcua-client/src/client_subscription.js
@@ -646,9 +646,17 @@ ClientSubscription.prototype._remove = function (monitoredItem) {
     var self = this;
     var clientHandle = monitoredItem.monitoringParameters.clientHandle;
     assert(clientHandle);
-    assert(self.monitoredItems.hasOwnProperty(clientHandle));
-    monitoredItem.removeAllListeners();
-    delete self.monitoredItems[clientHandle];
+
+    var deleteMonitoredItem = function(){
+        monitoredItem.removeAllListeners();
+        delete self.monitoredItems[clientHandle];
+    };
+
+    if(self.monitoredItems.hasOwnProperty(clientHandle)){
+        deleteMonitoredItem();
+    } else {
+        monitoredItem.on("initialized", deleteMonitoredItem);
+    }
 };
 
 ClientSubscription.prototype._delete_monitored_items = function (monitoredItems, callback) {


### PR DESCRIPTION
I have tested that this does fix #386. I don't see many tests specifically for the OPCUA client, but the ones that are there still pass. Let me know if you'd like to see additional test coverage for this change.