### PR TITLE
fix: unencrypted password on empty buffer server certificate

### DIFF
--- a/packages/node-opcua-client/source/private/opcua_client_impl.ts
+++ b/packages/node-opcua-client/source/private/opcua_client_impl.ts
@@ -295,7 +295,7 @@ function createUserNameIdentityToken(
     let identityToken;
     let serverCertificate: Buffer | string | null = session.serverCertificate;
     // if server does not provide certificate use unencrypted password
-    if (!serverCertificate) {
+    if (!serverCertificate || serverCertificate.length === 0) {
         identityToken = new UserNameIdentityToken({
             encryptionAlgorithm: null,
             password: Buffer.from(password as string, "utf-8"),


### PR DESCRIPTION
This PR addresses https://github.com/node-opcua/node-opcua/issues/1431

When using the dockerized asyncua opc server, the `serverCertificate` becomes the empty Buffer. This PR adds a fallback so that empty buffers and strings also use the unencrypted password.