### PR TITLE
Add a max retry to findServers and findServersOnNetwork to prevent infinite retries

### DIFF
--- a/packages/node-opcua-client/source/tools/findservers.ts
+++ b/packages/node-opcua-client/source/tools/findservers.ts
@@ -28,7 +28,7 @@ export function findServers(
     discoveryServerEndpointUri: string,
     callback?: (err: Error | null, result?: FindServerResults) => void
 ): any {
-    const client = new ClientBaseImpl({});
+    const client = new ClientBaseImpl({ connectionStrategy: { maxRetry: 3 } });
 
     let servers: ApplicationDescription[] = [];
     let endpoints: EndpointDescription[] = [];
@@ -77,7 +77,7 @@ export function findServersOnNetwork(
     discoveryServerEndpointUri: string,
     callback?: (err: Error | null, servers?: ServerOnNetwork[]) => void
 ): any {
-    const client = new ClientBaseImpl({});
+    const client = new ClientBaseImpl({ connectionStrategy: { maxRetry: 3 } });
 
     client.connect(discoveryServerEndpointUri, (err?: Error) => {
         if (!err) {


### PR DESCRIPTION
A max retry should be used so that the connect attempt will throw an error if the discovery server cannot be reached. Without a max retry the callback is never executed, leaving any callers of these functions without any way to handle this type of scenario.