### PR TITLE
fix: check if requestData exists before getting callback in client secure channel

### DIFF
--- a/packages/node-opcua-secure-channel/source/client/client_secure_channel_layer.ts
+++ b/packages/node-opcua-secure-channel/source/client/client_secure_channel_layer.ts
@@ -505,7 +505,7 @@ export class ClientSecureChannelLayer extends EventEmitter {
                     }
                 });
 
-                const callback = requestData.callback;
+                const callback = requestData ? requestData.callback : null;
                 delete this._requests[requestId];
                 callback && callback(null, err);
             })
@@ -531,7 +531,7 @@ export class ClientSecureChannelLayer extends EventEmitter {
                     errorLog(" message was 2:", requestData ? requestData.request.toString() : "<null>");
                 }
 
-                const callback = requestData.callback;
+                const callback = requestData ?  requestData.callback : null;
                 delete this._requests[requestId];
                 callback && callback(err, undefined);
 


### PR DESCRIPTION
I've come across a bug when connected after some time on a OPCUA server. 

I didn't succeed to reproduce the error or test my fix because I don't know what trigger the error at first. However, here is the error I got which led me to this fix: 

`TypeError: Cannot read properties of undefined (reading 'callback')
at MessageBuilder.<anonymous> (/Users/nicolasburger/IdeaProjects/OIBus/backend/node_modules/node-opcua-secure-channel/dist/source/client/client_secure_channel_layer.js:243:42)
at MessageBuilder.emit (node:events:513:28)
at MessageBuilder._report_error (/Users/nicolasburger/IdeaProjects/OIBus/backend/node_modules/node-opcua-transport/dist/source/message_builder_base.js:127:14)
at MessageBuilder._feed_messageChunk (/Users/nicolasburger/IdeaProjects/OIBus/backend/node_modules/node-opcua-transport/dist/source/message_builder_base.js:192:22)
at PacketAssembler.<anonymous> (/Users/nicolasburger/IdeaProjects/OIBus/backend/node_modules/node-opcua-transport/dist/source/message_builder_base.js:64:66)
at PacketAssembler.emit (node:events:513:28)
at PacketAssembler.feed (/Users/nicolasburger/IdeaProjects/OIBus/backend/node_modules/node-opcua-packet-assembler/dist/packet_assembler.js:75:18)
at MessageBuilder.feed (/Users/nicolasburger/IdeaProjects/OIBus/backend/node_modules/node-opcua-transport/dist/source/message_builder_base.js:94:35)
at ClientSecureChannelLayer._on_receive_message_chunk (/Users/nicolasburger/IdeaProjects/OIBus/backend/node_modules/node-opcua-secure-channel/dist/source/client/client_secure_channel_layer.js:961:29)
at ClientTCP_transport.<anonymous> (/Users/nicolasburger/IdeaProjects/OIBus/backend/node_modules/node-opcua-secure-channel/dist/source/client/client_secure_channel_layer.js:806:18)`

