### PR TITLE
fix: illegal access error

### DIFF
--- a/packages/node-opcua-server/source/user_manager.ts
+++ b/packages/node-opcua-server/source/user_manager.ts
@@ -45,7 +45,7 @@ export class UAUserManager1 extends UAUserManagerBase {
         super();
     }
     getUserRoles(user: string): NodeId[] {
-        return this.options.getUserRoles!(user);
+        return this.options.getUserRoles != null ? this.options.getUserRoles(user) : [];
     }
 
     async isValidUser(session: ServerSession, username: string, password: string): Promise<boolean> {
@@ -56,9 +56,11 @@ export class UAUserManager1 extends UAUserManagerBase {
                     resolve(isAuthorized!);
                 });
             });
-        } else {
+        } else if(typeof this.options.isValidUser === "function") {
             const authorized = this.options.isValidUser!.call(session, username, password);
             return authorized;
+        } else {
+            return false;
         }
     }
     getIdentitiesForRole(role: NodeId): IdentityMappingRuleType[] {


### PR DESCRIPTION
When initializing a OPCUAServer with a valid `userManager`
configuration (according to the provided interfaces), the server
crashes with a runtime exception caused by an illegal access error.