### PR TITLE
fix(sample): correct simple_server imports (fix #1216)

### DIFF
--- a/packages/node-opcua-samples/bin/simple_server.js
+++ b/packages/node-opcua-samples/bin/simple_server.js
@@ -20,13 +20,19 @@ const {
     standardUnits,
     makeApplicationUrn,
     nodesets,
-    install_optional_cpu_and_memory_usage_node,
-    build_address_space_for_conformance_testing,
     RegisterServerMethod,
     extractFullyQualifiedDomainName,
     makeRoles,
     WellKnownRoles
 } = require("node-opcua");
+
+const {
+    build_address_space_for_conformance_testing,
+} = require("node-opcua-address-space-for-conformance-testing");
+
+const {
+    install_optional_cpu_and_memory_usage_node
+} = require("node-opcua-vendor-diagnostic");
 
 Error.stackTraceLimit = Infinity;
 


### PR DESCRIPTION
I was trying to run the sample application and ran into some errors that appear to have been caused by the sample getting out of sync with the main codebase as far as what to import from where (see https://github.com/node-opcua/node-opcua/issues/1216). Making the same local changes as in this PR corrected the problem for me. Please confirm/review commit 214d4724c0eb6b322b3f39de07985514ca5dccbe along with this before merging as it was not clear to me how things were intended to be organized (this is my first time working with this module).

(This PR is mutually exclusive with #1218)