### PR TITLE
Closes #802 improves the uninstallAlarmMonitoring function

### DIFF
--- a/packages/node-opcua-client/source/alarms_and_conditions/client_alarm_tools.ts
+++ b/packages/node-opcua-client/source/alarms_and_conditions/client_alarm_tools.ts
@@ -24,7 +24,7 @@ function r(_key: string, o: { dataType?: unknown; value?: unknown }) {
     }
     return o;
 }
-interface ClientSessionPriv extends ClientSession {
+export interface ClientSessionPriv extends ClientSession {
     $clientAlarmList: ClientAlarmList | null;
     $monitoredItemForAlarmList: ClientMonitoredItem | null;
     $subscriptionforAlarmList: ClientSubscription | null;
@@ -32,7 +32,7 @@ interface ClientSessionPriv extends ClientSession {
 // ------------------------------------------------------------------------------------------------------------------------------
 export async function uninstallAlarmMonitoring(session: ClientSession): Promise<void> {
     const _sessionPriv = session as ClientSessionPriv;
-    if (!_sessionPriv.$clientAlarmList) {
+    if (!areClientSessionPrivFieldsValid(_sessionPriv)) {
         return;
     }
 
@@ -45,6 +45,18 @@ export async function uninstallAlarmMonitoring(session: ClientSession): Promise<
     return;
 }
 
+/**
+ * Checks if all fields in the `ClientSessionPriv` interface are valid.
+ * @param session - The `ClientSessionPriv` object to check.
+ * @returns `true` if all fields are valid, `false` otherwise.
+ */
+export function areClientSessionPrivFieldsValid(session: ClientSessionPriv): boolean {
+    return (
+        session.$clientAlarmList !== null &&
+        session.$monitoredItemForAlarmList !== null &&
+        session.$subscriptionforAlarmList !== null
+    );
+}
 // Release 1.04 8 OPC Unified Architecture, Part 9
 // 4.5 Condition state synchronization
 //
@@ -110,7 +122,6 @@ export async function installAlarmMonitoring(session: ClientSession): Promise<Cl
 
     let inInit = true;
     eventMonitoringItem.on("changed", (eventFields: Variant[]) => {
-        
         const pojo = fieldsToJson(fields, eventFields);
         const { eventType, eventId, conditionId, conditionName } = pojo;
 

--- a/packages/node-opcua-client/test/test_client_alarm.ts
+++ b/packages/node-opcua-client/test/test_client_alarm.ts
@@ -1,5 +1,18 @@
 import * as should from "should";
-import { ClientAlarm, ClientAlarmList, DataType, EventStuff, NodeId, resolveNodeId, TVariant, Variant } from "../source/index";
+import {
+    ClientAlarm,
+    ClientAlarmList,
+    DataType,
+    EventStuff,
+    NodeId,
+    resolveNodeId,
+    TVariant,
+    Variant,
+    ClientSessionPriv,
+    ClientMonitoredItem,
+    ClientSubscription,
+    areClientSessionPrivFieldsValid
+} from "../source/index";
 
 class VariantId extends Variant {
     public id: TVariant<boolean>;
@@ -75,5 +88,57 @@ describe("Testing client alarm", () => {
         alarmCreatedCount.should.eql(2);
 
         alarmList.length.should.eql(2);
+    });
+});
+
+describe("Ensure that all fields in the ClientSessionPriv interface are valid", () => {
+    it("should return true when all fields are not null", () => {
+        const session: Partial<ClientSessionPriv> = {
+            $clientAlarmList: new ClientAlarmList(),
+            $monitoredItemForAlarmList: new ClientMonitoredItem(),
+            $subscriptionforAlarmList: new ClientSubscription()
+        };
+        const result: boolean = areClientSessionPrivFieldsValid(session as ClientSessionPriv);
+        result.should.be.true;
+    });
+
+    it("should return false when $clientAlarmList is null", () => {
+        const session: Partial<ClientSessionPriv> = {
+            $clientAlarmList: null,
+            $monitoredItemForAlarmList: new ClientMonitoredItem(),
+            $subscriptionforAlarmList: new ClientSubscription()
+        };
+        const result: boolean = areClientSessionPrivFieldsValid(session as ClientSessionPriv);
+        result.should.be.false;
+    });
+
+    it("should return false when $monitoredItemForAlarmList is null", () => {
+        const session: Partial<ClientSessionPriv> = {
+            $clientAlarmList: new ClientAlarmList(),
+            $monitoredItemForAlarmList: null,
+            $subscriptionforAlarmList: new ClientSubscription()
+        };
+        const result: boolean = areClientSessionPrivFieldsValid(session as ClientSessionPriv);
+        result.should.be.false;
+    });
+
+    it("should return false when $subscriptionforAlarmList is null", () => {
+        const session: Partial<ClientSessionPriv> = {
+            $clientAlarmList: new ClientAlarmList(),
+            $monitoredItemForAlarmList: new ClientMonitoredItem(),
+            $subscriptionforAlarmList: null
+        };
+        const result: boolean = areClientSessionPrivFieldsValid(session as ClientSessionPriv);
+        result.should.be.false;
+    });
+
+    it("should return false when all fields are set to null", () => {
+        const session: Partial<ClientSessionPriv> = {
+            $clientAlarmList: null,
+            $monitoredItemForAlarmList: null,
+            $subscriptionforAlarmList: null
+        };
+        const result: boolean = areClientSessionPrivFieldsValid(session as ClientSessionPriv);
+        result.should.be.false;
     });
 });


### PR DESCRIPTION
Closes #802
This pull request modifies the existing **uninstallAlarmMonitoring** function to improve the safety and reliability of the uninstallation process. The function now uses a new utility function, **areClientSessionPrivFieldsValid**, to check if all required fields in the **ClientSessionPriv** interface are valid before proceeding with the uninstallation process.