### PR TITLE
rename endpoint_must_exist to endpointMustExist in Documentation

### DIFF
--- a/documentation/client_typescript.js
+++ b/documentation/client_typescript.js
@@ -3,7 +3,7 @@ async function main() {
     try {
         const endpointUrl2 = "opc.tcp://localhost:48010";
         const client = OPCUAClient.create({
-            endpoint_must_exist: false
+            endpointMustExist: false
         });
         await client.connect(endpointUrl2);
         const session = await client.createSession();

--- a/documentation/client_typescript.ts
+++ b/documentation/client_typescript.ts
@@ -17,7 +17,7 @@ async function main() {
         const endpointUrl2 = "opc.tcp://localhost:48010";
 
         const client = OPCUAClient.create({
-            endpoint_must_exist: false
+            endpointMustExist: false
         });
         await client.connect(endpointUrl2);
 

--- a/documentation/creating_a_client_callback.md
+++ b/documentation/creating_a_client_callback.md
@@ -62,13 +62,13 @@ server is running. `UA/MyLittleServer` is the endpoint defined by the server and
 
 ```javascript
 const client = OPCUAClient.create({
-    endpoint_must_exist: false
+    endpointMustExist: false
 });
 _"adding some helpers to diagnose connection issues"
 ```
 
 > Note that by default, the `endpointUrl` must match the url exposed by the server, this means that `<hostname>` cannot be replaced by
-> an hostname alias or a straight ip address. To relax this restriction, one can use the `endpoint_must_exist: false`
+> an hostname alias or a straight ip address. To relax this restriction, one can use the `endpointMustExist: false`
 > option when creating the OPUA Client
 
 ### adding some helpers to diagnose connection issues

--- a/documentation/creating_a_client_typescript.md
+++ b/documentation/creating_a_client_typescript.md
@@ -81,7 +81,7 @@ const client = OPCUAClient.create({
   connectionStrategy: connectionStrategy,
   securityMode: MessageSecurityMode.None,
   securityPolicy: SecurityPolicy.None,
-  endpoint_must_exist: false
+  endpointMustExist: false
 });
 //const endpointUrl = "opc.tcp://opcuademo.sterfive.com:26543";
 const endpointUrl = "opc.tcp://" + require("os").hostname() + ":4334/UA/MyLittleServer";

--- a/documentation/mini_crawler.ts
+++ b/documentation/mini_crawler.ts
@@ -38,7 +38,7 @@ const nodeId = "ns=1;i=1000"; // MyDevices
             NodeCrawler.follow(crawler, cacheNode, myUserData, "HasProperty", BrowseDirection.Forward);
         }
 
-        const client = OPCUAClient.create({ endpoint_must_exist: false });
+        const client = OPCUAClient.create({ endpointMustExist: false });
         client.on("backoff", () => { console.log("keep trying to connect"); });
         const pojo = await client.withSessionAsync(endpointUrl, async (session: ClientSession) => {
             const crawler = new NodeCrawler(session);

--- a/documentation/sample_client.js
+++ b/documentation/sample_client.js
@@ -4,7 +4,7 @@
     // const endpointUrl = "opc.tcp://<hostname>:4334/UA/MyLittleServer";
     const endpointUrl = "opc.tcp://" + require("os").hostname() + ":4334/UA/MyLittleServer";
     const client = OPCUAClient.create({
-        endpoint_must_exist: false
+        endpointMustExist: false
     });
     client.on("backoff", (retry, delay) =>
       console.log(

--- a/documentation/sample_client_ts.ts
+++ b/documentation/sample_client_ts.ts
@@ -24,7 +24,7 @@ const client = OPCUAClient.create({
   connectionStrategy: connectionStrategy,
   securityMode: MessageSecurityMode.None,
   securityPolicy: SecurityPolicy.None,
-  endpoint_must_exist: false
+  endpointMustExist: false
 });
 //const endpointUrl = "opc.tcp://opcuademo.sterfive.com:26543";
 const endpointUrl = "opc.tcp://" + require("os").hostname() + ":4334/UA/MyLittleServer";

--- a/documentation/test_client_reconnection.js
+++ b/documentation/test_client_reconnection.js
@@ -84,7 +84,7 @@ const certificateFile = path.join(certificateFolder, "client_selfsigned_cert_204
 const privateKeyFile =  path.join(certificateFolder, "client_key_2048.pem");
 
 const client = opcua.OPCUAClient.create({
-    endpoint_must_exist: false,
+    endpointMustExist: false,
     keepSessionAlive: true,
     requestedSessionTimeout: 60000,
 


### PR DESCRIPTION
I am currently working my way into the software. Very good work by the way. 

in the examples from the documentation I get a warning message that endpoint_must_exist is depcricated.  So i renamed it in the documentation. 