### PR TITLE
avoid exposure of restricted endpoints in createsessionresponse message

### DIFF
--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -280,7 +280,7 @@ function _serverEndpointsForCreateSessionResponse(server: OPCUAServer, endpointU
     return server
         ._get_endpoints(endpointUrl)
         .map(getRequiredEndpointInfo)
-        .filter((e) => matchUri(e.endpointUrl, endpointUrl));
+        .filter((e) => matchUri(e.endpointUrl, endpointUrl) && !(e as any).restricted);
 }
 
 function adjustSecurityPolicy(


### PR DESCRIPTION
filter out restricted endpoints from the create session response. In the _on_CreateSessionRequest, the endpoint to use in the session needs to  be an non-restricted endpoint. Some OPC clients e.g. UA Expert then try to connect using an UserIdentityToken that is not present for the endpoint and cannot be found in the function:

findUserTokenByPolicy of opc_server.ts