### PR TITLE
fix: add missing chalk dependency

### DIFF
--- a/packages/node-opcua-convert-nodeset-to-javascript/package.json
+++ b/packages/node-opcua-convert-nodeset-to-javascript/package.json
@@ -12,6 +12,7 @@
         "test-generated": "tsc --build tsconfig-generated.json"
     },
     "dependencies": {
+        "chalk": "4.1.2",
         "@types/wordwrap": "^1.0.1",
         "case-anything": "1.1.5",
         "node-opcua-address-space": "2.75.0",

--- a/packages/node-opcua-schemas/package.json
+++ b/packages/node-opcua-schemas/package.json
@@ -12,6 +12,7 @@
         "test": "echo no test"
     },
     "dependencies": {
+        "chalk": "4.1.2",
         "node-opcua-assert": "2.74.0",
         "node-opcua-binary-stream": "2.74.0",
         "node-opcua-data-model": "2.75.0",

--- a/packages/node-opcua-server/package.json
+++ b/packages/node-opcua-server/package.json
@@ -15,6 +15,7 @@
         "@ster5/global-mutex": "^1.2.0",
         "@types/underscore": "^1.11.4",
         "async": "^3.2.4",
+        "chalk": "4.1.2",
         "dequeue": "^1.0.5",
         "lodash": "4.17.21",
         "node-opcua-address-space": "2.75.0",

--- a/packages/node-opcua-service-discovery/package.json
+++ b/packages/node-opcua-service-discovery/package.json
@@ -11,6 +11,7 @@
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "dependencies": {
+        "chalk": "4.1.2",
         "@types/bonjour": "^3.5.10",
         "node-opcua-assert": "2.74.0",
         "node-opcua-basic-types": "2.74.0",


### PR DESCRIPTION
In multiple internal packages `chalk` is a missing dependency, causing the production build to fail: 

```
Error: Cannot find module 'chalk'
Require stack:
- /home/node/core/node_modules/node-opcua-service-discovery/dist/bonjour.js
- /home/node/core/node_modules/node-opcua-service-discovery/dist/index.js
- /home/node/core/node_modules/node-opcua/dist/index.js
- /home/node/core/index.js
```

I added missing dependency in the packages that use `chalk` but have no `chalk` dependency specified in `package.json` 
