### PR TITLE
change Service parameter to browse Objects forward (siemens S7-1500)

### DIFF
--- a/packages/node-opcua-client/src/client_session.js
+++ b/packages/node-opcua-client/src/client_session.js
@@ -72,19 +72,14 @@ ClientSession.prototype.getPublishEngine = function () {
 
 function coerceBrowseDescription(data) {
     if (typeof data === "string" || data instanceof NodeId) {
-      var tmp = coerceBrowseDescription({
+        return coerceBrowseDescription({
             nodeId: data,
-                //includeSubtypes: false,
             includeSubtypes: true,
-                //browseDirection: BrowseDirection.Both,
-                browseDirection: BrowseDirection.Forward,
+            browseDirection: BrowseDirection.Forward,
             nodeClassMask: 0,
-                //resultMask: 255
-            resultMask: 63
+            resultMask: 63,
+            referenceTypeId: "HierarchicalReferences"
         });
-
-            tmp.referenceTypeId.value = 33;
-            return tmp;
     } else {
         data.nodeId = resolveNodeId(data.nodeId);
         data.referenceTypeId = data.referenceTypeId ? resolveNodeId(data.referenceTypeId) : null;

--- a/packages/node-opcua-client/src/client_session.js
+++ b/packages/node-opcua-client/src/client_session.js
@@ -72,13 +72,19 @@ ClientSession.prototype.getPublishEngine = function () {
 
 function coerceBrowseDescription(data) {
     if (typeof data === "string" || data instanceof NodeId) {
-        return coerceBrowseDescription({
+      var tmp = coerceBrowseDescription({
             nodeId: data,
+                //includeSubtypes: false,
             includeSubtypes: true,
-            browseDirection: BrowseDirection.Both,
+                //browseDirection: BrowseDirection.Both,
+                browseDirection: BrowseDirection.Forward,
             nodeClassMask: 0,
+                //resultMask: 255
             resultMask: 63
         });
+
+            tmp.referenceTypeId.value = 33;
+            return tmp;
     } else {
         data.nodeId = resolveNodeId(data.nodeId);
         data.referenceTypeId = data.referenceTypeId ? resolveNodeId(data.referenceTypeId) : null;

--- a/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_browse_read.js
+++ b/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_browse_read.js
@@ -68,18 +68,28 @@ module.exports = function (test) {
             });
 
         });
-
+        
         it("T8-1 - should browse RootFolder", function (done) {
 
             g_session.browse("RootFolder", function (err, browseResult) {
                 if (!err) {
                     browseResult._schema.name.should.equal("BrowseResult");
                 }
+
+                // xx console.log(browseResult.toString());//.length.should.eql(4);
+
+                browseResult.statusCode.should.eql(StatusCodes.Good);
+                browseResult.references.length.should.eql(3);
+                browseResult.references[0].browseName.toString().should.eql("Objects");
+                browseResult.references[1].browseName.toString().should.eql("Types");
+                browseResult.references[2].browseName.toString().should.eql("Views");
+
+
                 done(err);
             });
 
         });
-
+        
         it("T8-2 - browse should return BadReferenceTypeIdInvalid if referenceTypeId is invalid", function (done) {
 
             const bad_referenceid_node = "ns=3;i=3500";


### PR DESCRIPTION
<!--
IF YOU DON'T FILL OUT THE FOLLOWING INFORMATION WE MIGHT CLOSE YOUR ISSUE WITHOUT INVESTIGATING
-->

**I'm submitting a ...**  (check one with "x")


 - ( ) bug report => search github for a similar issue or PR before submitting
 - ( ) feature request
 - ( ) support request => Please do not submit support request here, instead see use 
      - use [gitter](https://gitter.im/node-opcua/node-opcua) or [stackoverflow](https://stackoverflow.com/questions/tagged/node-opcua) for community support, or 
      - [contact Sterfive for commercial support](https://www.sterfive.com)
 - (x) new feature

**Current behavior**
<!-- Describe how the bug manifests. -->
The node-opcua does not return the contain references in the item 'DataBlocksGlobal'

**Expected behavior**
<!-- Describe what the behavior would be without the bug. -->
The node-opcua could browse forward references and the S7-1500 Object 'DataBlocksGlobal'.

**Minimal reproduction of the problem with instructions**
<!--
If the current behavior is a bug or you can illustrate your feature request better with an example, 
please provide the *STEPS TO REPRODUCE* and if possible a *MINIMAL DEMO* of the problem.
-->
  1. create a client instance
  2. create a none secure session
  3. call self.client.session.browse('ns=3;s=DataBlocksGlobal', function (err, itemResults, diagnostics) {});
  ...
  
**What is the motivation / use case for changing the behavior?**
<!-- Describe the motivation or the concrete use case -->
You can use the Siemens OPC UA Server S7-1500.

**Please tell us about your environment:**
<!-- Operating system, opcua server or client type, package manager,  equipment , vendor info -->


  * ( ) I have installed node-opcua from source ( using git clone)
  * (x ) I have installed node-opcua as a package ( using npm install )
  * ( ) I am using an application that uses node-opcua 
  
       - (x ) node-red
       - ( ) other : please specify 
        
  * Device: NIOT-E-TIJCX-GB-RE
  * OS version: yocto linux
    
    - ( ) Windows : version : _________
    - (x ) Linux   : version : yocto linux
    - ( ) MacOs   : version : _________
    - ( ) Raspbian: version : _________
    - ( ) Other   : specify :
   
   * Description of the other OPCUA system I am trying to connect to:
   
     - Name: Siemens S7-1500
     - Version: CPU 1511-1 
     - Manufacturer/Software vendor: PN/6ES7 511-1AK01-0AB0/V2.0
     - link : https://-
     
    
* **node-opcua version:** ``
node-opcua@0.4.5

* **Node:** 
   `node --version` = 8.11.3


