### PR TITLE
client missing FIN,ACK after CloseSecureChannelRequest

### DIFF
--- a/packages/node-opcua-secure-channel/src/client/client_secure_channel_layer.js
+++ b/packages/node-opcua-secure-channel/src/client/client_secure_channel_layer.js
@@ -1313,12 +1313,16 @@ ClientSecureChannelLayer.prototype.close = function (callback) {
         return callback(new Error("Transport disconnected"));
     }
 
+	/* The Client closes the connection by sending a CloseSecureChannel request and closing the
+		socket gracefully. */
     self._performMessageTransaction("CLO", request, function () {
         ///xx self._transport.disconnect(function() {
         self.dispose();
         callback();
         //xxx });
     });
+	/* socket close */
+	self._transport.disconnect(); // send [FIN,ACK]
 };
 
 ClientSecureChannelLayer.prototype.__defineGetter__("bytesRead", function () {

--- a/packages/node-opcua-secure-channel/src/client/client_secure_channel_layer.js
+++ b/packages/node-opcua-secure-channel/src/client/client_secure_channel_layer.js
@@ -1322,7 +1322,10 @@ ClientSecureChannelLayer.prototype.close = function (callback) {
         //xxx });
     });
 	/* socket close */
-	self._transport.disconnect(); // send [FIN,ACK]
+	if(self._transport){
+		self._transport.disconnect(function(){return;}); // send [FIN,ACK]	
+	}
+	
 };
 
 ClientSecureChannelLayer.prototype.__defineGetter__("bytesRead", function () {


### PR DESCRIPTION

I had connect my Client with an Comtrol 8-EIP device (opcua Server). This Device does not send an [FIN,ACK] after closing the Securechannel. This is a different to the UaExpert.
After the CloseSecureChannelRequest the Client running in an timeout (1min) bevor they connect again. The Problem is the Client does not close the Socket and is waiting for an anwser from the Server.
This is a failure, see also the specification part 6. The Client must close the Socket:
![spec_closing_connection](https://user-images.githubusercontent.com/11854198/41339502-40cfbcbc-6ef5-11e8-92f8-ab495566af82.PNG)

After changing the source, the Client send the [FIN,ACK] after closing the Securechannel and send the new 'Hello Message' direct (client 192.168.0.113 / server 192.168.0.31).
![closesecurechannel_correct](https://user-images.githubusercontent.com/11854198/41341544-423c0182-6efa-11e8-86f9-c7a90e6db81e.PNG)

