### PR TITLE
fix(mdns): emit onRegisterServer events for mDNS discovered servers

### DIFF
--- a/packages/node-opcua-server/source/register_server_manager_mdns_only.ts
+++ b/packages/node-opcua-server/source/register_server_manager_mdns_only.ts
@@ -6,8 +6,23 @@
 import { EventEmitter } from "events";
 import { assert } from "node-opcua-assert";
 import { BonjourHolder } from "node-opcua-service-discovery";
+import { getFullyQualifiedDomainName } from "node-opcua-hostname";
 import { OPCUABaseServer } from "./base_server";
 import { IRegisterServerManager, RegisterServerManagerStatus } from "./i_register_server_manager";
+
+/**
+ * Extract hostname and path from an OPC UA endpoint URL
+ * @param endpointUrl - URL like "opc.tcp://hostname:port/path"
+ * @returns { host, path } or null if parsing fails
+ */
+function parseEndpointUrl(endpointUrl: string): { host: string; path: string } | null {
+    const match = endpointUrl.match(/^opc\.tcp:\/\/([^:/]+)(?::\d+)?(\/.*)?$/);
+    if (!match) return null;
+    return {
+        host: match[1],
+        path: match[2] || "/"
+    };
+}
 
 /**
  * a RegisterServerManager that declare the server the OPCUA Bonjour service
@@ -46,17 +61,24 @@ export class RegisterServerManagerMDNSONLY extends EventEmitter implements IRegi
         }
         assert(this.server instanceof OPCUABaseServer);
 
-        const host = "TODO-find how to extract hostname";
         const capabilities = this.server.capabilitiesForMDNS;
         const name = this.server.serverInfo.applicationUri!;
         const port = this.server.endpoints[0].port;
 
+        // Extract hostname and path from the first endpoint's URL
+        const endpointDescriptions = this.server.endpoints[0].endpointDescriptions();
+        const endpointUrl = endpointDescriptions[0]?.endpointUrl;
+        const parsed = endpointUrl ? parseEndpointUrl(endpointUrl) : null;
+
+        // Use parsed hostname, or fall back to FQDN
+        const host = parsed?.host || getFullyQualifiedDomainName();
+        const path = parsed?.path || "/";
 
         this._state = RegisterServerManagerStatus.REGISTERING;
         await this.bonjour.announcedOnMulticastSubnet({
             capabilities: capabilities,
             name: name,
-            path: "/", // <- to do
+            path: path,
             host,
             port: port
         });


### PR DESCRIPTION
Fixes #1479

## Changes

### 1. mDNS server discovery events
- `MDNSResponder` now extends `EventEmitter` and emits typed `serverUp`/`serverDown` events
- `OPCUADiscoveryServer` forwards these as unified `onRegisterServer`/`onUnregisterServer` events
- Discovery clients can now handle mDNS-discovered servers the same way as LDS-registered servers

### 2. Hostname extraction fix
- Added `parseEndpointUrl()` to extract hostname from endpoint URL
- Replaces `"TODO-find how to extract hostname"` placeholder
- Falls back to `getFullyQualifiedDomainName()` if parsing fails

## Files Changed

- `packages/node-opcua-server/source/register_server_manager_mdns_only.ts`
- `packages/node-opcua-server-discovery/source/mdns_responder.ts`
- `packages/node-opcua-server-discovery/source/opcua_discovery_server.ts`