### PR TITLE
refactor

### DIFF
--- a/packages/node-opcua-address-space/package.json
+++ b/packages/node-opcua-address-space/package.json
@@ -49,8 +49,6 @@
         "thenify": "^3.3.1",
         "lodash": "4.17.20",
         "@types/lodash": "4.14.161",
-        "underscore": "^1.11.0",
-        "@types/underscore": "^1.10.23",
         "xml-writer": "^1.7.0"
     },
     "devDependencies": {

--- a/packages/node-opcua-address-space/source/address_space_ts.ts
+++ b/packages/node-opcua-address-space/source/address_space_ts.ts
@@ -2347,7 +2347,7 @@ export interface IEventData {
 export interface AddressSpace {
     rootFolder: RootFolder;
 
-    historizingNodes?: any;
+    historizingNodes?: { [key: string]: UAVariable };
 
     /**
      * when this flag is set, properties and components are not added as javascript

--- a/packages/node-opcua-address-space/source/helpers/argument_list.ts
+++ b/packages/node-opcua-address-space/source/helpers/argument_list.ts
@@ -2,7 +2,6 @@
  * @module node-opcua-address-space
  */
 import * as chalk from "chalk";
-import * as _ from "underscore";
 
 import { assert } from "node-opcua-assert";
 import * as ec from "node-opcua-basic-types";
@@ -312,19 +311,4 @@ export function build_retrieveInputArgumentsDefinition(addressSpace: AddressSpac
         assert(Array.isArray(methodInputArguments));
         return methodInputArguments;
     };
-}
-
-export function convertJavaScriptToVariant(argumentDefinition: ArgumentOptions[], values: any[]): Variant[] {
-    assert(argumentDefinition.length === values.length);
-    assert(Array.isArray(argumentDefinition));
-    assert(Array.isArray(values));
-
-    return _.zip(values, argumentDefinition).map((pair: any) => {
-        pair = pair as [VariantLike, Argument];
-        const value = pair[0];
-        const arg = pair[1];
-        const variant = _.extend({}, arg);
-        variant.value = value;
-        return new Variant(variant);
-    });
 }

--- a/packages/node-opcua-address-space/source/helpers/call_helpers.ts
+++ b/packages/node-opcua-address-space/source/helpers/call_helpers.ts
@@ -75,8 +75,11 @@ export function callMethodHelper(
 
     let l_extraDataTypeManager: ExtraDataTypeManager;
 
-    ensureDatatypeExtractedWithCallback(addressSpace, (err2: Error | null, extraDataTypeManager: ExtraDataTypeManager) => {
-        l_extraDataTypeManager = extraDataTypeManager;
+    ensureDatatypeExtractedWithCallback(addressSpace, (err2: Error | null, extraDataTypeManager?: ExtraDataTypeManager) => {
+        if (err2) {
+            return callback(err2);
+        }
+        l_extraDataTypeManager = extraDataTypeManager!;
 
         // resolve opaque data structure from inputArguments
         for (const variant of inputArguments) {

--- a/packages/node-opcua-address-space/source/helpers/coerce_enum_value.ts
+++ b/packages/node-opcua-address-space/source/helpers/coerce_enum_value.ts
@@ -2,8 +2,6 @@
  * @module node-opcua-address-space
  */
 import { assert } from "node-opcua-assert";
-import * as _ from "underscore";
-
 import { Int64 } from "node-opcua-basic-types";
 import { coerceLocalizedText } from "node-opcua-data-model";
 import { EnumValueType } from "node-opcua-types";
@@ -11,7 +9,7 @@ import { EnumValueType } from "node-opcua-types";
 export function coerceEnumValues(enumValues: any): EnumValueType[] {
     if (Array.isArray(enumValues)) {
         //
-        return _.map(enumValues, (en: any) => {
+        return enumValues.map((en: any) => {
             assert(en.hasOwnProperty("value"));
             assert(en.hasOwnProperty("displayName"));
             return new EnumValueType({
@@ -21,7 +19,8 @@ export function coerceEnumValues(enumValues: any): EnumValueType[] {
         });
     } else {
         return coerceEnumValues(
-            _.map(enumValues, (value: Int64, key) => {
+            Object.entries(enumValues as { [key: string]: Int64 }).map((entrie: [string, Int64]) => {
+                const [key, value] = entrie;
                 return new EnumValueType({
                     description: coerceLocalizedText(key),
                     displayName: coerceLocalizedText(key),

--- a/packages/node-opcua-address-space/source_nodejs/generate_address_space.ts
+++ b/packages/node-opcua-address-space/source_nodejs/generate_address_space.ts
@@ -34,7 +34,7 @@ export function generateAddressSpace(addressSpace: AddressSpacePublic, xmlFiles:
             });
         },
         (err?: Error | null) => {
-            stuff.terminate(callback!);
+            stuff.terminate(callback!); 
         }
     );
 }

--- a/packages/node-opcua-address-space/src/address_space.ts
+++ b/packages/node-opcua-address-space/src/address_space.ts
@@ -3,7 +3,6 @@
  */
 
 import * as chalk from "chalk";
-import * as _ from "underscore";
 
 import { assert } from "node-opcua-assert";
 import { ExtraDataTypeManager } from "node-opcua-client-dynamic-extension-object";
@@ -25,8 +24,6 @@ import {
 import * as utils from "node-opcua-utils";
 import { lowerFirstLetter } from "node-opcua-utils";
 import { DataType, Variant, VariantT } from "node-opcua-variant";
-import { AnyConstructorFunc } from "node-opcua-schemas";
-import { ConstructorFuncWithSchema } from "node-opcua-factory";
 import {
     AddReferenceOpts,
     AddressSpace as AddressSpacePublic,
@@ -141,7 +138,7 @@ export class AddressSpace implements AddressSpacePrivate {
      */
     public suspendBackReference: boolean = false;
     public isFrugal: boolean = false;
-    public historizingNodes?: any = {};
+    public historizingNodes?: { [key: string]: UAVariable } = {};
     public _condition_refresh_in_progress: boolean = false;
 
     public readonly isNodeIdString = isNodeIdString;
@@ -1207,7 +1204,9 @@ export class AddressSpace implements AddressSpacePrivate {
                 // xx console.log( "xx dealing with ",this._modelChanges.length);
                 // increase version number of participating nodes
 
-                const nodeIds = _.uniq(this._modelChanges.map((c: any) => c.affected));
+                // https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore
+                // const nodeIds = _.uniq(this._modelChanges.map((c: any) => c.affected));
+                const nodeIds = [...new Set(this._modelChanges.map((c: any) => c.affected))];
 
                 const nodes = nodeIds.map((nodeId: NodeId) => addressSpace.findNode(nodeId)!);
 
@@ -1481,7 +1480,7 @@ export class AddressSpace implements AddressSpacePrivate {
 
         if (!el) {
             // verify that node Id exists in standard type map typeMap
-            const find = _.filter(typeMap, (a) => a === nodeId!.value);
+            const find = Object.values(typeMap).filter((a) => a === nodeId!.value);
             /* istanbul ignore next */
             if (find.length !== 1) {
                 throw new Error(" cannot find " + dataType.toString() + " in typeMap " + typeMapName + " L = " + find.length);

--- a/packages/node-opcua-address-space/src/alarms_and_conditions/ua_condition_base.ts
+++ b/packages/node-opcua-address-space/src/alarms_and_conditions/ua_condition_base.ts
@@ -2,7 +2,6 @@
  * @module node-opcua-address-space.AlarmsAndConditions
  */
 import * as chalk from "chalk";
-import * as _ from "underscore";
 
 import { assert } from "node-opcua-assert";
 import { ByteString, DateTime } from "node-opcua-basic-types";
@@ -211,7 +210,7 @@ export class UAConditionBase extends BaseEventType {
     }
     private _branch0: ConditionSnapshot = null as any;
     private _previousRetainFlag: boolean = false;
-    private _branches: any = {};
+    private _branches: { [key: string]: ConditionSnapshot } = {};
 
     /**
      * @method initialize
@@ -656,9 +655,9 @@ export class UAConditionBase extends BaseEventType {
         if (sameBuffer(conditionNode.eventId!.readValue().value.value, eventId)) {
             return conditionNode.currentBranch();
         }
-        const e = _.filter(conditionNode._branches, (branch: ConditionSnapshot, key: string) => {
-            return sameBuffer(branch.getEventId(), eventId);
-        });
+        const e = Object.values(conditionNode._branches).filter((branch: ConditionSnapshot) =>
+            sameBuffer(branch.getEventId(), eventId)
+        );
         if (e.length === 1) {
             return e[0];
         }

--- a/packages/node-opcua-address-space/src/base_node_private.ts
+++ b/packages/node-opcua-address-space/src/base_node_private.ts
@@ -3,8 +3,6 @@
  */
 // tslint:disable:no-bitwise
 import * as chalk from "chalk";
-import * as _ from "underscore";
-
 import { assert } from "node-opcua-assert";
 import {
     AccessLevelFlag,
@@ -189,9 +187,9 @@ export function BaseNode_References_toString(this: BaseNode, options: ToStringOp
     }
 
     // direct reference
-    _.forEach(_private._referenceIdx, dump_reference.bind(null, true));
+    (Object.values(_private._referenceIdx) as Reference[]).forEach(dump_reference.bind(null, true));
 
-    const br = _.map(_private._back_referenceIdx, (x: Reference) => x);
+    const br = (Object.values(_private._back_referenceIdx) as Reference[]).map((x: Reference) => x);
 
     options.add(
         options.padding +
@@ -458,13 +456,14 @@ export function _clone(
     );
     assert(!(this as any).subtypeOf, "We do not do cloning of Type yet");
 
-    options = _.extend(options, {
+    options = {
+        ...options,
         addressSpace: this.addressSpace,
         browseName: this.browseName,
         description: this.description,
         displayName: this.displayName,
         nodeClass: this.nodeClass
-    });
+    };
     options.references = options.references || [];
 
     if (this.typeDefinition) {
@@ -627,7 +626,9 @@ export function BaseNode_add_backward_reference(this: BaseNode, reference: Refer
         // tslint:disable-next-line:no-console
         console.warn(" already found in ===>");
         // tslint:disable-next-line:no-console
-        console.warn(_.map(_private._back_referenceIdx, (c: Reference) => c.toString(opts)).join("\n"));
+        console.warn(
+            (Object.values(_private._back_referenceIdx) as Reference[]).map((c: Reference) => c.toString(opts)).join("\n")
+        );
         // tslint:disable-next-line:no-console
         console.warn("===>");
         throw new Error("reference exists already in _back_references");

--- a/packages/node-opcua-address-space/src/namespace.ts
+++ b/packages/node-opcua-address-space/src/namespace.ts
@@ -3,7 +3,6 @@
  */
 // tslint:disable:no-console
 import * as chalk from "chalk";
-import * as _ from "underscore";
 
 import { assert } from "node-opcua-assert";
 import { coerceInt64 } from "node-opcua-basic-types";
@@ -224,9 +223,9 @@ export class UANamespace implements NamespacePublic {
     }
 
     public dispose() {
-        _.forEach(this._nodeid_index, (node: BaseNode) => {
+        for (const node of Object.values(this._nodeid_index)) {
             node.dispose();
-        });
+        }
 
         this._nodeid_index = {};
         this.addressSpace = {} as AddressSpacePrivate;
@@ -534,17 +533,18 @@ export class UANamespace implements NamespacePublic {
 
         options.value = options.value === undefined ? 0 : options.value;
 
-        const variable = namespace.addVariable(
-            _.extend(options, {
-                dataType: "UInteger",
-                typeDefinition: multiStateDiscreteType.nodeId,
-                value: new Variant({
-                    dataType: DataType.UInt32,
-                    value: options.value
-                }),
-                valueRank: -2
-            })
-        ) as UAMultiStateDiscrete;
+        const variable = namespace.addVariable({
+            ...options,
+
+            dataType: "UInteger",
+            typeDefinition: multiStateDiscreteType.nodeId,
+            value: new Variant({
+                dataType: DataType.UInt32,
+                value: options.value
+            }),
+
+            valueRank: -2
+        }) as UAMultiStateDiscrete;
         Object.setPrototypeOf(variable, UAMultiStateDiscrete.prototype);
 
         add_dataItem_stuff(variable, options);
@@ -741,10 +741,10 @@ export class UANamespace implements NamespacePublic {
             referenceTypeIds: {} as { [key: string]: string }
         };
 
-        for (const referenceType of _.values(this._referenceTypeMap)) {
+        for (const referenceType of Object.values(this._referenceTypeMap)) {
             standardNodeIds.referenceTypeIds[referenceType!.browseName!.name!] = referenceType.nodeId.toString();
         }
-        for (const objectType of _.values(this._objectTypeMap)) {
+        for (const objectType of Object.values(this._objectTypeMap)) {
             standardNodeIds.objectTypeIds[objectType!.browseName!.name!] = objectType.nodeId.toString();
         }
         return standardNodeIds;
@@ -802,12 +802,11 @@ export class UANamespace implements NamespacePublic {
         if (!dataItemType) {
             throw new Error("Cannot find DataItemType");
         }
-        const variable = namespace.addVariable(
-            _.extend(options, {
-                dataType,
-                typeDefinition: dataItemType.nodeId
-            })
-        ) as UAVariable;
+        const variable = namespace.addVariable({
+            ...options,
+            dataType,
+            typeDefinition: dataItemType.nodeId
+        }) as UAVariable;
 
         add_dataItem_stuff(variable, options);
 
@@ -876,12 +875,7 @@ export class UANamespace implements NamespacePublic {
             throw new Error("expecting AnalogItemType to be defined , check nodeset xml file");
         }
 
-        let clone_options = _.clone(options) as AddVariableOptions;
-
-        clone_options = _.extend(clone_options, {
-            dataType,
-            typeDefinition: analogItemType.nodeId
-        });
+        const clone_options = { ...options, dataType, typeDefinition: analogItemType.nodeId } as AddVariableOptions;
 
         const variable = namespace.addVariable(clone_options) as UAVariable;
 
@@ -1043,15 +1037,15 @@ export class UANamespace implements NamespacePublic {
             options.value = enumValues[0].value; // Int64
         }
 
-        let cloned_options = _.clone(options) as AddVariableOptions;
-        cloned_options = _.extend(cloned_options, {
+        const cloned_options = {
+            ...options,
             dataType: "Number",
             typeDefinition: multiStateValueDiscreteType.nodeId,
             // valueRank:
             // note : OPCUA Spec 1.03 specifies -1:Scalar (part 8 page 8) but nodeset file specifies -2:Any
             value: new Variant({ dataType: DataType.UInt32, value: options.value }),
             valueRank: -1 // -1 : Scalar
-        });
+        };
 
         const variable = namespace.addVariable(cloned_options) as UAMultiStateValueDiscrete;
 

--- a/packages/node-opcua-address-space/src/nodeset_tools/construct_namespace_dependency.ts
+++ b/packages/node-opcua-address-space/src/nodeset_tools/construct_namespace_dependency.ts
@@ -1,11 +1,7 @@
 import { NamespacePrivate } from "../namespace_private";
 import { Namespace } from "../../source/address_space_ts";
-import * as _ from "underscore";
 
-export function constructNamespaceDependency(
-    namespace: NamespacePrivate
-): Namespace[] {
-
+export function constructNamespaceDependency(namespace: NamespacePrivate): Namespace[] {
     const addressSpace = namespace.addressSpace;
 
     // navigate all namespace recursively to
@@ -22,7 +18,7 @@ export function constructNamespaceDependency(
         depMap.add(namespace.index);
     }
 
-    for (const node of _.values(namespace._nodeid_index)) {
+    for (const node of Object.values(namespace._nodeid_index)) {
         // visit all reference
         const references = node.ownReferences();
         for (const reference of references) {

--- a/packages/node-opcua-address-space/src/nodeset_tools/nodeset_to_xml.ts
+++ b/packages/node-opcua-address-space/src/nodeset_tools/nodeset_to_xml.ts
@@ -6,8 +6,6 @@ import { AddressSpacePrivate } from "../address_space_private";
 
 // tslint:disable:no-var-requires
 const XMLWriter = require("xml-writer");
-import * as _ from "underscore";
-
 import { assert } from "node-opcua-assert";
 import {
     BrowseDirection,
@@ -496,7 +494,7 @@ function visitUANode(node: BaseNode, options: any, forward: boolean) {
         }
     }
 
-    _.forEach(node.ownReferences(), process_reference);
+    node.ownReferences().forEach(process_reference);
     options.elements.push(node);
     return node;
 }
@@ -983,7 +981,7 @@ function buildUpAliases(node: BaseNode, xw: XmlWriter, options: any) {
         }
     }
 
-    _.forEach(node.allReferences(), collectReferenceNameInAlias);
+    node.allReferences().forEach(collectReferenceNameInAlias);
 }
 
 function writeAliases(xw: XmlWriter, aliases: any) {
@@ -1111,7 +1109,7 @@ UANamespace.prototype.toNodeset2XML = function (this: UANamespace) {
     xw.endElement();
 
     const s: any = {};
-    for (const node of _.values(this._nodeid_index)) {
+    for (const node of Object.values(this._nodeid_index)) {
         buildUpAliases(node, xw, s);
     }
     writeAliases(xw, s.aliases);
@@ -1120,7 +1118,7 @@ UANamespace.prototype.toNodeset2XML = function (this: UANamespace) {
 
     // -------------- writeReferences
     xw.writeComment("ReferenceTypes");
-    const referenceTypes = _.values(this._referenceTypeMap).sort(sortByBrowseName);
+    const referenceTypes = Object.values(this._referenceTypeMap).sort(sortByBrowseName);
     for (const referenceType of referenceTypes) {
         dumpReferenceType(xw, referenceType);
     }
@@ -1148,7 +1146,7 @@ UANamespace.prototype.toNodeset2XML = function (this: UANamespace) {
         }
     }
     // -------------- DataTypes
-    const dataTypes = _.values(this._dataTypeMap).sort(sortByBrowseName);
+    const dataTypes = Object.values(this._dataTypeMap).sort(sortByBrowseName);
     if (dataTypes.length) {
         xw.writeComment("DataTypes");
         // xx xw.writeComment(" "+ objectTypes.map(x=>x.browseName.name.toString()).join(" "));
@@ -1160,7 +1158,7 @@ UANamespace.prototype.toNodeset2XML = function (this: UANamespace) {
     }
     // -------------- ObjectTypes
     xw.writeComment("ObjectTypes");
-    const objectTypes = _.values(this._objectTypeMap).sort(sortByBrowseName);
+    const objectTypes = Object.values(this._objectTypeMap).sort(sortByBrowseName);
     // xx xw.writeComment(" "+ objectTypes.map(x=>x.browseName.name.toString()).join(" "));
     for (const objectType of objectTypes) {
         if (!xw.visitedNode[_hash(objectType)]) {
@@ -1170,7 +1168,7 @@ UANamespace.prototype.toNodeset2XML = function (this: UANamespace) {
 
     // -------------- VariableTypes
     xw.writeComment("VariableTypes");
-    const variableTypes = _.values(this._variableTypeMap).sort(sortByBrowseName);
+    const variableTypes = Object.values(this._variableTypeMap).sort(sortByBrowseName);
     // xx xw.writeComment("ObjectTypes "+ variableTypes.map(x=>x.browseName.name.toString()).join(" "));
     for (const variableType of variableTypes) {
         if (!xw.visitedNode[_hash(variableType)]) {
@@ -1180,7 +1178,7 @@ UANamespace.prototype.toNodeset2XML = function (this: UANamespace) {
 
     // -------------- Any   thing else
     xw.writeComment("Other Nodes");
-    const nodes = _.values(this._nodeid_index).sort(sortByBrowseName);
+    const nodes = Object.values(this._nodeid_index).sort(sortByBrowseName);
     for (const node of nodes) {
         if (!xw.visitedNode[_hash(node)]) {
             node.dumpXML(xw);

--- a/packages/node-opcua-address-space/src/nodeset_tools/typedictionary_to_xml.ts
+++ b/packages/node-opcua-address-space/src/nodeset_tools/typedictionary_to_xml.ts
@@ -1,4 +1,3 @@
-import * as _ from "underscore";
 import { assert } from "node-opcua-assert";
 import { StructureDefinition, EnumDefinition, EnumDescription } from "node-opcua-types";
 import { constructNamespaceDependency } from "./construct_namespace_dependency";
@@ -167,7 +166,7 @@ export function dumpToBSD(namespace: UANamespace) {
     xw.writeAttribute("DefaultByteOrder", "LittleEndian");
     xw.writeAttribute("TargetNamespace", namespace.namespaceUri);
 
-    const dataTypes = _.values(namespace._dataTypeMap);
+    const dataTypes = Object.values(namespace._dataTypeMap);
     for (const dataType of dataTypes) {
         dumpDataTypeToBSD(xw, dataType, map);
     }

--- a/packages/node-opcua-address-space/src/ua_data_type.ts
+++ b/packages/node-opcua-address-space/src/ua_data_type.ts
@@ -2,7 +2,6 @@
  * @module node-opcua-address-space
  */
 import * as chalk from "chalk";
-import * as _ from "underscore";
 
 import { assert } from "node-opcua-assert";
 import { NodeClass } from "node-opcua-data-model";
@@ -225,7 +224,7 @@ export class UADataType extends BaseNode implements UADataTypePublic {
             assert(this.enumValues, "must have a enumValues property");
             const enumValues = this.enumValues.readValue().value.value;
             assert(Array.isArray(enumValues));
-            definition = _.map(enumValues, (e: any) => {
+            definition = enumValues.map((e: any) => {
                 return {
                     name: e.displayName.text,
                     value: e.value[1]

--- a/packages/node-opcua-address-space/src/ua_method.ts
+++ b/packages/node-opcua-address-space/src/ua_method.ts
@@ -4,7 +4,6 @@
 // tslint:disable:no-console
 import * as chalk from "chalk";
 import { assert } from "node-opcua-assert";
-import * as _ from "underscore";
 
 import { AttributeIds } from "node-opcua-data-model";
 import { DiagnosticInfo, NodeClass } from "node-opcua-data-model";
@@ -193,9 +192,7 @@ export class UAMethod extends BaseNode implements UAMethodPublic {
         assert(!options.componentOf || options.componentOf, "trying to create an orphan method ?");
 
         options = options || {};
-        options = _.extend(_.clone(options), {
-            methodDeclarationId: this.nodeId
-        });
+        options = { ...options, methodDeclarationId: this.nodeId };
         options.references = options.references || [];
 
         const addressSpace = this.addressSpace;

--- a/packages/node-opcua-address-space/src/ua_object.ts
+++ b/packages/node-opcua-address-space/src/ua_object.ts
@@ -2,7 +2,6 @@
  * @module node-opcua-address-space
  */
 import * as chalk from "chalk";
-import * as _ from "underscore";
 
 import { assert } from "node-opcua-assert";
 import { isValidByte } from "node-opcua-basic-types";
@@ -60,10 +59,11 @@ export class UAObject extends BaseNode implements UAObjectPublic {
 
     public clone(options: any, optionalFilter?: any, extraInfo?: any): UAObject {
         options = options || {};
-        options = _.extend(_.clone(options), {
+        options = {
+            ...options,
             eventNotifier: this.eventNotifier,
             symbolicName: this.symbolicName
-        });
+        };
 
         const cloneObject = _clone.call(this, UAObject, options, optionalFilter, extraInfo) as UAObject;
         // xx  newObject.propagate_back_references();

--- a/packages/node-opcua-address-space/src/ua_reference_type.ts
+++ b/packages/node-opcua-address-space/src/ua_reference_type.ts
@@ -12,19 +12,18 @@ import { DataValue, DataValueLike } from "node-opcua-data-value";
 import { NodeId } from "node-opcua-nodeid";
 import { StatusCodes } from "node-opcua-status-code";
 import { DataType } from "node-opcua-variant";
-import { SessionContext, UAReferenceType  as UAReferenceTypePublic} from "../source";
+import { SessionContext, UAReferenceType as UAReferenceTypePublic } from "../source";
 import { BaseNode } from "./base_node";
 import { getSubtypeIndex, ReferenceTypeCounter } from "./base_node_private";
 import * as tools from "./tool_isSupertypeOf";
 import { get_subtypeOf, get_subtypeOfObj } from "./tool_isSupertypeOf";
 
 export class UAReferenceType extends BaseNode implements UAReferenceTypePublic {
-
     public readonly nodeClass = NodeClass.ReferenceType;
-    public get subtypeOfObj(): UAReferenceTypePublic  | null {
+    public get subtypeOfObj(): UAReferenceTypePublic | null {
         return get_subtypeOfObj.call(this) as UAReferenceType;
     }
-    public get subtypeOf(): NodeId  | null {
+    public get subtypeOf(): NodeId | null {
         return get_subtypeOf.call(this);
     }
     public isAbstract: boolean;
@@ -34,11 +33,11 @@ export class UAReferenceType extends BaseNode implements UAReferenceTypePublic {
     /**
      * returns true if self is  a super type of baseType
      */
-     public isSupertypeOf: (baseType: UAReferenceType) => boolean
-      = tools.construct_isSupertypeOf<UAReferenceType>(UAReferenceType);
+    public isSupertypeOf: (baseType: UAReferenceType) => boolean = tools.construct_isSupertypeOf<UAReferenceType>(UAReferenceType);
 
-    public _slow_isSupertypeOf: (baseType: UAReferenceType) => boolean
-      = tools.construct_slow_isSupertypeOf<UAReferenceType>(UAReferenceType);
+    public _slow_isSupertypeOf: (baseType: UAReferenceType) => boolean = tools.construct_slow_isSupertypeOf<UAReferenceType>(
+        UAReferenceType
+    );
 
     constructor(options: any) {
         super(options);
@@ -48,8 +47,7 @@ export class UAReferenceType extends BaseNode implements UAReferenceTypePublic {
         ReferenceTypeCounter.count += 1;
     }
 
-    public readAttribute(context: SessionContext  | null, attributeId: AttributeIds): DataValue {
-
+    public readAttribute(context: SessionContext | null, attributeId: AttributeIds): DataValue {
         assert(!context || context instanceof SessionContext);
 
         const options: DataValueLike = {};
@@ -89,11 +87,9 @@ export class UAReferenceType extends BaseNode implements UAReferenceTypePublic {
      * returns a array of all ReferenceTypes in the addressSpace that are self or a subType of self
      */
     public getAllSubtypes(): UAReferenceType[] {
-
         const _cache = BaseNode._getCache(this);
 
         if (!_cache._allSubTypesVersion || _cache._allSubTypesVersion < ReferenceTypeCounter) {
-
             _cache._allSubTypes = null;
         }
         if (!_cache._allSubTypes) {
@@ -107,11 +103,9 @@ export class UAReferenceType extends BaseNode implements UAReferenceTypePublic {
         const referenceType: UAReferenceTypePublic = this.addressSpace.findReferenceType(referenceTypeString)!;
         return getSubtypeIndex.call(this).hasOwnProperty(referenceType.toString());
     }
-
 }
 
 function findAllSubTypes(referenceType: UAReferenceType): UAReferenceTypePublic[] {
-
     const addressSpace = referenceType.addressSpace;
     const possibleReferenceTypes: UAReferenceTypePublic[] = [];
 

--- a/packages/node-opcua-address-space/src/ua_variable.ts
+++ b/packages/node-opcua-address-space/src/ua_variable.ts
@@ -6,7 +6,6 @@
 // tslint:disable:max-line-length
 import * as chalk from "chalk";
 import { assert } from "node-opcua-assert";
-import * as _ from "underscore";
 
 import {
     isValidDataEncoding,
@@ -223,7 +222,7 @@ export function verifyRankAndDimensions(options: { valueRank?: number; arrayDime
     assert(typeof options.valueRank === "number");
 
     options.arrayDimensions = options.arrayDimensions || null;
-    assert(_.isNull(options.arrayDimensions) || Array.isArray(options.arrayDimensions));
+    assert(options.arrayDimensions === null || Array.isArray(options.arrayDimensions));
 
     if (options.arrayDimensions && options.valueRank <= 0) {
         throw new Error("[CONFORMANCE] arrayDimensions must be null if valueRank <=0");
@@ -1078,7 +1077,8 @@ export class UAVariable extends BaseNode implements UAVariablePublic {
 
     public clone(options?: any, optionalFilter?: any, extraInfo?: any): UAVariable {
         options = options || {};
-        options = _.extend(_.clone(options), {
+        options = {
+            ...options,
             // check this eventNotifier: this.eventNotifier,
             // check this symbolicName: this.symbolicName,
 
@@ -1089,7 +1089,7 @@ export class UAVariable extends BaseNode implements UAVariablePublic {
             minimumSamplingInterval: this.minimumSamplingInterval,
             userAccessLevel: this.userAccessLevel,
             valueRank: this.valueRank
-        });
+        };
 
         const newVariable = _clone.call(this, UAVariable, options, optionalFilter, extraInfo) as UAVariable;
 

--- a/packages/node-opcua-address-space/src/ua_variable_type.ts
+++ b/packages/node-opcua-address-space/src/ua_variable_type.ts
@@ -4,7 +4,6 @@
 // tslint:disable:max-classes-per-file
 // tslint:disable:no-console
 import * as chalk from "chalk";
-import * as _ from "underscore";
 
 import { assert } from "node-opcua-assert";
 import { UInt32 } from "node-opcua-basic-types";
@@ -511,12 +510,11 @@ const hasModellingRuleNodeId = makeNodeId(37);
 
 function _remove_unwanted_ref(references: UAReference[]): UAReference[] {
     // filter out HasTypeDefinition (i=40) , HasModellingRule (i=37);
-    references = _.filter(references, (reference: UAReference) => {
-        return (
+    references = references.filter(
+        (reference: UAReference) =>
             !sameNodeId(reference.referenceType, hasTypeDefinitionNodeId) &&
             !sameNodeId(reference.referenceType, hasModellingRuleNodeId)
-        );
-    });
+    );
     return references;
 }
 
@@ -572,7 +570,7 @@ function reconstructNonHierarchicalReferences(extraInfo: any): any {
     // have been cloned .
     // this could be node organized by some FunctionalGroup
     //
-    _.forEach(extraInfo.mapOrgToClone, (value: any, key: any) => {
+    Object.values(extraInfo.mapOrgToClone).forEach((value: any) => {
         const originalObject = value.original;
         const clonedObject = value.cloned;
 
@@ -649,7 +647,7 @@ function reconstructNonHierarchicalReferences(extraInfo: any): any {
  */
 function reconstructFunctionalGroupType(extraInfo: any) {
     // navigate through original objects to find those that are being organized by some FunctionalGroup
-    _.forEach(extraInfo.mapOrgToClone, (value: any, key: any) => {
+    Object.values(extraInfo.mapOrgToClone).forEach((value: any) => {
         const originalObject = value.original;
         const instantiatedObject = value.cloned;
         const organizedByArray = originalObject.findReferencesEx("Organizes", BrowseDirection.Inverse);

--- a/packages/node-opcua-address-space/test/historical_access/test_address_space_historical_data_node_enumeration.ts
+++ b/packages/node-opcua-address-space/test/historical_access/test_address_space_historical_data_node_enumeration.ts
@@ -1,7 +1,6 @@
 import * as fs from "fs";
 import * as nodesets from "node-opcua-nodesets";
 import * as should from "should";
-import * as _ from "underscore";
 
 import { AddressSpace, SessionContext } from "../..";
 import { generateAddressSpace } from "../../nodeJS";
@@ -54,8 +53,8 @@ describe("Testing Historical Data Node Enumeration", () => {
     });
 
     it("should be easy to enumerate  UAVariable with History from a addressSpace", () => {
-        Object.keys(addressSpace.historizingNodes).length.should.eql(3);
-        const historizingNode = _.map(addressSpace.historizingNodes, (x: any) => x);
-        historizingNode.map((x: any) => x.browseName.toString()).should.eql(["1:MyVar1", "1:MyVar2", "1:MyVar3"]);
+        const historizingNode = Object.values(addressSpace.historizingNodes || {});
+        historizingNode.length.should.eql(3);
+        historizingNode.map((x) => x.browseName.toString()).should.eql(["1:MyVar1", "1:MyVar2", "1:MyVar3"]);
     });
 });

--- a/packages/node-opcua-address-space/test/test_argument_list.ts
+++ b/packages/node-opcua-address-space/test/test_argument_list.ts
@@ -1,42 +1,19 @@
 import * as should from "should";
-import * as _ from "underscore";
-
-import { DataType, VariantArrayType } from "node-opcua-variant";
-import { Variant } from "node-opcua-variant";
-
+import { DataType, VariantArrayType, Variant } from "node-opcua-variant";
+import { nodesets } from "node-opcua-nodesets";
+import { Argument } from "node-opcua-types";
+import { resolveNodeId } from "node-opcua-nodeid";
+import { StatusCodes } from "node-opcua-status-code";
 import { BinaryStream } from "node-opcua-binary-stream";
+
 import {
     binaryStoreSize_ArgumentList,
-    convertJavaScriptToVariant,
     decode_ArgumentList,
     encode_ArgumentList,
     verifyArguments_ArgumentList,
     AddressSpace
 } from "..";
 import { generateAddressSpace } from "../nodeJS";
-
-import { nodesets } from "node-opcua-nodesets";
-import { Argument, ArgumentOptions } from "node-opcua-types";
-import { resolveNodeId } from "node-opcua-nodeid";
-import { StatusCodes, StatusCode } from "node-opcua-status-code";
-
-function extractValues(arrayVariant: Variant[]) {
-    return arrayVariant.map(_.property("value"));
-}
-
-describe("convertJavaScriptToVariant", () => {
-    it("should convertJavaScriptToVariant", () => {
-        const definition = [{ dataType: DataType.UInt32 }];
-        const args = [100];
-
-        const args_as_variant = convertJavaScriptToVariant(definition, args);
-
-        args_as_variant.length.should.eql(1);
-        args_as_variant[0].should.eql(new Variant({ dataType: DataType.UInt32, value: 100 }));
-
-        extractValues(args_as_variant).should.eql([100]);
-    });
-});
 
 describe("testing ArgumentList special encode/decode process", () => {
     it("should encode/decode an ArgumentList (scalar)", () => {

--- a/packages/node-opcua-address-space/test/test_browse_node.ts
+++ b/packages/node-opcua-address-space/test/test_browse_node.ts
@@ -1,5 +1,4 @@
 import * as should from "should";
-import * as _ from "underscore";
 
 import { BrowseDirection } from "node-opcua-data-model";
 import { redirectToFile } from "node-opcua-debug";
@@ -21,15 +20,11 @@ describe("testing address space", () => {
     });
 
     it("should dump references", (done: any) => {
-        const hr = addressSpace.findReferenceType("HierarchicalReferences")!;
-
+        const references = addressSpace.rootFolder.findReferencesEx("References", BrowseDirection.Forward);
         redirectToFile(
             "dumpReferences.log",
             () => {
-                dumpReferences(
-                    addressSpace,
-                    _.map((hr as any)._references, (x: any) => x)
-                );
+                dumpReferences(addressSpace, references);
             },
             done
         );

--- a/packages/node-opcua-address-space/test/test_referencetype.ts
+++ b/packages/node-opcua-address-space/test/test_referencetype.ts
@@ -1,5 +1,3 @@
-import * as _ from "underscore";
-
 import { AttributeIds, BrowseDirection, makeNodeClassMask } from "node-opcua-data-model";
 import { NodeClass } from "node-opcua-data-model";
 import { redirectToFile } from "node-opcua-debug";
@@ -103,11 +101,12 @@ describe("testing ReferenceType", () => {
         });
         references.length.should.be.greaterThan(2);
 
-        const names = references.map((ref) => {
+        const browseNames = references.map((ref) => {
             return addressSpace.findNode(ref.nodeId)!.browseName.toString();
         });
-        const expectedNames = ["FolderType", "Objects", "Types", "Views"];
-        _.intersection(names, expectedNames).length.should.eql(expectedNames.length);
+        const expectedBrowseNames = ["FolderType", "Objects", "Types", "Views"];
+        browseNames.sort().should.eql(expectedBrowseNames.sort());
+        // xx _.intersection(names, expectedNames).length.should.eql(expectedNames.length);
     });
 
     it("should return 1 refs for browseNode on RootFolder ,  NonHierarchicalReferences, includeSubtypes  ", () => {
@@ -131,11 +130,10 @@ describe("testing ReferenceType", () => {
         });
         references.length.should.be.greaterThan(2);
 
-        const names = references.map((ref) => {
-            return addressSpace.findNode(ref.nodeId)!.browseName.toString();
-        });
-        const expectedNames = ["Objects", "Types", "Views"];
-        _.intersection(names, expectedNames).length.should.eql(expectedNames.length);
+        const browseNames = references.map((ref) => addressSpace.findNode(ref.nodeId)!.browseName.toString());
+        const expectedBrowseNames = ["Objects", "Types", "Views"];
+        // _.intersection(names, expectedNames).length.should.eql(expectedNames.length);
+        browseNames.sort().should.eql(expectedBrowseNames.sort());
     });
 
     it("should return 0 refs for browseNode on RootFolder , HierarchicalReferences ,!includeSubtypes  ", () => {
@@ -186,8 +184,8 @@ describe("testing ReferenceType", () => {
         references.length.should.equal(6);
 
         const expectedBrowseNames = ["StartTime", "CurrentTime", "State", "BuildInfo", "SecondsTillShutdown", "ShutdownReason"];
-
-        _.intersection(browseNames, expectedBrowseNames).length.should.eql(expectedBrowseNames.length);
+        // _.intersection(browseNames, expectedBrowseNames).length.should.eql(expectedBrowseNames.length);
+        browseNames.sort().should.eql(expectedBrowseNames.sort());
     });
 
     it("ServerStatus parent shall be Server", () => {
@@ -220,7 +218,8 @@ describe("testing ReferenceType", () => {
 
         // xx references.length.should.equal(7);
         const expectedBrowseNames = ["Server"];
-        _.intersection(browseNames, expectedBrowseNames).length.should.eql(expectedBrowseNames.length);
+        // xx   _.intersection(browseNames, expectedBrowseNames).length.should.eql(expectedBrowseNames.length);
+        browseNames.sort().should.eql(expectedBrowseNames.sort());
 
         redirectToFile(
             "ReferenceDescription1.log",
@@ -256,7 +255,7 @@ describe("testing ReferenceType", () => {
             "ShutdownReason",
             "Server"
         ];
-        _.intersection(browseNames, expectedBrowseNames).length.should.eql(expectedBrowseNames.length);
+        browseNames.sort().should.eql(expectedBrowseNames.sort());
 
         redirectToFile(
             "ReferenceDescription2.log",
@@ -284,7 +283,7 @@ describe("testing ReferenceType", () => {
             return r.browseName.name;
         });
         const expectedBrowseNames = ["Server"];
-        _.intersection(browseNames, expectedBrowseNames).length.should.eql(expectedBrowseNames.length);
+        browseNames.sort().should.eql(expectedBrowseNames.sort());
     });
 
     it("should return 1 refs for browseNode on Server (BrowseDirection.Forward) and NodeClass set to Method", () => {
@@ -306,7 +305,8 @@ describe("testing ReferenceType", () => {
         references.length.should.equal(1);
 
         const expectedBrowseNames = ["GetMonitoredItems"];
-        _.intersection(browseNames, expectedBrowseNames).length.should.eql(expectedBrowseNames.length);
+        browseNames.sort().should.eql(expectedBrowseNames.sort());
+        // xx _.intersection(browseNames, expectedBrowseNames).length.should.eql(expectedBrowseNames.length);
     });
 
     it("ReferenceType should have a toString (HierarchicalReferences)", () => {

--- a/packages/node-opcua-aggregates/package.json
+++ b/packages/node-opcua-aggregates/package.json
@@ -25,7 +25,6 @@
         "node-opcua-variant": "2.16.0"
     },
     "devDependencies": {
-        "async": "^3.2.0",
         "colors": "^1.4.0",
         "delayed": "^2.0.0",
         "node-opcua-assert": "2.16.0",

--- a/packages/node-opcua-basic-types/package.json
+++ b/packages/node-opcua-basic-types/package.json
@@ -19,9 +19,7 @@
         "node-opcua-guid": "2.16.0",
         "node-opcua-nodeid": "2.16.0",
         "node-opcua-status-code": "2.16.0",
-        "node-opcua-utils": "2.16.0",
-        "underscore": "^1.11.0",
-        "@types/underscore": "^1.10.23"
+        "node-opcua-utils": "2.16.0"
     },
     "devDependencies": {
         "@types/node": "^14.11.1",

--- a/packages/node-opcua-basic-types/source/attributeIds.ts
+++ b/packages/node-opcua-basic-types/source/attributeIds.ts
@@ -2,7 +2,6 @@
  * @module node-opcua-basic-types
  */
 import { assert } from "node-opcua-assert";
-import * as _ from "underscore";
 
 export enum AttributeIds {
     NodeId = 1,
@@ -37,8 +36,14 @@ export enum AttributeIds {
     INVALID = 999
 }
 
-// deprecated use getAttributeName(attributeId: AttributeIds);
-export const attributeNameById = _.invert(AttributeIds);
+// see https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore/issues/296
+function invert(a: { [key: string]: string | number }) {
+    return Object.entries(a).reduce((c, [k, v]) => {
+        c[v] = k;
+        return c;
+    }, {} as { [key: string]: string | number });
+}
+export const attributeNameById = invert(AttributeIds);
 
 export function isValidAttributeId(attributeId: any) {
     assert(isFinite(attributeId));

--- a/packages/node-opcua-benchmarker/package.json
+++ b/packages/node-opcua-benchmarker/package.json
@@ -10,7 +10,6 @@
 		"lint": "tslint source/**/*.ts"
 	},
 	"dependencies": {
-		"async": "^3.2.0",
 		"browser-process-hrtime": "^1.0.0",
 		"node-opcua-assert": "2.16.0"
 	},

--- a/packages/node-opcua-binary-stream/package.json
+++ b/packages/node-opcua-binary-stream/package.json
@@ -13,9 +13,7 @@
 	"dependencies": {
 		"colors": "^1.4.0",
 		"node-opcua-assert": "2.16.0",
-		"node-opcua-buffer-utils": "2.16.0",
-		"@types/underscore": "^1.10.23",
-		"underscore": "^1.11.0"
+		"node-opcua-buffer-utils": "2.16.0"
 	},
 	"devDependencies": {
 		"node-opcua-benchmarker": "2.16.0",

--- a/packages/node-opcua-certificate-manager/package.json
+++ b/packages/node-opcua-certificate-manager/package.json
@@ -16,7 +16,6 @@
     "types": "./dist/index.d.ts",
     "dependencies": {
         "@types/mkdirp": "0.5.2",
-        "async": "^3.2.0",
         "chalk": "^4.1.0",
         "delayed": "^2.0.0",
         "env-paths": "^2.2.0",

--- a/packages/node-opcua-client-proxy/package.json
+++ b/packages/node-opcua-client-proxy/package.json
@@ -26,9 +26,7 @@
         "node-opcua-service-write": "2.16.0",
         "node-opcua-status-code": "2.16.0",
         "node-opcua-utils": "2.16.0",
-        "node-opcua-variant": "2.16.0",
-        "@types/underscore": "^1.10.23",
-        "underscore": "^1.11.0"
+        "node-opcua-variant": "2.16.0"
     },
     "author": "Etienne Rossignon",
     "license": "MIT",

--- a/packages/node-opcua-client-proxy/source/object_explorer.ts
+++ b/packages/node-opcua-client-proxy/source/object_explorer.ts
@@ -2,7 +2,6 @@
  * @module node-opcua-client-proxy
  */
 import * as async from "async";
-import * as _ from "underscore";
 
 import { assert } from "node-opcua-assert";
 import { Callback, ErrorCallback } from "node-opcua-status-code";
@@ -191,14 +190,12 @@ function add_method(proxyManager: UAProxyManager, obj: any, reference: Reference
             const outputArgs: any = {};
 
             const outputArgsDef = obj[name].outputArguments;
-
-            _.zip(outputArgsDef, callResult.outputArguments).forEach((pair: any) => {
-                const arg = pair[0];
-                const variant = pair[1];
-
+            outputArgsDef.map((arg: any, index: number) => {
+                const variant = callResult!.outputArguments![index];
                 const propName = lowerFirstLetter(arg.name);
                 outputArgs[propName] = variant.value;
             });
+
             callback(err, outputArgs);
         });
     };

--- a/packages/node-opcua-client/source/private/client_session_impl.ts
+++ b/packages/node-opcua-client/source/private/client_session_impl.ts
@@ -166,9 +166,9 @@ function coerceReadValueId(node: any): ReadValueId {
 const keys = Object.keys(AttributeIds).filter((k: any) => (AttributeIds as any)[k] !== AttributeIds.INVALID);
 
 const attributeNames: string[] = ((): string[] => {
-    const r = [];
+    const r: string[] = [];
     for (let i = 1; i <= 22; i++) {
-        r.push(attributeNameById[i]);
+        r.push(attributeNameById[i].toString());
     }
     return r;
 })();

--- a/packages/node-opcua-debug/package.json
+++ b/packages/node-opcua-debug/package.json
@@ -11,9 +11,7 @@
         "chalk": "^4.1.0",
         "hexy": "^0.3.0",
         "node-opcua-assert": "2.16.0",
-        "node-opcua-buffer-utils": "2.16.0",
-        "@types/underscore": "^1.10.23",
-        "underscore": "^1.11.0"
+        "node-opcua-buffer-utils": "2.16.0"
     },
     "devDependencies": {
         "chalk": "^4.1.0",

--- a/packages/node-opcua-debug/source/make_loggers.ts
+++ b/packages/node-opcua-debug/source/make_loggers.ts
@@ -4,13 +4,14 @@
 // tslint:disable:no-console
 import * as chalk from "chalk";
 import * as path from "path";
-import * as _ from "underscore";
 import { format } from "util";
 
 const debugFlags: { [id: string]: boolean } = {};
 
-const maxLines = (process.env && process.env.NODEOPCUA_DEBUG_MAXLINE_PER_MESSAGE) ?
-    parseInt(process.env.NODEOPCUA_DEBUG_MAXLINE_PER_MESSAGE, 10) : 25;
+const maxLines =
+    process.env && process.env.NODEOPCUA_DEBUG_MAXLINE_PER_MESSAGE
+        ? parseInt(process.env.NODEOPCUA_DEBUG_MAXLINE_PER_MESSAGE, 10)
+        : 25;
 
 function extractBasename(name: string) {
     return path.basename(name).replace(/\.(js|ts)$/, "");
@@ -38,7 +39,7 @@ export function checkDebugFlag(scriptFullPath: string): boolean {
     const filename = extractBasename(scriptFullPath);
     let doDebug: boolean = debugFlags[filename];
     if (process && process.env && process.env.DEBUG && !debugFlags.hasOwnProperty(filename)) {
-        doDebug = (process.env.DEBUG.indexOf(filename) >= 0 || process.env.DEBUG.indexOf("ALL") >= 0);
+        doDebug = process.env.DEBUG.indexOf(filename) >= 0 || process.env.DEBUG.indexOf("ALL") >= 0;
         setDebugFlag(filename, doDebug);
     }
     return doDebug;
@@ -50,7 +51,7 @@ export function checkDebugFlag(scriptFullPath: string): boolean {
  * @param callerLine
  */
 function file_line(mode: "E" | "D", filename: string, callerLine: number): string {
-    const d = (new Date()).toISOString().substr(11);
+    const d = new Date().toISOString().substr(11);
     if (mode === "D") {
         return chalk.bgWhite.cyan(w(d, 14) + ":" + w(filename, 30) + ":" + w(callerLine.toString(), 5));
     } else {
@@ -70,8 +71,7 @@ function buildPrefix(mode: "E" | "D"): string {
 }
 
 function dump(mode: "E" | "D", args1: [any?, ...any[]]) {
-
-    const a2 = _.values(args1) as [string, ...string[]];
+    const a2 = Object.values(args1) as [string, ...string[]];
     const output = format.apply(null, a2);
     let a1 = [buildPrefix(mode)];
 
@@ -87,7 +87,6 @@ function dump(mode: "E" | "D", args1: [any?, ...any[]]) {
             break;
         }
     }
-
 }
 
 /**
@@ -98,7 +97,6 @@ function dump(mode: "E" | "D", args1: [any?, ...any[]]) {
  *
  */
 export function make_debugLog(scriptFullPath: string): (...arg: any[]) => void {
-
     const filename = extractBasename(scriptFullPath);
 
     function debugLogFunc(...args: [any?, ...any[]]) {
@@ -111,7 +109,6 @@ export function make_debugLog(scriptFullPath: string): (...arg: any[]) => void {
 }
 
 export function make_errorLog(context: string): (...arg: any[]) => void {
-
     function errorLogFunc(...args: [any?, ...any[]]) {
         dump("E", args);
     }

--- a/packages/node-opcua-debug/source/redirect_to_file.ts
+++ b/packages/node-opcua-debug/source/redirect_to_file.ts
@@ -44,6 +44,7 @@ export function redirectToFile(tmpFile: string, actionFct: Function, callback: (
         // async version
         try {
             actionFct();
+            f.end(callback);
         } catch (err) {
             console.log = oldConsoleLog;
 
@@ -59,9 +60,9 @@ export function redirectToFile(tmpFile: string, actionFct: Function, callback: (
                     callback(err);
                 }
             });
+        } finally {
+            console.log = oldConsoleLog;
         }
-        console.log = oldConsoleLog;
-        f.end(callback);
     } else {
         oldConsoleLog = console.log;
         console.log = _write_to_file;

--- a/packages/node-opcua-factory/package.json
+++ b/packages/node-opcua-factory/package.json
@@ -20,9 +20,7 @@
         "node-opcua-guid": "2.16.0",
         "node-opcua-nodeid": "2.16.0",
         "node-opcua-status-code": "2.16.0",
-        "node-opcua-utils": "2.16.0",
-        "@types/underscore": "^1.10.23",
-        "underscore": "^1.11.0"
+        "node-opcua-utils": "2.16.0"
     },
     "author": "Etienne Rossignon",
     "license": "MIT",

--- a/packages/node-opcua-factory/source/factories_baseobject.ts
+++ b/packages/node-opcua-factory/source/factories_baseobject.ts
@@ -247,6 +247,7 @@ function _exploreObject(self: BaseUAObject, field: StructuredTypeField, data: Ex
             if (!typeDictionary) {
                 // tslint:disable-next-line: no-console
                 console.log(" No typeDictionary for ", self.schema);
+                return;
             }
             field.fieldTypeConstructor = field.fieldTypeConstructor || typeDictionary.getStructureTypeConstructor(fieldType);
             const fieldTypeConstructor = field.fieldTypeConstructor;

--- a/packages/node-opcua-factory/source/factories_structuredTypeSchema.ts
+++ b/packages/node-opcua-factory/source/factories_structuredTypeSchema.ts
@@ -2,7 +2,6 @@
  * @module node-opcua-factory
  */
 import * as chalk from "chalk";
-import * as _ from "underscore";
 import { CommonInterface, FieldCategory, FieldInterfaceOptions, FieldType, StructuredTypeOptions, TypeSchemaBase } from "./types";
 
 import { assert } from "node-opcua-assert";
@@ -291,13 +290,17 @@ export function check_options_correctness_against_schema(obj: any, schema: Struc
     }
 
     // extract the possible fields from the schema.
-    const possibleFields = obj.constructor.possibleFields || schema._possibleFields;
+    const possibleFields: string[] = obj.constructor.possibleFields || schema._possibleFields;
 
     // extracts the fields exposed by the option object
     const currentFields = Object.keys(options);
 
     // get a list of field that are in the 'options' object but not in schema
-    const invalidOptionsFields = _.difference(currentFields, possibleFields);
+    // https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore
+    function difference<T>(a1: T[], a2: T[]) {
+        return [a1, a2].reduce((a, b) => a.filter((value) => !b.includes(value)));
+    }
+    const invalidOptionsFields = difference(currentFields, possibleFields);
 
     /* istanbul ignore next */
     if (invalidOptionsFields.length > 0) {

--- a/packages/node-opcua-local-discovery-server/package.json
+++ b/packages/node-opcua-local-discovery-server/package.json
@@ -13,7 +13,6 @@
     "build-docker": "docker build . -t lds"
   },
   "dependencies": {
-    "async": "^3.2.0",
     "bonjour": "^3.5.0",
     "colors": "^1.4.0",
     "env-paths": "^2.2.0",

--- a/packages/node-opcua-model/bin/extract_schema.js
+++ b/packages/node-opcua-model/bin/extract_schema.js
@@ -1,55 +1,54 @@
 const { OPCUAClient } = require("node-opcua-client");
-const { parse_opcua_common  } = require("../lib/parse_server_common");
-const { callbackify } = require("util")
+const { parse_opcua_common } = require("../lib/parse_server_common");
 
 const yargs = require("yargs/yargs");
 
 const argv = yargs(process.argv)
-    .wrap(132)
-    //.usage("Usage: $0 -d --endpoint <endpointUrl> [--securityMode (None|SignAndEncrypt|Sign)] [--securityPolicy (None|Basic256|Basic128Rsa15)] --node <node_id_to_monitor> --crawl")
-    .demand("endpoint")
-    .string("endpoint")
-    .describe("endpoint", "the end point to connect to ")
-    .string("securityMode")
-    .describe("securityMode", "the security mode")
-    .string("securityPolicy")
-    .describe("securityPolicy", "the policy mode")
-    .string("userName")
-    .describe("userName", "specify the user name of a UserNameIdentityToken ")
-    .string("password")
-    .describe("password", "specify the password of a UserNameIdentityToken")
-    .alias("e", "endpoint")
-    .alias("s", "securityMode")
-    .alias("P", "securityPolicy")
-    .alias("u", "userName")
-    .alias("p", "password")
-    .argv;
+  .wrap(132)
+  //.usage("Usage: $0 -d --endpoint <endpointUrl> [--securityMode (None|SignAndEncrypt|Sign)] [--securityPolicy (None|Basic256|Basic128Rsa15)] --node <node_id_to_monitor> --crawl")
+  .demand("endpoint")
+  .string("endpoint")
+  .describe("endpoint", "the end point to connect to ")
+  .string("securityMode")
+  .describe("securityMode", "the security mode")
+  .string("securityPolicy")
+  .describe("securityPolicy", "the policy mode")
+  .string("userName")
+  .describe("userName", "specify the user name of a UserNameIdentityToken ")
+  .string("password")
+  .describe("password", "specify the password of a UserNameIdentityToken")
+  .alias("e", "endpoint")
+  .alias("s", "securityMode")
+  .alias("P", "securityPolicy")
+  .alias("u", "userName")
+  .alias("p", "password")
+  .argv;
 
 const endpointUrl = argv.endpoint || "opc.tcp://localhost:48010";
 
 
 function parse_opcua_server(endpoint, callback) {
 
-    const options = {
-        endpoint_must_exist: false,
-        keepSessionAlive: true,
-        connectionStrategy: {
-            maxRetry: 10,
-            initialDelay: 2000,
-            maxDelay: 10 * 1000
-        }
-    };
+  const options = {
+    endpoint_must_exist: false,
+    keepSessionAlive: true,
+    connectionStrategy: {
+      maxRetry: 10,
+      initialDelay: 2000,
+      maxDelay: 10 * 1000
+    }
+  };
 
-    const client = OPCUAClient.create(options);
-    client.withSession(endpointUrl, function (session, callback) {
-        callbackify(parse_opcua_common)(session, callback);
-    }, function (err) {
-        callback(err);
-    });
+  const client = OPCUAClient.create(options);
+  client.withSession(endpointUrl, function(session, callback) {
+    parse_opcua_common(session).then(() => callback()).catch(err => callback(err));
+  }, function(err) {
+    callback(err);
+  });
 }
 
-parse_opcua_server(endpointUrl, function (err) {
-    console.log("done", err);
+parse_opcua_server(endpointUrl, function(err) {
+  console.log("done", err);
 });
 
 //

--- a/packages/node-opcua-object-registry/package.json
+++ b/packages/node-opcua-object-registry/package.json
@@ -12,9 +12,7 @@
     "license": "MIT",
     "dependencies": {
         "node-opcua-assert": "2.16.0",
-        "node-opcua-debug": "2.16.0",
-        "@types/underscore": "^1.10.23",
-        "underscore": "^1.11.0"
+        "node-opcua-debug": "2.16.0"
     },
     "devDependencies": {
         "colors": "^1.4.0",

--- a/packages/node-opcua-object-registry/source/objectRegistry.ts
+++ b/packages/node-opcua-object-registry/source/objectRegistry.ts
@@ -3,13 +3,11 @@
  */
 import { assert } from "node-opcua-assert";
 import { trace_from_this_projet_only } from "node-opcua-debug";
-import * as _ from "underscore";
 
 const gRegistries: ObjectRegistry[] = [];
 let hashCounter = 1;
 
 export class ObjectRegistry {
-
     public static doDebug = false;
     public static registries: any = gRegistries;
 
@@ -17,7 +15,6 @@ export class ObjectRegistry {
     private readonly _cache: any;
 
     constructor(objectType?: any) {
-
         this._objectType = objectType;
         this._cache = {};
         gRegistries.push(this);
@@ -28,7 +25,6 @@ export class ObjectRegistry {
     }
 
     public register(obj: any): void {
-
         if (!this._objectType) {
             this._objectType = obj.constructor;
         }
@@ -56,17 +52,17 @@ export class ObjectRegistry {
     }
 
     public toString(): string {
-
         const className = this.getClassName();
         let str = " className :" + className + " found => " + this.count() + " object leaking\n";
 
-        _.forEach(this._cache, (obj: any/*,key*/) => {
+        Object.values(this._cache).forEach((obj: any /*,key*/) => {
             str += obj.constructor.name + " " + obj.toString() + "\n";
         });
 
         if (ObjectRegistry.doDebug) {
-            _.forEach(this._cache, (obj: any, key) => {
+            Object.values(this._cache).forEach((obj: any, key) => {
                 const cachedObject = this._cache[key];
+                if (!cachedObject) return;
                 assert(cachedObject.hasOwnProperty("_____trace"));
                 str += "   " + key + cachedObject._____trace + "\n";
             });

--- a/packages/node-opcua-packet-analyzer/package.json
+++ b/packages/node-opcua-packet-analyzer/package.json
@@ -18,9 +18,7 @@
         "node-opcua-binary-stream": "2.16.0",
         "node-opcua-debug": "2.16.0",
         "node-opcua-factory": "2.16.0",
-        "node-opcua-utils": "2.16.0",
-        "@types/underscore": "^1.10.23",
-        "underscore": "^1.11.0"
+        "node-opcua-utils": "2.16.0"
     },
     "devDependencies": {
         "node-opcua-test-helpers": "2.6.1",

--- a/packages/node-opcua-packet-analyzer/source/packet_analyzer/packet_analyzer.ts
+++ b/packages/node-opcua-packet-analyzer/source/packet_analyzer/packet_analyzer.ts
@@ -5,7 +5,6 @@
 
 import * as chalk from "chalk";
 import { assert } from "node-opcua-assert";
-import * as  _ from "underscore";
 import * as util from "util";
 
 import { decodeByte, decodeExpandedNodeId, decodeNodeId, decodeUInt32 } from "node-opcua-basic-types";
@@ -14,16 +13,15 @@ import { hexDump } from "node-opcua-debug";
 import { BaseUAObject, constructObject } from "node-opcua-factory";
 import { buffer_ellipsis } from "node-opcua-utils";
 
-const spaces = "                                                                                                                                                                             ";
+const spaces =
+    "                                                                                                                                                                             ";
 
 function f(n: number, width: number): string {
     const s = n.toString();
     return (s + "      ").substr(0, Math.max(s.length, width));
 }
 
-
 function display_encoding_mask(padding: string, encodingMask: any, encodingInfo: any) {
-
     for (const v in encodingInfo) {
         if (!encodingInfo.hasOwnProperty(v)) {
             continue;
@@ -37,7 +35,7 @@ function display_encoding_mask(padding: string, encodingMask: any, encodingInfo:
         const bit = Math.log(mask) / Math.log(2);
 
         const bits = [".", ".", ".", ".", ".", ".", ".", ".", "."];
-        bits[bit] = ((encodingMask & mask) === mask) ? "Y" : "n";
+        bits[bit] = (encodingMask & mask) === mask ? "Y" : "n";
 
         console.log(padding + " ", bits.join(""), " <- has " + enumKey + " 0x" + mask.toString(16));
     }
@@ -47,11 +45,12 @@ function display_encoding_mask(padding: string, encodingMask: any, encodingInfo:
 function hex_block(start: number, end: number, buffer: Buffer) {
     const n = end - start;
     const strBuf = buffer_ellipsis(buffer);
-    return chalk.cyan("s:") + f(start, 4) + chalk.cyan(" e:") + f(end, 4) + chalk.cyan(" n:") + f(n, 4) + " " + chalk.yellow(strBuf);
+    return (
+        chalk.cyan("s:") + f(start, 4) + chalk.cyan(" e:") + f(end, 4) + chalk.cyan(" n:") + f(n, 4) + " " + chalk.yellow(strBuf)
+    );
 }
 
 function make_tracer(buffer: Buffer, padding: number, offset?: number) {
-
     padding = !padding ? 0 : padding;
     offset = offset || 0;
 
@@ -60,9 +59,7 @@ function make_tracer(buffer: Buffer, padding: number, offset?: number) {
     function _display(str: string, hexInfo?: string) {
         hexInfo = hexInfo || "";
         // account for ESC codes for colors
-        const nbColorAttributes = _.filter(str, (c) => {
-            return c === "\u001b";
-        }).length;
+        const nbColorAttributes = [...str].filter((c) => c === "\u001b").length;
         const extra = nbColorAttributes * 5;
         console.log((pad() + str + spaces).substr(0, 132 + extra) + "|" + hexInfo);
     }
@@ -84,13 +81,10 @@ function make_tracer(buffer: Buffer, padding: number, offset?: number) {
         display(chalk.green("     encoding mask =") + " " + encodingMask);
         display(chalk.green("            length =") + " " + length);
         analyzePacket(bufferExtract.slice(stream.length), value.encodingDefaultBinary, padding + 2, start + stream.length);
-
     }
 
     return {
-
         tracer: {
-
             dump: (title: string, value: any) => display(title + "  " + chalk.green(value.toString())),
 
             encoding_byte: (encodingMask: any, valueEnum: any, start: number, end: number) => {
@@ -101,12 +95,10 @@ function make_tracer(buffer: Buffer, padding: number, offset?: number) {
             },
 
             trace: (operation: any, name: any, value: any, start: number, end: number, fieldType: string) => {
-
                 const b = buffer.slice(start, end);
                 let _hexDump = "";
 
                 switch (operation) {
-
                     case "start":
                         padding += 2;
                         display(name.toString());
@@ -158,27 +150,29 @@ function make_tracer(buffer: Buffer, padding: number, offset?: number) {
                         }
                         break;
                 }
-            },
-        },
+            }
+        }
     };
 }
 
-interface AnalyzePacketOptions {
+interface AnalyzePacketOptions {}
 
-}
-
-export function analyzePacket(buffer: Buffer, objMessage: any, padding: number, offset?: number, customOptions?: AnalyzePacketOptions) {
+export function analyzePacket(
+    buffer: Buffer,
+    objMessage: any,
+    padding: number,
+    offset?: number,
+    customOptions?: AnalyzePacketOptions
+) {
     const stream = new BinaryStream(buffer);
     _internalAnalyzePacket(buffer, stream, objMessage, padding, customOptions, offset);
 }
 
 export function analyseExtensionObject(buffer: Buffer, padding: number, offset: number, customOptions?: AnalyzePacketOptions) {
-
     const stream = new BinaryStream(buffer);
     let id;
     let objMessage;
     try {
-
         id = decodeExpandedNodeId(stream);
         objMessage = constructObject(id);
     } catch (err) {
@@ -189,11 +183,17 @@ export function analyseExtensionObject(buffer: Buffer, padding: number, offset: 
     _internalAnalyzePacket(buffer, stream, objMessage, padding, customOptions, offset);
 }
 
-function _internalAnalyzePacket(buffer: Buffer, stream: BinaryStream, objMessage: any, padding: number, customOptions?: AnalyzePacketOptions, offset?: number) {
-
+function _internalAnalyzePacket(
+    buffer: Buffer,
+    stream: BinaryStream,
+    objMessage: any,
+    padding: number,
+    customOptions?: AnalyzePacketOptions,
+    offset?: number
+) {
     let options: any = make_tracer(buffer, padding, offset);
     options.name = "message";
-    options = _.extend(options, customOptions);
+    if (customOptions) options = { ...options, ...customOptions };
     try {
         if (objMessage) {
             objMessage.decodeDebug(stream, options);
@@ -203,12 +203,11 @@ function _internalAnalyzePacket(buffer: Buffer, stream: BinaryStream, objMessage
     } catch (err) {
         console.log(" Error in ", err);
         console.log(" Error in ", err.stack);
-        console.log(" objMessage ", util.inspect(objMessage, {colors: true}));
+        console.log(" objMessage ", util.inspect(objMessage, { colors: true }));
     }
 }
 
 export function analyze_object_binary_encoding(obj: BaseUAObject) {
-
     assert(obj);
 
     const size = obj.binaryStoreSize();
@@ -226,5 +225,4 @@ export function analyze_object_binary_encoding(obj: BaseUAObject) {
 
     const reloadedObject = new (obj.constructor as any)();
     analyzePacket(stream.buffer, reloadedObject, 0);
-
 }

--- a/packages/node-opcua-packet-analyzer/test_helpers/encode_decode_round_trip_test.ts
+++ b/packages/node-opcua-packet-analyzer/test_helpers/encode_decode_round_trip_test.ts
@@ -5,7 +5,6 @@ import { hexDump } from "node-opcua-debug";
 import { BaseUAObject, constructObject } from "node-opcua-factory";
 import { assert_arrays_are_equal } from "node-opcua-test-helpers";
 import * as should from "should";
-import * as _ from "underscore";
 
 import { analyze_object_binary_encoding, analyzePacket } from "../source";
 // tslint:disable:no-console

--- a/packages/node-opcua-pseudo-session/package.json
+++ b/packages/node-opcua-pseudo-session/package.json
@@ -11,7 +11,6 @@
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "dependencies": {
-        "async": "^3.2.0",
         "node-opcua-data-model": "2.16.0",
         "node-opcua-data-value": "2.16.0",
         "node-opcua-nodeid": "2.16.0",

--- a/packages/node-opcua-samples/package.json
+++ b/packages/node-opcua-samples/package.json
@@ -17,7 +17,6 @@
     },
     "dependencies": {
         "@types/yargs": "^15.0.5",
-        "async": "^3.2.0",
         "colors": "^1.4.0",
         "easy-table": "^1.1.1",
         "exit": "^0.1.2",

--- a/packages/node-opcua-server/source/server_engine.ts
+++ b/packages/node-opcua-server/source/server_engine.ts
@@ -6,7 +6,6 @@ import * as async from "async";
 import * as chalk from "chalk";
 import { EventEmitter } from "events";
 import { assert } from "node-opcua-assert";
-import * as _ from "underscore";
 
 import {
     addElement,
@@ -152,8 +151,6 @@ function getMonitoredItemsId(this: ServerEngine, inputArguments: any, context: S
 
 function __bindVariable(self: ServerEngine, nodeId: NodeIdLike, options?: any) {
     options = options || {};
-    // must have a get and a set property
-    assert(_.difference(["get", "set"], _.keys(options)).length === 0);
 
     const variable = self.addressSpace!.findNode(nodeId) as UAVariable;
     if (variable && variable.bindVariable) {
@@ -292,7 +289,7 @@ export class ServerEngine extends EventEmitter {
             // currentSubscriptionCount returns the total number of subscriptions
             // that are currently active on all sessions
             let counter = 0;
-            _.values(this._sessions).forEach((session: ServerSession) => {
+            Object.values(this._sessions).forEach((session: ServerSession) => {
                 counter += session.currentSubscriptionCount;
             });
             return counter;
@@ -1251,15 +1248,18 @@ export class ServerEngine extends EventEmitter {
             this.writeSingleNode(context, writeValue, inner_callback);
         };
 
-        ensureDatatypeExtractedWithCallback(this.addressSpace, (err2: Error | null, extraDataTypeManager: ExtraDataTypeManager) => {
-            l_extraDataTypeManager = extraDataTypeManager;
+        ensureDatatypeExtractedWithCallback(
+            this.addressSpace!,
+            (err2: Error | null, extraDataTypeManager?: ExtraDataTypeManager) => {
+                l_extraDataTypeManager = extraDataTypeManager!;
 
-            // tslint:disable:array-type
-            async.map(nodesToWrite, performWrite, (err?: Error | null, statusCodes?: (StatusCode | undefined)[]) => {
-                assert(Array.isArray(statusCodes));
-                callback(err!, statusCodes as StatusCode[]);
-            });
-        });
+                // tslint:disable:array-type
+                async.map(nodesToWrite, performWrite, (err?: Error | null, statusCodes?: (StatusCode | undefined)[]) => {
+                    assert(Array.isArray(statusCodes));
+                    callback(err!, statusCodes as StatusCode[]);
+                });
+            }
+        );
     }
 
     /**
@@ -1352,7 +1352,7 @@ export class ServerEngine extends EventEmitter {
     }
 
     public getOldestUnactivatedSession(): ServerSession | null {
-        const tmp = _.filter(this._sessions, (session1: ServerSession) => {
+        const tmp = Object.values(this._sessions).filter((session1: ServerSession) => {
             return session1.status === "new";
         });
         if (tmp.length === 0) {
@@ -1508,7 +1508,7 @@ export class ServerEngine extends EventEmitter {
 
     public findSubscription(subscriptionId: number): Subscription | null {
         const subscriptions: Subscription[] = [];
-        _.map(this._sessions, (session) => {
+        Object.values(this._sessions).map((session) => {
             if (subscriptions.length) {
                 return;
             }


### PR DESCRIPTION
- reducing usage of underscore
  replace by native version whenever possible.
  (see https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore)
- cleanup package.json from unnecessary modules
- do not use util.callbackify in node-opcua-address-space so it
  can be browserified.