### PR TITLE
fix: inherited member type compatibility in TypeScript generator

### DIFF
--- a/packages/node-opcua-convert-nodeset-to-javascript/CHANGELOG.md
+++ b/packages/node-opcua-convert-nodeset-to-javascript/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+#### Fix #1: Inherited member type compatibility
+
+**Problem:**  
+When a derived class overrides a member without adding new sub-members, the generator used the raw TypeDefinition type instead of the specialized type from the base class.
+
+**Example:**
+```typescript
+// Base class defines specialized type:
+interface UAIJoiningSystemAsset_identification 
+    extends Omit<UAMachineryItemIdentification, "manufacturer"|"serialNumber"> { ... }
+
+// BEFORE (wrong): Generator used generic type
+identification: UAMachineryItemIdentification;
+
+// AFTER (correct): Generator uses specialized type from base class  
+identification: UAIJoiningSystemAsset_identification;
+```
+
+This caused TS2430 errors in some NodeSets (e.g., LADS):
+```
+error TS2430: Interface 'UAMultiSensorFunction_Base' incorrectly extends interface 'UABaseSensorFunction_Base'.
+```
+
+**Solution:**  
+If the base class has a specialized type for a member, use that type to maintain compatibility in the inheritance chain.
+
+---
+
+#### Fix #2: Correct type arguments for inherited generic types
+
+**Problem:**  
+When `childType` was inherited from the base class (via Fix #1), the type arguments (suffix) were still computed based on the TypeDefinition, not the inherited type.
+
+**Example:**
+```typescript
+// Base class: (with Fix #1)
+currentValue: UADiscreteItem<any, any>;        // 2 type args (generic)
+
+// TypeDefinition (TwoStateDiscreteType) has dataType=Boolean, so only 1 param
+
+// BEFORE (wrong): 
+currentValue: UADiscreteItem<boolean>;         // 1 arg - TS2314 error!
+
+// AFTER (correct):
+currentValue: UADiscreteItem<boolean, DataType.Boolean>;  // 2 args, specific ✓
+```
+
+**Solution:**  
+When inheriting `childType` from the base class, recalculate the type arguments based on the base type's generic parameters, combined with the current node's specific dataType.
+
+---
+
+### Affected NodeSets
+
+The fixes correct type generation in the following existing NodeSets:
+- node-opcua-nodeset-ua (3 files)
+- node-opcua-nodeset-ijt-base (14 files)
+- node-opcua-nodeset-scales-v-2 (7 files)
+- node-opcua-nodeset-glass-flat (2 files)
+- node-opcua-nodeset-machine-tool (1 file)
+- node-opcua-nodeset-padim (1 file)

--- a/packages/node-opcua-nodeset-glass-flat/source/ua_production_job.ts
+++ b/packages/node-opcua-nodeset-glass-flat/source/ua_production_job.ts
@@ -3,7 +3,7 @@ import { UAObject, UAMethod, UAProperty } from "node-opcua-address-space-base"
 import { DataType } from "node-opcua-variant"
 import { LocalizedText } from "node-opcua-data-model"
 import { UInt16, UAString } from "node-opcua-basic-types"
-import { UAFiniteStateVariable } from "node-opcua-nodeset-ua/dist/ua_finite_state_variable"
+import { UAStateVariable } from "node-opcua-nodeset-ua/dist/ua_state_variable"
 import { UABaseDataVariable } from "node-opcua-nodeset-ua/dist/ua_base_data_variable"
 import { UAFolder } from "node-opcua-nodeset-ua/dist/ua_folder"
 import { UALockingServices } from "node-opcua-nodeset-di/dist/ua_locking_services"
@@ -11,7 +11,7 @@ import { UAProductionStateMachine } from "./ua_production_state_machine"
 import { UAInitializingSubStateMachine } from "./ua_initializing_sub_state_machine"
 import { UAInstruction } from "./ua_instruction"
 export interface UAProductionJob_state extends Omit<UAProductionStateMachine, "currentState"> { // Object
-      currentState: UAFiniteStateVariable<LocalizedText>;
+      currentState: UAStateVariable<LocalizedText>;
       initializedState: UAInitializingSubStateMachine;
 }
 /**

--- a/packages/node-opcua-nodeset-glass-flat/source/ua_production_state_machine.ts
+++ b/packages/node-opcua-nodeset-glass-flat/source/ua_production_state_machine.ts
@@ -3,7 +3,7 @@ import { LocalizedText } from "node-opcua-data-model"
 import { UAFiniteStateMachine, UAFiniteStateMachine_Base } from "node-opcua-nodeset-ua/dist/ua_finite_state_machine"
 import { UAState } from "node-opcua-nodeset-ua/dist/ua_state"
 import { UATransition } from "node-opcua-nodeset-ua/dist/ua_transition"
-import { UAFiniteStateVariable } from "node-opcua-nodeset-ua/dist/ua_finite_state_variable"
+import { UAStateVariable } from "node-opcua-nodeset-ua/dist/ua_state_variable"
 import { UAInitialState } from "node-opcua-nodeset-ua/dist/ua_initial_state"
 import { UAInitializingSubStateMachine } from "./ua_initializing_sub_state_machine"
 /**
@@ -17,7 +17,7 @@ import { UAInitializingSubStateMachine } from "./ua_initializing_sub_state_machi
 export interface UAProductionStateMachine_Base extends UAFiniteStateMachine_Base {
     aborted: UAState;
     abortedToInitializing: UATransition;
-    currentState: UAFiniteStateVariable<LocalizedText>;
+    currentState: UAStateVariable<LocalizedText>;
     ended: UAState;
     endedToInitializing: UATransition;
     initializing: UAInitialState;

--- a/packages/node-opcua-nodeset-ijt-base/source/ua_i_accessory.ts
+++ b/packages/node-opcua-nodeset-ijt-base/source/ua_i_accessory.ts
@@ -2,8 +2,7 @@
 import { DataType } from "node-opcua-variant"
 import { UAString } from "node-opcua-basic-types"
 import { UABaseDataVariable } from "node-opcua-nodeset-ua/dist/ua_base_data_variable"
-import { UAMachineryItemIdentification } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_identification"
-import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base } from "./ua_i_joining_system_asset"
+import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base, UAIJoiningSystemAsset_identification } from "./ua_i_joining_system_asset"
 export interface UAIAccessory_parameters extends UAIJoiningSystemAsset_parameters { // Object
       /**
        * type
@@ -32,7 +31,7 @@ export interface UAIAccessory_Base extends UAIJoiningSystemAsset_Base {
      * it with MachineIdentificationType or
      * MachineryComponentIdentificationType.
      */
-    identification: UAMachineryItemIdentification;
+    identification: UAIJoiningSystemAsset_identification;
     /**
      * parameters
      * The Parameters Object is an instance of

--- a/packages/node-opcua-nodeset-ijt-base/source/ua_i_battery.ts
+++ b/packages/node-opcua-nodeset-ijt-base/source/ua_i_battery.ts
@@ -2,8 +2,7 @@
 import { DataType } from "node-opcua-variant"
 import { Int64, Byte, UAString } from "node-opcua-basic-types"
 import { UABaseDataVariable } from "node-opcua-nodeset-ua/dist/ua_base_data_variable"
-import { UAMachineryItemIdentification } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_identification"
-import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base } from "./ua_i_joining_system_asset"
+import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base, UAIJoiningSystemAsset_identification } from "./ua_i_joining_system_asset"
 import { UAJoiningDataVariable } from "./ua_joining_data_variable"
 export interface UAIBattery_parameters extends UAIJoiningSystemAsset_parameters { // Object
       /**
@@ -71,7 +70,7 @@ export interface UAIBattery_Base extends UAIJoiningSystemAsset_Base {
      * it with MachineIdentificationType or
      * MachineryComponentIdentificationType.
      */
-    identification: UAMachineryItemIdentification;
+    identification: UAIJoiningSystemAsset_identification;
     /**
      * parameters
      * The Parameters Object is an instance of

--- a/packages/node-opcua-nodeset-ijt-base/source/ua_i_cable.ts
+++ b/packages/node-opcua-nodeset-ijt-base/source/ua_i_cable.ts
@@ -2,8 +2,7 @@
 import { DataType } from "node-opcua-variant"
 import { Byte } from "node-opcua-basic-types"
 import { UAMultiStateDiscrete } from "node-opcua-nodeset-ua/dist/ua_multi_state_discrete"
-import { UAMachineryItemIdentification } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_identification"
-import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base } from "./ua_i_joining_system_asset"
+import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base, UAIJoiningSystemAsset_identification } from "./ua_i_joining_system_asset"
 import { UAJoiningDataVariable } from "./ua_joining_data_variable"
 export interface UAICable_parameters extends UAIJoiningSystemAsset_parameters { // Object
       /**
@@ -36,7 +35,7 @@ export interface UAICable_Base extends UAIJoiningSystemAsset_Base {
      * it with MachineIdentificationType or
      * MachineryComponentIdentificationType.
      */
-    identification: UAMachineryItemIdentification;
+    identification: UAIJoiningSystemAsset_identification;
     /**
      * parameters
      * The Parameters Object is an instance of

--- a/packages/node-opcua-nodeset-ijt-base/source/ua_i_controller.ts
+++ b/packages/node-opcua-nodeset-ijt-base/source/ua_i_controller.ts
@@ -2,8 +2,7 @@
 import { DataType } from "node-opcua-variant"
 import { Byte } from "node-opcua-basic-types"
 import { UAMultiStateDiscrete } from "node-opcua-nodeset-ua/dist/ua_multi_state_discrete"
-import { UAMachineryItemIdentification } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_identification"
-import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base } from "./ua_i_joining_system_asset"
+import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base, UAIJoiningSystemAsset_identification } from "./ua_i_joining_system_asset"
 export interface UAIController_parameters extends UAIJoiningSystemAsset_parameters { // Object
       /**
        * type
@@ -30,7 +29,7 @@ export interface UAIController_Base extends UAIJoiningSystemAsset_Base {
      * it with MachineIdentificationType or
      * MachineryComponentIdentificationType.
      */
-    identification: UAMachineryItemIdentification;
+    identification: UAIJoiningSystemAsset_identification;
     /**
      * parameters
      * The Parameters Object is an instance of

--- a/packages/node-opcua-nodeset-ijt-base/source/ua_i_feeder.ts
+++ b/packages/node-opcua-nodeset-ijt-base/source/ua_i_feeder.ts
@@ -3,8 +3,7 @@ import { DataType } from "node-opcua-variant"
 import { Byte, UAString } from "node-opcua-basic-types"
 import { UABaseDataVariable } from "node-opcua-nodeset-ua/dist/ua_base_data_variable"
 import { UAMultiStateDiscrete } from "node-opcua-nodeset-ua/dist/ua_multi_state_discrete"
-import { UAMachineryItemIdentification } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_identification"
-import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base } from "./ua_i_joining_system_asset"
+import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base, UAIJoiningSystemAsset_identification } from "./ua_i_joining_system_asset"
 import { UAJoiningDataVariable } from "./ua_joining_data_variable"
 export interface UAIFeeder_parameters extends UAIJoiningSystemAsset_parameters { // Object
       /**
@@ -50,7 +49,7 @@ export interface UAIFeeder_Base extends UAIJoiningSystemAsset_Base {
      * it with MachineIdentificationType or
      * MachineryComponentIdentificationType.
      */
-    identification: UAMachineryItemIdentification;
+    identification: UAIJoiningSystemAsset_identification;
     /**
      * parameters
      * The Parameters Object is an instance of

--- a/packages/node-opcua-nodeset-ijt-base/source/ua_i_memory_device.ts
+++ b/packages/node-opcua-nodeset-ijt-base/source/ua_i_memory_device.ts
@@ -2,8 +2,7 @@
 import { DataType } from "node-opcua-variant"
 import { UInt64, UAString } from "node-opcua-basic-types"
 import { UABaseDataVariable } from "node-opcua-nodeset-ua/dist/ua_base_data_variable"
-import { UAMachineryItemIdentification } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_identification"
-import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base } from "./ua_i_joining_system_asset"
+import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base, UAIJoiningSystemAsset_identification } from "./ua_i_joining_system_asset"
 export interface UAIMemoryDevice_parameters extends UAIJoiningSystemAsset_parameters { // Object
       /**
        * storageCapacity
@@ -44,7 +43,7 @@ export interface UAIMemoryDevice_Base extends UAIJoiningSystemAsset_Base {
      * it with MachineIdentificationType or
      * MachineryComponentIdentificationType.
      */
-    identification: UAMachineryItemIdentification;
+    identification: UAIJoiningSystemAsset_identification;
     /**
      * parameters
      * The Parameters Object is an instance of

--- a/packages/node-opcua-nodeset-ijt-base/source/ua_i_power_supply.ts
+++ b/packages/node-opcua-nodeset-ijt-base/source/ua_i_power_supply.ts
@@ -2,8 +2,7 @@
 import { DataType } from "node-opcua-variant"
 import { UAString } from "node-opcua-basic-types"
 import { UABaseDataVariable } from "node-opcua-nodeset-ua/dist/ua_base_data_variable"
-import { UAMachineryItemIdentification } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_identification"
-import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base } from "./ua_i_joining_system_asset"
+import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base, UAIJoiningSystemAsset_identification } from "./ua_i_joining_system_asset"
 import { UAJoiningDataVariable } from "./ua_joining_data_variable"
 export interface UAIPowerSupply_parameters extends UAIJoiningSystemAsset_parameters { // Object
       /**
@@ -50,7 +49,7 @@ export interface UAIPowerSupply_Base extends UAIJoiningSystemAsset_Base {
      * it with MachineIdentificationType or
      * MachineryComponentIdentificationType.
      */
-    identification: UAMachineryItemIdentification;
+    identification: UAIJoiningSystemAsset_identification;
     /**
      * parameters
      * The Parameters Object is an instance of

--- a/packages/node-opcua-nodeset-ijt-base/source/ua_i_sensor.ts
+++ b/packages/node-opcua-nodeset-ijt-base/source/ua_i_sensor.ts
@@ -3,8 +3,7 @@ import { DataType } from "node-opcua-variant"
 import { Int64, Byte } from "node-opcua-basic-types"
 import { UABaseDataVariable } from "node-opcua-nodeset-ua/dist/ua_base_data_variable"
 import { UAMultiStateDiscrete } from "node-opcua-nodeset-ua/dist/ua_multi_state_discrete"
-import { UAMachineryItemIdentification } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_identification"
-import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base } from "./ua_i_joining_system_asset"
+import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base, UAIJoiningSystemAsset_identification } from "./ua_i_joining_system_asset"
 export interface UAISensor_parameters extends UAIJoiningSystemAsset_parameters { // Object
       /**
        * measuredValue
@@ -44,7 +43,7 @@ export interface UAISensor_Base extends UAIJoiningSystemAsset_Base {
      * it with MachineIdentificationType or
      * MachineryComponentIdentificationType.
      */
-    identification: UAMachineryItemIdentification;
+    identification: UAIJoiningSystemAsset_identification;
     /**
      * parameters
      * The Parameters Object is an instance of

--- a/packages/node-opcua-nodeset-ijt-base/source/ua_i_servo.ts
+++ b/packages/node-opcua-nodeset-ijt-base/source/ua_i_servo.ts
@@ -2,8 +2,7 @@
 import { DataType } from "node-opcua-variant"
 import { Int16 } from "node-opcua-basic-types"
 import { UABaseDataVariable } from "node-opcua-nodeset-ua/dist/ua_base_data_variable"
-import { UAMachineryItemIdentification } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_identification"
-import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base } from "./ua_i_joining_system_asset"
+import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base, UAIJoiningSystemAsset_identification } from "./ua_i_joining_system_asset"
 export interface UAIServo_parameters extends UAIJoiningSystemAsset_parameters { // Object
       /**
        * nodeNumber
@@ -32,7 +31,7 @@ export interface UAIServo_Base extends UAIJoiningSystemAsset_Base {
      * it with MachineIdentificationType or
      * MachineryComponentIdentificationType.
      */
-    identification: UAMachineryItemIdentification;
+    identification: UAIJoiningSystemAsset_identification;
     /**
      * parameters
      * The Parameters Object is an instance of

--- a/packages/node-opcua-nodeset-ijt-base/source/ua_i_software.ts
+++ b/packages/node-opcua-nodeset-ijt-base/source/ua_i_software.ts
@@ -1,6 +1,5 @@
 // ----- this file has been automatically generated - do not edit
-import { UAMachineryItemIdentification } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_identification"
-import { UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base } from "./ua_i_joining_system_asset"
+import { UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base, UAIJoiningSystemAsset_identification } from "./ua_i_joining_system_asset"
 /**
  * |                |                                                            |
  * |----------------|------------------------------------------------------------|
@@ -20,7 +19,7 @@ export interface UAISoftware_Base extends UAIJoiningSystemAsset_Base {
      * it with MachineIdentificationType or
      * MachineryComponentIdentificationType.
      */
-    identification: UAMachineryItemIdentification;
+    identification: UAIJoiningSystemAsset_identification;
 }
 export interface UAISoftware extends Omit<UAIJoiningSystemAsset, "identification">, UAISoftware_Base {
 }

