### PR TITLE
Remove zalgo spam from colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
         "chalk": "4.1.2",
         "cli-table3": "^0.6.0",
         "cli-truncate": "2.1.0",
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "csv-parse": "5.0.3",
         "date-utils": "^1.2.21",
         "deassertify": "^0.1.2",


### PR DESCRIPTION
Pinning the color.js dependency to 1.4.0 fixes the Zalgo Spam issue:
https://github.com/Marak/colors.js/issues/285

Leaving it with 1.4.1 causes an infinite loop and prevents any application depending on node-opcua from deploying.