### PR TITLE
adds displayname to object- and variable-types

### DIFF
--- a/packages/node-opcua-address-space/src/address_space.js
+++ b/packages/node-opcua-address-space/src/address_space.js
@@ -1015,6 +1015,7 @@ AddressSpace.prototype._addObjectOrVariableType = function (options,topMostBaseT
 
     var objectType = this._createNode({
         browseName:    options.browseName,
+        displayName:   options.displayName || options.browseName,
         nodeClass:     nodeClass,
         isAbstract:    !!options.isAbstract,
         eventNotifier: +options.eventNotifier,


### PR DESCRIPTION
adds displayname to object-/variabletypes.
maybe change default behavior if no displayname is present to something else maybe empty?