### PR TITLE
Add missing dependencies to node-opcua

### DIFF
--- a/packages/node-opcua/package.json
+++ b/packages/node-opcua/package.json
@@ -52,7 +52,8 @@
   "node-opcua-transport": "^0.2.3",
   "node-opcua-utils": "^0.2.3",
   "node-opcua-variant": "^0.2.3",
-  "node-opcua-vendor-diagnostic": "^0.2.3"
+  "node-opcua-vendor-diagnostic": "^0.2.3",
+  "semver": "^5.5.0"
  },
  "devDependencies": {
   "should": "13.2.1"

--- a/packages/node-opcua/package.json
+++ b/packages/node-opcua/package.json
@@ -9,6 +9,7 @@
  },
  "typings": "./node-opcua.d.ts",
  "dependencies": {
+  "colors": "^1.2.1",
   "node-opcua-address-space": "^0.2.3",
   "node-opcua-address-space-for-conformance-testing": "^0.2.3",
   "node-opcua-assert": "^0.2.0",


### PR DESCRIPTION
a3a3d2d4d51b18e95ba427d572b8cffc2c0b55dc required ` semver`  and `colors`.
While `colors` gets pulled in by the sub-packages, ` semver` gets not (anymore?).
