### PR TITLE
changed check for minBufSize to 8192 for secured connections

### DIFF
--- a/packages/node-opcua-secure-channel/src/message_chunker.js
+++ b/packages/node-opcua-secure-channel/src/message_chunker.js
@@ -64,7 +64,7 @@ MessageChunker.prototype.update = function(options) {
  * @param msgType {String}
  * @param options
  * @param options.tokenId
- * @param options.chunkSize    [default=8196]
+ * @param options.chunkSize    [default=8192]
  *
  * @param options.signatureLength  {Integer} [default=0]
  * @param options.signingFunc {Function} [default=null]

--- a/packages/node-opcua-secure-channel/src/secure_message_chunk_manager.js
+++ b/packages/node-opcua-secure-channel/src/secure_message_chunk_manager.js
@@ -29,7 +29,7 @@ exports.chooseSecurityHeader = chooseSecurityHeader;
  *
  * @param msgType
  * @param options
- * @param options.chunkSize {Integer} [=8196]
+ * @param options.chunkSize {Integer} [=8192]
  * @param options.secureChannelId
  * @param options.requestId
  * @param options.signatureLength  {Integer}  [undefined]
@@ -49,7 +49,7 @@ const SecureMessageChunkManager = function(msgType, options, securityHeader, seq
     assert(_.isObject(securityHeader));
 
     // the maximum size of a message chunk:
-    // Note: OPCUA requires that chunkSize is at least 8196
+    // Note: OPCUA requires that chunkSize is at least 8192
     self.chunkSize = options.chunkSize || 1024 * 128;
 
     self.msgType = msgType;

--- a/packages/node-opcua-secure-channel/src/server/server_secure_channel_layer.js
+++ b/packages/node-opcua-secure-channel/src/server/server_secure_channel_layer.js
@@ -1178,6 +1178,18 @@ function _on_initial_OpenSecureChannelRequest(message, callback) {
     self.securityMode = request.securityMode;
     self.messageBuilder.securityMode = self.securityMode;
 
+    const minSecuredBufferSize = 8192; // see Part 6, chapter "OPC UA Secure Conversation"
+    if(self.securityMode !== MessageSecurityMode.NONE) {
+        if(self.transport.receiveBufferSize < minSecuredBufferSize) {
+            description = "receiveBufferSize=" + self.transport.receiveBufferSize + " is too small for secured channel, minimum is " + minSecuredBufferSize;
+            return _send_error.call(this, StatusCodes.BadCommunicationError, description, message, callback);
+        }
+        if(self.transport.sendBufferSize < minSecuredBufferSize) {
+            description = "sendBufferSize=" + self.transport.sendBufferSize + " is too small for secured channel, minimum is " + minSecuredBufferSize;
+            return _send_error.call(this, StatusCodes.BadCommunicationError, description, message, callback);
+        }
+    }
+
     const has_endpoint = self.has_endpoint_for_security_mode_and_policy(self.securityMode, securityPolicy);
 
     if (!has_endpoint) {

--- a/packages/node-opcua-transport/src/client_tcp_transport.js
+++ b/packages/node-opcua-transport/src/client_tcp_transport.js
@@ -273,7 +273,7 @@ ClientTCP_transport.prototype._send_HELLO_request = function () {
     const request = new HelloMessage({
         protocolVersion: self.protocolVersion,
         receiveBufferSize:    1024 * 64 * 10,
-        sendBufferSize:       1024 * 64 * 10,// 8196 min,
+        sendBufferSize:       1024 * 64 * 10,// 8192 min for secured communication,
         maxMessageSize:       0, // 0 - no limits
         maxChunkCount:        0, // 0 - no limits
         endpointUrl: self.endpointUrl

--- a/packages/node-opcua-transport/src/server_tcp_transport.js
+++ b/packages/node-opcua-transport/src/server_tcp_transport.js
@@ -93,8 +93,9 @@ ServerTCP_transport.prototype._send_ACK_response = function (helloMessage) {
 
     const self = this;
 
-    self.receiveBufferSize = clamp_value(helloMessage.receiveBufferSize, 8196, 512 * 1024);
-    self.sendBufferSize    = clamp_value(helloMessage.sendBufferSize,    8196, 512 * 1024);
+    // the validation of the minimum buffersize for secured connections is done in _on_initial_OpenSecureChannelRequest()
+    self.receiveBufferSize = clamp_value(helloMessage.receiveBufferSize, 64, 512 * 1024);
+    self.sendBufferSize    = clamp_value(helloMessage.sendBufferSize,    64, 512 * 1024);
     self.maxMessageSize    = clamp_value(helloMessage.maxMessageSize,  100000, 16 * 1024 * 1024);
     self.maxChunkCount     = clamp_value(helloMessage.maxChunkCount,        0, 65535);
 


### PR DESCRIPTION
and to 64 bytes for non-secured connections. Fixes issue #504.

I'm totally sure, that the minsize of 8196 is incorrect and has to be 8192 (see my comments in the issue #504).
I'm not sure if the error handling I added is correct.
