### PR TITLE
Add missing var keyword for CallMethodResult_Schema

### DIFF
--- a/packages/node-opcua-service-call/schemas/CallMethodResult_schema.js
+++ b/packages/node-opcua-service-call/schemas/CallMethodResult_schema.js
@@ -10,7 +10,7 @@ var NodeId = require("node-opcua-nodeid").NodeId;
  * CallMethodResult
  *
  */
-CallMethodResult_Schema = {
+var CallMethodResult_Schema = {
     name: "CallMethodResult",
     documentation: "The result of a Method call.",
     fields: [


### PR DESCRIPTION
I ran into a crash where `CallMethodResult_Schema` was undefined. I believe this is just missing a `var` keyword, and after modifying this file, it seems to solve the issue.