### PR TITLE
userAccessLevel is not matched with variable accessLevel

### DIFF
--- a/packages/node-opcua-address-space/src/ua_variable.js
+++ b/packages/node-opcua-address-space/src/ua_variable.js
@@ -59,10 +59,12 @@ function adjust_accessLevel(accessLevel) {
     return accessLevel;
 }
 
-function adjust_userAccessLevel(accessLevel) {
+function adjust_userAccessLevel(userAccessLevel, accessLevel) {
+    userAccessLevel = utils.isNullOrUndefined(userAccessLevel) ? "CurrentRead | CurrentWrite" : userAccessLevel;
+    userAccessLevel = makeAccessLevel(userAccessLevel);
     accessLevel = utils.isNullOrUndefined(accessLevel) ? "CurrentRead | CurrentWrite" : accessLevel;
     accessLevel = makeAccessLevel(accessLevel);
-    return accessLevel;
+    return makeAccessLevel(accessLevel.value & userAccessLevel.value);
 }
 
 function adjust_samplingInterval(minimumSamplingInterval) {
@@ -255,15 +257,21 @@ function UAVariable(options) {
     /**
      * @property accessLevel
      * @type {number}
+     * The AccessLevel Attribute is used to indicate how the Value of a Variable can be accessed 
+     * (read/write) and if it contains current and/or historic data. The AccessLevel does not take 
+     * any user access rights into account, i.e. although the Variable is writable this may be 
+     * restricted to a certain user / user group. The AccessLevelType is defined in 8.57.
      */
     self.accessLevel = adjust_accessLevel(options.accessLevel);
 
     /**
      * @property userAccessLevel
      * @type {number}
-     *
+     * The UserAccessLevel Attribute is used to indicate how the Value of a Variable can be accessed 
+     * (read/write) and if it contains current or historic data taking user access rights into account.
+     * The AccessLevelType is defined in 8.57.
      */
-    self.userAccessLevel = adjust_userAccessLevel(options.userAccessLevel);
+    self.userAccessLevel = adjust_userAccessLevel(options.userAccessLevel, options.accessLevel);
 
     /**
      * The MinimumSamplingInterval Attribute indicates how 'current' the Value of the Variable will

--- a/packages/node-opcua-address-space/test/test_accessLevel_userAccessLevel_pullrequest.js
+++ b/packages/node-opcua-address-space/test/test_accessLevel_userAccessLevel_pullrequest.js
@@ -1,0 +1,312 @@
+"use strict";
+
+var _ = require("underscore");
+var should = require("should");
+
+var async = require("async");
+var path = require("path");
+
+var StatusCodes = require("node-opcua-status-code").StatusCodes;
+var DataType = require("node-opcua-variant").DataType;
+var Variant = require("node-opcua-variant").Variant;
+var DataValue = require("node-opcua-data-value").DataValue;
+var VariantArrayType = require("node-opcua-variant").VariantArrayType;
+var AttributeIds = require("node-opcua-data-model").AttributeIds;
+var NodeClass = require("node-opcua-data-model").NodeClass;
+var NodeId = require("node-opcua-nodeid").NodeId;
+var makeNodeId = require("node-opcua-nodeid").makeNodeId;
+
+var nodeset_filename = path.join(__dirname, "../test_helpers/test_fixtures/mini.Node.Set2.xml");
+
+
+var address_space = require("..");
+var UAVariable = address_space.UAVariable;
+var SessionContext = address_space.SessionContext;
+var generate_address_space = address_space.generate_address_space;
+var context = SessionContext.defaultContext;
+
+var describe = require("node-opcua-leak-detector").describeWithLeakDetector;
+describe("testing Variables ", function () {
+    it("accessLevel: CurrentRead | CurrentWrite\tuserAccessLevel: CurrentRead | CurrentWrite", function(){
+        var addressSpace = new address_space.AddressSpace();
+
+        var v = new UAVariable({
+            browseName: "some variable",
+            addressSpace: addressSpace,
+            minimumSamplingInterval: 10,
+            arrayDimensions: [1, 2, 3],
+            accessLevel: "CurrentRead | CurrentWrite",
+            userAccessLevel: "CurrentRead | CurrentWrite"
+        });
+
+        v.accessLevel.key.should.eql("CurrentRead | CurrentWrite");
+        v.userAccessLevel.key.should.eql("CurrentRead | CurrentWrite");
+
+        addressSpace.dispose();
+    });
+
+    it("accessLevel: CurrentRead | CurrentWrite\tuserAccessLevel: CurrentRead", function(){
+        var addressSpace = new address_space.AddressSpace();
+
+        var v = new UAVariable({
+            browseName: "some variable",
+            addressSpace: addressSpace,
+            minimumSamplingInterval: 10,
+            arrayDimensions: [1, 2, 3],
+            accessLevel: "CurrentRead",
+            userAccessLevel: "CurrentRead | CurrentWrite"
+        });
+
+        v.accessLevel.key.should.eql("CurrentRead");
+        v.userAccessLevel.key.should.eql("CurrentRead");
+
+        addressSpace.dispose();
+    });
+
+    it("accessLevel: CurrentRead | CurrentWrite\tuserAccessLevel: CurrentWrite", function(){
+        var addressSpace = new address_space.AddressSpace();
+
+        var v = new UAVariable({
+            browseName: "some variable",
+            addressSpace: addressSpace,
+            minimumSamplingInterval: 10,
+            arrayDimensions: [1, 2, 3],
+            accessLevel: "CurrentRead | CurrentWrite",
+            userAccessLevel: "CurrentWrite"
+        });
+
+        v.accessLevel.key.should.eql("CurrentRead | CurrentWrite");
+        v.userAccessLevel.key.should.eql("CurrentWrite");
+
+        addressSpace.dispose();
+    });
+
+    it("accessLevel: CurrentRead | CurrentWrite\tuserAccessLevel: undefined", function(){
+        var addressSpace = new address_space.AddressSpace();
+
+        var v = new UAVariable({
+            browseName: "some variable",
+            addressSpace: addressSpace,
+            minimumSamplingInterval: 10,
+            arrayDimensions: [1, 2, 3],
+            accessLevel: "CurrentRead | CurrentWrite"
+        });
+
+        v.accessLevel.key.should.eql("CurrentRead | CurrentWrite");
+        v.userAccessLevel.key.should.eql("CurrentRead | CurrentWrite");
+
+        addressSpace.dispose();
+    });
+
+    // accessLevel CurrentRead
+    it("accessLevel: CurrentRead \tuserAccessLevel: CurrentRead | CurrentWrite", function(){
+        var addressSpace = new address_space.AddressSpace();
+
+        var v = new UAVariable({
+            browseName: "some variable",
+            addressSpace: addressSpace,
+            minimumSamplingInterval: 10,
+            arrayDimensions: [1, 2, 3],
+            accessLevel: "CurrentRead",
+            userAccessLevel: "CurrentRead | CurrentWrite"
+        });
+
+        v.accessLevel.key.should.eql("CurrentRead");
+        v.userAccessLevel.key.should.eql("CurrentRead");
+
+        addressSpace.dispose();
+    });
+
+    it("accessLevel: CurrentRead \tuserAccessLevel: CurrentRead", function(){
+        var addressSpace = new address_space.AddressSpace();
+
+        var v = new UAVariable({
+            browseName: "some variable",
+            addressSpace: addressSpace,
+            minimumSamplingInterval: 10,
+            arrayDimensions: [1, 2, 3],
+            accessLevel: "CurrentRead",
+            userAccessLevel: "CurrentRead"
+        });
+
+        v.accessLevel.key.should.eql("CurrentRead");
+        v.userAccessLevel.key.should.eql("CurrentRead");
+
+        addressSpace.dispose();
+    });
+
+    it("accessLevel: CurrentRead \tuserAccessLevel: CurrentWrite", function(){
+        var addressSpace = new address_space.AddressSpace();
+
+        var v = new UAVariable({
+            browseName: "some variable",
+            addressSpace: addressSpace,
+            minimumSamplingInterval: 10,
+            arrayDimensions: [1, 2, 3],
+            accessLevel: "CurrentRead",
+            userAccessLevel: "CurrentWrite"
+        });
+
+        v.accessLevel.key.should.eql("CurrentRead");
+        v.userAccessLevel.key.should.eql("NONE");
+
+        addressSpace.dispose();
+    });
+
+    it("accessLevel: CurrentRead \tuserAccessLevel: undefined", function(){
+        var addressSpace = new address_space.AddressSpace();
+
+        var v = new UAVariable({
+            browseName: "some variable",
+            addressSpace: addressSpace,
+            minimumSamplingInterval: 10,
+            arrayDimensions: [1, 2, 3],
+            accessLevel: "CurrentRead"
+        });
+
+        v.accessLevel.key.should.eql("CurrentRead");
+        v.userAccessLevel.key.should.eql("CurrentRead");
+
+        addressSpace.dispose();
+    });
+
+    // accessLevel CurrentWrite
+    it("accessLevel: CurrentWrite \tuserAccessLevel: CurrentRead | CurrentWrite", function(){
+        var addressSpace = new address_space.AddressSpace();
+
+        var v = new UAVariable({
+            browseName: "some variable",
+            addressSpace: addressSpace,
+            minimumSamplingInterval: 10,
+            arrayDimensions: [1, 2, 3],
+            accessLevel: "CurrentWrite",
+            userAccessLevel: "CurrentRead | CurrentWrite"
+        });
+
+        v.accessLevel.key.should.eql("CurrentWrite");
+        v.userAccessLevel.key.should.eql("CurrentWrite");
+
+        addressSpace.dispose();
+    });
+
+    it("accessLevel: CurrentWrite \tuserAccessLevel: CurrentRead", function(){
+        var addressSpace = new address_space.AddressSpace();
+
+        var v = new UAVariable({
+            browseName: "some variable",
+            addressSpace: addressSpace,
+            minimumSamplingInterval: 10,
+            arrayDimensions: [1, 2, 3],
+            accessLevel: "CurrentWrite",
+            userAccessLevel: "CurrentRead"
+        });
+
+        v.accessLevel.key.should.eql("CurrentWrite");
+        v.userAccessLevel.key.should.eql("NONE");
+
+        addressSpace.dispose();
+    });
+
+    it("accessLevel: CurrentWrite \tuserAccessLevel: CurrentWrite", function(){
+        var addressSpace = new address_space.AddressSpace();
+
+        var v = new UAVariable({
+            browseName: "some variable",
+            addressSpace: addressSpace,
+            minimumSamplingInterval: 10,
+            arrayDimensions: [1, 2, 3],
+            accessLevel: "CurrentWrite",
+            userAccessLevel: "CurrentWrite"
+        });
+
+        v.accessLevel.key.should.eql("CurrentWrite");
+        v.userAccessLevel.key.should.eql("CurrentWrite");
+
+        addressSpace.dispose();
+    });
+
+    it("accessLevel: CurrentWrite \tuserAccessLevel: undefined", function(){
+        var addressSpace = new address_space.AddressSpace();
+
+        var v = new UAVariable({
+            browseName: "some variable",
+            addressSpace: addressSpace,
+            minimumSamplingInterval: 10,
+            arrayDimensions: [1, 2, 3],
+            accessLevel: "CurrentWrite"
+        });
+
+        v.accessLevel.key.should.eql("CurrentWrite");
+        v.userAccessLevel.key.should.eql("CurrentWrite");
+
+        addressSpace.dispose();
+    });
+
+    // accessLevel undefined
+    it("accessLevel: undefined \tuserAccessLevel: CurrentRead | CurrentWrite", function(){
+        var addressSpace = new address_space.AddressSpace();
+
+        var v = new UAVariable({
+            browseName: "some variable",
+            addressSpace: addressSpace,
+            minimumSamplingInterval: 10,
+            arrayDimensions: [1, 2, 3],
+            userAccessLevel: "CurrentRead | CurrentWrite"
+        });
+
+        v.accessLevel.key.should.eql("CurrentRead | CurrentWrite");
+        v.userAccessLevel.key.should.eql("CurrentRead | CurrentWrite");
+
+        addressSpace.dispose();
+    });
+
+    it("accessLevel: undefined \tuserAccessLevel: CurrentRead", function(){
+        var addressSpace = new address_space.AddressSpace();
+
+        var v = new UAVariable({
+            browseName: "some variable",
+            addressSpace: addressSpace,
+            minimumSamplingInterval: 10,
+            arrayDimensions: [1, 2, 3],
+            userAccessLevel: "CurrentRead"
+        });
+
+        v.accessLevel.key.should.eql("CurrentRead | CurrentWrite");
+        v.userAccessLevel.key.should.eql("CurrentRead");
+
+        addressSpace.dispose();
+    });
+
+    it("accessLevel: undefined \tuserAccessLevel: CurrentWrite", function(){
+        var addressSpace = new address_space.AddressSpace();
+
+        var v = new UAVariable({
+            browseName: "some variable",
+            addressSpace: addressSpace,
+            minimumSamplingInterval: 10,
+            arrayDimensions: [1, 2, 3],
+            userAccessLevel: "CurrentWrite"
+        });
+
+        v.accessLevel.key.should.eql("CurrentRead | CurrentWrite");
+        v.userAccessLevel.key.should.eql("CurrentWrite");
+
+        addressSpace.dispose();
+    });
+
+    it("accessLevel: undefined \tuserAccessLevel: undefined", function(){
+        var addressSpace = new address_space.AddressSpace();
+
+        var v = new UAVariable({
+            browseName: "some variable",
+            addressSpace: addressSpace,
+            minimumSamplingInterval: 10,
+            arrayDimensions: [1, 2, 3]
+        });
+
+        v.accessLevel.key.should.eql("CurrentRead | CurrentWrite");
+        v.userAccessLevel.key.should.eql("CurrentRead | CurrentWrite");
+
+        addressSpace.dispose();
+    });
+});


### PR DESCRIPTION
userAccessLevel can't be higher than accessLevel of variables but by creating the variables the server doesn't compare this accessLevels so in node-opcua it can be higher:
![accesslevels](https://user-images.githubusercontent.com/24451509/37082270-5f6799a2-21ec-11e8-8d24-d4bc1ce1dd13.png)

Spec Part 3 R 1.04 page 27
![spec](https://user-images.githubusercontent.com/24451509/37082281-66a34f40-21ec-11e8-830b-61a54ff56f29.png)
