### PR TITLE
readVariableValue() should return both timestamps

### DIFF
--- a/packages/node-opcua-client/src/client_session.js
+++ b/packages/node-opcua-client/src/client_session.js
@@ -317,7 +317,7 @@ ClientSession.prototype.readVariableValue = function (nodes, callback) {
 
     const request = new read_service.ReadRequest({
         nodesToRead: nodesToRead,
-        timestampsToReturn: read_service.TimestampsToReturn.Neither
+        timestampsToReturn: read_service.TimestampsToReturn.Both
     });
 
     assert(nodes.length === request.nodesToRead.length);


### PR DESCRIPTION
I think it could be a good option to return the `serverTimestamp` and the `sourceTimestamp` when the client reads the value of a variable. 
Is interesting to be able to know when the signal was recorded and when it was stored in the server especially if you are working with time/value pairs in tiny granularities.