### PR TITLE
Create dummy key using crypto iso parsing invalid key.

### DIFF
--- a/packages/node-opcua-secure-channel/source/message_builder.ts
+++ b/packages/node-opcua-secure-channel/source/message_builder.ts
@@ -5,7 +5,7 @@
 // tslint:disable:max-line-length
 
 
-import { createPrivateKey } from "crypto";
+import { generateKeyPairSync } from "crypto";
 import * as chalk from "chalk";
 
 import { assert } from "node-opcua-assert";
@@ -87,21 +87,17 @@ export interface SecurityTokenAndDerivedKeys {
     derivedKeys: DerivedKeys | null;
 }
 
-export const invalidPrivateKey = createPrivateKey(`-----BEGIN RSA PRIVATE KEY-----
-MIICXAIBAAKBgQC04ltMWV1bf/WLIWHp2BWe+6DHOzbTa9Xqxh7U+RFUBwyNFcNg
-IpIWWRZQp1w3g5Gegj4aetJqBHjns9Rwu4iwl8Iyb0iL45pQ6/CDkC9uGWPiqqlN
-hGadBcAG7Nwmkp8w0+VaOGACTfomSABMjdiqMS04M+wZH+sujmikBQwljwIDAQAB
-AoGACwr6qemWwnxIYEsUcDNJ9p/EDAW4biXaNHAN99CQ10Fq6b4XZGoX4xdjPl9J
-SPZWUIgBBJrU97X4L6UR5iP8zzjb3cpDJ+Pi9UQwHdRQIz4VlrqcNs2KkwRaMKgl
-CR7thpI8XsNwjMLF8+eleg9wUmm0F6vQAXEAzjdrJQ1XGpECQQDdAP37TqxEAenf
-r9VARue0GgIh6rfQjqVp3ZM1KKXbxnR8wklBQWdAghFNu6f3aJ9pcfDifxdxK4rq
-tz8dBH5nAkEA0YcAfWKbB6SdGuFoWaLPlEN9mibaLllOocIC9NNZjvF3MF3NuvRd
-CAx7P+wbmnG3FmZIqvXJwpFdXuMUYipWmQJAfrJp6F9izJ4YOJ9x7qZ3gL2ESXNp
-K4wLclSPZuNFqmfsMfWjz2AyVD38s4aINYLqGKY0hXR8uOlQe1zQNs9zswJAB4uN
-APbkDkpnPeiQEWpDf1tO0pZDlReyNTD/WkGiH/uiByPZnLnf/8IzTgH6nH0r0qqs
-QzvGoDML4bbbrQ1JQQJBAJWb5pApj32rXPhQ+qMLVqy+CWJBWDd9sEuAYDhjIP1p
-8B8zGo/PAP52VYDpy2YDDSfceMcAIhmsCjZv1AAP4eM=
------END RSA PRIVATE KEY-----`);
+export const { invalidPrivateKey, _} = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: {
+      type: 'spki',
+      format: 'pem'
+    },
+    privateKeyEncoding: {
+      type: 'pkcs8',
+      format: 'pem'
+    }
+  }); 
 let counter = 0;
 
 type PacketInfo = any;

--- a/packages/node-opcua-secure-channel/source/message_builder.ts
+++ b/packages/node-opcua-secure-channel/source/message_builder.ts
@@ -89,14 +89,6 @@ export interface SecurityTokenAndDerivedKeys {
 
 export const { privateKey: invalidPrivateKey } = generateKeyPairSync('rsa', {
     modulusLength: 2048,
-    publicKeyEncoding: {
-      type: 'spki',
-      format: 'pem'
-    },
-    privateKeyEncoding: {
-      type: 'pkcs8',
-      format: 'pem'
-    }
   }); 
 let counter = 0;
 

--- a/packages/node-opcua-secure-channel/source/message_builder.ts
+++ b/packages/node-opcua-secure-channel/source/message_builder.ts
@@ -87,7 +87,7 @@ export interface SecurityTokenAndDerivedKeys {
     derivedKeys: DerivedKeys | null;
 }
 
-export const { invalidPrivateKey, _} = generateKeyPairSync('rsa', {
+export const { privateKey: invalidPrivateKey } = generateKeyPairSync('rsa', {
     modulusLength: 2048,
     publicKeyEncoding: {
       type: 'spki',


### PR DESCRIPTION
Fixes #1238

Since `invalidPrivateKey` is AFAICT  essentially only used to have a value of the right type and to detect that the private key has not been set by the API user, a random private key can suffice as there is an insignificant chance there will ever be a collision. Also creating a private key from value 0 is a bug magnet as was demonstrated by the Java TLS implementation quite recently.

By creating a key, the key will be created by the same library which will be using it, so the likelihood of subtle conflicts between BoringSSL and OpenSSL becomes much more remote.