### PR TITLE
fix for #1093. filter out unrequested diagnostic information.

### DIFF
--- a/packages/node-opcua-data-model/source/diagnostic_info.ts
+++ b/packages/node-opcua-data-model/source/diagnostic_info.ts
@@ -141,23 +141,15 @@ export class DiagnosticInfo extends BaseUAObject {
         decodeDebug_DiagnosticInfo(this, stream, options);
     }
 
-    public static filterForResponse(diagnostic: DiagnosticInfo, mask: number): DiagnosticInfo {
+    public static filterForResponse(diagnostic: DiagnosticInfo, mask: number, enumeration: DiagnosticInfo_Mask): DiagnosticInfo {
         const options: DiagnosticInfoOptions = {
-            symbolicId: (mask & DiagnosticInfo_ServiceLevelMask.SymbolicId || mask & DiagnosticInfo_OperationLevelMask.SymbolicId)
-                ? diagnostic.symbolicId
-                : undefined,
-            localizedText: (mask & DiagnosticInfo_ServiceLevelMask.LocalizedText || mask & DiagnosticInfo_OperationLevelMask.LocalizedText)
-                ? diagnostic.localizedText
-                : undefined,
-            additionalInfo: (mask & DiagnosticInfo_ServiceLevelMask.AdditionalInfo || mask & DiagnosticInfo_OperationLevelMask.AdditionalInfo)
-                ? diagnostic.additionalInfo
-                : undefined,
-            innerStatusCode: (mask & DiagnosticInfo_ServiceLevelMask.InnerStatusCode || mask & DiagnosticInfo_OperationLevelMask.InnerStatusCode)
-                ? diagnostic.innerStatusCode
-                : undefined,
-            innerDiagnosticInfo: (mask & DiagnosticInfo_ServiceLevelMask.InnerDiagnostics || mask & DiagnosticInfo_OperationLevelMask.InnerDiagnostics)
-                ? diagnostic.innerDiagnosticInfo
-                : (diagnostic.innerDiagnosticInfo ? DiagnosticInfo.filterForResponse(diagnostic.innerDiagnosticInfo, mask) : undefined),
+            symbolicId: (mask & enumeration.SymbolicId) ? diagnostic.symbolicId: undefined,
+            localizedText: (mask & enumeration.LocalizedText) ? diagnostic.localizedText: undefined,
+            additionalInfo: (mask & enumeration.AdditionalInfo) ? diagnostic.additionalInfo: undefined,
+            innerStatusCode: (mask & enumeration.InnerStatusCode) ? diagnostic.innerStatusCode: undefined,
+            innerDiagnosticInfo: (mask & enumeration.InnerDiagnostics) ? diagnostic.innerDiagnosticInfo : (
+                diagnostic.innerDiagnosticInfo ? DiagnosticInfo.filterForResponse(diagnostic.innerDiagnosticInfo, mask, enumeration) : undefined
+            ),
         }
         return new DiagnosticInfo(options);
     }
@@ -193,14 +185,17 @@ export enum DiagnosticInfo_OperationLevelMask {
     InnerDiagnostics = 0x0200
 }
 
+type DiagnosticInfo_Mask = typeof DiagnosticInfo_ServiceLevelMask | typeof DiagnosticInfo_OperationLevelMask;
+
 export const RESPONSE_DIAGNOSTICS_MASK_ALL = 0x3FF;
 
-export function filterDiagnosticInfoLevel(returnDiagnostics: number, diagnostic: DiagnosticInfo | null): DiagnosticInfo | null {
+export function filterDiagnosticInfoLevel(returnDiagnostics: number, diagnostic: DiagnosticInfo | null, level: "service" | "operation"): DiagnosticInfo | null {
     if (!diagnostic) {
         return null;
     }
 
-    return DiagnosticInfo.filterForResponse(diagnostic, returnDiagnostics);
+    const enumeration = level === "service" ? DiagnosticInfo_ServiceLevelMask : DiagnosticInfo_OperationLevelMask;
+    return DiagnosticInfo.filterForResponse(diagnostic, returnDiagnostics, enumeration);
 }
 
 export enum DiagnosticInfo_EncodingByte {

--- a/packages/node-opcua-data-model/source/diagnostic_info.ts
+++ b/packages/node-opcua-data-model/source/diagnostic_info.ts
@@ -140,6 +140,27 @@ export class DiagnosticInfo extends BaseUAObject {
     public decodeDebug(stream: BinaryStream, options: DecodeDebugOptions): void {
         decodeDebug_DiagnosticInfo(this, stream, options);
     }
+
+    public filterForResponse(fields: number): void {
+        const schema = schemaDiagnosticInfo;
+        if (!(fields & DiagnosticInfo_ResponseDiagnostics.SymbolicId)) {
+            this.symbolicId = initialize_field(schema.fields[0], undefined) as Int32;
+        }
+        if (!(fields & DiagnosticInfo_ResponseDiagnostics.LocalizedText)) {
+            this.localizedText = initialize_field(schema.fields[3], undefined) as Int32;
+        }
+        if (!(fields & DiagnosticInfo_ResponseDiagnostics.AdditionalInfo)) {
+            this.additionalInfo = initialize_field(schema.fields[4], undefined) as UAString;
+        }
+        if (!(fields & DiagnosticInfo_ResponseDiagnostics.InnerStatusCode)) {
+            this.innerStatusCode = initialize_field(schema.fields[5], undefined) as StatusCode;
+        }
+        if (!(fields & DiagnosticInfo_ResponseDiagnostics.InnerDiagnostics)) {
+            this.innerDiagnosticInfo = initialize_field(schema.fields[6], undefined) as DiagnosticInfo;
+        } else if (this.innerDiagnosticInfo) {
+            this.innerDiagnosticInfo.filterForResponse(fields);
+        }
+    }
 }
 
 DiagnosticInfo.prototype.schema = DiagnosticInfo.schema;
@@ -153,6 +174,34 @@ export interface DiagnosticInfoOptions {
     additionalInfo?: UAString;
     innerStatusCode?: StatusCode;
     innerDiagnosticInfo?: DiagnosticInfo;
+}
+
+export enum DiagnosticInfo_ResponseDiagnosticsLevel {
+    Service = 0x01,
+    Operation = 0x20
+}
+
+export enum DiagnosticInfo_ResponseDiagnostics {
+    None = 0x00,
+    SymbolicId = 0x01,
+    LocalizedText = 0x02,
+    AdditionalInfo = 0x04,
+    InnerStatusCode = 0x08,
+    InnerDiagnostics = 0x10
+}
+
+export const RESPONSE_DIAGNOSTICS_MASK_ALL =
+    DiagnosticInfo_ResponseDiagnostics.SymbolicId | DiagnosticInfo_ResponseDiagnostics.LocalizedText | DiagnosticInfo_ResponseDiagnostics.AdditionalInfo |
+    DiagnosticInfo_ResponseDiagnostics.InnerStatusCode | DiagnosticInfo_ResponseDiagnostics.InnerDiagnostics;
+
+export function filterDiagnosticInfoLevel(returnDiagnostics: number, diagnosticInfo: DiagnosticInfo | (DiagnosticInfo | null)[] | null): void {
+    const items = Array.isArray(diagnosticInfo) ? diagnosticInfo : [diagnosticInfo];
+    for (const entry of items) {
+        if (!entry) {
+            continue;
+        }
+        entry.filterForResponse(returnDiagnostics);
+    }
 }
 
 export enum DiagnosticInfo_EncodingByte {

--- a/packages/node-opcua-data-model/source/diagnostic_info.ts
+++ b/packages/node-opcua-data-model/source/diagnostic_info.ts
@@ -141,14 +141,14 @@ export class DiagnosticInfo extends BaseUAObject {
         decodeDebug_DiagnosticInfo(this, stream, options);
     }
 
-    public static filterForResponse(diagnostic: DiagnosticInfo, mask: number, enumeration: DiagnosticInfo_Mask): DiagnosticInfo {
+    public static filterForResponse(diagnostic: DiagnosticInfo, requestedDiagnostics: number, diagnosticInfoMask: DiagnosticInfo_Mask): DiagnosticInfo {
         const options: DiagnosticInfoOptions = {
-            symbolicId: (mask & enumeration.SymbolicId) ? diagnostic.symbolicId: undefined,
-            localizedText: (mask & enumeration.LocalizedText) ? diagnostic.localizedText: undefined,
-            additionalInfo: (mask & enumeration.AdditionalInfo) ? diagnostic.additionalInfo: undefined,
-            innerStatusCode: (mask & enumeration.InnerStatusCode) ? diagnostic.innerStatusCode: undefined,
-            innerDiagnosticInfo: (mask & enumeration.InnerDiagnostics) ? diagnostic.innerDiagnosticInfo : (
-                diagnostic.innerDiagnosticInfo ? DiagnosticInfo.filterForResponse(diagnostic.innerDiagnosticInfo, mask, enumeration) : undefined
+            symbolicId: (requestedDiagnostics & diagnosticInfoMask.SymbolicId) ? diagnostic.symbolicId: undefined,
+            localizedText: (requestedDiagnostics & diagnosticInfoMask.LocalizedText) ? diagnostic.localizedText: undefined,
+            additionalInfo: (requestedDiagnostics & diagnosticInfoMask.AdditionalInfo) ? diagnostic.additionalInfo: undefined,
+            innerStatusCode: (requestedDiagnostics & diagnosticInfoMask.InnerStatusCode) ? diagnostic.innerStatusCode: undefined,
+            innerDiagnosticInfo: (requestedDiagnostics & diagnosticInfoMask.InnerDiagnostics) ? diagnostic.innerDiagnosticInfo : (
+                diagnostic.innerDiagnosticInfo ? DiagnosticInfo.filterForResponse(diagnostic.innerDiagnosticInfo, requestedDiagnostics, diagnosticInfoMask) : undefined
             ),
         }
         return new DiagnosticInfo(options);
@@ -189,13 +189,20 @@ type DiagnosticInfo_Mask = typeof DiagnosticInfo_ServiceLevelMask | typeof Diagn
 
 export const RESPONSE_DIAGNOSTICS_MASK_ALL = 0x3FF;
 
-export function filterDiagnosticInfoLevel(returnDiagnostics: number, diagnostic: DiagnosticInfo | null, level: "service" | "operation"): DiagnosticInfo | null {
+export function filterDiagnosticInfoLevel(returnDiagnostics: number, diagnostic: DiagnosticInfo | null, diagnosticInfoMask: DiagnosticInfo_Mask): DiagnosticInfo | null {
     if (!diagnostic) {
         return null;
     }
 
-    const enumeration = level === "service" ? DiagnosticInfo_ServiceLevelMask : DiagnosticInfo_OperationLevelMask;
-    return DiagnosticInfo.filterForResponse(diagnostic, returnDiagnostics, enumeration);
+    return DiagnosticInfo.filterForResponse(diagnostic, returnDiagnostics, diagnosticInfoMask);
+}
+
+export function filterDiagnosticOperationLevel(returnDiagnostics: number, diagnostic: DiagnosticInfo | null): DiagnosticInfo | null {
+    return filterDiagnosticInfoLevel(returnDiagnostics, diagnostic, DiagnosticInfo_OperationLevelMask);
+}
+
+export function filterDiagnosticServiceLevel(returnDiagnostics: number, diagnostic: DiagnosticInfo | null): DiagnosticInfo | null {
+    return filterDiagnosticInfoLevel(returnDiagnostics, diagnostic, DiagnosticInfo_ServiceLevelMask);
 }
 
 export enum DiagnosticInfo_EncodingByte {

--- a/packages/node-opcua-data-model/test/test_diagnostic_info.js
+++ b/packages/node-opcua-data-model/test/test_diagnostic_info.js
@@ -6,7 +6,7 @@ const { encode_decode_round_trip_test } = require("node-opcua-packet-analyzer/di
 const { BinaryStream } = require("node-opcua-binary-stream");
 const { StatusCodes } = require("node-opcua-status-code");
 
-const { DiagnosticInfo, encodeDiagnosticInfo, decodeDiagnosticInfo } = require("..");
+const { DiagnosticInfo, encodeDiagnosticInfo, decodeDiagnosticInfo, DiagnosticInfo_ResponseDiagnostics } = require("..");
 
 describe("DiagnosticInfo", function () {
     //xx it("should have encodingDefaultBinary = 25",function(){
@@ -119,6 +119,63 @@ describe("DiagnosticInfo", function () {
         encode_decode_round_trip_test(diag, function (buffer) {
             buffer.length.should.equal(1 + 4 + 4 + 4);
         });
+    });
+
+    it("should not strip away diagnostic information if requested", function () {
+        const diag = new DiagnosticInfo({
+            localizedText: 2345,
+            symbolicId: 3456,
+            additionalInfo: "test",
+            innerStatusCode: StatusCodes.Bad,
+            innerDiagnosticInfo: new DiagnosticInfo({ additionalInfo: "test 2" })
+        });
+        const fields = DiagnosticInfo_ResponseDiagnostics.SymbolicId
+            | DiagnosticInfo_ResponseDiagnostics.LocalizedText
+            | DiagnosticInfo_ResponseDiagnostics.AdditionalInfo
+            | DiagnosticInfo_ResponseDiagnostics.InnerStatusCode
+            | DiagnosticInfo_ResponseDiagnostics.InnerDiagnostics;
+        diag.filterForResponse(fields);
+        diag.localizedText.should.equal(2345);
+        diag.symbolicId.should.equal(3456);
+        diag.additionalInfo.should.equal("test");
+        diag.innerStatusCode.should.equal(StatusCodes.Bad);
+        should(diag.innerDiagnosticInfo).not.equal(null);
+        diag.innerDiagnosticInfo.additionalInfo.should.equal("test 2");
+    });
+
+    it("should not return any diagnostic info if not specifically requested", function () {
+        const diag = new DiagnosticInfo({
+            localizedText: 2345,
+            symbolicId: 3456,
+            additionalInfo: "test",
+            innerStatusCode: StatusCodes.Bad,
+            innerDiagnosticInfo: new DiagnosticInfo({ additionalInfo: "test 2" })
+        });
+        diag.filterForResponse(DiagnosticInfo_ResponseDiagnostics.None);
+        diag.localizedText.should.equal(-1);
+        diag.symbolicId.should.equal(-1);
+        should(diag.additionalInfo).equal(null);
+        diag.innerStatusCode.should.equal(StatusCodes.Good); // 'StatusCodes.Good' is the default value for 'innerStatusCode'
+        should(diag.innerDiagnosticInfo).equal(null);
+    });
+
+    it("should strip away unrequested details", function () {
+        const diag = new DiagnosticInfo({
+            localizedText: 2345,
+            symbolicId: 3456,
+            additionalInfo: "test",
+            innerStatusCode: StatusCodes.Bad,
+            innerDiagnosticInfo: new DiagnosticInfo({ additionalInfo: "test 2" })
+        });
+        const fields = DiagnosticInfo_ResponseDiagnostics.LocalizedText
+            | DiagnosticInfo_ResponseDiagnostics.AdditionalInfo
+            | DiagnosticInfo_ResponseDiagnostics.InnerStatusCode;
+        diag.filterForResponse(fields);
+        diag.localizedText.should.equal(2345);
+        diag.symbolicId.should.equal(-1);
+        diag.additionalInfo.should.equal("test");
+        diag.innerStatusCode.should.equal(StatusCodes.Bad);
+        should(diag.innerDiagnosticInfo).equal(null);
     });
 
     it("encodeDiagnosticInfo/decodeDiagnosticInfo1", () => {

--- a/packages/node-opcua-data-model/test/test_diagnostic_info.js
+++ b/packages/node-opcua-data-model/test/test_diagnostic_info.js
@@ -137,7 +137,7 @@ describe("DiagnosticInfo", function () {
             | DiagnosticInfo_ServiceLevelMask.InnerStatusCode
             | DiagnosticInfo_ServiceLevelMask.InnerDiagnostics;
 
-        diag = DiagnosticInfo.filterForResponse(diag, serviceLevelMask);
+        diag = DiagnosticInfo.filterForResponse(diag, serviceLevelMask, DiagnosticInfo_ServiceLevelMask);
         diag.localizedText.should.equal(2345);
         diag.symbolicId.should.equal(3456);
         diag.additionalInfo.should.equal("test");
@@ -156,7 +156,7 @@ describe("DiagnosticInfo", function () {
             innerDiagnosticInfo: new DiagnosticInfo({ additionalInfo: "test 2" })
         });
 
-        diag = DiagnosticInfo.filterForResponse(diag, DiagnosticInfo_ServiceLevelMask.None);
+        diag = DiagnosticInfo.filterForResponse(diag, DiagnosticInfo_ServiceLevelMask.None, DiagnosticInfo_ServiceLevelMask);
         diag.localizedText.should.equal(-1);
         diag.symbolicId.should.equal(-1);
         should(diag.additionalInfo).equal(null);
@@ -181,7 +181,7 @@ describe("DiagnosticInfo", function () {
             | DiagnosticInfo_ServiceLevelMask.AdditionalInfo
             | DiagnosticInfo_ServiceLevelMask.SymbolicId;
 
-        diag = DiagnosticInfo.filterForResponse(diag, serviceLevelMask);
+        diag = DiagnosticInfo.filterForResponse(diag, serviceLevelMask, DiagnosticInfo_ServiceLevelMask);
         diag.localizedText.should.equal(2345);
         diag.symbolicId.should.equal(3456);
         diag.additionalInfo.should.equal("test");
@@ -205,7 +205,7 @@ describe("DiagnosticInfo", function () {
             innerStatusCode: StatusCodes.Bad,
             innerDiagnosticInfo: new DiagnosticInfo({ additionalInfo: "test 2", innerStatusCode: StatusCodes.Bad, symbolicId: 34567 })
         });
-        const filtered = filterDiagnosticInfoLevel(serviceLevelMask, diagnostic);
+        const filtered = filterDiagnosticInfoLevel(serviceLevelMask, diagnostic, "service");
 
         filtered.localizedText.should.equal(diagnostic.localizedText);
         filtered.symbolicId.should.equal(diagnostic.symbolicId);

--- a/packages/node-opcua-data-model/test/test_diagnostic_info.js
+++ b/packages/node-opcua-data-model/test/test_diagnostic_info.js
@@ -6,7 +6,9 @@ const { encode_decode_round_trip_test } = require("node-opcua-packet-analyzer/di
 const { BinaryStream } = require("node-opcua-binary-stream");
 const { StatusCodes } = require("node-opcua-status-code");
 
-const { DiagnosticInfo, encodeDiagnosticInfo, decodeDiagnosticInfo, DiagnosticInfo_ResponseDiagnostics } = require("..");
+const {
+    DiagnosticInfo, encodeDiagnosticInfo, decodeDiagnosticInfo, DiagnosticInfo_ServiceLevelMask, filterDiagnosticInfoLevel
+} = require("..");
 
 describe("DiagnosticInfo", function () {
     //xx it("should have encodingDefaultBinary = 25",function(){
@@ -129,13 +131,13 @@ describe("DiagnosticInfo", function () {
             innerStatusCode: StatusCodes.Bad,
             innerDiagnosticInfo: new DiagnosticInfo({ additionalInfo: "test 2" })
         });
-        const fields = DiagnosticInfo_ResponseDiagnostics.SymbolicId
-            | DiagnosticInfo_ResponseDiagnostics.LocalizedText
-            | DiagnosticInfo_ResponseDiagnostics.AdditionalInfo
-            | DiagnosticInfo_ResponseDiagnostics.InnerStatusCode
-            | DiagnosticInfo_ResponseDiagnostics.InnerDiagnostics;
+        const serviceLevelMask = DiagnosticInfo_ServiceLevelMask.SymbolicId
+            | DiagnosticInfo_ServiceLevelMask.LocalizedText
+            | DiagnosticInfo_ServiceLevelMask.AdditionalInfo
+            | DiagnosticInfo_ServiceLevelMask.InnerStatusCode
+            | DiagnosticInfo_ServiceLevelMask.InnerDiagnostics;
 
-        diag = DiagnosticInfo.filterForResponse(diag, fields);
+        diag = DiagnosticInfo.filterForResponse(diag, serviceLevelMask);
         diag.localizedText.should.equal(2345);
         diag.symbolicId.should.equal(3456);
         diag.additionalInfo.should.equal("test");
@@ -154,7 +156,7 @@ describe("DiagnosticInfo", function () {
             innerDiagnosticInfo: new DiagnosticInfo({ additionalInfo: "test 2" })
         });
 
-        diag = DiagnosticInfo.filterForResponse(diag, DiagnosticInfo_ResponseDiagnostics.None);
+        diag = DiagnosticInfo.filterForResponse(diag, DiagnosticInfo_ServiceLevelMask.None);
         diag.localizedText.should.equal(-1);
         diag.symbolicId.should.equal(-1);
         should(diag.additionalInfo).equal(null);
@@ -175,11 +177,11 @@ describe("DiagnosticInfo", function () {
             innerStatusCode: StatusCodes.Bad,
             innerDiagnosticInfo: new DiagnosticInfo({ additionalInfo: "test 2", innerStatusCode: StatusCodes.Bad, symbolicId: 34567 })
         });
-        const fields = DiagnosticInfo_ResponseDiagnostics.LocalizedText
-            | DiagnosticInfo_ResponseDiagnostics.AdditionalInfo
-            | DiagnosticInfo_ResponseDiagnostics.SymbolicId;
+        const serviceLevelMask = DiagnosticInfo_ServiceLevelMask.LocalizedText
+            | DiagnosticInfo_ServiceLevelMask.AdditionalInfo
+            | DiagnosticInfo_ServiceLevelMask.SymbolicId;
 
-        diag = DiagnosticInfo.filterForResponse(diag, fields);
+        diag = DiagnosticInfo.filterForResponse(diag, serviceLevelMask);
         diag.localizedText.should.equal(2345);
         diag.symbolicId.should.equal(3456);
         diag.additionalInfo.should.equal("test");
@@ -190,6 +192,34 @@ describe("DiagnosticInfo", function () {
         should(diag.innerDiagnosticInfo.additionalInfo).equal("test 2");
         diag.innerDiagnosticInfo.innerStatusCode.should.equal(StatusCodes.Good); // 'StatusCodes.Good' is the default value for 'innerStatusCode'
         should(diag.innerDiagnosticInfo.innerDiagnosticInfo).equal(null);
+    });
+
+    it("should filter the diagnostic info based on the mask supplied", () => {
+        const serviceLevelMask = DiagnosticInfo_ServiceLevelMask.LocalizedText
+            | DiagnosticInfo_ServiceLevelMask.AdditionalInfo
+            | DiagnosticInfo_ServiceLevelMask.SymbolicId;
+        const diagnostic = new DiagnosticInfo({
+            localizedText: 2345,
+            symbolicId: 3456,
+            additionalInfo: "test",
+            innerStatusCode: StatusCodes.Bad,
+            innerDiagnosticInfo: new DiagnosticInfo({ additionalInfo: "test 2", innerStatusCode: StatusCodes.Bad, symbolicId: 34567 })
+        });
+        const filtered = filterDiagnosticInfoLevel(serviceLevelMask, diagnostic);
+
+        filtered.localizedText.should.equal(diagnostic.localizedText);
+        filtered.symbolicId.should.equal(diagnostic.symbolicId);
+        filtered.additionalInfo.should.equal(diagnostic.additionalInfo);
+        filtered.innerStatusCode.should.not.equal(diagnostic.innerStatusCode);
+        filtered.innerStatusCode.should.equal(StatusCodes.Good); // 'StatusCodes.Good' is the default value for 'innerStatusCode'
+
+        filtered.innerDiagnosticInfo.localizedText.should.equal(-1);
+        filtered.innerDiagnosticInfo.symbolicId.should.equal(34567);
+        should(filtered.innerDiagnosticInfo.additionalInfo).equal(diagnostic.innerDiagnosticInfo.additionalInfo);
+        filtered.innerDiagnosticInfo.innerStatusCode.should.not.equal(diagnostic.innerDiagnosticInfo.innerStatusCode);
+        filtered.innerDiagnosticInfo.innerStatusCode.should.equal(StatusCodes.Good); // 'StatusCodes.Good' is the default value for 'innerStatusCode'
+        should(filtered.innerDiagnosticInfo.innerDiagnosticInfo).equal(null);
+        should(filtered.innerDiagnosticInfo.innerDiagnosticInfo).equal(diagnostic.innerDiagnosticInfo.innerDiagnosticInfo);
     });
 
     it("encodeDiagnosticInfo/decodeDiagnosticInfo1", () => {

--- a/packages/node-opcua-data-model/test/test_diagnostic_info.js
+++ b/packages/node-opcua-data-model/test/test_diagnostic_info.js
@@ -205,7 +205,7 @@ describe("DiagnosticInfo", function () {
             innerStatusCode: StatusCodes.Bad,
             innerDiagnosticInfo: new DiagnosticInfo({ additionalInfo: "test 2", innerStatusCode: StatusCodes.Bad, symbolicId: 34567 })
         });
-        const filtered = filterDiagnosticInfoLevel(serviceLevelMask, diagnostic, "service");
+        const filtered = filterDiagnosticInfoLevel(serviceLevelMask, diagnostic, DiagnosticInfo_ServiceLevelMask);
 
         filtered.localizedText.should.equal(diagnostic.localizedText);
         filtered.symbolicId.should.equal(diagnostic.symbolicId);

--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -679,14 +679,14 @@ function validate_security_endpoint(
     return { errCode: StatusCodes.Good, endpoint: endpoints_matching_security_policy[0] };
 }
 
-function filterDiagnosticInfo(returnDiagnostics: number, response: CallResponse): void {
+export function filterDiagnosticInfo(returnDiagnostics: number, response: CallResponse): void {
     if (RESPONSE_DIAGNOSTICS_MASK_ALL & returnDiagnostics) {
-        response.responseHeader.serviceDiagnostics = filterDiagnosticInfoLevel(returnDiagnostics, response.responseHeader.serviceDiagnostics);
+        response.responseHeader.serviceDiagnostics = filterDiagnosticInfoLevel(returnDiagnostics, response.responseHeader.serviceDiagnostics, "service");
 
         if (response.diagnosticInfos && response.diagnosticInfos.length > 0) {
             response.diagnosticInfos.forEach(
                 (diagnostic: DiagnosticInfo | null, index: number, array: (DiagnosticInfo | null)[]) =>
-                    array[index] = filterDiagnosticInfoLevel(returnDiagnostics, diagnostic)
+                    array[index] = filterDiagnosticInfoLevel(returnDiagnostics, diagnostic, "operation")
             );
         } else {
             response.diagnosticInfos = [];
@@ -697,7 +697,7 @@ function filterDiagnosticInfo(returnDiagnostics: number, response: CallResponse)
                 if (entry.inputArgumentDiagnosticInfos && entry.inputArgumentDiagnosticInfos.length > 0) {
                     entry.inputArgumentDiagnosticInfos.forEach(
                         (diagnostic: DiagnosticInfo | null, index: number, array: (DiagnosticInfo | null)[]) =>
-                            array[index] = filterDiagnosticInfoLevel(returnDiagnostics, diagnostic)
+                            array[index] = filterDiagnosticInfoLevel(returnDiagnostics, diagnostic, "operation")
                     );
                 } else {
                     entry.inputArgumentDiagnosticInfos = [];

--- a/packages/node-opcua-server/test/test_server_diagnostic_filter.js
+++ b/packages/node-opcua-server/test/test_server_diagnostic_filter.js
@@ -1,0 +1,65 @@
+"use strict";
+
+const should = require("should");
+
+const { CallResponse } = require("node-opcua-service-call");
+const { DiagnosticInfo, DiagnosticInfo_OperationLevelMask, DiagnosticInfo_ServiceLevelMask } = require("node-opcua-data-model");
+const { StatusCodes } = require("node-opcua-status-code");
+const { filterDiagnosticInfo } = require("..");
+
+describe("filterDiagnosticInfo", function () {
+    let response;
+
+    beforeEach(function () {
+        response = new CallResponse({
+            responseHeader: {
+                serviceDiagnostics: new DiagnosticInfo({
+                    localizedText: 2345,
+                    symbolicId: 3456,
+                    additionalInfo: "test",
+                    innerStatusCode: StatusCodes.Bad,
+                    innerDiagnosticInfo: new DiagnosticInfo({ additionalInfo: "test 2", innerStatusCode: StatusCodes.Bad, symbolicId: 34567 })
+                }),
+            },
+            results: [{ inputArgumentDiagnosticInfos: [
+                new DiagnosticInfo({ additionalInfo: "input argument", innerStatusCode: StatusCodes.Bad, symbolicId: 34567 })
+            ] }],
+            diagnosticInfos: [new DiagnosticInfo({ additionalInfo: "diagnostic infos", innerStatusCode: StatusCodes.Bad, symbolicId: 34567 })]
+        });
+    });
+
+    it("should filter diagnostic information", function () {
+        const serviceLevelMask = DiagnosticInfo_ServiceLevelMask.SymbolicId
+            | DiagnosticInfo_ServiceLevelMask.LocalizedText
+            | DiagnosticInfo_ServiceLevelMask.InnerStatusCode
+            | DiagnosticInfo_ServiceLevelMask.InnerDiagnostics
+            | DiagnosticInfo_OperationLevelMask.SymbolicId
+            | DiagnosticInfo_OperationLevelMask.LocalizedText
+            | DiagnosticInfo_OperationLevelMask.InnerStatusCode
+            | DiagnosticInfo_OperationLevelMask.AdditionalInfo
+            | DiagnosticInfo_OperationLevelMask.InnerDiagnostics;
+        filterDiagnosticInfo(serviceLevelMask, response);
+
+        response.responseHeader.serviceDiagnostics.localizedText.should.equal(2345);
+        response.responseHeader.serviceDiagnostics.symbolicId.should.equal(3456);
+        should(response.responseHeader.serviceDiagnostics.additionalInfo).equal(null);
+        response.responseHeader.serviceDiagnostics.innerStatusCode.should.equal(StatusCodes.Bad);
+
+        should(response.responseHeader.serviceDiagnostics.innerDiagnosticInfo).not.equal(null);
+        response.responseHeader.serviceDiagnostics.innerDiagnosticInfo.additionalInfo.should.equal("test 2");
+
+        for (const entry of response.results) {
+            for (const diag of entry.inputArgumentDiagnosticInfos) {
+                diag.additionalInfo.should.equal("input argument");
+                diag.symbolicId.should.equal(34567);
+                diag.innerStatusCode.should.equal(StatusCodes.Bad);
+            }
+        }
+
+        for (const diag of response.diagnosticInfos) {
+            diag.additionalInfo.should.equal("diagnostic infos");
+            diag.symbolicId.should.equal(34567);
+            diag.innerStatusCode.should.equal(StatusCodes.Bad);
+        }
+    });
+});

--- a/packages/node-opcua-server/test/test_server_diagnostic_filter.js
+++ b/packages/node-opcua-server/test/test_server_diagnostic_filter.js
@@ -29,7 +29,7 @@ describe("filterDiagnosticInfo", function () {
     });
 
     it("should filter diagnostic information", function () {
-        const serviceLevelMask = DiagnosticInfo_ServiceLevelMask.SymbolicId
+        const levelMask = DiagnosticInfo_ServiceLevelMask.SymbolicId
             | DiagnosticInfo_ServiceLevelMask.LocalizedText
             | DiagnosticInfo_ServiceLevelMask.InnerStatusCode
             | DiagnosticInfo_ServiceLevelMask.InnerDiagnostics
@@ -38,7 +38,7 @@ describe("filterDiagnosticInfo", function () {
             | DiagnosticInfo_OperationLevelMask.InnerStatusCode
             | DiagnosticInfo_OperationLevelMask.AdditionalInfo
             | DiagnosticInfo_OperationLevelMask.InnerDiagnostics;
-        filterDiagnosticInfo(serviceLevelMask, response);
+        filterDiagnosticInfo(levelMask, response);
 
         response.responseHeader.serviceDiagnostics.localizedText.should.equal(2345);
         response.responseHeader.serviceDiagnostics.symbolicId.should.equal(3456);


### PR DESCRIPTION
This PR corresponds to issue #1093. The diagnostic information is filtered out in the final response generation based on the bit values set in the `requestHeader` (`returnDiagnostics`). The translation is according to [this](https://reference.opcfoundation.org/v104/Core/docs/Part4/7.28/) specification.