### PR TITLE
better displayName

### DIFF
--- a/packages/node-opcua-address-space/src/base_node.js
+++ b/packages/node-opcua-address-space/src/base_node.js
@@ -115,7 +115,7 @@ function BaseNode(options) {
     this.browseName = _get_QualifiedBrowseName(options.browseName);
 
     // re-use browseName as displayName if displayName is missing
-    options.displayName = options.displayName || options.browseName.name.toString();
+    options.displayName = options.displayName || this.browseName.name;
 
     this._setDisplayName(options.displayName);
 


### PR DESCRIPTION
if displayName is not specified now use browseName AFTER it is decoded by _get_QualifiedBrowseName (eventually removes namespaceindex prefix). i.e: browseName = "1:MyName" now displayName is "MyName", before was "1:MyName"