### PR TITLE
emit Error object if MonitoredItemGroup fails on creation 

### DIFF
--- a/packages/node-opcua-client/source/client_monitored_item_group.ts
+++ b/packages/node-opcua-client/source/client_monitored_item_group.ts
@@ -15,7 +15,7 @@ export interface ClientMonitoredItemGroup extends EventEmitter, ClientMonitoredI
 
     on(event: "err", eventHandler: (message: string) => void): this;
 
-    on(event: "terminated", eventHandler: () => void): this;
+    on(event: "terminated", eventHandler: (error: Error) => void): this;
 
     on(event: "initialized", eventHandler: () => void): this;
 

--- a/packages/node-opcua-client/source/private/client_monitored_item_group_impl.ts
+++ b/packages/node-opcua-client/source/private/client_monitored_item_group_impl.ts
@@ -190,7 +190,7 @@ Please investigate the code of the event handler function to fix the error.`
             this.monitoredItems,
             (err?: Error) => {
                 if (err) {
-                    this.emit("terminated");
+                    this.emit("terminated", err);
                 } else {
                     this.emit("initialized");
                     // set the event handler

--- a/packages/node-opcua-client/test/test_monitoreditemtoolbox.ts
+++ b/packages/node-opcua-client/test/test_monitoreditemtoolbox.ts
@@ -1,0 +1,44 @@
+import * as should  from "should";
+import * as sinon from "sinon";
+import {TimestampsToReturn} from "node-opcua-data-value";
+import {SinonSandbox} from "sinon";
+import {ClientSubscriptionImpl} from "../source/private/client_subscription_impl";
+import { ClientSessionImpl } from "../source/private/client_session_impl";
+const {ClientMonitoredItemGroup, ClientSubscription } = require("..");
+
+describe('Testing the Monitored Items Group', () => {
+
+    let sandbox: SinonSandbox;
+    let monitoredItemGroup: any;
+    let fakeSubscription: any
+
+    before(() => {
+        sandbox = sinon.createSandbox();
+
+        fakeSubscription = sandbox.createStubInstance(ClientSubscriptionImpl);
+        fakeSubscription._wait_for_subscription_to_be_ready
+            .callsFake((cb:any) => setTimeout(() => (cb(null)), 500))
+        const fakeSession = sandbox.createStubInstance(ClientSessionImpl)
+        fakeSession.createMonitoredItems.yields(new Error('something bad happened'))
+        sandbox.stub(fakeSubscription, 'session').value(fakeSession)
+
+        monitoredItemGroup = ClientMonitoredItemGroup.create(
+            fakeSubscription,
+            [],
+            {},
+            TimestampsToReturn.Both
+        );
+    });
+
+    it('should transmit an error object if it occurs ', (done) => {
+        monitoredItemGroup.on('terminated', (err: Error) => {
+            err.message.should.eql('something bad happened')
+            done()
+        })
+
+    })
+
+    after(() => {
+        sandbox.restore()
+    })
+})


### PR DESCRIPTION
if the createMonitoredItems call inside the  MonitoredItemToolbox returns an error ( e.g. BadTooManyOperations) from the server, this error cannot be handled specifically at the moment because the terminated event is thrown without any error information so the user cannot handle the situation specifically. 