### PR TITLE
Dispose MonitoredItem after event

### DIFF
--- a/packages/node-opcua-server/source/server_subscription.ts
+++ b/packages/node-opcua-server/source/server_subscription.ts
@@ -1145,14 +1145,14 @@ export class Subscription extends EventEmitter {
 
         monitoredItem.terminate();
 
-        monitoredItem.dispose();
-
         /**
          *
          * notify that a monitored item has been removed from the subscription
          * @param monitoredItem {MonitoredItem}
          */
         this.emit("removeMonitoredItem", monitoredItem);
+
+        monitoredItem.dispose();
 
         delete this.monitoredItems[monitoredItemId];
         this.globalCounter.totalMonitoredItemCount -= 1;


### PR DESCRIPTION
Prior to emitting the `removeMonitoredItem` event, the MonitoredItem instance is disposed. This resets all properties of that MonitoredItem. When the `removeMonitoredItem` event is raised, a subscriber cannot retrieve any information from this instance (i.e. the item which was monitored).
Therefore the MonitoredItem instance is disposed after emitting the event.