### PR TITLE
feat: bind hostname to tcp server when passed to OPCUAServer

### DIFF
--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -720,7 +720,14 @@ export interface OPCUAServerEndpointOptions {
      * @default getFullyQualifiedDomainName()
      */
     hostname?: string;
-
+    /**
+     * Host IP address or hostname where the TCP server listens for connections.
+     * If omitted, defaults to listening on all network interfaces:
+     * - Unspecified IPv6 address (::) if IPv6 is available,
+     * - Unspecified IPv4 address (0.0.0.0) otherwise.
+     * Use this to bind the server to a specific interface or IP.
+     */
+    host?: string;
     /**
      * the TCP port to listen to.
      * @default 26543
@@ -1202,7 +1209,7 @@ export class OPCUAServer extends OPCUABaseServer {
                 endpointDefinitions.push({
                     port: options.port === undefined ? 26543 : options.port,
                     hostname: options.hostname || hostname,
-
+                    host: options.host,
                     allowAnonymous: options.allowAnonymous,
                     alternateHostname: options.alternateHostname,
                     disableDiscovery: options.disableDiscovery,
@@ -3537,12 +3544,12 @@ export class OPCUAServer extends OPCUABaseServer {
 
     private createEndpoint(
         port1: number,
-        serverOptions: { defaultSecureTokenLifetime?: number; timeout?: number }
+        serverOptions: { defaultSecureTokenLifetime?: number; timeout?: number; host?:string }
     ): OPCUAServerEndPoint {
         // add the tcp/ip endpoint with no security
         const endPoint = new OPCUAServerEndPoint({
             port: port1,
-
+            host: serverOptions.host,
             certificateManager: this.serverCertificateManager,
 
             certificateChain: this.getCertificateChain(),

--- a/packages/node-opcua-server/source/server_end_point.ts
+++ b/packages/node-opcua-server/source/server_end_point.ts
@@ -122,6 +122,10 @@ export interface OPCUAServerEndPointOptions {
      */
     port: number;
     /**
+     * the tcp host
+     */
+    host?: string;
+    /**
      * the DER certificate chain
      */
     certificateChain: Certificate;
@@ -208,6 +212,7 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
      * the tcp port
      */
     public port: number;
+    public host: string | undefined;
     public certificateManager: OPCUACertificateManager;
     public defaultSecureTokenLifetime: number;
     public maxConnections: number;
@@ -245,6 +250,7 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
         options.port = options.port || 0;
 
         this.port = parseInt(options.port.toString(), 10);
+        this.host = options.host;
         assert(typeof this.port === "number");
 
         this._certificateChain = options.certificateChain;
@@ -510,8 +516,13 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
             debugLog("server is listening");
         });
 
