### PR TITLE
Fixed bug #985

### DIFF
--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -1489,6 +1489,7 @@ export class OPCUAServer extends OPCUABaseServer {
             // server certificate may be invalid and asymmetricDecrypt may fail
             if (!buff || buff.length <4) {
                 async.setImmediate(() => callback(null, false));
+                return;
             }
             
             const length = buff.readUInt32LE(0) - serverNonce.length;


### PR DESCRIPTION
The commit `711e16d1fe1d44adad8fd88fe4fcdbebe043acda` is not completely fixing the issue.
Even if the wrong certificate case is detected, the execution is left running, generating the same problem.

I added just a return also stopping the check, after the bad case detection