### PR TITLE
feat: add description and displayName

### DIFF
--- a/packages/node-opcua-client-crawler/source/node_crawler.ts
+++ b/packages/node-opcua-client-crawler/source/node_crawler.ts
@@ -159,7 +159,9 @@ export class NodeCrawler extends NodeCrawlerBase {
          */
         const obj: any = {
             browseName: object.browseName.name,
-            nodeId: object.nodeId.toString()
+            nodeId: object.nodeId.toString(),
+            displayName: object.displayName.text,
+            description:object.description.text,
         };
 
         // Append nodeClass


### PR DESCRIPTION
add description and displayName to base object when crawling. Those values are already present in the CacheNode object