### PR TITLE
Update node-opcua.d.ts  OPCUAClientBase event on

### DIFF
--- a/packages/node-opcua/node-opcua.d.ts
+++ b/packages/node-opcua/node-opcua.d.ts
@@ -271,7 +271,7 @@ export declare class OPCUAClientBase {
      * @returns {OPCUAClientBase}
      * @chainable
      */
-    on(event: string, eventHandler: () => void): OPCUAClientBase;
+    on(event: string, eventHandler: (...args:any) => void): OPCUAClientBase;
 }
 
 export interface BrowseResponse {


### PR DESCRIPTION
The OPCUAClientBase expose the "on" method to subscribe on events, but "eventHandler" function does not declare any args. This is a problem (in Typescript)  when the client would like to subscribe on "backoff" event like:
this.client.on("backoff", (number, delay) => {
})

This is not possible because the eventHadler is declared such this:
eventHandler: () => void