### PR TITLE
Expose endpoint hostname option in server options

### DIFF
--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -11,7 +11,7 @@ import { EventEmitter } from "events";
 import * as _ from "underscore";
 import { callbackify } from "util";
 
-import { extractFullyQualifiedDomainName } from "node-opcua-hostname";
+import { extractFullyQualifiedDomainName, getFullyQualifiedDomainName } from "node-opcua-hostname";
 
 import { assert } from "node-opcua-assert";
 import * as utils from "node-opcua-utils";
@@ -644,6 +644,12 @@ export enum RegisterServerMethod {
 export interface OPCUAServerEndpointOptions {
 
   /**
+   * the primary hostname of the endpoint.
+   * @default getFullyQualifiedDomainName()
+   */
+  hostname?: string;
+
+  /**
    * the TCP port to listen to.
    * @default 26543
    */
@@ -1075,10 +1081,11 @@ export class OPCUAServer extends OPCUABaseServer {
       this.objectFactory = new Factory(this.engine);
 
       const endpointDefinitions = options.alternateEndpoints || [];
+      var hostname = getFullyQualifiedDomainName();
 
       endpointDefinitions.push({
         port: options.port || 26543,
-
+        hostname: options.hostname || hostname,
         allowAnonymous: options.allowAnonymous,
         alternateHostname: options.alternateHostname,
         disableDiscovery: options.disableDiscovery,
@@ -3313,7 +3320,8 @@ export class OPCUAServer extends OPCUABaseServer {
     if (!endpointOptions) {
       throw new Error("internal error");
     }
-
+    var hostname = getFullyQualifiedDomainName();
+    endpointOptions.hostname = endpointOptions.hostname || hostname;
     endpointOptions.port = endpointOptions.port || 26543;
 
     /* istanbul ignore next */
@@ -3334,6 +3342,7 @@ export class OPCUAServer extends OPCUABaseServer {
       securityModes: endpointOptions.securityModes,
       securityPolicies: endpointOptions.securityPolicies,
 
+      hostname: endpointOptions.hostname,
       alternateHostname,
 
       disableDiscovery: !!endpointOptions.disableDiscovery,

--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -1081,7 +1081,7 @@ export class OPCUAServer extends OPCUABaseServer {
       this.objectFactory = new Factory(this.engine);
 
       const endpointDefinitions = options.alternateEndpoints || [];
-      var hostname = getFullyQualifiedDomainName();
+      const hostname = getFullyQualifiedDomainName();
 
       endpointDefinitions.push({
         port: options.port || 26543,

--- a/packages/node-opcua-server/test/test_server_with_multiple_hostname.ts
+++ b/packages/node-opcua-server/test/test_server_with_multiple_hostname.ts
@@ -1,5 +1,8 @@
 import { nodesets } from "node-opcua-nodesets";
+import { getFullyQualifiedDomainName } from "node-opcua-hostname";
 import { OPCUAServer } from "..";
+
+//const os = require("os");
 
 // tslint:disable:no-var-requires
 const describe = require("node-opcua-leak-detector").describeWithLeakDetector;
@@ -36,6 +39,78 @@ describe("OPCUAServerEndpoint#addEndpointDescription multiple hostname", () => {
 
         matching1234Count.should.eql(7, "we should have 7 endpoints matches the IP address");
         matchingMyName.should.eql(7, "we should have 7 endpoints matches the Hostname");
+
+        await server.shutdown();
+
+        server.dispose();
+    });
+});
+describe("OPCUAServerEndpoint#addEndpointDescription default hostname", () => {
+
+    it("should default to using the machine hostname as the hostname", async () => {
+        
+        // Given a server with no explicit hostname
+        const server = new OPCUAServer({
+            port: 2011,
+
+            nodeset_filename: [ nodesets.standard ],
+
+        });
+
+        await server.start();
+
+	    let defaultHostname = getFullyQualifiedDomainName();
+		let defaultHostnameRegex = RegExp(defaultHostname);
+
+        // When we count the exposed endpoint
+        let matchingDefault = 0;
+
+        for (const e of server.endpoints) {
+            for (const ed of e.endpointDescriptions()) {
+                // console.log("", ed.endpointUrl);
+                if (ed.endpointUrl!.match(defaultHostnameRegex)) {
+                    matchingDefault++;
+                }
+            }
+        }
+
+        matchingDefault.should.eql(7, "we should have 7 endpoints matching the machine hostname");
+
+        await server.shutdown();
+
+        server.dispose();
+    });
+});
+describe("OPCUAServerEndpoint#addEndpointDescription custom hostname", () => {
+
+    it("should be possible to create endpoints on multiple host names", async () => {
+		
+		let myHostname = 'my.test.website';
+        
+        // Given a server with two host names
+        let server = new OPCUAServer({
+			hostname: myHostname,
+            port: 2011,
+
+            nodeset_filename: [ nodesets.standard ],
+
+        });
+
+        await server.start();
+
+        // When we count the exposed endpoint
+        let matchingHostname = 0;
+
+        for (const e of server.endpoints) {
+            for (const ed of e.endpointDescriptions()) {
+                // console.log("", ed.endpointUrl);
+                if (ed.endpointUrl!.match(/my.test.website/)) {
+                    matchingHostname++;
+                }
+            }
+        }
+
+        matchingHostname.should.eql(7, "we should have 7 endpoints matches the custom hostname");
 
         await server.shutdown();
 


### PR DESCRIPTION
Related to issue #647, this is a fairly lightweight change to expose the hostname option when creating the default endpoints.