### PR TITLE
TCP transport does not close dependants in case of timeout

### DIFF
--- a/packages/node-opcua-transport/source/tcp_transport.ts
+++ b/packages/node-opcua-transport/source/tcp_transport.ts
@@ -355,7 +355,6 @@ export class TCP_transport extends EventEmitter {
             _s.emit("error", err);
             this._socket = null;
             this.dispose();
-            _s.removeAllListeners();
         }
         // this.gracefullShutdown(err);
     }

--- a/packages/node-opcua-transport/test/test_client_tcp_transport.js
+++ b/packages/node-opcua-transport/test/test_client_tcp_transport.js
@@ -365,6 +365,28 @@ describe("testing ClientTCP_transport", function () {
         });
     });
 
+    it("Should send socket_closed on internal timeout", function (done) {
+        transport.timeout = 100;
+
+        const spyOnServerWrite = sinon.spy(function (socket, data) {
+            assert(data);
+            // received Fake HEL Message
+            // send Fake ACK response
+            const messageChunk = packTcpMessage("ACK", fakeAcknowledgeMessage);
+            socket.write(messageChunk);
+        });
+
+        fakeServer.pushResponse(spyOnServerWrite);
+
+        transport.on("socket_closed", function () {
+            done();
+        });
+
+        transport.connect(endpointUrl, function () {
+            /* */
+        });
+    });
+
     it("should returns an error if url has invalid port", function (done) {
         transport.connect("opc.tcp://localhost:XXXXX/SomeAddress", function (err) {
             if (err) {


### PR DESCRIPTION
Background: in `tcp_transport`, `prematureTerminate` calls Socket::destroy which asynchronously emits the `close` event, but that same function removes all the listeners before nodeJS can process this close event. As a result the `socket_closed` event is not emitted by TcpTransport and the open connections from base_server leak. This eventually causes the OPC-UA servers to refuse all connections as it thinks that it reached its max (DDOS protection)

I observed the bug as we have an LDS running and some OPC-UA servers (both from this library) registering to it. For some reason not fully clear to me, when the OPC-UA server has its internal clock in the future compared to the LDS, it does not properly close the socket. This causes the LDS tcp_transport to use its internal timeout to terminate the connection. However due to the bug mentioned above, `base_server` is not made aware that this channel can be closed, and it builds the amount of opened channels in `base_server` that are never cleaned up, even on manual cleanup due to DDOS protection. After some point, all the channels are dead ones and the LDS silently refuses all further connections until it is rebooted.

Here is the detailed conclusion from looking at the code, OPC-UA server side and LDS side:

- Server sends a request to the LDS, and (among other things), receives a security token, with a "createdAt" date set by the LDS.
- During the next messages with the LDS, the Server confirms that the token that the 2 use to communicate, including if its lifetime has not expired. If the server has its internal clock in the future compared to the LDS, that will fail and the server will drop the connection.
- Since the server does not properly close the connection, the LDS has a timeout to "prematurely terminate" the socket after 30s of idle. This is then triggered.
- The termination function expects the socket to emit a "close" event, as on "close" event from the socket, the transport layer emits itself a "socket_closed" event, which is then picked up by the LDS to free its internal registry of open connections. However, the transport layer removes the listeners before the "close" event is emitted. As a result the transport layer never sends a "socket_closed".
- This means that the LDS management layer never cleans up the open connections. After a while the connections pile up, and once they exceed the maximum amount of connections allowed, the LDS stops accepting all the connections as it cannot clean them up at all.

Steps to reproduce:
- Spin up a standard LDS using node-opcua, and enable debug logs
- Spin up a standard node-opcua server on a different PC with its internal clock set in the future compared to the LDS (more than 10m), and configure it to register to the first LDS
- After ~90 minutes (10 leaking connections times 8-ish minutes of delay for the renewal interval), you will see the ddos protection trigger, even though all the logs mention "CONCURRENT CONNECTION" being well below that threshold
- If you spin a second node-opcua server registering to this LDS but with a synchronized clock, you will see in the LDS logs some debug messages "un-registering channel  - Count =  xxx" when that working server opens then closes its connection normally, but you will still see the count go up which is a symptom of that first server having its connections leaked on the LDS