--- a/packages/node-opcua-nodeset-ijt-base/source/ua_i_sub_component.ts
+++ b/packages/node-opcua-nodeset-ijt-base/source/ua_i_sub_component.ts
@@ -2,8 +2,7 @@
 import { DataType } from "node-opcua-variant"
 import { UAString } from "node-opcua-basic-types"
 import { UABaseDataVariable } from "node-opcua-nodeset-ua/dist/ua_base_data_variable"
-import { UAMachineryItemIdentification } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_identification"
-import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base } from "./ua_i_joining_system_asset"
+import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base, UAIJoiningSystemAsset_identification } from "./ua_i_joining_system_asset"
 export interface UAISubComponent_parameters extends UAIJoiningSystemAsset_parameters { // Object
       /**
        * type
@@ -32,7 +31,7 @@ export interface UAISubComponent_Base extends UAIJoiningSystemAsset_Base {
      * it with MachineIdentificationType or
      * MachineryComponentIdentificationType.
      */
-    identification: UAMachineryItemIdentification;
+    identification: UAIJoiningSystemAsset_identification;
     /**
      * parameters
      * The Parameters Object is an instance of

--- a/packages/node-opcua-nodeset-ijt-base/source/ua_i_tool.ts
+++ b/packages/node-opcua-nodeset-ijt-base/source/ua_i_tool.ts
@@ -2,8 +2,7 @@
 import { DataType } from "node-opcua-variant"
 import { Byte } from "node-opcua-basic-types"
 import { UAMultiStateDiscrete } from "node-opcua-nodeset-ua/dist/ua_multi_state_discrete"
-import { UAMachineryItemIdentification } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_identification"
-import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base } from "./ua_i_joining_system_asset"
+import { UAIJoiningSystemAsset_parameters, UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base, UAIJoiningSystemAsset_identification } from "./ua_i_joining_system_asset"
 export interface UAITool_parameters extends UAIJoiningSystemAsset_parameters { // Object
       /**
        * type
@@ -30,7 +29,7 @@ export interface UAITool_Base extends UAIJoiningSystemAsset_Base {
      * it with MachineIdentificationType or
      * MachineryComponentIdentificationType.
      */
-    identification: UAMachineryItemIdentification;
+    identification: UAIJoiningSystemAsset_identification;
     /**
      * parameters
      * The Parameters Object is an instance of

--- a/packages/node-opcua-nodeset-ijt-base/source/ua_i_virtual_station.ts
+++ b/packages/node-opcua-nodeset-ijt-base/source/ua_i_virtual_station.ts
@@ -1,6 +1,5 @@
 // ----- this file has been automatically generated - do not edit
-import { UAMachineryItemIdentification } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_identification"
-import { UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base } from "./ua_i_joining_system_asset"
+import { UAIJoiningSystemAsset, UAIJoiningSystemAsset_Base, UAIJoiningSystemAsset_identification } from "./ua_i_joining_system_asset"
 /**
  * |                |                                                            |
  * |----------------|------------------------------------------------------------|
@@ -20,7 +19,7 @@ export interface UAIVirtualStation_Base extends UAIJoiningSystemAsset_Base {
      * it with MachineIdentificationType or
      * MachineryComponentIdentificationType.
      */
-    identification: UAMachineryItemIdentification;
+    identification: UAIJoiningSystemAsset_identification;
 }
 export interface UAIVirtualStation extends Omit<UAIJoiningSystemAsset, "identification">, UAIVirtualStation_Base {
 }

