### PR TITLE
feat: bind hostname to tcp server when passed to OPCUAServer

### DIFF
--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -3498,12 +3498,13 @@ export class OPCUAServer extends OPCUABaseServer {
 
     private createEndpoint(
         port1: number,
+        hostname: string | undefined,
         serverOptions: { defaultSecureTokenLifetime?: number; timeout?: number }
     ): OPCUAServerEndPoint {
         // add the tcp/ip endpoint with no security
         const endPoint = new OPCUAServerEndPoint({
             port: port1,
-
+            hostname,
             certificateManager: this.serverCertificateManager,
 
             certificateChain: this.getCertificateChain(),
@@ -3528,6 +3529,7 @@ export class OPCUAServer extends OPCUABaseServer {
             throw new Error("internal error");
         }
         const hostname = getFullyQualifiedDomainName();
+        const serverOptionHostname = serverOption.hostname;
         endpointOptions.hostname = endpointOptions.hostname || hostname;
         endpointOptions.port = endpointOptions.port === undefined ? 26543 : endpointOptions.port;
 
@@ -3542,7 +3544,7 @@ export class OPCUAServer extends OPCUABaseServer {
 
         const port = Number(endpointOptions.port || 0);
 
-        const endPoint = this.createEndpoint(port, serverOption);
+        const endPoint = this.createEndpoint(port, serverOptionHostname, serverOption);
 
         endpointOptions.alternateHostname = endpointOptions.alternateHostname || [];
         const alternateHostname =

--- a/packages/node-opcua-server/source/server_end_point.ts
+++ b/packages/node-opcua-server/source/server_end_point.ts
@@ -38,8 +38,14 @@ const doDebug = checkDebugFlag(__filename);
 
 const default_transportProfileUri = "http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary";
 
-function isLoopbackAddress(address: string): boolean {
-    return address === "127.0.0.1" || address.toLowerCase() === "localhost";
+function isLoopbackAddress(ipAddress: string): boolean {
+    // Check for IPv4 loopback addresses (127.0.0.0 - 127.255.255.255)
+    const ipv4LoopbackRegex = /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
+
+    // Check for IPv6 loopback addresses (::1 and loopback range)
+    const ipv6LoopbackRegex = /^(::1|fe80::1|::ffff:127\.\d{1,3}\.\d{1,3}\.\d{1,3})$/;
+
+    return ipv4LoopbackRegex.test(ipAddress) || ipv6LoopbackRegex.test(ipAddress);
 }
 
 function validateHostname(desiredHostname: string): Promise<string | undefined> {

--- a/packages/node-opcua-server/test/test_server_issue_1303.ts
+++ b/packages/node-opcua-server/test/test_server_issue_1303.ts
@@ -79,7 +79,7 @@ describe("OPCUAServer - issue#1303", () => {
             // or the unspecified IPv4 address (0.0.0.0) otherwise.
             const server = new OPCUAServer();
             await server.start();
-            await executeNetstat(["0.0.0.0", "[::]"], 26543);
+            await executeNetstat(["0.0.0.0", "[::]", "::"], 26543);
             await server.shutdown();
             server.dispose();
         } catch (err) {
@@ -92,7 +92,7 @@ describe("OPCUAServer - issue#1303", () => {
             const hostname = getFullyQualifiedDomainName();
             const server = new OPCUAServer({ hostname, port });
             await server.start();
-            await executeNetstat(["0.0.0.0", "[::]"], port);
+            await executeNetstat(["0.0.0.0", "[::]", "::"], port);
             await server.shutdown();
             server.dispose();
         } catch (err) {

--- a/packages/node-opcua-server/test/test_server_issue_1303.ts
+++ b/packages/node-opcua-server/test/test_server_issue_1303.ts
@@ -1,0 +1,93 @@
+import { spawn } from "child_process";
+import net from "net";
+import should from "should";
+import { getFullyQualifiedDomainName } from "node-opcua-hostname";
+import { OPCUAServer } from "..";
+
+async function findAvailablePort(): Promise<number> {
+    return new Promise((resolve) => {
+        const server = net.createServer();
+
+        server.listen(0); // 0 tells the OS to choose an available port
+
+        server.on("listening", function () {
+            const addressInfo = server.address() as net.AddressInfo;
+            const port = addressInfo.port;
+            server.once("close", function () {
+                console.log(`Found available port ${port}`);
+                resolve(port);
+            });
+            server.close();
+        });
+    });
+}
+
+async function executeNetstat(hostnames: string[], port: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const netstatProcess = spawn("sh", ["-c", "netstat -an"]);
+        let netstatOutput = "";
+
+        netstatProcess.stdout?.on("data", (data) => {
+            netstatOutput += data.toString();
+        });
+
+        netstatProcess.stderr?.on("data", (data) => {
+            console.error(`netstat error: ${data}`);
+        });
+
+        netstatProcess.on("close", (code) => {
+            if (code !== 0) {
+                console.error("netstat command failed.");
+                reject(new Error("netstat command failed."));
+            } else {
+                should(code).equal(0); // Ensure netstat command executed successfully
+                for (const hostname of hostnames) {
+                    should(netstatOutput).containEql(`${hostname}:${port}`);
+                }
+                resolve();
+            }
+        });
+    });
+}
+
+describe("OPCUAServer - issue#1303", () => {
+    it("should start a OPCUAServer on specific host and port", async () => {
+        try {
+            const port = await findAvailablePort();
+            const hostname = "127.0.0.1";
+            const server = new OPCUAServer({ hostname, port });
+            await server.start();
+            await executeNetstat([hostname], port);
+            await server.shutdown();
+            server.dispose();
+        } catch (err) {
+            should.fail(err, undefined, "An error occurred.");
+        }
+    });
+    it("should start a OPCUAServer on default host and port 26543", async () => {
+        try {
+            // If hostname is omitted, the server will accept connections on the unspecified IPv6 address (::) when IPv6 is available,
+            // or the unspecified IPv4 address (0.0.0.0) otherwise.
+            const server = new OPCUAServer();
+            await server.start();
+            await executeNetstat(["0.0.0.0", "[::]"], 26543);
+            await server.shutdown();
+            server.dispose();
+        } catch (err) {
+            should.fail(err, undefined, "An error occurred.");
+        }
+    });
+    it("should start a OPCUAServer on FullyQualifiedDomainName and available port", async () => {
+        try {
+            const port = await findAvailablePort();
+            const hostname = getFullyQualifiedDomainName();
+            const server = new OPCUAServer({ hostname, port });
+            await server.start();
+            await executeNetstat(["0.0.0.0", "[::]"], port);
+            await server.shutdown();
+            server.dispose();
+        } catch (err) {
+            should.fail(err, undefined, "An error occurred.");
+        }
+    });
+});


### PR DESCRIPTION
Closes #1303

Ensure that the OPCUAServer correctly binds to the provided hostname when creating the TCP server. 
Previously, it was defaulting to [unspecified IPv6 address](https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address) (::) when IPv6 is available, or the [unspecified IPv4 address](https://en.wikipedia.org/wiki/0.0.0.0) (0.0.0.0) otherwise.

## Testing
- Added new test cases to validate the hostname parameter behavior.