### PR TITLE
node-opcua-nodeid - Adjust NodeId creation on coerceNodeId

### DIFF
--- a/packages/node-opcua-nodeid/src/nodeid.js
+++ b/packages/node-opcua-nodeid/src/nodeid.js
@@ -270,9 +270,9 @@ function coerceNodeId(value, namespace) {
         console.log( "xxxx VALUE = ",value);
 
         var tmp = value;
-        value = value || tmp.value;
-        namespace = namespace || tmp.namespace;
-        identifierType = identifierType || tmp.identifierType;
+        value = tmp.value || value;
+        namespace = tmp.namespace || namespace;
+        identifierType = tmp.identifierType || identifierType;
         return new NodeId(identifierType, value, namespace);
     }
     return new NodeId(identifierType, value, namespace);

--- a/packages/node-opcua-nodeid/src/nodeid.js
+++ b/packages/node-opcua-nodeid/src/nodeid.js
@@ -270,10 +270,10 @@ function coerceNodeId(value, namespace) {
         console.log( "xxxx VALUE = ",value);
 
         var tmp = value;
-        value = tmp.value;
+        value = value || tmp.value;
         namespace = namespace || tmp.namespace;
-        identifierType = tmp.identifierTypes;
-        return new NodeId(value, namespace);
+        identifierType = identifierType || tmp.identifierType;
+        return new NodeId(identifierType, value, namespace);
     }
     return new NodeId(identifierType, value, namespace);
 }


### PR DESCRIPTION
Hello, one of my applications detected the following behaviour when creating a NodeId.
A NodeId instantiation from coerceNodeId could end on an assertion error (no identifierType).