### PR TITLE
checks minimumSamplingInterval is present (closes #467)

### DIFF
--- a/packages/node-opcua-server/src/monitored_item.js
+++ b/packages/node-opcua-server/src/monitored_item.js
@@ -403,7 +403,7 @@ MonitoredItem.prototype._set_parameters = function (monitoredParameters) {
     // exception-based model. The fastest supported sampling interval may be equal to 0, which indicates
     // that the data item is exception-based rather than being sampled at some period. An exception-based
     // model means that the underlying system does not require sampling and reports data changes.
-    self.samplingInterval = _adjust_sampling_interval(monitoredParameters.samplingInterval,self.node ?  self.node.minimumSamplingInterval : 0 );
+    self.samplingInterval = _adjust_sampling_interval(monitoredParameters.samplingInterval,self.node && self.node.minimumSamplingInterval ?  self.node.minimumSamplingInterval : 0 );
     self.discardOldest = monitoredParameters.discardOldest;
     self.queueSize = _adjust_queue_size(monitoredParameters.queueSize);
 };


### PR DESCRIPTION
Checks minimumSamplingInterval is present while adjusting samplingterval. 
MinimumSamplingInterval is not present if monitored node is an eventNotifier object.
Maybe this Solution is better?