### PR TITLE
fix issue in BaseNode.remove_reference

### DIFF
--- a/packages/node-opcua-address-space/src/base_node_impl.ts
+++ b/packages/node-opcua-address-space/src/base_node_impl.ts
@@ -940,10 +940,6 @@ export class BaseNodeImpl extends EventEmitter implements BaseNode {
 
         const addressSpace = this.addressSpace as AddressSpacePrivate;
 
-        // istanbul ignore next
-        if (!addressSpace) {
-            debugLog("Where is addressSpace ?");
-        }
         const reference = addressSpace.normalizeReferenceTypes([referenceOpts!])![0];
         const h = (<ReferenceImpl>reference).hash;
 
@@ -1015,6 +1011,15 @@ export class BaseNodeImpl extends EventEmitter implements BaseNode {
         if (addressSpace.isFrugal) {
             // skipping
             return;
+        }
+        if (!reference.isForward) {
+            const parentNode = resolveReferenceNode(addressSpace, reference);
+            // uninstall backward
+            (parentNode as BaseNodeImpl).uninstall_extra_properties({
+                isForward: true,
+                nodeId: this.nodeId,
+                referenceType: reference.referenceType
+            });
         }
         const childNode = resolveReferenceNode(addressSpace, reference);
 

--- a/packages/node-opcua-address-space/test/test_referencetype.ts
+++ b/packages/node-opcua-address-space/test/test_referencetype.ts
@@ -1,3 +1,4 @@
+import "should";
 import { AttributeIds, BrowseDirection, makeNodeClassMask } from "node-opcua-data-model";
 import { NodeClass } from "node-opcua-data-model";
 import { redirectToFile } from "node-opcua-debug/nodeJS";

--- a/packages/node-opcua-address-space/test/test_remove_reference.ts
+++ b/packages/node-opcua-address-space/test/test_remove_reference.ts
@@ -1,0 +1,82 @@
+import { sameNodeId } from "node-opcua-nodeid";
+import { AddressSpace, BaseNode, UARootFolder } from "..";
+import { getMiniAddressSpace } from "../distHelpers";
+import should from  "should";
+import { BrowseDirection } from "node-opcua-data-model";
+
+describe("AddressSpace : removeReference", ()=>{
+
+    let addressSpace: AddressSpace;
+    let rootFolder: UARootFolder;
+    let variable1: BaseNode;
+    let variable2: BaseNode;
+    let obj: BaseNode & { variable1?: BaseNode, variable2?: BaseNode };
+    
+    beforeEach(async () => {
+        addressSpace = await getMiniAddressSpace();
+        rootFolder = addressSpace.rootFolder;
+        rootFolder.browseName.toString().should.equal("Root");
+
+        const namespace = addressSpace.getOwnNamespace();
+
+         obj = namespace.addObject({
+            browseName: "Object1"
+        });
+
+         variable1 = namespace.addVariable({
+            browseName: "Variable1",
+            componentOf: obj,
+            dataType: "Double",
+            value: { dataType: "Double", value: 3.14 },
+            minimumSamplingInterval: 1000
+        });
+
+        variable2 = namespace.addVariable({
+            browseName: "Variable2",
+            componentOf: obj,
+            dataType: "Double",
+            value: { dataType: "Double", value: 3.14 },
+            minimumSamplingInterval: 1000
+        });
+
+    });
+
+    afterEach(() => {
+        if (addressSpace) {
+            addressSpace.dispose();
+        }
+    });
+    
+    it("should remove a reference -> pre-condition ", ()=>{  
+        should.exist(obj["variable1"]);
+        should.exist(obj["variable2"]);
+        should.exist(obj.getChildByName("Variable1"));  
+        should.exist(obj.getChildByName("Variable2"));  
+    });
+
+    it("should remove a reference -> when deleting from parent", ()=>{
+
+        const ref = obj.findReferences("HasComponent", true).filter((x)=>sameNodeId(x.nodeId, variable1.nodeId))[0];
+
+        obj.removeReference(ref);
+
+        should.not.exist(obj["variable1"]);
+        should.not.exist(obj.getChildByName("Variable1"));  
+        should.exist(obj["variable2"]);
+        should.exist(obj.getChildByName("Variable2"));  
+        
+
+    });
+    it("should remove a reference -> when deleting from child", ()=>{
+
+        const ref = variable1.findReferencesEx("HasComponent", BrowseDirection.Inverse)[0];
+        
+        variable1.removeReference(ref);
+
+        should.not.exist(obj["variable1"]);
+        should.not.exist(obj.getChildByName("Variable1"));  
+        should.exist(obj["variable2"]);
+        should.exist(obj.getChildByName("Variable2"));  
+    });
+
+});


### PR DESCRIPTION
fix an issue in BaseNode.remove_reference that would not clear the added javascript properties on the parent Node when remove_reference is called on the child.