### PR TITLE
fix: code behaves differently when executed in `jest` runtime

### DIFF
--- a/packages/node-opcua-address-space/src/historical_access/address_space_historical_data_node.ts
+++ b/packages/node-opcua-address-space/src/historical_access/address_space_historical_data_node.ts
@@ -172,7 +172,7 @@ export class VariableHistorian implements IVariableHistorian {
         reverseDataValue: boolean,
         callback: CallbackT<DataValue[]>
     ): void {
-        assert(callback instanceof Function);
+        assert(typeof callback === 'function');
 
         let dataValues = filter_dequeue(this._timeline, historyReadRawModifiedDetails, maxNumberToExtract, isReversed);
 
@@ -322,7 +322,7 @@ function _historyReadRawAsync(
     reverseDataValue: boolean,
     callback: CallbackT<DataValue[]>
 ) {
-    assert(callback instanceof Function);
+    assert(typeof callback === 'function');
     this.varHistorian!.extractDataValues(historyReadRawModifiedDetails, maxNumberToExtract, isReversed, reverseDataValue, callback);
 }
 
@@ -546,7 +546,7 @@ function _historyRead(
     continuationData: ContinuationData,
     callback: CallbackT<HistoryReadResult>
 ) {
-    assert(callback instanceof Function);
+    assert(typeof callback === 'function');
     if (historyReadDetails instanceof ReadRawModifiedDetails) {
         // note: only ReadRawModifiedDetails supported at this time
         return this._historyReadRawModify(context, historyReadDetails, indexRange, dataEncoding, continuationData, callback);

--- a/packages/node-opcua-address-space/src/ua_variable_impl.ts
+++ b/packages/node-opcua-address-space/src/ua_variable_impl.ts
@@ -1167,7 +1167,7 @@ export class UAVariableImpl extends BaseNodeImpl implements UAVariable {
         if (!context) {
             context = SessionContext.defaultContext;
         }
-        assert(callback instanceof Function);
+        assert(typeof callback  === 'function');
 
         this.__waiting_callbacks = this.__waiting_callbacks || [];
         this.__waiting_callbacks.push(callback);
@@ -1412,7 +1412,7 @@ export class UAVariableImpl extends BaseNodeImpl implements UAVariable {
         callback?: CallbackT<HistoryReadResult>
     ): any {
         assert(context instanceof SessionContext);
-        assert(callback instanceof Function);
+        assert(typeof callback === 'function');
         if (typeof this._historyRead !== "function") {
             return callback!(null, new HistoryReadResult({ statusCode: StatusCodes.BadNotReadable }));
         }

--- a/packages/node-opcua-certificate-manager/source/certificate_manager.ts
+++ b/packages/node-opcua-certificate-manager/source/certificate_manager.ts
@@ -105,7 +105,7 @@ export class OPCUACertificateManager extends CertificateManager implements ICert
     public initialize(callback: (err?: Error) => void): void;
     public initialize(...args: any[]): any {
         const callback = args[0];
-        assert(callback && callback instanceof Function);
+        assert(callback && typeof callback === 'function');
         return super.initialize(callback);
     }
 

--- a/packages/node-opcua-client-crawler/source/node_crawler_base.ts
+++ b/packages/node-opcua-client-crawler/source/node_crawler_base.ts
@@ -317,7 +317,7 @@ export class NodeCrawlerBase extends EventEmitter implements NodeCrawlerEvents {
     public crawl(nodeId: NodeIdLike, userData: UserData, endCallback: ErrorCallback): void;
     public crawl(nodeId: NodeIdLike, userData: UserData, ...args: any[]): any {
         const endCallback = args[0] as ErrorCallback;
-        assert(endCallback instanceof Function, "expecting callback");
+        assert(typeof endCallback === 'function', "expecting callback");
         nodeId = resolveNodeId(nodeId) as NodeId;
         assert(typeof endCallback === "function");
         this._readOperationalLimits((err?: Error) => {

--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -1472,7 +1472,7 @@ export class OPCUAServer extends OPCUABaseServer {
         callback: (err: Error | null, statusCode?: StatusCode) => void
     ): void {
         assert(userIdentityToken instanceof X509IdentityToken);
-        assert(callback instanceof Function);
+        assert(typeof callback === 'function');
 
         const securityPolicy = adjustSecurityPolicy(channel, userTokenPolicy.securityPolicyUri);
 
@@ -1605,7 +1605,7 @@ export class OPCUAServer extends OPCUABaseServer {
         endpointDescription: EndpointDescription,
         callback: (err: Error | null, statusCode?: StatusCode) => void
     ): void {
-        assert(callback instanceof Function);
+        assert(typeof callback === 'function');
         /* istanbul ignore next */
         if (!userIdentityToken) {
             throw new Error("Invalid token");

--- a/packages/node-opcua-server/source/server_engine.ts
+++ b/packages/node-opcua-server/source/server_engine.ts
@@ -1893,7 +1893,7 @@ export class ServerEngine extends EventEmitter {
     ): void {
         const referenceTime = new Date(Date.now() - maxAge);
 
-        assert(callback instanceof Function);
+        assert(typeof callback === 'function');
         const objectMap: Record<string, BaseNode> = {};
         for (const nodeToRefresh of nodesToRefresh) {
             // only consider node  for which the caller wants to read the Value attribute
@@ -2078,7 +2078,7 @@ export class ServerEngine extends EventEmitter {
         callback: CallbackT<HistoryReadResult>
     ): void {
         assert(context instanceof SessionContext);
-        assert(callback instanceof Function);
+        assert(typeof callback === 'function');
 
         const nodeId = nodeToRead.nodeId;
         const indexRange = nodeToRead.indexRange;

--- a/packages/node-opcua-server/test/test_server_engine.js
+++ b/packages/node-opcua-server/test/test_server_engine.js
@@ -374,7 +374,7 @@ describe("testing ServerEngine", () => {
                 },
                 historyRead: function (context, historyReadDetails, indexRange, dataEncoding, continuationPoint, callback) {
                     assert(context instanceof SessionContext);
-                    assert(callback instanceof Function);
+                    assert(typeof callback === 'function');
 
                     const results = [];
                     const d = new Date();

--- a/packages/node-opcua-xml2json/source/xml2json.ts
+++ b/packages/node-opcua-xml2json/source/xml2json.ts
@@ -359,7 +359,7 @@ export class Xml2Json {
     }
 
     protected _prepareParser(callback: Callback<any> | SimpleCallback): LtxParser {
-        assert(callback instanceof Function);
+        assert(typeof callback === 'function');
         const parser = new LtxParser();
         this.currentLevel = 0;
         parser.on("startElement", (name: string, attrs: XmlAttributes) => {


### PR DESCRIPTION
When implementing tests using `jest` in projects that use this
library, tests fail for no apparent reason. This is because the
implementation of this library uses `promisify` of the node internal
`util` module to promisify some functions implemented using
callbacks. The callback functions created by `promisify` do not
fulfill the `instanceof Function` check when executed in a `jest`
environment which leads to unexpected errors during tests execution.
This issue is related to the following issue in the `jest` project
https://github.com/facebook/jest/issues/2549.
A simple workaround was to replace all `instanceof Function` checks
by a `typeof callback === 'function'` check.
The issue was described in the following comment:
https://github.com/facebook/jest/issues/2549#issuecomment-1104834577