--- a/packages/node-opcua-nodeset-ijt-base/source/ua_joining_system_result_ready_event.ts
+++ b/packages/node-opcua-nodeset-ijt-base/source/ua_joining_system_result_ready_event.ts
@@ -1,7 +1,8 @@
 // ----- this file has been automatically generated - do not edit
 import { DTResult } from "node-opcua-nodeset-machinery-result/dist/dt_result"
 import { UAResultReadyEvent, UAResultReadyEvent_Base } from "node-opcua-nodeset-machinery-result/dist/ua_result_ready_event"
-import { UAJoiningSystemResult } from "./ua_joining_system_result"
+import { UAResult } from "node-opcua-nodeset-machinery-result/dist/ua_result"
+
 /**
  * This EventType provides information of a complete
  * or partial result from a joining system.
@@ -14,7 +15,7 @@ import { UAJoiningSystemResult } from "./ua_joining_system_result"
  * |isAbstract      |true                                                        |
  */
 export interface UAJoiningSystemResultReadyEvent_Base extends UAResultReadyEvent_Base {
-    result: UAJoiningSystemResult<DTResult>;
+    result: UAResult<DTResult>;
 }
 export interface UAJoiningSystemResultReadyEvent extends Omit<UAResultReadyEvent, "result">, UAJoiningSystemResultReadyEvent_Base {
 }

