### PR TITLE
refactor(server): improve MonitoredItem#setMonitoringMode behavior

### DIFF
--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -3333,8 +3333,8 @@ export class OPCUAServer extends OPCUABaseServer {
                     if (!monitoredItem) {
                         return StatusCodes.BadMonitoredItemIdInvalid;
                     }
-                    monitoredItem.setMonitoringMode(monitoringMode);
-                    return StatusCodes.Good;
+                    const statusCode = monitoredItem.setMonitoringMode(monitoringMode);
+                    return statusCode;
                 });
 
                 const response = new SetMonitoringModeResponse({


### PR DESCRIPTION
This commit refactors the `setMonitoringMode` method in `MonitoredItem` to provide more robust error handling and feedback.

- The method now returns a `StatusCode` to indicate the outcome of the operation (e.g., `Good`, `BadNothingToDo`, `BadInvalidArgument`).
- The internal `monitoringMode` property has been encapsulated to prevent direct modification.
- The `OPCUAServer`'s `setMonitoringMode` endpoint has been updated to propagate the `StatusCode` to the client.
- A new test case has been added to verify the new behavior.