### PR TITLE
fixes the parsing of the ClientSession.timestampsToReturn argument

### DIFF
--- a/packages/node-opcua-client/source/private/client_session_impl.ts
+++ b/packages/node-opcua-client/source/private/client_session_impl.ts
@@ -632,7 +632,7 @@ export class ClientSessionImpl extends EventEmitter implements ClientSession, Re
         options.numValuesPerNode = options.numValuesPerNode || 0;
         options.returnBounds = options.returnBounds || options.returnBounds === undefined ? true : false;
         options.isReadModified = options.isReadModified || false;
-        options.timestampsToReturn = options.timestampsToReturn || TimestampsToReturn.Both;
+        options.timestampsToReturn = options.timestampsToReturn ?? TimestampsToReturn.Both;
 
         const arg0 = args[0];
         const isArray = Array.isArray(arg0);


### PR DESCRIPTION
Hello, 

this PR is to fix the error reported in #1387 

I am not sure how to set a working test since it would require the complexity of mocking a server and create a session, but I tried to run all the tests that have already been defined, and they are successful. 