### PR TITLE
alternative fqdn implementation without fqdn+shelljs deps

### DIFF
--- a/packages/node-opcua-hostname/package.json
+++ b/packages/node-opcua-hostname/package.json
@@ -7,7 +7,6 @@
   "test": "mocha test"
  },
  "dependencies": {
-  "fqdn": "0.0.3",
   "node-opcua-assert": "^0.5.0"
  },
  "author": "Etienne Rossignon",

--- a/packages/node-opcua-hostname/src/hostname.js
+++ b/packages/node-opcua-hostname/src/hostname.js
@@ -1,5 +1,5 @@
 "use strict";
-const os = require("os");
+const childProcess = require("child_process");
 
 const trim = function (str, length) {
     if (!length) {
@@ -24,18 +24,8 @@ function get_fully_qualified_domain_name(optional_max_length) {
 
     } else {
 
-        fqdn = null;
-        try {
-            fqdn = require("fqdn");
-            _fully_qualified_domain_name_cache = fqdn();
-            if (/sethostname/.test(_fully_qualified_domain_name_cache)) {
-                throw new Error("Detecting fqdn  on windows !!!");
-            }
-
-        } catch (err) {
-            // fall back to old method
-            _fully_qualified_domain_name_cache = os.hostname();
-        }
+        const hostname = childProcess.execSync("hostname", ["-f"]);
+        _fully_qualified_domain_name_cache = hostname.toString().trim();
 
     }
     return trim(_fully_qualified_domain_name_cache, optional_max_length);


### PR DESCRIPTION
see https://github.com/node-opcua/node-opcua/issues/607

this is an implementation without relying on fqdn and the old version of shelljs.

Tested to work on linux, mac, including debian packaged for linux.

It essentially does the same as fqdn, but just using the standard node library.