### PR TITLE
switch encoding of Binary NodeId Like Strings to Base64

### DIFF
--- a/packages/node-opcua-nodeid/source/nodeid.ts
+++ b/packages/node-opcua-nodeid/source/nodeid.ts
@@ -125,7 +125,7 @@ export class NodeId {
             default:
                 assert(this.identifierType === NodeIdType.BYTESTRING, "invalid identifierType in NodeId : " + this.identifierType);
                 if (this.value) {
-                    str = "ns=" + this.namespace + ";b=" + (this.value as Buffer).toString("hex");
+                    str = "ns=" + this.namespace + ";b=" + (this.value as Buffer).toString("base64");
                 } else {
                     str = "ns=" + this.namespace + ";b=<null>";
                 }
@@ -228,7 +228,7 @@ export function coerceNodeId(value: any, namespace?: number): NodeId {
             value = value.substr(2);
         } else if (twoFirst === "b=") {
             identifierType = NodeIdType.BYTESTRING;
-            value = Buffer.from(value.substr(2), "hex");
+            value = Buffer.from(value.substr(2), "base64");
         } else if (twoFirst === "g=") {
             identifierType = NodeIdType.GUID;
             value = value.substr(2);
@@ -245,7 +245,7 @@ export function coerceNodeId(value: any, namespace?: number): NodeId {
         } else if ((matches = regexNamespaceB.exec(value)) !== null) {
             identifierType = NodeIdType.BYTESTRING;
             namespace = parseInt(matches[1], 10);
-            value = Buffer.from(matches[2], "hex");
+            value = Buffer.from(matches[2], "base64");
         } else if ((matches = regexNamespaceG.exec(value)) !== null) {
             identifierType = NodeIdType.GUID;
             namespace = parseInt(matches[1], 10);

--- a/packages/node-opcua-nodeid/test/test_nodeid.js
+++ b/packages/node-opcua-nodeid/test/test_nodeid.js
@@ -44,14 +44,14 @@ describe("testing NodeIds", function() {
     });
 
     it("should create a OPAQUE nodeID", function() {
-        const buffer = Buffer.alloc(8);
-        buffer.write("deadbeef", "utf-8");
+        const buffer = Buffer.alloc(4);
+        buffer.writeUInt32BE(0xdeadbeef, 0);
 
         const nodeId = new NodeId(NodeIdType.BYTESTRING, buffer, 4);
-        nodeId.value.toString("utf-8").should.equal("deadbeef");
+        nodeId.value.toString('hex').should.equal("deadbeef");
         nodeId.namespace.should.equal(4);
         nodeId.identifierType.should.eql(NodeIdType.BYTESTRING);
-        nodeId.toString().should.eql("ns=4;b=ZGVhZGJlZWY=");
+        nodeId.toString().should.eql("ns=4;b=3q2+7w==");
     });
     it("should create a OPAQUE nodeID with null buffer", function() {
         const nodeId = new NodeId(NodeIdType.BYTESTRING, null, 4);

--- a/packages/node-opcua-nodeid/test/test_nodeid.js
+++ b/packages/node-opcua-nodeid/test/test_nodeid.js
@@ -45,13 +45,13 @@ describe("testing NodeIds", function() {
 
     it("should create a OPAQUE nodeID", function() {
         const buffer = Buffer.alloc(4);
-        buffer.writeUInt32BE(0xdeadbeef, 0);
+        buffer.write("deadbeef", "base64");
 
         const nodeId = new NodeId(NodeIdType.BYTESTRING, buffer, 4);
-        nodeId.value.toString("hex").should.equal("deadbeef");
+        nodeId.value.toString("base64").should.equal("deadbeef");
         nodeId.namespace.should.equal(4);
         nodeId.identifierType.should.eql(NodeIdType.BYTESTRING);
-        nodeId.toString().should.eql("ns=4;b=deadbeef");
+        nodeId.toString().should.eql("ns=4;b=ZGVhZGJlZWY=");
     });
     it("should create a OPAQUE nodeID with null buffer", function() {
         const nodeId = new NodeId(NodeIdType.BYTESTRING, null, 4);

--- a/packages/node-opcua-nodeid/test/test_nodeid.js
+++ b/packages/node-opcua-nodeid/test/test_nodeid.js
@@ -44,11 +44,11 @@ describe("testing NodeIds", function() {
     });
 
     it("should create a OPAQUE nodeID", function() {
-        const buffer = Buffer.alloc(4);
-        buffer.write("deadbeef", "base64");
+        const buffer = Buffer.alloc(8);
+        buffer.write("deadbeef", "utf-8");
 
         const nodeId = new NodeId(NodeIdType.BYTESTRING, buffer, 4);
-        nodeId.value.toString("base64").should.equal("deadbeef");
+        nodeId.value.toString("utf-8").should.equal("deadbeef");
         nodeId.namespace.should.equal(4);
         nodeId.identifierType.should.eql(NodeIdType.BYTESTRING);
         nodeId.toString().should.eql("ns=4;b=ZGVhZGJlZWY=");

--- a/packages/node-opcua-nodeid/test/test_nodeid.js
+++ b/packages/node-opcua-nodeid/test/test_nodeid.js
@@ -152,7 +152,7 @@ describe("testing coerceNodeId", function() {
     })
     it("makeNodeId(buffer)", () => {
         const nodeId2 = makeNodeId(Buffer.from([1, 2, 3]));
-        nodeId2.toString().should.eql("ns=0;b=010203");
+        nodeId2.toString().should.eql("ns=0;b=AQID");
     })
     it("resolveNodeId", () => {
         resolveNodeId("i=12");
@@ -163,21 +163,21 @@ describe("testing coerceNodeId", function() {
         buffer.writeUInt32BE(0xb1dedada, 0);
         buffer.writeUInt32BE(0xb0b0abba, 4);
         const nodeId = coerceNodeId(buffer);
-        nodeId.toString().should.eql("ns=0;b=b1dedadab0b0abba");
-        nodeId.value.toString("hex").should.eql("b1dedadab0b0abba");
+        nodeId.toString().should.eql("ns=0;b=sd7a2rCwq7o=");
+        nodeId.value.toString("base64").should.eql("sd7a2rCwq7o=");
     });
 
     it("should coerce a OPAQUE buffer in a string ( with namespace ) ", function() {
-        const nodeId = coerceNodeId("ns=0;b=b1dedadab0b0abba");
+        const nodeId = coerceNodeId("ns=0;b=dGVzdDEyMzQ1Cg==");
         nodeId.identifierType.should.eql(NodeIdType.BYTESTRING);
-        nodeId.toString().should.eql("ns=0;b=b1dedadab0b0abba");
-        nodeId.value.toString("hex").should.eql("b1dedadab0b0abba");
+        nodeId.toString().should.eql("ns=0;b=dGVzdDEyMzQ1Cg==");
+        nodeId.value.toString("base64").should.eql("dGVzdDEyMzQ1Cg==");
     });
     it("should coerce a OPAQUE buffer in a string ( without namespace ) ", function() {
-        const nodeId = coerceNodeId("b=b1dedadab0b0abba");
+        const nodeId = coerceNodeId("b=dGVzdDEyMzQ1Cg==");
         nodeId.identifierType.should.eql(NodeIdType.BYTESTRING);
-        nodeId.toString().should.eql("ns=0;b=b1dedadab0b0abba");
-        nodeId.value.toString("hex").should.eql("b1dedadab0b0abba");
+        nodeId.toString().should.eql("ns=0;b=dGVzdDEyMzQ1Cg==");
+        nodeId.value.toString("base64").should.eql("dGVzdDEyMzQ1Cg==");
     });
     it("should coerce a GUID node id (without namespace)", function() {
         const nodeId = coerceNodeId("g=1E14849E-3744-470d-8C7B-5F9110C2FA32");

--- a/packages/node-opcua-nodeid/test/test_nodeid.js
+++ b/packages/node-opcua-nodeid/test/test_nodeid.js
@@ -48,7 +48,7 @@ describe("testing NodeIds", function() {
         buffer.writeUInt32BE(0xdeadbeef, 0);
 
         const nodeId = new NodeId(NodeIdType.BYTESTRING, buffer, 4);
-        nodeId.value.toString('hex').should.equal("deadbeef");
+        nodeId.value.toString("hex").should.equal("deadbeef");
         nodeId.namespace.should.equal(4);
         nodeId.identifierType.should.eql(NodeIdType.BYTESTRING);
         nodeId.toString().should.eql("ns=4;b=3q2+7w==");
@@ -168,16 +168,16 @@ describe("testing coerceNodeId", function() {
     });
 
     it("should coerce a OPAQUE buffer in a string ( with namespace ) ", function() {
-        const nodeId = coerceNodeId("ns=0;b=dGVzdDEyMzQ1Cg==");
+        const nodeId = coerceNodeId("ns=0;b=sd7a2rCwq7o=");
         nodeId.identifierType.should.eql(NodeIdType.BYTESTRING);
-        nodeId.toString().should.eql("ns=0;b=dGVzdDEyMzQ1Cg==");
-        nodeId.value.toString("base64").should.eql("dGVzdDEyMzQ1Cg==");
+        nodeId.toString().should.eql("ns=0;b=sd7a2rCwq7o=");
+        nodeId.value.toString("hex").should.eql("b1dedadab0b0abba");
     });
     it("should coerce a OPAQUE buffer in a string ( without namespace ) ", function() {
-        const nodeId = coerceNodeId("b=dGVzdDEyMzQ1Cg==");
+        const nodeId = coerceNodeId("b=sd7a2rCwq7o=");
         nodeId.identifierType.should.eql(NodeIdType.BYTESTRING);
-        nodeId.toString().should.eql("ns=0;b=dGVzdDEyMzQ1Cg==");
-        nodeId.value.toString("base64").should.eql("dGVzdDEyMzQ1Cg==");
+        nodeId.toString().should.eql("ns=0;b=sd7a2rCwq7o=");
+        nodeId.value.toString("hex").should.eql("b1dedadab0b0abba");
     });
     it("should coerce a GUID node id (without namespace)", function() {
         const nodeId = coerceNodeId("g=1E14849E-3744-470d-8C7B-5F9110C2FA32");

--- a/packages_extra/node-opcua-example/pnpm-lock.yaml
+++ b/packages_extra/node-opcua-example/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.3
 
 specifiers:
-  node-opcua: 2.41.1
+  node-opcua: 2.41.0
   should: ^13.2.3
 
 dependencies:

--- a/packages_extra/node-opcua-example/pnpm-lock.yaml
+++ b/packages_extra/node-opcua-example/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.3
 
 specifiers:
-  node-opcua: 2.41.0
+  node-opcua: 2.41.1
   should: ^13.2.3
 
 dependencies:


### PR DESCRIPTION
the aim of this Pull Request is to implement the proposed binary encoding formats of nodeIds. The current version of the OPC-UA spec uses Base64 encoding:

https://reference.opcfoundation.org/v104/Core/docs/Part6/5.3.1/#Table20

The examples given indicate that Base64 is used for opaque / bytestring nodeIds. Also the encoding of Bytestring NodeId Strings in XML files are clearly specified as base64. Also most other SDKs use base64 as well so I would suggest to also use base64