+        const listenOptions: net.ListenOptions = {
+            port: this.port,
+            host: this.host
+        };
+
         this._server!.listen(
-            this.port,
+            listenOptions,
             /*"::",*/ (err?: Error) => {
                 // 'listening' listener
                 debugLog(chalk.green.bold("LISTENING TO PORT "), this.port, "err  ", err);

--- a/packages/node-opcua-server/test/test_server_issue_1303.ts
+++ b/packages/node-opcua-server/test/test_server_issue_1303.ts
@@ -1,0 +1,128 @@
+import net from "net";
+import os from "os";
+import should from "should";
+import { OPCUAServer } from "..";
+
+async function findAvailablePort(): Promise<number> {
+    return new Promise((resolve) => {
+        const server = net.createServer();
+        server.listen(0);
+        server.on("listening", function () {
+            const port = (server.address() as net.AddressInfo).port;
+            console.log(`INFO: Found available port ${port}`);
+            server.close(() => resolve(port));
+        });
+    });
+}
+
+function findLanIp(): string | undefined {
+    const networkInterfaces = os.networkInterfaces();
+
+    for (const iface of Object.values(networkInterfaces)) {
+        if (!iface) {
+            continue;
+        }
+
+        for (const alias of iface) {
+            if (alias.family === "IPv4" && !alias.internal) {
+                return alias.address;
+            }
+        }
+    }
+
+    return undefined;
+}
+
+function checkServer(host: string | undefined, port: number): Promise<boolean> {
+    return new Promise((resolve) => {
+        const socket = net.createConnection(port, host, () => {
+            socket.end();
+            resolve(true);
+        });
+
+        socket.on("error", () => {
+            resolve(false);
+        });
+    });
+}
+
+async function testServerStartupAndShutdown(host: string | undefined, port: number, endpointsToTest: string[]): Promise<boolean[]> {
+    try {
+        const serverOptions = host === undefined ? { port } : { host, port };
+        console.log("INFO: starting OPCUAServer with serverOptions: ", serverOptions);
+        console.log("INFO: endpointsToTest: ", endpointsToTest);
+
+        const server = new OPCUAServer(serverOptions);
+        await server.start();
+
+        const results: boolean[] = [];
+
+        for (const endpoint of endpointsToTest) {
+            const isEndpointConnected = await checkServer(endpoint, port);
+            results.push(isEndpointConnected);
+        }
+
+        await server.shutdown();
+        server.dispose();
+
+        return results;
+    } catch (err) {
+        console.error(`ERROR: failed server startup/shutdown with msg: ${err.message}`);
+        throw err;
+    }
+}
+
+describe("OPCUAServer - issue#1303", () => {
+    it("should start a net.Server on loopback address", async () => {
+        const port = await findAvailablePort();
+        const host = "localhost";
+
+        const lanIP = findLanIp();
+        const endpointsToTest = ["localhost"];
+
+        console.log(lanIP ? `WARNING: LAN IP found: ${lanIP}` : "WARNING: No LAN IP available, skipping test...");
+
+        if (lanIP) {
+            endpointsToTest.push(lanIP);
+
+            const results = await testServerStartupAndShutdown(host, port, endpointsToTest);
+
+            should(results[0]).eql(true, "It should be possible to connect to loopback interface (localhost)");
+            should(results[1]).eql(false, "It should not be possible to connect to external LAN IP");
+        }
+    });
+
+    it("should start a net.Server on LAN IP", async () => {
+        const port = await findAvailablePort();
+        const host = findLanIp();
+
+        console.log(host ? `WARNING: LAN IP found: ${host}` : "WARNING: No LAN IP available, skipping test...");
+
+        if (host) {
+            const endpointsToTest = [host, "localhost"];
+            const results = await testServerStartupAndShutdown(host, port, endpointsToTest);
+
+            should(results[0]).eql(true, "It should be possible to connect to LAN IP");
+            should(results[1]).eql(false, "It should not be possible to connect to loopback interface (localhost)");
+        }
+    });
+
+    it("should start a net.Server on default host (ensures backward compatibility)", async () => {
+        const port = await findAvailablePort();
+        const lanIP = findLanIp();
+        const endpointsToTest = ["127.0.0.1", "localhost", "::1"];
+
+        console.log(lanIP ? `WARNING: LAN IP found: ${lanIP}` : "WARNING: No LAN IP available, skipping test...");
+
+        if (lanIP) {
+            endpointsToTest.push(lanIP);
+
+            const results = await testServerStartupAndShutdown(undefined, port, endpointsToTest);
+
+            should(results[0]).eql(true, "It should be possible to connect to loopback interface (127.0.0.1)");
+            should(results[1]).eql(true, "It should be possible to connect to loopback interface (localhost)");
+            should(results[2]).eql(true, "It should be possible to connect to loopback interface (::1)");
+            should(results[3]).eql(true, "It should be possible to connect to external LAN IP");
+        }
+    });
+});


### PR DESCRIPTION
Closes #1303

Ensure that the OPCUAServer correctly binds to the provided hostname when creating the TCP server. 
Previously, it was defaulting to [unspecified IPv6 address](https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address) (::) when IPv6 is available, or the [unspecified IPv4 address](https://en.wikipedia.org/wiki/0.0.0.0) (0.0.0.0) otherwise.

## Testing
- Added new test cases to validate the hostname parameter behavior.