### PR TITLE
feat: Update OPCUAServer to correctly bind provided hostname

### DIFF
--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -3498,12 +3498,13 @@ export class OPCUAServer extends OPCUABaseServer {
 
     private createEndpoint(
         port1: number,
+        hostname: string | undefined,
         serverOptions: { defaultSecureTokenLifetime?: number; timeout?: number }
     ): OPCUAServerEndPoint {
         // add the tcp/ip endpoint with no security
         const endPoint = new OPCUAServerEndPoint({
             port: port1,
-
+            hostname,
             certificateManager: this.serverCertificateManager,
 
             certificateChain: this.getCertificateChain(),
@@ -3528,6 +3529,7 @@ export class OPCUAServer extends OPCUABaseServer {
             throw new Error("internal error");
         }
         const hostname = getFullyQualifiedDomainName();
+        const serverOptionHostname = serverOption.hostname;
         endpointOptions.hostname = endpointOptions.hostname || hostname;
         endpointOptions.port = endpointOptions.port === undefined ? 26543 : endpointOptions.port;
 
@@ -3542,7 +3544,7 @@ export class OPCUAServer extends OPCUABaseServer {
 
         const port = Number(endpointOptions.port || 0);
 
-        const endPoint = this.createEndpoint(port, serverOption);
+        const endPoint = this.createEndpoint(port, serverOptionHostname, serverOption);
 
         endpointOptions.alternateHostname = endpointOptions.alternateHostname || [];
         const alternateHostname =

--- a/packages/node-opcua-server/source/server_end_point.ts
+++ b/packages/node-opcua-server/source/server_end_point.ts
@@ -121,6 +121,10 @@ export interface OPCUAServerEndPointOptions {
      */
     port: number;
     /**
+     * the tcp host
+     */
+    hostname?: string;
+    /**
      * the DER certificate chain
      */
     certificateChain: Certificate;
@@ -207,6 +211,7 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
      * the tcp port
      */
     public port: number;
+    public hostname?: string;
     public certificateManager: OPCUACertificateManager;
     public defaultSecureTokenLifetime: number;
     public maxConnections: number;
@@ -245,6 +250,7 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
 
         this.port = parseInt(options.port.toString(), 10);
         assert(typeof this.port === "number");
+        this.hostname = options.hostname;
 
         this._certificateChain = options.certificateChain;
         this._privateKey = options.privateKey;
@@ -510,8 +516,16 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
             debugLog("server is listening");
         });
 
+        const listenOptions: net.ListenOptions = {
+            port: this.port
+        };
+
+        if (this.hostname !== undefined && typeof this.hostname === "string" && this.hostname.length > 0) {
+            listenOptions.host = this.hostname;
+        }
+
         this._server!.listen(
-            this.port,
+            listenOptions,
             /*"::",*/ (err?: Error) => {
                 // 'listening' listener
                 debugLog(chalk.green.bold("LISTENING TO PORT "), this.port, "err  ", err);

--- a/packages/node-opcua-server/source/server_end_point.ts
+++ b/packages/node-opcua-server/source/server_end_point.ts
@@ -45,14 +45,13 @@ function isLoopbackAddress(address: string): boolean {
 function validateHostname(desiredHostname: string): Promise<string | undefined> {
     return new Promise<string | undefined>((resolve) => {
         if (isLoopbackAddress(desiredHostname)) {
-            resolve("127.0.0.1"); // Skip DNS validation for loopback address
+            resolve(desiredHostname); // Skip DNS validation for loopback address
         } else {
             dns.resolve4(desiredHostname, (err, addresses) => {
                 if (err || addresses.length === 0) {
                     resolve(undefined);
                 } else {
-                    const hostname = addresses[0]; // Use the first resolved IP address as the hostname
-                    resolve(hostname);
+                    resolve(desiredHostname);
                 }
             });
         }
@@ -272,7 +271,7 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
 
         this.port = parseInt(options.port.toString(), 10);
         assert(typeof this.port === "number");
-        if (options.hostname) {
+        if (options.hostname && options.hostname !== getFullyQualifiedDomainName()) {
             this.initializeHostname(options.hostname);
         }
 
@@ -328,9 +327,8 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
     }
 
     public toString(): string {
+        const privateKeyThumpPrint = makePrivateKeyThumbPrint(this.getPrivateKey());
 
-        const privateKeyThumpPrint = makePrivateKeyThumbPrint(this.getPrivateKey())
-        
         const txt =
             " end point" +
             this._counter +

--- a/packages/node-opcua-server/test/test_server_issue_1303.ts
+++ b/packages/node-opcua-server/test/test_server_issue_1303.ts
@@ -1,0 +1,79 @@
+import { spawn } from "child_process";
+import net from "net";
+import should from "should";
+import { OPCUAServer } from "..";
+
+async function findAvailablePort(): Promise<number> {
+    return new Promise((resolve) => {
+        const server = net.createServer();
+
+        server.listen(0); // 0 tells the OS to choose an available port
+
+        server.on("listening", function () {
+            const addressInfo = server.address() as net.AddressInfo;
+            const port = addressInfo.port;
+            server.once("close", function () {
+                console.log(`Found available port ${port}`);
+                resolve(port);
+            });
+            server.close();
+        });
+    });
+}
+
+async function executeNetstat(hostnames: string[], port: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const netstatProcess = spawn("sh", ["-c", "netstat -an"]);
+        let netstatOutput = "";
+
+        netstatProcess.stdout?.on("data", (data) => {
+            netstatOutput += data.toString();
+        });
+
+        netstatProcess.stderr?.on("data", (data) => {
+            console.error(`netstat error: ${data}`);
+        });
+
+        netstatProcess.on("close", (code) => {
+            if (code !== 0) {
+                console.error("netstat command failed.");
+                reject(new Error("netstat command failed."));
+            } else {
+                should(code).equal(0); // Ensure netstat command executed successfully
+                for (const hostname of hostnames) {
+                    should(netstatOutput).containEql(`${hostname}:${port}`);
+                }
+                resolve();
+            }
+        });
+    });
+}
+
+describe("OPCUAServer - issue#1303", () => {
+    it("should start a OPCUAServer on specific host and port", async () => {
+        try {
+            const port = await findAvailablePort();
+            const hostname = "127.0.0.1";
+            const server = new OPCUAServer({ hostname, port });
+            await server.start();
+            await executeNetstat([hostname], port);
+            await server.shutdown();
+            server.dispose();
+        } catch (err) {
+            should.fail(err, undefined, "An error occurred.");
+        }
+    });
+    it("should start a OPCUAServer on default host and port 26543", async () => {
+        try {
+            // If hostname is omitted, the server will accept connections on the unspecified IPv6 address (::) when IPv6 is available,
+            // or the unspecified IPv4 address (0.0.0.0) otherwise.
+            const server = new OPCUAServer();
+            await server.start();
+            await executeNetstat(["0.0.0.0", "[::]"], 26543);
+            await server.shutdown();
+            server.dispose();
+        } catch (err) {
+            should.fail(err, undefined, "An error occurred.");
+        }
+    });
+});

--- a/packages/node-opcua-server/test/test_server_issue_1303.ts
+++ b/packages/node-opcua-server/test/test_server_issue_1303.ts
@@ -1,6 +1,7 @@
 import { spawn } from "child_process";
 import net from "net";
 import should from "should";
+import { getFullyQualifiedDomainName } from "node-opcua-hostname";
 import { OPCUAServer } from "..";
 
 async function findAvailablePort(): Promise<number> {
@@ -70,6 +71,19 @@ describe("OPCUAServer - issue#1303", () => {
             const server = new OPCUAServer();
             await server.start();
             await executeNetstat(["0.0.0.0", "[::]"], 26543);
+            await server.shutdown();
+            server.dispose();
+        } catch (err) {
+            should.fail(err, undefined, "An error occurred.");
+        }
+    });
+    it("should start a OPCUAServer on FullyQualifiedDomainName and available port", async () => {
+        try {
+            const port = await findAvailablePort();
+            const hostname = getFullyQualifiedDomainName();
+            const server = new OPCUAServer({ hostname, port });
+            await server.start();
+            await executeNetstat(["0.0.0.0", "[::]"], port);
             await server.shutdown();
             server.dispose();
         } catch (err) {


### PR DESCRIPTION
Closes #1303

Ensure that the OPCUAServer correctly binds to the provided hostname when creating the TCP server. 
Previously, it was defaulting to [unspecified IPv6 address](https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address) (::) when IPv6 is available, or the [unspecified IPv4 address](https://en.wikipedia.org/wiki/0.0.0.0) (0.0.0.0) otherwise.

## Testing
- Added new test cases to validate the hostname parameter behavior.