### PR TITLE
feat: Update OPCUAServer to correctly bind provided hostname

### DIFF
--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -3498,12 +3498,13 @@ export class OPCUAServer extends OPCUABaseServer {
 
     private createEndpoint(
         port1: number,
+        hostname: string | undefined,
         serverOptions: { defaultSecureTokenLifetime?: number; timeout?: number }
     ): OPCUAServerEndPoint {
         // add the tcp/ip endpoint with no security
         const endPoint = new OPCUAServerEndPoint({
             port: port1,
-
+            hostname,
             certificateManager: this.serverCertificateManager,
 
             certificateChain: this.getCertificateChain(),
@@ -3528,6 +3529,7 @@ export class OPCUAServer extends OPCUABaseServer {
             throw new Error("internal error");
         }
         const hostname = getFullyQualifiedDomainName();
+        const serverOptionHostname = serverOption.hostname;
         endpointOptions.hostname = endpointOptions.hostname || hostname;
         endpointOptions.port = endpointOptions.port === undefined ? 26543 : endpointOptions.port;
 
@@ -3542,7 +3544,7 @@ export class OPCUAServer extends OPCUABaseServer {
 
         const port = Number(endpointOptions.port || 0);
 
-        const endPoint = this.createEndpoint(port, serverOption);
+        const endPoint = this.createEndpoint(port, serverOptionHostname, serverOption);
 
         endpointOptions.alternateHostname = endpointOptions.alternateHostname || [];
         const alternateHostname =

--- a/packages/node-opcua-server/source/server_end_point.ts
+++ b/packages/node-opcua-server/source/server_end_point.ts
@@ -121,6 +121,10 @@ export interface OPCUAServerEndPointOptions {
      */
     port: number;
     /**
+     * the tcp host
+     */
+    hostname?: string;
+    /**
      * the DER certificate chain
      */
     certificateChain: Certificate;
@@ -207,6 +211,7 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
      * the tcp port
      */
     public port: number;
+    public hostname?: string;
     public certificateManager: OPCUACertificateManager;
     public defaultSecureTokenLifetime: number;
     public maxConnections: number;
@@ -245,6 +250,7 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
 
         this.port = parseInt(options.port.toString(), 10);
         assert(typeof this.port === "number");
+        this.hostname = options.hostname;
 
         this._certificateChain = options.certificateChain;
         this._privateKey = options.privateKey;
@@ -510,8 +516,16 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
             debugLog("server is listening");
         });
 
+        const listenOptions: net.ListenOptions = {
+            port: this.port
+        };
+
+        if (this.hostname !== undefined && typeof this.hostname === "string" && this.hostname.length > 0) {
+            listenOptions.host = this.hostname;
+        }
+
         this._server!.listen(
-            this.port,
+            listenOptions,
             /*"::",*/ (err?: Error) => {
                 // 'listening' listener
                 debugLog(chalk.green.bold("LISTENING TO PORT "), this.port, "err  ", err);

--- a/packages/node-opcua-server/test/test_server_issue_1303.ts
+++ b/packages/node-opcua-server/test/test_server_issue_1303.ts
@@ -1,0 +1,83 @@
+import { spawn } from "child_process";
+import net from "net";
+import should from "should";
+import { OPCUAServer } from "..";
+
+async function findAvailablePortAndStartServer(): Promise<number> {
+    return new Promise((resolve, reject) => {
+        const server = net.createServer();
+
+        server.listen(0, () => {
+            const addressInfo = server.address() as net.AddressInfo;
+            const port = addressInfo.port;
+            console.log(`Server is listening on port ${port}`);
+
+            server.on("close", () => {
+                console.log("Server closed");
+                resolve(port);
+            });
+
+            server.on("error", (err) => {
+                console.error(`Error starting server: ${err.message}`);
+                reject(err);
+            });
+        });
+    });
+}
+
+async function executeNetstat(hostnames: string[], port: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const netstatProcess = spawn("sh", ["-c", "netstat -an"]);
+        let netstatOutput = "";
+
+        netstatProcess.stdout?.on("data", (data) => {
+            netstatOutput += data.toString();
+        });
+
+        netstatProcess.stderr?.on("data", (data) => {
+            console.error(`netstat error: ${data}`);
+        });
+
+        netstatProcess.on("close", (code) => {
+            if (code !== 0) {
+                console.error("netstat command failed.");
+                reject(new Error("netstat command failed."));
+            } else {
+                should(code).equal(0); // Ensure netstat command executed successfully
+                for (const hostname of hostnames) {
+                    should(netstatOutput).containEql(`${hostname}:${port}`);
+                }
+                resolve();
+            }
+        });
+    });
+}
+
+describe("OPCUAServer - issue#1303", () => {
+    it("should start a OPCUAServer on specific host and port", async () => {
+        try {
+            const port = await findAvailablePortAndStartServer();
+            const hostname = "127.0.0.1";
+            const server = new OPCUAServer({ hostname, port });
+            await server.start();
+            await executeNetstat([hostname], port);
+            await server.shutdown();
+            server.dispose();
+        } catch (err) {
+            should.fail(err, undefined, "An error occurred.");
+        }
+    });
+    it("should start a OPCUAServer on default host and port 26543", async () => {
+        try {
+            // If hostname is omitted, the server will accept connections on the unspecified IPv6 address (::) when IPv6 is available,
+            // or the unspecified IPv4 address (0.0.0.0) otherwise.
+            const server = new OPCUAServer();
+            await server.start();
+            await executeNetstat(["0.0.0.0", "[::]"], 26543);
+            await server.shutdown();
+            server.dispose();
+        } catch (err) {
+            should.fail(err, undefined, "An error occurred.");
+        }
+    });
+});


### PR DESCRIPTION
Closes #1303

Ensure that the OPCUAServer correctly binds to the provided hostname when creating the TCP server. 
Previously, it was defaulting to [unspecified IPv6 address](https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address) (::) when IPv6 is available, or the [unspecified IPv4 address](https://en.wikipedia.org/wiki/0.0.0.0) (0.0.0.0) otherwise.

## Testing
- Added new test cases to validate the hostname parameter behavior.