### PR TITLE
Added custom hostname support to the OPCUA Discovery Server

### DIFF
--- a/packages/node-opcua-server-discovery/source/opcua_discovery_server.ts
+++ b/packages/node-opcua-server-discovery/source/opcua_discovery_server.ts
@@ -14,7 +14,7 @@ import { makeApplicationUrn } from "node-opcua-common";
 import { checkDebugFlag, make_debugLog } from "node-opcua-debug";
 import { extractFullyQualifiedDomainName, resolveFullyQualifiedDomainName } from "node-opcua-hostname";
 import { Message, Response, ServerSecureChannelLayer } from "node-opcua-secure-channel";
-import { OPCUABaseServer, OPCUABaseServerOptions, OPCUAServerEndPoint } from "node-opcua-server";
+import { OPCUABaseServer, OPCUAServerEndpointOptions, OPCUABaseServerOptions, OPCUAServerEndPoint } from "node-opcua-server";
 
 import {
     Announcement,
@@ -55,9 +55,8 @@ function hasCapabilities(serverCapabilities: UAString[] | null, serverCapability
     return !!serverCapabilities.join(" ").match(serverCapabilityFilter);
 }
 
-export interface OPCUADiscoveryServerOptions extends OPCUABaseServerOptions {
+export interface OPCUADiscoveryServerOptions extends OPCUABaseServerOptions, OPCUAServerEndpointOptions {
     certificateFile?: string;
-    port?: number;
 }
 
 interface RegisteredServerExtended extends RegisteredServer {
@@ -86,6 +85,7 @@ function getDefaultCertificateManager(): OPCUACertificateManager {
 export class OPCUADiscoveryServer extends OPCUABaseServer {
     private mDnsResponder?: MDNSResponder;
     private readonly registeredServers: RegisterServerMap;
+    private _primaryEndpoint: OPCUAServerEndpointOptions;
     private bonjourHolder: BonjourHolder;
     private _delayInit?: () => void;
 
@@ -113,6 +113,16 @@ export class OPCUADiscoveryServer extends OPCUABaseServer {
 
         super(options);
 
+        this._primaryEndpoint = {
+            hostname: options.hostname,
+            port: options.port,
+            securityPolicies: options.securityPolicies,
+            securityModes: options.securityModes,
+            allowAnonymous: options.allowAnonymous,
+            alternateHostname: options.alternateHostname,
+            disableDiscovery: options.disableDiscovery
+        };
+
         this.bonjourHolder = new BonjourHolder();
 
         // see OPC UA Spec 1.2 part 6 : 7.4 Well Known Addresses
@@ -135,7 +145,15 @@ export class OPCUADiscoveryServer extends OPCUABaseServer {
                 privateKey: this.getPrivateKey(),
                 serverInfo: this.serverInfo
             });
-            endPoint.addStandardEndpointDescriptions();
+            
+            endPoint.addStandardEndpointDescriptions({
+                securityModes: this._primaryEndpoint.securityModes,
+                securityPolicies: this._primaryEndpoint.securityPolicies,
+                disableDiscovery: this._primaryEndpoint.disableDiscovery,
+
+                allowAnonymous: this._primaryEndpoint.allowAnonymous,
+                hostname: this._primaryEndpoint.hostname
+            });
 
             this.endpoints.push(endPoint);
 


### PR DESCRIPTION
In the project I work on currently we have a LDS deployed on a Kubernetes cluster in the cloud. When trying to register a server on it, every time the LDS would take its local hostname, a name that cannot be resolved by any server who's on a different network. 

This pull request adds a way to define custom hostnames to the OPCUADiscoveryServer class in the same manner the OPCUAServer can. Now you can pass a custom hostname that does get resolved outside of the network.