### PR TITLE
fix: typo in comment

### DIFF
--- a/packages/node-opcua-client/source/alarms_and_conditions/client_alarm_tools_extractConditionFields.ts
+++ b/packages/node-opcua-client/source/alarms_and_conditions/client_alarm_tools_extractConditionFields.ts
@@ -10,7 +10,7 @@ import { BrowseDescriptionOptions } from "node-opcua-service-browse";
  */
 export async function extractConditionFields(session: IBasicSession, conditionNodeId: NodeIdLike): Promise<string[]> {
     // conditionNodeId could be a Object of type ConditionType
-    // or it could be directly a ObhectType which is a  subType of ConditionType
+    // or it could be directly a ObhjectType which is a  subType of ConditionType
 
     const _duplicateMap: any = {};
     const fields1: string[] = [];


### PR DESCRIPTION
just found a typo in https://github.com/node-opcua/node-opcua/blob/master/packages/node-opcua-client/source/alarms_and_conditions/client_alarm_tools_extractConditionFields.ts