### PR TITLE
fix: uncomment server-stuff exports (fix #1216)

### DIFF
--- a/packages/node-opcua/source/server-stuff.ts
+++ b/packages/node-opcua/source/server-stuff.ts
@@ -7,8 +7,6 @@ export * from "node-opcua-server";
 
 export { OPCUADiscoveryServer } from "node-opcua-server-discovery";
 
-/**
- * export { build_address_space_for_conformance_testing } from "node-opcua-address-space-for-conformance-testing";
- * export { install_optional_cpu_and_memory_usage_node } from "node-opcua-vendor-diagnostic";
- * export { makeBoiler } from "node-opcua-address-space/testHelpers";
- */
+export { build_address_space_for_conformance_testing } from "node-opcua-address-space-for-conformance-testing";
+export { install_optional_cpu_and_memory_usage_node } from "node-opcua-vendor-diagnostic";
+export { makeBoiler } from "node-opcua-address-space/testHelpers";


### PR DESCRIPTION
Closes #1217 (supersedes)

These commented out exports look like a typo (regression in 214d4724c0eb6b322b3f39de07985514ca5dccbe / v2.83.0 and still present in v2.84.0) to me as they break the sample code (see #1216). I'm guessing uncommenting them like this is probably a more appropriate correction than modifying the imports of the sample application (as in #1217).