--- a/packages/node-opcua-nodeset-machine-tool/source/ua_production_state_machine.ts
+++ b/packages/node-opcua-nodeset-machine-tool/source/ua_production_state_machine.ts
@@ -4,17 +4,17 @@ import { DataType } from "node-opcua-variant"
 import { LocalizedText } from "node-opcua-data-model"
 import { NodeId } from "node-opcua-nodeid"
 import { UInt32 } from "node-opcua-basic-types"
-import { UAFiniteStateVariable } from "node-opcua-nodeset-ua/dist/ua_finite_state_variable"
-import { UAFiniteTransitionVariable } from "node-opcua-nodeset-ua/dist/ua_finite_transition_variable"
+import { UAStateVariable } from "node-opcua-nodeset-ua/dist/ua_state_variable"
+import { UATransitionVariable } from "node-opcua-nodeset-ua/dist/ua_transition_variable"
 import { UAFiniteStateMachine, UAFiniteStateMachine_Base } from "node-opcua-nodeset-ua/dist/ua_finite_state_machine"
 import { UAState } from "node-opcua-nodeset-ua/dist/ua_state"
 import { UATransition } from "node-opcua-nodeset-ua/dist/ua_transition"
 import { UAInitialState } from "node-opcua-nodeset-ua/dist/ua_initial_state"
