### PR TITLE
resourcePath should start with / if defined

### DIFF
--- a/documentation/creating_a_server.md
+++ b/documentation/creating_a_server.md
@@ -64,7 +64,7 @@ For a simple server, you just need to specify a TCP port.
 // Let's create an instance of OPCUAServer
 const server = new opcua.OPCUAServer({
     port: 4334, // the port of the listening socket of the server
-    resourcePath: "UA/MyLittleServer", // this path will be added to the endpoint resource name
+    resourcePath: "/UA/MyLittleServer", // this path will be added to the endpoint resource name
     _"setting server info"
 });
 ```
@@ -118,11 +118,11 @@ function construct_my_address_space(server) {
 
     const addressSpace = server.engine.addressSpace;
     const namespace = addressSpace.getOwnNamespace();
-    
+
     // declare a new object
     _"add a new object into the objects folder"
-    
-    // add some variables 
+
+    // add some variables
     _"add some variables"
 }
 construct_my_address_space(server);
@@ -173,15 +173,15 @@ Let's create a more comprehensive Read-Write variable with a fancy nodeId
 let variable2 = 10.0;
 
 namespace.addVariable({
-    
+
     componentOf: device,
-    
+
     nodeId: "ns=1;b=1020FFAA", // some opaque NodeId in namespace 4
-    
+
     browseName: "MyVariable2",
-    
+
     dataType: "Double",    
-    
+
     value: {
         get: function () {
             return new opcua.Variant({dataType: opcua.DataType.Double, value: variable2 });
@@ -217,9 +217,9 @@ Now let's expose our OPCUA Variable
 
 ```javascript
 namespace.addVariable({
-    
+
     componentOf: device,
-    
+
     nodeId: "s=free_memory", // a string nodeID
     browseName: "FreeMemory",
     dataType: "Double",    
@@ -257,4 +257,3 @@ console.log(" the primary server endpoint url is ", endpointUrl );
 ``` sh
 $ node sample_server.js
 ```
-

--- a/documentation/creating_a_server_with_a_historizing_variable.md
+++ b/documentation/creating_a_server_with_a_historizing_variable.md
@@ -15,7 +15,7 @@ const path = require("path");
 // Let's create an instance of OPCUAServer
 const server = new opcua.OPCUAServer({
     port: 26543, // the port of the listening socket of the server
-    resourcePath: "UA/MyLittleServer", // this path will be added to the endpoint resource name
+    resourcePath: "/UA/MyLittleServer", // this path will be added to the endpoint resource name
     nodeset_filename: [
         opcua.standard_nodeset_file,
     ]

--- a/documentation/sample_server.js
+++ b/documentation/sample_server.js
@@ -4,7 +4,7 @@ const opcua = require("node-opcua");
 // Let's create an instance of OPCUAServer
 const server = new opcua.OPCUAServer({
     port: 4334, // the port of the listening socket of the server
-    resourcePath: "UA/MyLittleServer", // this path will be added to the endpoint resource name
+    resourcePath: "/UA/MyLittleServer", // this path will be added to the endpoint resource name
      buildInfo : {
         productName: "MySampleServer1",
         buildNumber: "7658",
@@ -15,23 +15,23 @@ const server = new opcua.OPCUAServer({
 function post_initialize() {
     console.log("initialized");
     function construct_my_address_space(server) {
-    
+
         const addressSpace = server.engine.addressSpace;
         const namespace = addressSpace.getOwnNamespace();
-        
+
         // declare a new object
         const device = namespace.addObject({
             organizedBy: addressSpace.rootFolder.objects,
             browseName: "MyDevice"
         });
-        
-        // add some variables 
+
+        // add some variables
         // add a variable named MyVariable1 to the newly created folder "MyDevice"
         let variable1 = 1;
-        
+
         // emulate variable1 changing every 500 ms
         setInterval(function(){  variable1+=1; }, 500);
-        
+
         namespace.addVariable({
             componentOf: device,
             browseName: "MyVariable1",
@@ -42,20 +42,20 @@ function post_initialize() {
                 }
             }
         });
-        
+
         // add a variable named MyVariable2 to the newly created folder "MyDevice"
         let variable2 = 10.0;
-        
+
         namespace.addVariable({
-            
+
             componentOf: device,
-            
+
             nodeId: "ns=1;b=1020FFAA", // some opaque NodeId in namespace 4
-            
+
             browseName: "MyVariable2",
-            
-            dataType: "Double",    
-            
+
+            dataType: "Double",
+
             value: {
                 get: function () {
                     return new opcua.Variant({dataType: opcua.DataType.Double, value: variable2 });
@@ -77,12 +77,12 @@ function post_initialize() {
             return percentageMemUsed;
         }
         namespace.addVariable({
-            
+
             componentOf: device,
-            
+
             nodeId: "s=free_memory", // a string nodeID
             browseName: "FreeMemory",
-            dataType: "Double",    
+            dataType: "Double",
             value: {
                 get: function () {return new opcua.Variant({dataType: opcua.DataType.Double, value: available_memory() });}
             }

--- a/documentation/sample_server_with_historizing_variable.js
+++ b/documentation/sample_server_with_historizing_variable.js
@@ -4,7 +4,7 @@ const path = require("path");
 // Let's create an instance of OPCUAServer
 const server = new opcua.OPCUAServer({
     port: 26543, // the port of the listening socket of the server
-    resourcePath: "UA/MyLittleServer", // this path will be added to the endpoint resource name
+    resourcePath: "/UA/MyLittleServer", // this path will be added to the endpoint resource name
     nodeset_filename: [
         opcua.nodesets.standard_nodeset_file,
     ]
@@ -16,7 +16,7 @@ function construct_address_space(server) {
       browseName: "Vessel",
       organizedBy: addressSpace.rootFolder.objects
   });
-  
+
   const vesselPressure = namespace.addAnalogDataItem({
       browseName: "Pressure",
       engineeringUnitsRange: {

--- a/packages/node-opcua-samples/bin/demo_server_with_alarm.js
+++ b/packages/node-opcua-samples/bin/demo_server_with_alarm.js
@@ -16,7 +16,7 @@ const server = new opcua.OPCUAServer({
     privateKeyFile: server_certificate_privatekey_file,
 
     port: 4334, // the port of the listening socket of the server
-    resourcePath: "UA/MyLittleServer", // this path will be added to the endpoint resource name
+    resourcePath: "/UA/MyLittleServer", // this path will be added to the endpoint resource name
     buildInfo : {
         productName: "DemoAlarmServer",
         buildNumber: "1",


### PR DESCRIPTION
I replace all occurance of `resourcePath: "UA/MyLittleServer"` into `resourcePath: "/UA/MyLittleServer"`.

I am new to opcua, when I follow the document to create a server instance, I would get 

```
$ node ./demo_server_with_alarm.js
/Users/agu/workshop/opcua-server-demo/node_modules/node-opcua-assert/dist/index.js:19
        throw err;
        ^

Error: Certificate file must exist :/Users/agu/workshop/certificates/server_selfsigned_cert_2048.pem
    at Object.assert (/Users/agu/workshop/opcua-server-demo/node_modules/node-opcua-assert/dist/index.js:10:21)
    at OPCUAServer.getCertificateChain (/Users/agu/workshop/opcua-server-demo/node_modules/node-opcua-common/dist/opcua_secure_object.js:45:33)
    at createEndpoint (/Users/agu/workshop/opcua-server-demo/node_modules/node-opcua-server/dist/opcua_server.js:463:44)
    at createEndpointDescriptions (/Users/agu/workshop/opcua-server-demo/node_modules/node-opcua-server/dist/opcua_server.js:483:34)
    at OPCUAServer._delayInit (/Users/agu/workshop/opcua-server-demo/node_modules/node-opcua-server/dist/opcua_server.js:499:34)
    at util_1.callbackify (/Users/agu/workshop/opcua-server-demo/node_modules/node-opcua-server/dist/opcua_server.js:610:22)
    at cb (util.js:353:39)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

If I prepend it with `/`, the sample code works. So I assume we need an correction for the doc and the sample code. 

Regards.