### PR TITLE
Fix for issue #985

### DIFF
--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -1485,6 +1485,10 @@ export class OPCUAServer extends OPCUABaseServer {
                 return callback(new Error(" Unsupported security Policy"));
             }
             const buff = cryptoFactory.asymmetricDecrypt(password, serverPrivateKey);
+            if (!buff?.length || buff.compare(Buffer.alloc(buff.length)) === 0) {
+                async.setImmediate(() => callback(null, false));
+                return;
+            }
             const length = buff.readUInt32LE(0) - serverNonce.length;
             password = buff.slice(4, 4 + length).toString("utf-8");
         }


### PR DESCRIPTION
When an invalid certificate is received, the server replies with failed authentication instead of crashing on a bad memory address on `buff.readUInt32LE(0)`
