### PR TITLE
Fixed wrong asymmetricSignatureAlgorithm

### DIFF
--- a/packages/node-opcua-secure-channel/src/security_policy.js
+++ b/packages/node-opcua-secure-channel/src/security_policy.js
@@ -47,7 +47,7 @@ var _ = require("underscore");
  * A suite of algorithms that are for 256-Bit encryption, algorithms include.
  *   -> SymmetricSignatureAlgorithm   - Hmac_Sha256 -(http://www.w3.org/2000/09/xmldsig#hmac-sha256).
  *   -> SymmetricEncryptionAlgorithm  -  Aes256_CBC -(http://www.w3.org/2001/04/xmlenc#aes256-cbc).
- *   -> AsymmetricSignatureAlgorithm  -  Rsa_Sha256 -(http://www.w3.org/2000/09/xmldsig#rsa-sha256).
+ *   -> AsymmetricSignatureAlgorithm  -  Rsa_Sha256 -(http://www.w3.org/2001/04/xmldsig-more#rsa-sha256).
  *   -> AsymmetricKeyWrapAlgorithm    -   KwRsaOaep -(http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p).
  *   -> AsymmetricEncryptionAlgorithm -    Rsa_Oaep -(http://www.w3.org/2001/04/xmlenc#rsa-oaep).
  *   -> KeyDerivationAlgorithm        -     PSHA256 -(http://docs.oasis-open.org/ws-sx/ws-secureconversation/200512/dk/p_sha256).
@@ -296,7 +296,7 @@ var _Basic256Sha256 = {
     asymmetricVerifyChunk: asymmetricVerifyChunk,
     asymmetricSign: RSAPKCS1V15SHA256_Sign,
     asymmetricVerify: RSAPKCS1OAEPSHA256_Verify,
-    asymmetricSignatureAlgorithm: "http://www.w3.org/2000/09/xmldsig#rsa-sha256",
+    asymmetricSignatureAlgorithm: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
 
     /* asymmetric encryption algorithm */
     asymmetricEncrypt: RSAOAEP_Encrypt,


### PR DESCRIPTION
Fixed wrong Uri for _Basic256Sha256_ `asymmetricSignatureAlgorithm`
See **OPCFoundation** UA-.NETStandard [SecurityConstants](https://github.com/OPCFoundation/UA-.NETStandard/blob/7c0fe4f44af0ead9679995e4e87b634499e08e9b/Stack/Opc.Ua.Core/Security/Constants/SecurityConstants.cs) _(line 38)_
