### PR TITLE
WIP: Add websocket support

### DIFF
--- a/packages/node-opcua-server/package.json
+++ b/packages/node-opcua-server/package.json
@@ -50,7 +50,8 @@
   "node-opcua-status-code": "^0.1.0-7",
   "node-opcua-utils": "^0.1.0-11",
   "node-opcua-variant": "^0.1.0-11",
-  "underscore": "^1.8.3"
+  "underscore": "^1.8.3",
+  "ws": "^3.3.2"
  },
  "devDependencies": {
   "node-opcua-data-access": "^0.1.0-11",

--- a/packages/node-opcua-server/src/opcua_server.js
+++ b/packages/node-opcua-server/src/opcua_server.js
@@ -252,6 +252,7 @@ function OPCUAServer(options) {
     // add the tcp/ip endpoint with no security
     var endPoint = new OPCUAServerEndPoint({
         port: port,
+        websocket: options.websocket,
         defaultSecureTokenLifetime: options.defaultSecureTokenLifetime || 600000,
         timeout: options.timeout || 10000,
         certificateChain: self.getCertificateChain(),


### PR DESCRIPTION
OPC UA 1.04 adds support for WebSocket transport. I did a quick and dirty implementation for the server by wrapping the websocket into a compatible API. What's the best way to implement this in a clean way?