-export interface UAProductionStateMachine_currentState<T extends LocalizedText> extends Omit<UAFiniteStateVariable<T>, "id"|"number"> { // Variable
+export interface UAProductionStateMachine_currentState<T extends LocalizedText> extends Omit<UAStateVariable<T>, "id"|"number"> { // Variable
       id: UAProperty<NodeId, DataType.NodeId>;
       number: UAProperty<UInt32, DataType.UInt32>;
 }
-export interface UAProductionStateMachine_lastTransition<T extends LocalizedText> extends Omit<UAFiniteTransitionVariable<T>, "id"|"number"> { // Variable
+export interface UAProductionStateMachine_lastTransition<T extends LocalizedText> extends Omit<UATransitionVariable<T>, "id"|"number"> { // Variable
       id: UAProperty<NodeId, DataType.NodeId>;
       number: UAProperty<UInt32, DataType.UInt32>;
 }

--- a/packages/node-opcua-nodeset-padim/source/ua_analytical_signal.ts
+++ b/packages/node-opcua-nodeset-padim/source/ua_analytical_signal.ts
@@ -1,6 +1,7 @@
 // ----- this file has been automatically generated - do not edit
+import { DataType } from "node-opcua-variant"
 import { UAAnalogSignal, UAAnalogSignal_Base } from "./ua_analog_signal"
-import { UAPatMeasurementVariable } from "./ua_pat_measurement_variable"
+import { UAAnalogSignalVariable } from "./ua_analog_signal_variable"
 /**
  * |                |                                                            |
  * |----------------|------------------------------------------------------------|
@@ -10,7 +11,7 @@ import { UAPatMeasurementVariable } from "./ua_pat_measurement_variable"
  * |isAbstract      |false                                                       |
  */
 export interface UAAnalyticalSignal_Base extends UAAnalogSignal_Base {
-    analogSignal: UAPatMeasurementVariable<number>;
+    analogSignal: UAAnalogSignalVariable<number, DataType.Float>;
 }
 export interface UAAnalyticalSignal extends Omit<UAAnalogSignal, "analogSignal">, UAAnalyticalSignal_Base {
 }

--- a/packages/node-opcua-nodeset-scales-v-2/source/ua_analog_condition_sleep.ts
+++ b/packages/node-opcua-nodeset-scales-v-2/source/ua_analog_condition_sleep.ts
@@ -1,9 +1,9 @@
 // ----- this file has been automatically generated - do not edit
 import { UAProperty } from "node-opcua-address-space-base"
 import { DataType } from "node-opcua-variant"
+import { UADataItem } from "node-opcua-nodeset-ua/dist/ua_data_item"
 import { EnumEqualityAndRelationalOperator } from "./enum_equality_and_relational_operator"
 import { UAConditionSleep, UAConditionSleep_Base } from "./ua_condition_sleep"
-import { UATargetItem } from "./ua_target_item"
 /**
  * Represents a condition sleep step in a recipe.
  *
@@ -26,7 +26,7 @@ export interface UAAnalogConditionSleep_Base extends UAConditionSleep_Base {
      * The target value with which the threshold value
      * is compared.
      */
-    targetThresholdValue: UATargetItem<any, any>;
+    targetThresholdValue: UADataItem<any, any>;
 }
 export interface UAAnalogConditionSleep extends Omit<UAConditionSleep, "targetThresholdValue">, UAAnalogConditionSleep_Base {
 }

--- a/packages/node-opcua-nodeset-scales-v-2/source/ua_automatic_weight_price_labeler_product.ts
+++ b/packages/node-opcua-nodeset-scales-v-2/source/ua_automatic_weight_price_labeler_product.ts
@@ -4,7 +4,7 @@ import { DataType } from "node-opcua-variant"
 import { DTCurrencyUnit } from "node-opcua-nodeset-ua/dist/dt_currency_unit"
 import { UABaseDataVariable } from "node-opcua-nodeset-ua/dist/ua_base_data_variable"
 import { UACatchweigherProduct, UACatchweigherProduct_Base } from "./ua_catchweigher_product"
-import { UAPriceItem } from "./ua_price_item"
+import { UAWeighingItem } from "./ua_weighing_item"
 export interface UAAutomaticWeightPriceLabelerProduct_unitPrice<T, DT extends DataType> extends UABaseDataVariable<T, DT> { // Variable
       currencyUnit: UAProperty<DTCurrencyUnit, DataType.ExtensionObject>;
 }
@@ -20,7 +20,7 @@ export interface UAAutomaticWeightPriceLabelerProduct_unitPrice<T, DT extends Da
  * |isAbstract      |false                                                       |
  */
 export interface UAAutomaticWeightPriceLabelerProduct_Base extends UACatchweigherProduct_Base {
-    lastItem?: UAPriceItem;
+    lastItem?: UAWeighingItem;
     /**
      * unitPrice
      * Defines the price per weight unit.

--- a/packages/node-opcua-nodeset-scales-v-2/source/ua_checkweigher_product.ts
+++ b/packages/node-opcua-nodeset-scales-v-2/source/ua_checkweigher_product.ts
@@ -2,7 +2,7 @@
 import { UAAnalogUnit } from "node-opcua-nodeset-ua/dist/ua_analog_unit"
 import { UACatchweigherProduct, UACatchweigherProduct_Base } from "./ua_catchweigher_product"
 import { UATargetItem } from "./ua_target_item"
-import { UACheckweigherStatistic } from "./ua_checkweigher_statistic"
+import { UAStatistic } from "./ua_statistic"
 /**
  * Represents a product of a Checkweigher.
  *
@@ -27,7 +27,7 @@ export interface UACheckweigherProduct_Base extends UACatchweigherProduct_Base {
      * Contains the different statistic values of the
      * product.
      */
-    statistic?: UACheckweigherStatistic;
+    statistic?: UAStatistic;
 }
 export interface UACheckweigherProduct extends Omit<UACatchweigherProduct, "statistic">, UACheckweigherProduct_Base {
 }

--- a/packages/node-opcua-nodeset-scales-v-2/source/ua_feeder_module.ts
+++ b/packages/node-opcua-nodeset-scales-v-2/source/ua_feeder_module.ts
@@ -4,9 +4,9 @@ import { DataType } from "node-opcua-variant"
 import { UAFolder } from "node-opcua-nodeset-ua/dist/ua_folder"
 import { UAAnalogUnit } from "node-opcua-nodeset-ua/dist/ua_analog_unit"
 import { UAComponent, UAComponent_Base } from "node-opcua-nodeset-di/dist/ua_component"
+import { UAFunctionalGroup } from "node-opcua-nodeset-di/dist/ua_functional_group"
 import { UAMachineryItemState_StateMachine } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_state_state_machine"
 import { UAMachineryOperationModeStateMachine } from "node-opcua-nodeset-machinery/dist/ua_machinery_operation_mode_state_machine"
-import { UAMachineryItemIdentification } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_identification"
 import { UAMeasuredItem } from "./ua_measured_item"
 import { UATargetItem } from "./ua_target_item"
 export interface UAFeederModule_machineryBuildingBlocks extends UAFolder { // Object
@@ -49,7 +49,7 @@ export interface UAFeederModule_Base extends UAComponent_Base {
      * Used to organize parameters for identification of
      * this TopologyElement
      */
-    identification: UAMachineryItemIdentification;
+    identification: UAFunctionalGroup;
     machineryBuildingBlocks?: UAFeederModule_machineryBuildingBlocks;
     machineryItemState?: UAMachineryItemState_StateMachine;
     machineryOperationMode?: UAMachineryOperationModeStateMachine;

--- a/packages/node-opcua-nodeset-scales-v-2/source/ua_printer_module.ts
+++ b/packages/node-opcua-nodeset-scales-v-2/source/ua_printer_module.ts
@@ -6,9 +6,9 @@ import { UAAnalogUnit } from "node-opcua-nodeset-ua/dist/ua_analog_unit"
 import { UAAnalogItem } from "node-opcua-nodeset-ua/dist/ua_analog_item"
 import { UABaseDataVariable } from "node-opcua-nodeset-ua/dist/ua_base_data_variable"
 import { UAComponent, UAComponent_Base } from "node-opcua-nodeset-di/dist/ua_component"
+import { UAFunctionalGroup } from "node-opcua-nodeset-di/dist/ua_functional_group"
 import { UAMachineryItemState_StateMachine } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_state_state_machine"
 import { UAMachineryOperationModeStateMachine } from "node-opcua-nodeset-machinery/dist/ua_machinery_operation_mode_state_machine"
-import { UAMachineryItemIdentification } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_identification"
 export interface UAPrinterModule_machineryBuildingBlocks extends UAFolder { // Object
       machineryItemState?: UAMachineryItemState_StateMachine;
       machineryOperationMode?: UAMachineryOperationModeStateMachine;
@@ -32,7 +32,7 @@ export interface UAPrinterModule_Base extends UAComponent_Base {
      * Used to organize parameters for identification of
      * this TopologyElement
      */
-    identification: UAMachineryItemIdentification;
+    identification: UAFunctionalGroup;
     /**
      * labelLength
      * Defines the length of the labels in stock.

--- a/packages/node-opcua-nodeset-scales-v-2/source/ua_scale_device.ts
+++ b/packages/node-opcua-nodeset-scales-v-2/source/ua_scale_device.ts
@@ -7,10 +7,10 @@ import { UAString } from "node-opcua-basic-types"
 import { UAFolder } from "node-opcua-nodeset-ua/dist/ua_folder"
 import { UAAnalogUnit } from "node-opcua-nodeset-ua/dist/ua_analog_unit"
 import { UAComponent, UAComponent_Base } from "node-opcua-nodeset-di/dist/ua_component"
+import { UAFunctionalGroup } from "node-opcua-nodeset-di/dist/ua_functional_group"
 import { UAConfigurableObject } from "node-opcua-nodeset-di/dist/ua_configurable_object"
 import { UAMachineryItemState_StateMachine } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_state_state_machine"
 import { UAMachineryOperationModeStateMachine } from "node-opcua-nodeset-machinery/dist/ua_machinery_operation_mode_state_machine"
-import { UAMachineIdentification } from "node-opcua-nodeset-machinery/dist/ua_machine_identification"
 import { UAPackMLBaseStateMachine } from "node-opcua-nodeset-pack-ml/dist/ua_pack_ml_base_state_machine"
 import { DTWeight } from "./dt_weight"
 import { UAWeightItem } from "./ua_weight_item"
@@ -46,7 +46,7 @@ export interface UAScaleDevice_Base extends UAComponent_Base {
      * Used to organize parameters for identification of
      * this TopologyElement
      */
-    identification: UAMachineIdentification;
+    identification: UAFunctionalGroup;
     machineryBuildingBlocks?: UAScaleDevice_machineryBuildingBlocks;
     machineryItemState?: UAMachineryItemState_StateMachine;
     machineryOperationMode?: UAMachineryOperationModeStateMachine;

--- a/packages/node-opcua-nodeset-scales-v-2/source/ua_scale_system.ts
+++ b/packages/node-opcua-nodeset-scales-v-2/source/ua_scale_system.ts
@@ -5,10 +5,10 @@ import { LocalizedText } from "node-opcua-data-model"
 import { UAString } from "node-opcua-basic-types"
 import { UAFolder } from "node-opcua-nodeset-ua/dist/ua_folder"
 import { UAComponent, UAComponent_Base } from "node-opcua-nodeset-di/dist/ua_component"
+import { UAFunctionalGroup } from "node-opcua-nodeset-di/dist/ua_functional_group"
 import { UAConfigurableObject } from "node-opcua-nodeset-di/dist/ua_configurable_object"
 import { UAMachineryItemState_StateMachine } from "node-opcua-nodeset-machinery/dist/ua_machinery_item_state_state_machine"
 import { UAMachineryOperationModeStateMachine } from "node-opcua-nodeset-machinery/dist/ua_machinery_operation_mode_state_machine"
-import { UAMachineIdentification } from "node-opcua-nodeset-machinery/dist/ua_machine_identification"
 import { UAPackMLBaseStateMachine } from "node-opcua-nodeset-pack-ml/dist/ua_pack_ml_base_state_machine"
 import { UAStatistic } from "./ua_statistic"
 import { UAProductionPreset } from "./ua_production_preset"
@@ -33,7 +33,7 @@ export interface UAScaleSystem_Base extends UAComponent_Base {
      * Used to organize parameters for identification of
      * this TopologyElement
      */
-    identification: UAMachineIdentification;
+    identification: UAFunctionalGroup;
     machineryBuildingBlocks?: UAScaleSystem_machineryBuildingBlocks;
     machineryItemState?: UAMachineryItemState_StateMachine;
     machineryOperationMode?: UAMachineryOperationModeStateMachine;

--- a/packages/node-opcua-nodeset-ua/source/ua_3_d_frame.ts
+++ b/packages/node-opcua-nodeset-ua/source/ua_3_d_frame.ts
@@ -3,8 +3,8 @@ import { DT3DFrame } from "./dt_3_d_frame"
 import { DT3DCartesianCoordinates } from "./dt_3_d_cartesian_coordinates"
 import { DT3DOrientation } from "./dt_3_d_orientation"
 import { UAFrame, UAFrame_Base } from "./ua_frame"
-import { UA3DCartesianCoordinates } from "./ua_3_d_cartesian_coordinates"
-import { UA3DOrientation } from "./ua_3_d_orientation"
+import { UACartesianCoordinates } from "./ua_cartesian_coordinates"
+import { UAOrientation } from "./ua_orientation"
 /**
  * |                |                                                            |
  * |----------------|------------------------------------------------------------|
@@ -17,8 +17,8 @@ import { UA3DOrientation } from "./ua_3_d_orientation"
  * |isAbstract      |false                                                       |
  */
 export interface UA3DFrame_Base<T extends DT3DFrame>  extends UAFrame_Base<T> {
-    cartesianCoordinates: UA3DCartesianCoordinates<DT3DCartesianCoordinates>;
-    orientation: UA3DOrientation<DT3DOrientation>;
+    cartesianCoordinates: UACartesianCoordinates<DT3DCartesianCoordinates>;
+    orientation: UAOrientation<DT3DOrientation>;
 }
 export interface UA3DFrame<T extends DT3DFrame> extends Omit<UAFrame<T>, "cartesianCoordinates"|"orientation">, UA3DFrame_Base<T> {
 }

--- a/packages/node-opcua-nodeset-ua/source/ua_finite_state_machine.ts
+++ b/packages/node-opcua-nodeset-ua/source/ua_finite_state_machine.ts
@@ -3,8 +3,8 @@ import { DataType } from "node-opcua-variant"
 import { LocalizedText } from "node-opcua-data-model"
 import { NodeId } from "node-opcua-nodeid"
 import { UAStateMachine, UAStateMachine_Base } from "./ua_state_machine"
-import { UAFiniteStateVariable } from "./ua_finite_state_variable"
-import { UAFiniteTransitionVariable } from "./ua_finite_transition_variable"
+import { UAStateVariable } from "./ua_state_variable"
+import { UATransitionVariable } from "./ua_transition_variable"
 import { UABaseDataVariable } from "./ua_base_data_variable"
 /**
  * |                |                                                            |
@@ -15,8 +15,8 @@ import { UABaseDataVariable } from "./ua_base_data_variable"
  * |isAbstract      |true                                                        |
  */
 export interface UAFiniteStateMachine_Base extends UAStateMachine_Base {
-    currentState: UAFiniteStateVariable<LocalizedText>;
-    lastTransition?: UAFiniteTransitionVariable<LocalizedText>;
+    currentState: UAStateVariable<LocalizedText>;
+    lastTransition?: UATransitionVariable<LocalizedText>;
     availableStates?: UABaseDataVariable<NodeId[], DataType.NodeId>;
     availableTransitions?: UABaseDataVariable<NodeId[], DataType.NodeId>;
 }

--- a/packages/node-opcua-nodeset-ua/source/ua_program_state_machine.ts
+++ b/packages/node-opcua-nodeset-ua/source/ua_program_state_machine.ts
@@ -5,17 +5,17 @@ import { LocalizedText } from "node-opcua-data-model"
 import { NodeId } from "node-opcua-nodeid"
 import { UInt32, Int32 } from "node-opcua-basic-types"
 import { DTProgramDiagnostic2 } from "./dt_program_diagnostic_2"
-import { UAFiniteStateVariable } from "./ua_finite_state_variable"
-import { UAFiniteTransitionVariable } from "./ua_finite_transition_variable"
+import { UAStateVariable } from "./ua_state_variable"
+import { UATransitionVariable } from "./ua_transition_variable"
 import { UAFiniteStateMachine, UAFiniteStateMachine_Base } from "./ua_finite_state_machine"
 import { UAProgramDiagnostic2 } from "./ua_program_diagnostic_2"
 import { UAState } from "./ua_state"
 import { UATransition } from "./ua_transition"
-export interface UAProgramStateMachine_currentState<T extends LocalizedText> extends Omit<UAFiniteStateVariable<T>, "id"|"number"> { // Variable
+export interface UAProgramStateMachine_currentState<T extends LocalizedText> extends Omit<UAStateVariable<T>, "id"|"number"> { // Variable
       id: UAProperty<NodeId, DataType.NodeId>;
       number: UAProperty<UInt32, DataType.UInt32>;
 }
-export interface UAProgramStateMachine_lastTransition<T extends LocalizedText> extends Omit<UAFiniteTransitionVariable<T>, "id"|"number"|"transitionTime"> { // Variable
+export interface UAProgramStateMachine_lastTransition<T extends LocalizedText> extends Omit<UATransitionVariable<T>, "id"|"number"|"transitionTime"> { // Variable
       id: UAProperty<NodeId, DataType.NodeId>;
       number: UAProperty<UInt32, DataType.UInt32>;
       transitionTime: UAProperty<Date, DataType.DateTime>;


### PR DESCRIPTION
Fixes node-opcua/node-opcua#1472

- Use specialized type from base class when available
- Recalculate type arguments for inherited generic types