### PR TITLE
fix: setValueFromSource corrupts terminal-type fields in bound extension objects

### DIFF
--- a/packages/node-opcua-address-space/src/ua_variable_impl_ext_obj.ts
+++ b/packages/node-opcua-address-space/src/ua_variable_impl_ext_obj.ts
@@ -153,13 +153,57 @@ export function setExtensionObjectPartialValue(node: UAVariableImpl, partialObje
 
     const extensionObject = node.$extensionObject;
     if (!extensionObject) {
-        throw new Error("setExtensionObjectValue node has no extension object " + node.browseName.toString());
+        throw new Error(`setExtensionObjectValue node has no extension object ${node.browseName.toString()}`);
+    }
+    /**
+     * Returns true if the value is a structure-like object that should
+     * be recursed into during a partial update.
+     *
+     * For the existing extension object (extObject[prop]):
+     *  - Proxied sub-extension objects → recurse (they have $isProxy)
+     * For the incoming partial object (partialObject1[prop]):
+     *  - Plain objects {} → recurse (from constructExtensionObject or literals)
+     *
+     * Everything else (Date, Buffer, NodeId, QualifiedName, LocalizedText,
+     * DiagnosticInfo, arrays, etc.) is a terminal value and should be
+     * assigned directly — even if it has a `schema` property.
+     */
+    function _shouldRecurseIntoExisting(value: any): boolean {
+        if (value === null || value === undefined) return false;
+        if (typeof value !== "object") return false;
+        if (Array.isArray(value)) return false;
+        // proxied sub-structures: installed by bindExtensionObject for nested structs
+        if (isProxy(value)) return true;
+        // plain objects (unlikely on the existing side but safe fallback)
+        const proto = Object.getPrototypeOf(value);
+        if (proto === Object.prototype || proto === null) return true;
+        return false;
+    }
+
+    function _shouldRecurseIntoNew(value: any): boolean {
+        if (value === null || value === undefined) return false;
+        if (typeof value !== "object") return false;
+        if (Array.isArray(value)) return false;
+        // plain objects: partial update literals like { field1: v1 }
+        const proto = Object.getPrototypeOf(value);
+        if (proto === Object.prototype || proto === null) return true;
+        // extension objects from constructExtensionObject have a schema
+        // but so do QualifiedName/LocalizedText — we disambiguate by
+        // checking the *existing* side with isProxy, not here.
+        // Instead, only recurse if it's a schema'd type AND has
+        // Extension-Object-like characteristics (constructor with schema.name)
+        if (value.schema !== undefined && value.constructor?.name !== "QualifiedName"
+            && value.constructor?.name !== "LocalizedText"
+            && value.constructor?.name !== "DiagnosticInfo") {
+            return true;
+        }
+        return false;
     }
 
     function _update_extension_object(extObject: any, partialObject1: any) {
         const keys = Object.keys(partialObject1);
         for (const prop of keys) {
-            if (extObject[prop] instanceof Object) {
+            if (_shouldRecurseIntoExisting(extObject[prop]) && _shouldRecurseIntoNew(partialObject1[prop])) {
                 _update_extension_object(extObject[prop], partialObject1[prop]);
             } else {
                 if (isProxy(extObject)) {

--- a/packages/node-opcua-address-space/test/test_bindExtensionObject.ts
+++ b/packages/node-opcua-address-space/test/test_bindExtensionObject.ts
@@ -1,39 +1,31 @@
 /* eslint-disable max-statements */
 // tslint:disable: no-console
+
+import { assert } from "node-opcua-assert";
+import type { DateTime, UInt32 } from "node-opcua-basic-types";
+import type { LocalizedText } from "node-opcua-data-model";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { nodesets } from "node-opcua-nodesets";
+import { StatusCodes } from "node-opcua-status-code";
+import { type StructureField, ServerState, type ServerStatusDataType, ServiceCounterDataType, type SessionDiagnosticsDataType } from "node-opcua-types";
+import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
 import should from "should";
 import sinon from "sinon";
-
-import { DateTime, Double, UAString, UInt32 } from "node-opcua-basic-types";
-import { LocalizedText } from "node-opcua-data-model";
-import { NodeIdLike } from "node-opcua-nodeid";
-import { StatusCodes } from "node-opcua-status-code";
-import {
-    ApplicationDescription,
-    ServerState,
-    ServerStatusDataType,
-    ServiceCounterDataType,
-    SessionDiagnosticsDataType
-} from "node-opcua-types";
-import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
-import { nodesets } from "node-opcua-nodesets";
-
 import {
     AddressSpace,
-    UARootFolder,
-    UAVariable,
-    UAVariableT,
-    Namespace,
-    UADataType,
-    UAVariableType,
-    UASessionDiagnosticsVariable,
-    DTSessionDiagnostics,
-    DTServiceCounter,
-    UABaseDataVariable
+    type DTServiceCounter,
+    type DTSessionDiagnostics,
+    type Namespace,
+    type UABaseDataVariable,
+    type UADataType,
+    type UARootFolder,
+    type UASessionDiagnosticsVariable,
+    type UAVariable,
+    type UAVariableT,
+    type UAVariableType
 } from "..";
-import { getMiniAddressSpace } from "../testHelpers";
 import { generateAddressSpace } from "../nodeJS";
-import { assert } from "node-opcua-assert";
-import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { getMiniAddressSpace } from "../testHelpers";
 
 const doDebug = false;
 
@@ -48,8 +40,8 @@ interface UASessionDiagnosticsVariableEx extends UASessionDiagnosticsVariable<DT
 interface ServerStatusVariable extends UAVariable {
     startTime: UAVariableT<DateTime, DataType.DateTime>;
     currentTime: UAVariableT<DateTime, DataType.DateTime>;
-    state: UAVariableT<any, DataType.ExtensionObject>; // ServerState
-    buildInfo: UAVariableT<any, DataType.ExtensionObject>; // BuildInfoOptions
+    state: UAVariableT<unknown, DataType.ExtensionObject>; // ServerState
+    buildInfo: UAVariableT<unknown, DataType.ExtensionObject>; // BuildInfoOptions
     secondsTillShutdown: UAVariableT<UInt32, DataType.UInt32>;
     shutdownReason: UAVariableT<LocalizedText, DataType.LocalizedText>;
 }
@@ -77,7 +69,7 @@ describe("Extension Object binding and sub  components\n", () => {
 
             const counter = 1;
             const extensionObjectVar = namespace.addVariable({
-                browseName: "VariableWithExtensionObjectArray" + counter,
+                browseName: `VariableWithExtensionObjectArray${counter}`,
                 dataType: serviceCounterDataType.nodeId,
                 valueRank: 1,
                 arrayDimensions: [0],
@@ -92,20 +84,23 @@ describe("Extension Object binding and sub  components\n", () => {
             extensionObjectVar.readValue().value.dataType.should.eql(DataType.Null); // Empty array
             extensionObjectVar.readValue().statusCode.should.eql(StatusCodes.UncertainInitialValue);
 
-            const extensionObjectArray = extensionObjectVar.bindExtensionObjectArray([
-                new ServiceCounterDataType({ errorCount: 1, totalCount: 2 }),
-                new ServiceCounterDataType({ errorCount: 3, totalCount: 4 })
-            ], { createMissingProp: true }) as ServiceCounterDataType[];
+            const extensionObjectArray = extensionObjectVar.bindExtensionObjectArray(
+                [
+                    new ServiceCounterDataType({ errorCount: 1, totalCount: 2 }),
+                    new ServiceCounterDataType({ errorCount: 3, totalCount: 4 })
+                ],
+                { createMissingProp: true }
+            ) as ServiceCounterDataType[];
             should.exist(extensionObjectVar.getComponentByName("0"));
             should.exist(extensionObjectVar.getComponentByName("1"));
-            should.exist(extensionObjectVar.getComponentByName("0")!.getChildByName("TotalCount"));
-            should.exist(extensionObjectVar.getComponentByName("1")!.getChildByName("TotalCount"));
+            should.exist(extensionObjectVar.getComponentByName("0")?.getChildByName("TotalCount"));
+            should.exist(extensionObjectVar.getComponentByName("1")?.getChildByName("TotalCount"));
 
             extensionObjectVar.installExtensionObjectVariables();
             should.exist(extensionObjectVar.getComponentByName("0"));
             should.exist(extensionObjectVar.getComponentByName("1"));
-            should.exist(extensionObjectVar.getComponentByName("0")!.getChildByName("TotalCount"));
-            should.exist(extensionObjectVar.getComponentByName("1")!.getChildByName("TotalCount"));
+            should.exist(extensionObjectVar.getComponentByName("0")?.getChildByName("TotalCount"));
+            should.exist(extensionObjectVar.getComponentByName("1")?.getChildByName("TotalCount"));
 
             extensionObjectArray.length.should.eql(2);
             extensionObjectArray[0].constructor.name.should.eql("ServiceCounterDataType");
@@ -118,7 +113,7 @@ describe("Extension Object binding and sub  components\n", () => {
             extensionObjectVar.readValue().value.value[0].constructor.name.should.eql("ServiceCounterDataType");
             extensionObjectVar.readValue().value.value[1].constructor.name.should.eql("ServiceCounterDataType");
 
-            // to do 
+            // to do
             const el1 = extensionObjectVar.getComponentByName("0") as UAVariable;
             const dataValueEl1 = el1.readValue();
             dataValueEl1.value.dataType.should.eql(DataType.ExtensionObject);
@@ -133,18 +128,18 @@ describe("Extension Object binding and sub  components\n", () => {
         });
 
         it("BEO1 - should handle a Variable containing a ServiceCounterDataType", () => {
-            const rootFolder = addressSpace.findNode("RootFolder")! as UARootFolder;
+            const rootFolder = addressSpace.findNode("RootFolder") as UARootFolder;
 
-            const serviceCounterDataType = addressSpace.findDataType("ServiceCounterDataType")!;
-            serviceCounterDataType.browseName.toString().should.eql("ServiceCounterDataType");
+            const serviceCounterDataType = addressSpace.findDataType("ServiceCounterDataType");
+            should(serviceCounterDataType?.browseName.toString()).eql("ServiceCounterDataType");
 
-            const baseVariableType = addressSpace.findVariableType("BaseVariableType")!;
-            baseVariableType.browseName.toString().should.eql("BaseVariableType");
+            const baseVariableType = addressSpace.findVariableType("BaseVariableType");
+            should(baseVariableType?.browseName.toString()).eql("BaseVariableType");
 
             const counter = 1;
-            const extensionObjectVar = baseVariableType.instantiate({
-                browseName: "VariableWithExtensionObject" + counter,
-                dataType: serviceCounterDataType.nodeId,
+            const extensionObjectVar = baseVariableType?.instantiate({
+                browseName: `VariableWithExtensionObject${counter}`,
+                dataType: serviceCounterDataType?.nodeId,
                 valueRank: -1,
                 minimumSamplingInterval: 0,
                 organizedBy: rootFolder.objects
@@ -195,18 +190,18 @@ describe("Extension Object binding and sub  components\n", () => {
         });
 
         it("BEO2 - should handle a Variable containing a ServerStatus", () => {
-            const rootFolder = addressSpace.findNode("RootFolder")! as UARootFolder;
+            const rootFolder = addressSpace.findNode("RootFolder") as UARootFolder;
 
-            const serverStatusDataType = addressSpace.findDataType("ServerStatusDataType")!;
-            serverStatusDataType.browseName.toString().should.eql("ServerStatusDataType");
+            const serverStatusDataType = addressSpace?.findDataType("ServerStatusDataType");
+            should(serverStatusDataType?.browseName.toString()).eql("ServerStatusDataType");
 
-            const serverStatusType = addressSpace.findVariableType("ServerStatusType")!;
-            serverStatusType.browseName.toString().should.eql("ServerStatusType");
-
+            const serverStatusType = addressSpace.findVariableType("ServerStatusType");
+            should.exist(serverStatusType);
+            should(serverStatusType?.browseName.toString()).eql("ServerStatusType");
             const counter = 1;
-            const extensionObjectVar = serverStatusType.instantiate({
-                browseName: "ServerStatusType" + counter,
-                dataType: serverStatusDataType.nodeId,
+            const extensionObjectVar = serverStatusType!.instantiate({
+                browseName: `ServerStatusType${counter}`,
+                dataType: serverStatusDataType?.nodeId,
                 minimumSamplingInterval: 0,
                 organizedBy: rootFolder.objects
             }) as ServerStatusVariable;
@@ -258,7 +253,7 @@ describe("Extension Object binding and sub  components\n", () => {
 
             const counter = 1;
             const uaVariable = sessionDiagnosticsVariableType.instantiate({
-                browseName: "SessionDiagnostics" + counter,
+                browseName: `SessionDiagnostics${counter}`,
                 dataType: sessionDiagnosticsDataType.nodeId,
                 minimumSamplingInterval: 0,
                 organizedBy: rootFolder.objects
@@ -295,8 +290,8 @@ describe("Extension Object binding and sub  components\n", () => {
 
             useTwoLevelsDeep && uaVariable.totalRequestCount.totalCount.readValue().value.value.should.eql(0);
 
-            const dv1 = uaVariable.totalRequestCount.readValue();
-            const dv2 = uaVariable.readValue();
+            const _dv1 = uaVariable.totalRequestCount.readValue();
+            const _dv2 = uaVariable.readValue();
 
             uaVariable.totalRequestCount.readValue().value.value.totalCount.should.eql(0);
 
@@ -322,21 +317,21 @@ describe("Extension Object binding and sub  components\n", () => {
     });
 
     describe("should be possible to bind an Extension Object properties with variable node properties", () => {
-        let _sessionDiagnostics: any;
-        let sessionDiagnostics: any;
+        let _sessionDiagnostics: UASessionDiagnosticsVariableEx;
+        let sessionDiagnostics: SessionDiagnosticsDataType;
 
-        let spy_on_sessionDiagnostics_value_changed: any;
-        let spy_on_sessionDiagnostics_totalRequestCount_value_changed: any;
-        let spy_on_sessionDiagnostics_totalRequestCount_totalCount_value_changed: any;
-        let spy_on_sessionDiagnostics_totalRequestCount_errorCount_value_changed: any;
-        let spy_on_sessionDiagnostics_clientDescription_value_changed: any;
+        let spy_on_sessionDiagnostics_value_changed: sinon.SinonSpy;
+        let spy_on_sessionDiagnostics_totalRequestCount_value_changed: sinon.SinonSpy;
+        let spy_on_sessionDiagnostics_totalRequestCount_totalCount_value_changed: sinon.SinonSpy;
+        let spy_on_sessionDiagnostics_totalRequestCount_errorCount_value_changed: sinon.SinonSpy;
+        let spy_on_sessionDiagnostics_clientDescription_value_changed: sinon.SinonSpy;
 
         let counter = 0;
 
         beforeEach(() => {
             const rootFolder = addressSpace.findNode("RootFolder")! as UARootFolder;
 
-            const sessionDiagnosticsDataType = addressSpace.findDataType("SessionDiagnosticsDataType")!;
+            const _sessionDiagnosticsDataType = addressSpace.findDataType("SessionDiagnosticsDataType")!;
             const sessionDiagnosticsVariableType = addressSpace.findVariableType("SessionDiagnosticsVariableType")!;
 
             // the extension object
@@ -344,7 +339,7 @@ describe("Extension Object binding and sub  components\n", () => {
 
             counter += 1;
             sessionDiagnostics = sessionDiagnosticsVariableType.instantiate({
-                browseName: "SessionDiagnostics" + counter,
+                browseName: `SessionDiagnostics${counter}`,
                 organizedBy: rootFolder.objects
             }) as UASessionDiagnosticsVariable<DTSessionDiagnostics>;
 
@@ -396,7 +391,7 @@ describe("Extension Object binding and sub  components\n", () => {
 
             const definition = dataTypeNode.getStructureDefinition();
             definition.fields
-                .map((x: any) => x.name)
+                .map((x: StructureField) => x.name)
                 .sort()
                 .should.eql([
                     "ActualSessionTimeout",
@@ -589,12 +584,12 @@ interface UAResultType extends UAVariable {
 }
 describe("Extension Object binding and sub  components On MachineVision", () => {
     let addressSpace: AddressSpace;
-    let namespace: Namespace;
+    let _namespace: Namespace;
 
     before(async () => {
         const nodesetFilename = [nodesets.standard, nodesets.machineVision];
         addressSpace = AddressSpace.create();
-        namespace = addressSpace.registerNamespace("private");
+        _namespace = addressSpace.registerNamespace("private");
         await generateAddressSpace(addressSpace, nodesetFilename);
     });
     after(async () => {
@@ -618,7 +613,6 @@ describe("Extension Object binding and sub  components On MachineVision", () => 
     });
 
     it("MV0a MachineVision-ResultClone ", () => {
-
         const configurationIdDataType = addressSpace.findDataType("ConfigurationIdDataType", nsMV)!;
 
         const configurationExtObj = addressSpace.constructExtensionObject(configurationIdDataType, {
@@ -627,7 +621,7 @@ describe("Extension Object binding and sub  components On MachineVision", () => 
             id: "IIII",
             version: "1.2"
         });
-     
+
         const variant = new Variant({
             dataType: DataType.ExtensionObject,
             value: configurationExtObj
@@ -638,11 +632,9 @@ describe("Extension Object binding and sub  components On MachineVision", () => 
         clone.value.hash.toString("hex").should.eql("deadbeef");
         clone.value.id.should.eql("IIII");
         clone.value.version.should.eql("1.2");
-
     });
 
-    it("MV0b MachineVision-ResultClone " , () => {
-
+    it("MV0b MachineVision-ResultClone ", () => {
         const configurationIdDataType = addressSpace.findDataType("ConfigurationIdDataType", nsMV)!;
 
         const rr = addressSpace.constructExtensionObject(configurationIdDataType, {
@@ -651,13 +643,13 @@ describe("Extension Object binding and sub  components On MachineVision", () => 
             id: "IIII",
             version: "1.2"
         });
-        should.exist((<any>rr).hash);
-        (<any>rr).hash.toString("hex").should.eql("deadbeef");
+        should.exist((rr as Record<string, unknown>).hash);
+        ((rr as Record<string, unknown>).hash as Buffer).toString("hex").should.eql("deadbeef");
 
         const recipeIdExternalD = addressSpace.findDataType("RecipeIdExternalDataType", nsMV)!;
 
         const resultContent1 = addressSpace.constructExtensionObject(recipeIdExternalD, {
-            description: "some description",
+            description: "some description"
         });
         const partId = "PartId-1";
         const extObj = addressSpace.constructExtensionObject(resultDataType, {
@@ -671,14 +663,12 @@ describe("Extension Object binding and sub  components On MachineVision", () => 
             partId,
             resultState: 32,
 
-            resultContent: [
-                resultContent1
-            ]
+            resultContent: [resultContent1]
         });
 
-        (extObj as any).internalConfigurationId.hash.toString("hex").should.eql("deadbeef");
-        (extObj as any).internalConfigurationId.id.should.eql("IIII");
-        (extObj as any).internalConfigurationId.version.should.eql("1.2");
+        ((extObj as Record<string, Record<string, unknown>>).internalConfigurationId.hash as Buffer).toString("hex").should.eql("deadbeef");
+        (extObj as Record<string, Record<string, unknown>>).internalConfigurationId.id.should.eql("IIII");
+        (extObj as Record<string, Record<string, unknown>>).internalConfigurationId.version.should.eql("1.2");
 
         const variant = new Variant({
             dataType: DataType.ExtensionObject,
@@ -690,7 +680,6 @@ describe("Extension Object binding and sub  components On MachineVision", () => 
         clone.value.internalConfigurationId.id.should.eql("IIII");
         clone.value.internalConfigurationId.version.should.eql("1.2");
         clone.value.toString().should.eql(extObj.toString());
-
     });
 
     it("MV1 MachineVision-BindExtensionObject should instantiate a ResultType", () => {
@@ -717,14 +706,13 @@ describe("Extension Object binding and sub  components On MachineVision", () => 
             id: "IIII",
             version: "1.2"
         });
-        should.exist((<any>rr).hash);
-        (<any>rr).hash.toString("hex").should.eql("deadbeef");
+        should.exist((rr as Record<string, unknown>).hash);
+        ((rr as Record<string, unknown>).hash as Buffer).toString("hex").should.eql("deadbeef");
 
         const recipeIdExternalD = addressSpace.findDataType("RecipeIdExternalDataType", nsMV)!;
 
         const resultContent1 = addressSpace.constructExtensionObject(recipeIdExternalD, {
-                description: "some description",
-               
+            description: "some description"
         });
         const extObj = addressSpace.constructExtensionObject(resultDataType, {
             hasTransferableDataOnFile: true,
@@ -737,15 +725,13 @@ describe("Extension Object binding and sub  components On MachineVision", () => 
             partId,
             resultState: 32,
 
-            resultContent: [
-              resultContent1
-            ]
+            resultContent: [resultContent1]
         });
         if (doDebug) {
             console.log("extObj", extObj.toString());
         }
-        should.exist((<any>extObj).internalConfigurationId.hash);
-        (<any>extObj).internalConfigurationId.hash.toString("hex").should.eql("deadbeef");
+        should.exist((extObj as Record<string, Record<string, unknown>>).internalConfigurationId.hash);
+        ((extObj as Record<string, Record<string, unknown>>).internalConfigurationId.hash as Buffer).toString("hex").should.eql("deadbeef");
 
         const result = resultType.instantiate({
             browseName: `Result2`,
@@ -756,7 +742,7 @@ describe("Extension Object binding and sub  components On MachineVision", () => 
             }
         }) as UAResultType;
 
-        const verif = result.readValue().value.value as any;
+        const verif = result.readValue().value.value as Record<string, Record<string, unknown>>;
         should.exist(verif.internalConfigurationId.hash);
         verif.internalConfigurationId.hash.toString("hex").should.eql("deadbeef");
 

--- a/packages/node-opcua-address-space/test/test_bug_setValueFromSource_terminal_values.ts
+++ b/packages/node-opcua-address-space/test/test_bug_setValueFromSource_terminal_values.ts
@@ -1,0 +1,251 @@
+import path from "node:path";
+import { DiagnosticInfo, LocalizedText, QualifiedName } from "node-opcua-data-model";
+import { coerceNodeId, NodeId } from "node-opcua-nodeid";
+import { nodesets } from "node-opcua-nodesets";
+import { DataType, Variant } from "node-opcua-variant";
+import should from "should";
+
+import { AddressSpace, SessionContext, type UAVariable } from "..";
+import { generateAddressSpace } from "../nodeJS";
+
+/**
+ * Bug: setValueFromSource on a bound extension object fails to update
+ * terminal value types that are `instanceof Object` (Date, Buffer, NodeId,
+ * QualifiedName, LocalizedText, DiagnosticInfo, arrays, etc.) because
+ * _update_extension_object recurses into them instead of assigning directly.
+ *
+ * Uses the all_terminal_value_types.xml fixture which defines:
+ * - InnerStruct (innerDateTime + innerInt32)
+ * - AllTerminalsStruct (all terminal types + nested InnerStruct)
+ * - A variable instance at ns=1;i=6000
+ */
+describe("Bug - setValueFromSource should correctly update terminal value types in extension objects", function (this: Mocha.Suite) {
+    this.timeout(200000);
+
+    let addressSpace: AddressSpace;
+    const context = SessionContext.defaultContext;
+
+    const xml_file = path.join(__dirname, "../test_helpers/test_fixtures/all_terminal_value_types.xml");
+
+    before(async () => {
+        addressSpace = AddressSpace.create();
+        await generateAddressSpace(addressSpace, [nodesets.standard, xml_file]);
+    });
+    after(() => {
+        addressSpace.dispose();
+    });
+
+    function getNamespaceIndex(): number {
+        return addressSpace.getNamespaceIndex("http://test-terminal-values.example.com");
+    }
+
+    let testVar: UAVariable;
+
+    beforeEach(() => {
+        const ns = getNamespaceIndex();
+        testVar = addressSpace.findNode(`ns=${ns};i=6000`) as UAVariable;
+        // Bind the extension object — this installs the proxy and overrides
+        // setValueFromSource to use setExtensionObjectPartialValue (the buggy path).
+        testVar.bindExtensionObject(undefined, { createMissingProp: true });
+    });
+
+    function constructNewExtObj(overrides: Record<string, unknown>) {
+        const ns = getNamespaceIndex();
+        const dt = addressSpace.findDataType("AllTerminalsStruct", ns)!;
+        const defaults: Record<string, unknown> = {
+            fieldDateTime: new Date("2026-01-01T00:00:00.000Z"),
+            fieldByteString: Buffer.from("AABB", "hex"),
+            fieldNodeId: coerceNodeId("ns=1;i=100"),
+            fieldQualifiedName: new QualifiedName({ namespaceIndex: 1, name: "Initial" }),
+            fieldLocalizedText: new LocalizedText({ locale: "en", text: "Hello" }),
+            fieldDiagnosticInfo: new DiagnosticInfo({}),
+            fieldInt32: 10,
+            fieldInt32Array: [1, 2, 3],
+            fieldInner: { innerDateTime: new Date("2026-01-01T00:00:00.000Z"), innerInt32: 5 }
+        };
+        return addressSpace.constructExtensionObject(dt, { ...defaults, ...overrides });
+    }
+
+    it("TV-1 setValueFromSource should update a DateTime (Date) field", () => {
+        const uaVar = testVar;
+        const updatedDate = new Date("2030-06-15T12:00:00.000Z");
+        const newExtObj = constructNewExtObj({ fieldDateTime: updatedDate });
+
+        uaVar.setValueFromSource(new Variant({ dataType: DataType.ExtensionObject, value: newExtObj }));
+
+        const result = uaVar.readValue(context).value.value;
+        result.fieldDateTime.should.be.instanceof(Date);
+        result.fieldDateTime.toISOString().should.eql("2030-06-15T12:00:00.000Z");
+    });
+
+    it("TV-2 setValueFromSource should update a ByteString (Buffer) field", () => {
+        const uaVar = testVar;
+        const updatedBuffer = Buffer.from("CCDD", "hex");
+        const newExtObj = constructNewExtObj({ fieldByteString: updatedBuffer });
+
+        uaVar.setValueFromSource(new Variant({ dataType: DataType.ExtensionObject, value: newExtObj }));
+
+        const result = uaVar.readValue(context).value.value;
+        Buffer.isBuffer(result.fieldByteString).should.eql(true);
+        result.fieldByteString.toString("hex").should.eql("ccdd");
+    });
+
+    it("TV-3 setValueFromSource should update a NodeId field", () => {
+        const uaVar = testVar;
+        const updatedNodeId = coerceNodeId("ns=2;i=999");
+        const newExtObj = constructNewExtObj({ fieldNodeId: updatedNodeId });
+
+        uaVar.setValueFromSource(new Variant({ dataType: DataType.ExtensionObject, value: newExtObj }));
+
+        const result = uaVar.readValue(context).value.value;
+        result.fieldNodeId.should.be.instanceof(NodeId);
+        result.fieldNodeId.toString().should.eql(updatedNodeId.toString());
+    });
+
+    it("TV-4 setValueFromSource should update a QualifiedName field", () => {
+        const uaVar = testVar;
+        const updatedQN = new QualifiedName({ namespaceIndex: 2, name: "Updated" });
+        const newExtObj = constructNewExtObj({ fieldQualifiedName: updatedQN });
+
+        uaVar.setValueFromSource(new Variant({ dataType: DataType.ExtensionObject, value: newExtObj }));
+
+        const result = uaVar.readValue(context).value.value;
+        result.fieldQualifiedName.name.should.eql("Updated");
+        result.fieldQualifiedName.namespaceIndex.should.eql(2);
+    });
+
+    it("TV-5 setValueFromSource should update a LocalizedText field", () => {
+        const uaVar = testVar;
+        const updatedLT = new LocalizedText({ locale: "fr", text: "Bonjour" });
+        const newExtObj = constructNewExtObj({ fieldLocalizedText: updatedLT });
+
+        uaVar.setValueFromSource(new Variant({ dataType: DataType.ExtensionObject, value: newExtObj }));
+
+        const result = uaVar.readValue(context).value.value;
+        result.fieldLocalizedText.text.should.eql("Bonjour");
+        result.fieldLocalizedText.locale.should.eql("fr");
+    });
+
+    it("TV-6 setValueFromSource should update a DiagnosticInfo field", () => {
+        const uaVar = testVar;
+        const updatedDI = new DiagnosticInfo({ additionalInfo: "updated" });
+        const newExtObj = constructNewExtObj({ fieldDiagnosticInfo: updatedDI });
+
+        uaVar.setValueFromSource(new Variant({ dataType: DataType.ExtensionObject, value: newExtObj }));
+
+        const result = uaVar.readValue(context).value.value;
+        result.fieldDiagnosticInfo.additionalInfo.should.eql("updated");
+    });
+
+    it("TV-7 setValueFromSource should update an Int32 array field", () => {
+        const uaVar = testVar;
+        const newExtObj = constructNewExtObj({ fieldInt32Array: [10, 20, 30, 40] });
+
+        uaVar.setValueFromSource(new Variant({ dataType: DataType.ExtensionObject, value: newExtObj }));
+
+        const result = uaVar.readValue(context).value.value;
+        Array.from(result.fieldInt32Array).should.eql([10, 20, 30, 40]);
+    });
+
+    it("TV-8 setValueFromSource should still recurse into nested extension objects (InnerStruct)", () => {
+        const uaVar = testVar;
+        const newInnerDate = new Date("2029-12-31T23:59:59.000Z");
+        const newExtObj = constructNewExtObj({
+            fieldInner: { innerDateTime: newInnerDate, innerInt32: 99 }
+        });
+
+        uaVar.setValueFromSource(new Variant({ dataType: DataType.ExtensionObject, value: newExtObj }));
+
+        const result = uaVar.readValue(context).value.value;
+        result.fieldInner.innerInt32.should.eql(99);
+        result.fieldInner.innerDateTime.should.be.instanceof(Date);
+        result.fieldInner.innerDateTime.toISOString().should.eql("2029-12-31T23:59:59.000Z");
+    });
+
+    it("TV-9 setValueFromSource should update a primitive Int32 field (control test)", () => {
+        const uaVar = testVar;
+        const newExtObj = constructNewExtObj({ fieldInt32: 42 });
+
+        uaVar.setValueFromSource(new Variant({ dataType: DataType.ExtensionObject, value: newExtObj }));
+
+        const result = uaVar.readValue(context).value.value;
+        result.fieldInt32.should.eql(42);
+    });
+
+    // --------------- Notification Bug Tests ---------------
+    // The deeper issue: with the broken code, terminal types are recursed
+    // into at the raw-object level, so the child variable's `value_changed`
+    // event is never emitted (touchValue is never called because the field
+    // never enters `variablesToUpdate`).
+
+    it("NB-1 setValueFromSource should emit value_changed on the NodeId child variable", () => {
+        const uaVar = testVar;
+        const fieldNodeIdVar = uaVar.getComponentByName("fieldNodeId") as UAVariable;
+        should.exist(fieldNodeIdVar, "fieldNodeId child variable should exist");
+
+        let notified = false;
+        fieldNodeIdVar.on("value_changed", () => {
+            notified = true;
+        });
+
+        const updatedNodeId = coerceNodeId("ns=2;i=999");
+        const newExtObj = constructNewExtObj({ fieldNodeId: updatedNodeId });
+        uaVar.setValueFromSource(new Variant({ dataType: DataType.ExtensionObject, value: newExtObj }));
+
+        fieldNodeIdVar.removeAllListeners("value_changed");
+        notified.should.eql(true, "value_changed should have been emitted on fieldNodeId child variable");
+    });
+
+    it("NB-2 setValueFromSource should emit value_changed on the QualifiedName child variable", () => {
+        const uaVar = testVar;
+        const fieldQNVar = uaVar.getComponentByName("fieldQualifiedName") as UAVariable;
+        should.exist(fieldQNVar, "fieldQualifiedName child variable should exist");
+
+        let notified = false;
+        fieldQNVar.on("value_changed", () => {
+            notified = true;
+        });
+
+        const updatedQN = new QualifiedName({ namespaceIndex: 2, name: "Updated" });
+        const newExtObj = constructNewExtObj({ fieldQualifiedName: updatedQN });
+        uaVar.setValueFromSource(new Variant({ dataType: DataType.ExtensionObject, value: newExtObj }));
+
+        fieldQNVar.removeAllListeners("value_changed");
+        notified.should.eql(true, "value_changed should have been emitted on fieldQualifiedName child variable");
+    });
+
+    it("NB-3 setValueFromSource should emit value_changed on the Int32 child (control - primitive)", () => {
+        const uaVar = testVar;
+        const fieldInt32Var = uaVar.getComponentByName("fieldInt32") as UAVariable;
+        should.exist(fieldInt32Var, "fieldInt32 child variable should exist");
+
+        let notified = false;
+        fieldInt32Var.on("value_changed", () => {
+            notified = true;
+        });
+
+        const newExtObj = constructNewExtObj({ fieldInt32: 42 });
+        uaVar.setValueFromSource(new Variant({ dataType: DataType.ExtensionObject, value: newExtObj }));
+
+        fieldInt32Var.removeAllListeners("value_changed");
+        notified.should.eql(true, "value_changed should have been emitted on fieldInt32 child variable (control)");
+    });
+
+    it("NB-4 setValueFromSource should emit value_changed on the LocalizedText child variable", () => {
+        const uaVar = testVar;
+        const fieldLTVar = uaVar.getComponentByName("fieldLocalizedText") as UAVariable;
+        should.exist(fieldLTVar, "fieldLocalizedText child variable should exist");
+
+        let notified = false;
+        fieldLTVar.on("value_changed", () => {
+            notified = true;
+        });
+
+        const updatedLT = new LocalizedText({ locale: "fr", text: "Bonjour" });
+        const newExtObj = constructNewExtObj({ fieldLocalizedText: updatedLT });
+        uaVar.setValueFromSource(new Variant({ dataType: DataType.ExtensionObject, value: newExtObj }));
+
+        fieldLTVar.removeAllListeners("value_changed");
+        notified.should.eql(true, "value_changed should have been emitted on fieldLocalizedText child variable");
+    });
+});

--- a/packages/node-opcua-address-space/test/test_extension_object_with_dates.ts
+++ b/packages/node-opcua-address-space/test/test_extension_object_with_dates.ts
@@ -1,0 +1,171 @@
+import path from "node:path";
+import { nodesets } from "node-opcua-nodesets";
+import { StatusCodes } from "node-opcua-status-code";
+import type { CallMethodResultOptions } from "node-opcua-types";
+import { DataType, Variant } from "node-opcua-variant";
+import should from "should";
+import { AddressSpace, type ISessionContext, SessionContext, type UAMethod, type UAObject, type UAVariable } from "..";
+import { generateAddressSpace } from "../nodeJS";
+
+describe("Testing loading nodeset with extension objects containing DateTime values", function (this: Mocha.Suite) {
+    this.timeout(200000);
+
+    let addressSpace: AddressSpace;
+    const context = SessionContext.defaultContext;
+
+    const xml_file = path.join(__dirname, "../test_helpers/test_fixtures/extension_object_with_dates.xml");
+
+    beforeEach(async () => {
+        addressSpace = AddressSpace.create();
+        await generateAddressSpace(addressSpace, [nodesets.standard, xml_file]);
+    });
+    afterEach(() => {
+        addressSpace.dispose();
+    });
+
+    it("EOD-1 should load the nodeset without error", () => {
+        const nsMyCompany = addressSpace.getNamespaceIndex("http://my-company.com");
+        nsMyCompany.should.be.greaterThanOrEqual(1);
+    });
+
+    it("EOD-2 should find the BasicComplexData datatype with a dateTime field", () => {
+        const nsMyCompany = addressSpace.getNamespaceIndex("http://my-company.com");
+        const basicComplexDataType = addressSpace.findDataType("BasicComplexData", nsMyCompany);
+        should.exist(basicComplexDataType, "BasicComplexData datatype should exist");
+    });
+
+    it("EOD-3 should read basicComplexData variable with a DateTime value in extension object", () => {
+        const nsMyCompany = addressSpace.getNamespaceIndex("http://my-company.com");
+
+        // ns=1;i=6029 is the basicComplexData variable
+        const basicComplexDataVar = addressSpace.findNode(`ns=${nsMyCompany};i=6029`) as UAVariable;
+        should.exist(basicComplexDataVar, "basicComplexData variable should exist");
+
+        const dataValue = basicComplexDataVar.readValue(context);
+        dataValue.value.dataType.should.eql(DataType.ExtensionObject);
+
+        const extObj = dataValue.value.value;
+        should.exist(extObj, "extension object value should exist");
+
+        // The dateTime field should be a Date with value 2026-02-06T10:30:00.000Z
+        extObj.dateTime.should.be.instanceof(Date);
+        extObj.dateTime.toISOString().should.eql("2026-02-06T10:30:00.000Z");
+
+        // verify other scalar fields are present
+        extObj.boolean.should.eql(false);
+        extObj.int32.should.eql(0);
+        extObj.double.should.eql(0);
+        extObj.float.should.eql(0);
+    });
+
+    it("EOD-4 should read the dateTime component variable", () => {
+        const nsMyCompany = addressSpace.getNamespaceIndex("http://my-company.com");
+
+        // ns=1;i=6009 is the dateTime sub-variable
+        const dateTimeVar = addressSpace.findNode(`ns=${nsMyCompany};i=6009`) as UAVariable;
+        should.exist(dateTimeVar, "dateTime component variable should exist");
+        should(dateTimeVar.browseName.name).eql("dateTime");
+    });
+
+    it("EOD-5 should read complexDataWithComplexArray containing nested BasicComplexData with dateTime", () => {
+        const nsMyCompany = addressSpace.getNamespaceIndex("http://my-company.com");
+
+        // ns=1;i=6034 is the complexDataWithComplexArray variable
+        const complexVar = addressSpace.findNode(`ns=${nsMyCompany};i=6034`) as UAVariable;
+        should.exist(complexVar, "complexDataWithComplexArray variable should exist");
+
+        const dataValue = complexVar.readValue(context);
+        dataValue.value.dataType.should.eql(DataType.ExtensionObject);
+
+        const extObj = dataValue.value.value;
+        should.exist(extObj);
+
+        extObj.name.should.eql("test");
+
+        // The complexDataArray field should contain BasicComplexData entries with dateTime
+        extObj.complexDataArray.should.be.an.Array();
+        extObj.complexDataArray.length.should.be.greaterThanOrEqual(1);
+
+        const nested = extObj.complexDataArray[0];
+        nested.dateTime.should.be.instanceof(Date);
+        nested.dateTime.toISOString().should.eql("2026-02-06T10:30:00.000Z");
+    });
+
+    it("EOD-6 should call callBasicComplexData method and verify the variable is updated with new DateTime", async () => {
+        const nsMyCompany = addressSpace.getNamespaceIndex("http://my-company.com");
+
+        // find the basicComplexData variable (ns=1;i=6029)
+        const basicComplexDataVar = addressSpace.findNode(`ns=${nsMyCompany};i=6029`) as UAVariable;
+        should.exist(basicComplexDataVar, "basicComplexData variable should exist");
+
+        // find the callBasicComplexData method (ns=1;i=7000)
+        const callBasicComplexDataMethod = addressSpace.findNode(`ns=${nsMyCompany};i=7000`) as UAMethod;
+        should.exist(callBasicComplexDataMethod, "callBasicComplexData method should exist");
+
+        // find the parent object (ns=1;i=5007 - ComplexData)
+        const complexDataObject = addressSpace.findNode(`ns=${nsMyCompany};i=5007`) as UAObject;
+        should.exist(complexDataObject, "ComplexData object should exist");
+
+        // bind the method: it updates the basicComplexData variable
+        // with the input extension object and returns the previous value
+        callBasicComplexDataMethod.bindMethod(async function (
+            this: UAMethod,
+            inputArguments: Variant[],
+            _context: ISessionContext
+        ): Promise<CallMethodResultOptions> {
+            const inputExtObj = inputArguments[0].value;
+            const previousValue: Variant = basicComplexDataVar.readValue().value;
+            basicComplexDataVar.setValueFromSource(
+                new Variant({
+                    dataType: DataType.ExtensionObject,
+                    value: inputExtObj
+                })
+            );
+            return {
+                statusCode: StatusCodes.Good,
+                outputArguments: [previousValue]
+            };
+        });
+
+        // verify initial dateTime value
+        const initialValue = basicComplexDataVar.readValue().value.value;
+        initialValue.dateTime.toISOString().should.eql("2026-02-06T10:30:00.000Z");
+
+        // construct a new extension object with a different dateTime
+        const basicComplexDataType = addressSpace.findDataType("BasicComplexData", nsMyCompany);
+        should.exist(basicComplexDataType, "BasicComplexData datatype should exist");
+
+        const newDate = new Date("2026-06-15T08:00:00.000Z");
+        const newExtObj = addressSpace.constructExtensionObject(basicComplexDataType!, {
+            boolean: true,
+            int32: 42,
+            double: 3.14,
+            float: 1.5,
+            int64: [0, 100],
+            dateTime: newDate
+        });
+
+        // call the method as if a client invoked it
+        const result = (await callBasicComplexDataMethod.execute(
+            complexDataObject,
+            [new Variant({ dataType: DataType.ExtensionObject, value: newExtObj })],
+            context
+        )) as CallMethodResultOptions;
+
+        should(result.statusCode).eql(StatusCodes.Good);
+
+        // the output should contain the previous value
+        should.exist(result.outputArguments);
+        should(result.outputArguments?.length).eql(1);
+        const previousExtObj = result.outputArguments?.[0].value;
+        previousExtObj.dateTime.toISOString().should.eql("2026-02-06T10:30:00.000Z");
+
+        // the variable should now have the new value
+        const updatedValue = basicComplexDataVar.readValue().value.value;
+        updatedValue.boolean.should.eql(true);
+        updatedValue.int32.should.eql(42);
+        updatedValue.double.should.eql(3.14);
+        updatedValue.dateTime.should.be.instanceof(Date);
+        updatedValue.dateTime.toISOString().should.eql("2026-06-15T08:00:00.000Z");
+    });
+});

--- a/packages/node-opcua-address-space/test_helpers/test_fixtures/all_terminal_value_types.xml
+++ b/packages/node-opcua-address-space/test_helpers/test_fixtures/all_terminal_value_types.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UANodeSet LastModified="2026-03-18T00:00:00Z"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd"
+  xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <NamespaceUris>
+        <Uri>http://test-terminal-values.example.com</Uri>
+    </NamespaceUris>
+    <Models>
+        <Model ModelUri="http://test-terminal-values.example.com" Version="1.0">
+            <RequiredModel ModelUri="http://opcfoundation.org/UA/" PublicationDate="2023-12-15T00:00:00Z" Version="1.05.03"/>
+        </Model>
+    </Models>
+    <Aliases>
+        <Alias Alias="Boolean">i=1</Alias>
+        <Alias Alias="Int32">i=6</Alias>
+        <Alias Alias="String">i=12</Alias>
+        <Alias Alias="DateTime">i=13</Alias>
+        <Alias Alias="ByteString">i=15</Alias>
+        <Alias Alias="NodeId">i=17</Alias>
+        <Alias Alias="QualifiedName">i=20</Alias>
+        <Alias Alias="LocalizedText">i=21</Alias>
+        <Alias Alias="DiagnosticInfo">i=25</Alias>
+        <Alias Alias="HasComponent">i=47</Alias>
+        <Alias Alias="Organizes">i=35</Alias>
+        <Alias Alias="HasSubtype">i=45</Alias>
+        <Alias Alias="HasTypeDefinition">i=40</Alias>
+        <Alias Alias="HasEncoding">i=38</Alias>
+    </Aliases>
+
+    <!-- InnerStruct: sub-structure for nesting test -->
+    <UADataType NodeId="ns=1;i=3000" BrowseName="1:InnerStruct">
+        <DisplayName>InnerStruct</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+            <Reference ReferenceType="HasEncoding">ns=1;i=5000</Reference>
+        </References>
+        <Definition Name="1:InnerStruct">
+            <Field DataType="DateTime" Name="innerDateTime"/>
+            <Field DataType="Int32" Name="innerInt32"/>
+        </Definition>
+    </UADataType>
+    <UAObject SymbolicName="DefaultBinary" NodeId="ns=1;i=5000" BrowseName="Default Binary">
+        <DisplayName>Default Binary</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+        </References>
+    </UAObject>
+
+    <!-- AllTerminalsStruct: the main data type with all terminal value type fields -->
+    <UADataType NodeId="ns=1;i=3001" BrowseName="1:AllTerminalsStruct">
+        <DisplayName>AllTerminalsStruct</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+            <Reference ReferenceType="HasEncoding">ns=1;i=5001</Reference>
+        </References>
+        <Definition Name="1:AllTerminalsStruct">
+            <Field DataType="DateTime" Name="fieldDateTime"/>
+            <Field DataType="ByteString" Name="fieldByteString"/>
+            <Field DataType="NodeId" Name="fieldNodeId"/>
+            <Field DataType="QualifiedName" Name="fieldQualifiedName"/>
+            <Field DataType="LocalizedText" Name="fieldLocalizedText"/>
+            <Field DataType="DiagnosticInfo" Name="fieldDiagnosticInfo"/>
+            <Field DataType="Int32" Name="fieldInt32"/>
+            <Field DataType="Int32" ValueRank="1" Name="fieldInt32Array"/>
+            <Field DataType="ns=1;i=3000" Name="fieldInner"/>
+        </Definition>
+    </UADataType>
+    <UAObject SymbolicName="DefaultBinary" NodeId="ns=1;i=5001" BrowseName="Default Binary">
+        <DisplayName>Default Binary</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+        </References>
+    </UAObject>
+
+    <!-- Container object -->
+    <UAObject NodeId="ns=1;i=5010" BrowseName="1:TerminalValuesTest" ParentNodeId="i=85">
+        <DisplayName>TerminalValuesTest</DisplayName>
+        <References>
+            <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=58</Reference>
+        </References>
+    </UAObject>
+
+    <!-- Variable instance with initial values -->
+    <UAVariable DataType="ns=1;i=3001" NodeId="ns=1;i=6000" BrowseName="1:testAllTerminals" ParentNodeId="ns=1;i=5010" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>testAllTerminals</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5010</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+        <Value>
+            <uax:ExtensionObject>
+                <uax:TypeId>
+                    <uax:Identifier>ns=1;i=5001</uax:Identifier>
+                </uax:TypeId>
+                <uax:Body>
+                    <AllTerminalsStruct xmlns="http://test-terminal-values.example.com/Types.xsd">
+                        <fieldDateTime>2026-01-01T00:00:00Z</fieldDateTime>
+                        <fieldByteString>qrs=</fieldByteString>
+                        <fieldNodeId>
+                            <uax:Identifier>ns=1;i=100</uax:Identifier>
+                        </fieldNodeId>
+                        <fieldQualifiedName>
+                            <uax:NamespaceIndex>1</uax:NamespaceIndex>
+                            <uax:Name>Initial</uax:Name>
+                        </fieldQualifiedName>
+                        <fieldLocalizedText>
+                            <uax:Locale>en</uax:Locale>
+                            <uax:Text>Hello</uax:Text>
+                        </fieldLocalizedText>
+                        <fieldDiagnosticInfo/>
+                        <fieldInt32>10</fieldInt32>
+                        <fieldInt32Array>
+                            <uax:Int32>1</uax:Int32>
+                            <uax:Int32>2</uax:Int32>
+                            <uax:Int32>3</uax:Int32>
+                        </fieldInt32Array>
+                        <fieldInner>
+                            <innerDateTime>2026-01-01T00:00:00Z</innerDateTime>
+                            <innerInt32>5</innerInt32>
+                        </fieldInner>
+                    </AllTerminalsStruct>
+                </uax:Body>
+            </uax:ExtensionObject>
+        </Value>
+    </UAVariable>
+</UANodeSet>

--- a/packages/node-opcua-address-space/test_helpers/test_fixtures/extension_object_with_dates.xml
+++ b/packages/node-opcua-address-space/test_helpers/test_fixtures/extension_object_with_dates.xml
@@ -1,0 +1,606 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UANodeSet LastModified="2026-02-06T09:52:06.352Z" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd" xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd" xmlns:si="http://www.siemens.com/OPCUA/2017/SimaticNodeSetExtensions" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <NamespaceUris>
+        <Uri>http://my-company.com</Uri>
+    </NamespaceUris>
+    <Models>
+        <Model ModelUri="http://my-company.com" PublicationDate="2026-02-03T10:31:01+00:00" Version="1.00">
+            <RequiredModel ModelUri="http://opcfoundation.org/UA/" PublicationDate="2023-12-15T00:00:00Z" Version="1.05.03"/>
+        </Model>
+    </Models>
+    <Aliases>
+        <Alias Alias="Boolean">i=1</Alias>
+        <Alias Alias="Int16">i=4</Alias>
+        <Alias Alias="Int32">i=6</Alias>
+        <Alias Alias="Int64">i=8</Alias>
+        <Alias Alias="Float">i=10</Alias>
+        <Alias Alias="Double">i=11</Alias>
+        <Alias Alias="DateTime">i=13</Alias>
+        <Alias Alias="String">i=12</Alias>
+        <Alias Alias="HasComponent">i=47</Alias>
+        <Alias Alias="HasProperty">i=46</Alias>
+        <Alias Alias="Organizes">i=35</Alias>
+        <Alias Alias="HasSubtype">i=45</Alias>
+        <Alias Alias="HasTypeDefinition">i=40</Alias>
+        <Alias Alias="HasEncoding">i=38</Alias>
+    </Aliases>
+    <Extensions>
+        <Extension>
+            <si:Generator Product="SiOME" Edition="Standard" Version="3.1.1-installer"/>
+        </Extension>
+        <Extension>
+            <si:GeneratorExtension Hash="2ae5ea5177019a8880a9c3f11ab10a2a"/>
+        </Extension>
+    </Extensions>
+    <UAObject SymbolicName="http___my-company_io" NodeId="ns=1;i=5000" BrowseName="1:http://my-company.com" ParentNodeId="i=11715">
+        <DisplayName>http://my-company.com</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">i=11715</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=11616</Reference>
+        </References>
+    </UAObject>
+    <UAVariable DataType="Boolean" NodeId="ns=1;i=6000" BrowseName="IsNamespaceSubset" ParentNodeId="ns=1;i=5000">
+        <DisplayName>IsNamespaceSubset</DisplayName>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5000</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="DateTime" NodeId="ns=1;i=6001" BrowseName="NamespacePublicationDate" ParentNodeId="ns=1;i=5000">
+        <DisplayName>NamespacePublicationDate</DisplayName>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5000</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+        <Value>
+            <uax:DateTime>2026-02-03T10:31:01+00:00</uax:DateTime>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="String" NodeId="ns=1;i=6002" BrowseName="NamespaceUri" ParentNodeId="ns=1;i=5000">
+        <DisplayName>NamespaceUri</DisplayName>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5000</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+        <Value>
+            <uax:String>http://my-company.com</uax:String>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="String" NodeId="ns=1;i=6003" BrowseName="NamespaceVersion" ParentNodeId="ns=1;i=5000">
+        <DisplayName>NamespaceVersion</DisplayName>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5000</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+        <Value>
+            <uax:String>1.00</uax:String>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="i=256" ValueRank="1" NodeId="ns=1;i=6004" BrowseName="StaticNodeIdTypes" ParentNodeId="ns=1;i=5000">
+        <DisplayName>StaticNodeIdTypes</DisplayName>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5000</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="i=291" ValueRank="1" NodeId="ns=1;i=6005" BrowseName="StaticNumericNodeIdRange" ParentNodeId="ns=1;i=5000">
+        <DisplayName>StaticNumericNodeIdRange</DisplayName>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5000</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="String" NodeId="ns=1;i=6006" BrowseName="StaticStringNodeIdPattern" ParentNodeId="ns=1;i=5000">
+        <DisplayName>StaticStringNodeIdPattern</DisplayName>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5000</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="i=96" ValueRank="1" NodeId="ns=1;i=6007" BrowseName="DefaultRolePermissions" ParentNodeId="ns=1;i=5000">
+        <DisplayName>DefaultRolePermissions</DisplayName>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5000</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="i=95" NodeId="ns=1;i=6008" BrowseName="DefaultAccessRestrictions" ParentNodeId="ns=1;i=5000">
+        <DisplayName>DefaultAccessRestrictions</DisplayName>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=5000</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+    </UAVariable>
+    <UADataType NodeId="ns=1;i=3000" BrowseName="1:BasicComplexData">
+        <DisplayName>BasicComplexData</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+            <Reference ReferenceType="HasEncoding">ns=1;i=5001</Reference>
+            <Reference ReferenceType="HasEncoding">ns=1;i=5002</Reference>
+        </References>
+        <Definition Name="1:BasicComplexData">
+            <Field DataType="Boolean" Name="boolean"/>
+            <Field DataType="Int32" Name="int32"/>
+            <Field DataType="Double" Name="double"/>
+            <Field DataType="Float" Name="float"/>
+            <Field DataType="Int64" Name="int64"/>
+            <Field DataType="DateTime" Name="dateTime"/>
+        </Definition>
+    </UADataType>
+    <UAObject SymbolicName="DefaultBinary" NodeId="ns=1;i=5001" BrowseName="Default Binary">
+        <DisplayName>Default Binary</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+        </References>
+    </UAObject>
+    <UAObject SymbolicName="DefaultXML" NodeId="ns=1;i=5002" BrowseName="Default XML">
+        <DisplayName>Default XML</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+        </References>
+    </UAObject>
+    <UADataType NodeId="ns=1;i=3001" BrowseName="1:ComplexDataArray">
+        <DisplayName>ComplexDataArray</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+            <Reference ReferenceType="HasEncoding">ns=1;i=5003</Reference>
+            <Reference ReferenceType="HasEncoding">ns=1;i=5004</Reference>
+        </References>
+        <Definition Name="1:ComplexDataArray">
+            <Field DataType="Boolean" ValueRank="1" Name="booleanArray"/>
+            <Field DataType="Int16" ValueRank="1" Name="int16Array"/>
+            <Field DataType="Double" ValueRank="1" Name="doubleArray"/>
+        </Definition>
+    </UADataType>
+    <UAObject SymbolicName="DefaultBinary" NodeId="ns=1;i=5003" BrowseName="Default Binary">
+        <DisplayName>Default Binary</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+        </References>
+    </UAObject>
+    <UAObject SymbolicName="DefaultXML" NodeId="ns=1;i=5004" BrowseName="Default XML">
+        <DisplayName>Default XML</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+        </References>
+    </UAObject>
+    <UADataType NodeId="ns=1;i=3002" BrowseName="1:ComplexDataWithComplexArray">
+        <DisplayName>ComplexDataWithComplexArray</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+            <Reference ReferenceType="HasEncoding">ns=1;i=5005</Reference>
+            <Reference ReferenceType="HasEncoding">ns=1;i=5006</Reference>
+        </References>
+        <Definition Name="1:ComplexDataWithComplexArray">
+            <Field DataType="String" Name="name"/>
+            <Field DataType="Boolean" ValueRank="1" Name="booleanArray"/>
+            <Field DataType="ns=1;i=3000" ValueRank="1" Name="complexDataArray"/>
+        </Definition>
+    </UADataType>
+    <UAObject SymbolicName="DefaultBinary" NodeId="ns=1;i=5005" BrowseName="Default Binary">
+        <DisplayName>Default Binary</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+        </References>
+    </UAObject>
+    <UAObject SymbolicName="DefaultXML" NodeId="ns=1;i=5006" BrowseName="Default XML">
+        <DisplayName>Default XML</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=76</Reference>
+        </References>
+    </UAObject>
+    <UAObject NodeId="ns=1;i=5007" BrowseName="1:ComplexData" ParentNodeId="i=85">
+        <DisplayName>ComplexData</DisplayName>
+        <References>
+            <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=58</Reference>
+        </References>
+    </UAObject>
+    <UAVariable DataType="ns=1;i=3001" NodeId="ns=1;i=6025" BrowseName="1:complexDataArray" ParentNodeId="ns=1;i=5007" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>complexDataArray</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5007</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+        <Value>
+            <uax:ExtensionObject>
+                <uax:TypeId>
+                    <uax:Identifier>ns=1;i=5004</uax:Identifier>
+                </uax:TypeId>
+                <uax:Body>
+                    <ComplexDataArray xmlns="http://my-company.com/Types.xsd">
+                        <booleanArray>
+                            <Boolean>false</Boolean>
+                        </booleanArray>
+                        <int16Array>
+                            <Int16>0</Int16>
+                        </int16Array>
+                        <doubleArray>
+                            <Double>0</Double>
+                        </doubleArray>
+                    </ComplexDataArray>
+                </uax:Body>
+            </uax:ExtensionObject>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="Boolean" ValueRank="1" NodeId="ns=1;i=6026" ArrayDimensions="1" BrowseName="1:booleanArray" ParentNodeId="ns=1;i=6025" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>booleanArray</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6025</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="Int16" ValueRank="1" NodeId="ns=1;i=6027" ArrayDimensions="1" BrowseName="1:int16Array" ParentNodeId="ns=1;i=6025" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>int16Array</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6025</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="Double" ValueRank="1" NodeId="ns=1;i=6028" ArrayDimensions="1" BrowseName="1:doubleArray" ParentNodeId="ns=1;i=6025" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>doubleArray</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6025</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="ns=1;i=3000" NodeId="ns=1;i=6029" BrowseName="1:basicComplexData" ParentNodeId="ns=1;i=5007" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>basicComplexData</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5007</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+        <Value>
+            <uax:ExtensionObject>
+                <uax:TypeId>
+                    <uax:Identifier>ns=1;i=5002</uax:Identifier>
+                </uax:TypeId>
+                <uax:Body>
+                    <BasicComplexData xmlns="http://my-company.com/Types.xsd">
+                        <boolean>false</boolean>
+                        <int32>0</int32>
+                        <double>0</double>
+                        <float>0</float>
+                        <int64>0</int64>
+                        <dateTime>2026-02-06T10:30:00.000Z</dateTime>
+                    </BasicComplexData>
+                </uax:Body>
+            </uax:ExtensionObject>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="Boolean" NodeId="ns=1;i=6030" BrowseName="1:boolean" ParentNodeId="ns=1;i=6029" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>boolean</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6029</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="Int32" NodeId="ns=1;i=6031" BrowseName="1:int32" ParentNodeId="ns=1;i=6029" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>int32</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6029</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="Double" NodeId="ns=1;i=6032" BrowseName="1:double" ParentNodeId="ns=1;i=6029" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>double</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6029</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="Float" NodeId="ns=1;i=6033" BrowseName="1:float" ParentNodeId="ns=1;i=6029" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>float</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6029</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="ns=1;i=3002" NodeId="ns=1;i=6034" BrowseName="1:complexDataWithComplexArray" ParentNodeId="ns=1;i=5007" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>complexDataWithComplexArray</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5007</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+        <Value>
+            <uax:ExtensionObject>
+                <uax:TypeId>
+                    <uax:Identifier>ns=1;i=5006</uax:Identifier>
+                </uax:TypeId>
+                <uax:Body>
+                    <ComplexDataWithComplexArray xmlns="http://my-company.com/Types.xsd">
+                        <name>test</name>
+                        <booleanArray>
+                            <Boolean>false</Boolean>
+                        </booleanArray>
+                        <complexDataArray>
+                            <BasicComplexData xmlns="http://my-company.com/Types.xsd">
+                                <boolean>false</boolean>
+                                <int32>0</int32>
+                                <double>0</double>
+                                <float>0</float>
+                                <int64>0</int64>
+                                <dateTime>2026-02-06T10:30:00.000Z</dateTime>
+                            </BasicComplexData>
+                        </complexDataArray>
+                    </ComplexDataWithComplexArray>
+                </uax:Body>
+            </uax:ExtensionObject>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="String" NodeId="ns=1;i=6035" BrowseName="1:name" ParentNodeId="ns=1;i=6034" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>name</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6034</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="Boolean" ValueRank="1" NodeId="ns=1;i=6036" ArrayDimensions="1" BrowseName="1:booleanArray" ParentNodeId="ns=1;i=6034" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>booleanArray</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6034</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="ns=1;i=3000" ValueRank="1" NodeId="ns=1;i=6037" ArrayDimensions="1" BrowseName="1:complexDataArray" ParentNodeId="ns=1;i=6034" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>complexDataArray</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6034</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+    </UAVariable>
+    <UAMethod NodeId="ns=1;i=7002" BrowseName="1:callComplexDataArray" ParentNodeId="ns=1;i=5007">
+        <DisplayName>callComplexDataArray</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5007</Reference>
+        </References>
+    </UAMethod>
+    <UAVariable DataType="i=296" ValueRank="1" NodeId="ns=1;i=6042" ArrayDimensions="2" BrowseName="InputArguments" ParentNodeId="ns=1;i=7002">
+        <DisplayName>InputArguments</DisplayName>
+        <Description>the definition of the input argument of method 1:ComplexData.1:complexDataArraySuccess</Description>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=7002</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+        <Value>
+            <uax:ListOfExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=297</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <uax:Argument>
+                            <uax:Name>data</uax:Name>
+                            <uax:DataType>
+                                <uax:Identifier>ns=1;i=3001</uax:Identifier>
+                            </uax:DataType>
+                            <uax:ValueRank>-1</uax:ValueRank>
+                            <uax:ArrayDimensions/>
+                            <uax:Description/>
+                        </uax:Argument>
+                    </uax:Body>
+                </uax:ExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=297</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <uax:Argument>
+                            <uax:Name>returnStatusCode</uax:Name>
+                            <uax:DataType>
+                                <uax:Identifier>i=12</uax:Identifier>
+                            </uax:DataType>
+                            <uax:ValueRank>-1</uax:ValueRank>
+                            <uax:ArrayDimensions/>
+                            <uax:Description>
+                                <uax:Text>The status code which server is expected to return back</uax:Text>
+                            </uax:Description>
+                        </uax:Argument>
+                    </uax:Body>
+                </uax:ExtensionObject>
+            </uax:ListOfExtensionObject>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="i=296" ValueRank="1" NodeId="ns=1;i=6043" ArrayDimensions="1" BrowseName="OutputArguments" ParentNodeId="ns=1;i=7002">
+        <DisplayName>OutputArguments</DisplayName>
+        <Description>the definition of the output arguments of method 1:ComplexData.1:complexDataArraySuccess</Description>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=7002</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+        <Value>
+            <uax:ListOfExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=297</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <uax:Argument>
+                            <uax:Name>result</uax:Name>
+                            <uax:DataType>
+                                <uax:Identifier>ns=1;i=3001</uax:Identifier>
+                            </uax:DataType>
+                            <uax:ValueRank>-1</uax:ValueRank>
+                            <uax:ArrayDimensions/>
+                            <uax:Description/>
+                        </uax:Argument>
+                    </uax:Body>
+                </uax:ExtensionObject>
+            </uax:ListOfExtensionObject>
+        </Value>
+    </UAVariable>
+    <UAMethod NodeId="ns=1;i=7004" BrowseName="1:callComplexDataWithComplexArray" ParentNodeId="ns=1;i=5007">
+        <DisplayName>callComplexDataWithComplexArray</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5007</Reference>
+        </References>
+    </UAMethod>
+    <UAVariable DataType="i=296" ValueRank="1" NodeId="ns=1;i=6046" ArrayDimensions="2" BrowseName="InputArguments" ParentNodeId="ns=1;i=7004">
+        <DisplayName>InputArguments</DisplayName>
+        <Description>the definition of the input argument of method 1:ComplexData.1:complexDataWithComplexArraySuccess</Description>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=7004</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+        <Value>
+            <uax:ListOfExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=297</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <uax:Argument>
+                            <uax:Name>data</uax:Name>
+                            <uax:DataType>
+                                <uax:Identifier>ns=1;i=3002</uax:Identifier>
+                            </uax:DataType>
+                            <uax:ValueRank>-1</uax:ValueRank>
+                            <uax:ArrayDimensions/>
+                            <uax:Description/>
+                        </uax:Argument>
+                    </uax:Body>
+                </uax:ExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=297</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <uax:Argument>
+                            <uax:Name>returnStatusCode</uax:Name>
+                            <uax:DataType>
+                                <uax:Identifier>i=12</uax:Identifier>
+                            </uax:DataType>
+                            <uax:ValueRank>-1</uax:ValueRank>
+                            <uax:ArrayDimensions/>
+                            <uax:Description>
+                                <uax:Text>The status code which server is expected to return back</uax:Text>
+                            </uax:Description>
+                        </uax:Argument>
+                    </uax:Body>
+                </uax:ExtensionObject>
+            </uax:ListOfExtensionObject>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="i=296" ValueRank="1" NodeId="ns=1;i=6047" ArrayDimensions="1" BrowseName="OutputArguments" ParentNodeId="ns=1;i=7004">
+        <DisplayName>OutputArguments</DisplayName>
+        <Description>the definition of the output arguments of method 1:ComplexData.1:complexDataWithComplexArraySuccess</Description>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=7004</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+        <Value>
+            <uax:ListOfExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=297</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <uax:Argument>
+                            <uax:Name>result</uax:Name>
+                            <uax:DataType>
+                                <uax:Identifier>ns=1;i=3002</uax:Identifier>
+                            </uax:DataType>
+                            <uax:ValueRank>-1</uax:ValueRank>
+                            <uax:ArrayDimensions/>
+                            <uax:Description/>
+                        </uax:Argument>
+                    </uax:Body>
+                </uax:ExtensionObject>
+            </uax:ListOfExtensionObject>
+        </Value>
+    </UAVariable>
+    <UAMethod NodeId="ns=1;i=7000" BrowseName="1:callBasicComplexData" ParentNodeId="ns=1;i=5007">
+        <DisplayName>callBasicComplexData</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=5007</Reference>
+        </References>
+    </UAMethod>
+    <UAVariable DataType="i=296" ValueRank="1" NodeId="ns=1;i=6011" ArrayDimensions="2" BrowseName="InputArguments" ParentNodeId="ns=1;i=7000">
+        <DisplayName>InputArguments</DisplayName>
+        <Description>the definition of the input argument of method 1:ComplexData.1:callBasicComplexData</Description>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=7000</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+        <Value>
+            <uax:ListOfExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=297</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <uax:Argument>
+                            <uax:Name>data</uax:Name>
+                            <uax:DataType>
+                                <uax:Identifier>ns=1;i=3000</uax:Identifier>
+                            </uax:DataType>
+                            <uax:ValueRank>-1</uax:ValueRank>
+                            <uax:ArrayDimensions/>
+                            <uax:Description/>
+                        </uax:Argument>
+                    </uax:Body>
+                </uax:ExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=297</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <uax:Argument>
+                            <uax:Name>returnStatusCode</uax:Name>
+                            <uax:DataType>
+                                <uax:Identifier>i=12</uax:Identifier>
+                            </uax:DataType>
+                            <uax:ValueRank>-1</uax:ValueRank>
+                            <uax:ArrayDimensions/>
+                            <uax:Description>
+                                <uax:Text>The status code which server is expected to return back</uax:Text>
+                            </uax:Description>
+                        </uax:Argument>
+                    </uax:Body>
+                </uax:ExtensionObject>
+            </uax:ListOfExtensionObject>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="i=296" ValueRank="1" NodeId="ns=1;i=6012" ArrayDimensions="1" BrowseName="OutputArguments" ParentNodeId="ns=1;i=7000">
+        <DisplayName>OutputArguments</DisplayName>
+        <Description>the definition of the output arguments of method 1:ComplexData.1:callBasicComplexData</Description>
+        <References>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=7000</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+        <Value>
+            <uax:ListOfExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=297</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <uax:Argument>
+                            <uax:Name>result</uax:Name>
+                            <uax:DataType>
+                                <uax:Identifier>ns=1;i=3000</uax:Identifier>
+                            </uax:DataType>
+                            <uax:ValueRank>-1</uax:ValueRank>
+                            <uax:ArrayDimensions/>
+                            <uax:Description/>
+                        </uax:Argument>
+                    </uax:Body>
+                </uax:ExtensionObject>
+            </uax:ListOfExtensionObject>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="DateTime" NodeId="ns=1;i=6009" BrowseName="1:dateTime" ParentNodeId="ns=1;i=6029" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>dateTime</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6029</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+    </UAVariable>
+    <UAVariable DataType="Int64" NodeId="ns=1;i=6010" BrowseName="1:int64" ParentNodeId="ns=1;i=6029" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>int64</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=6029</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+    </UAVariable>
+</UANodeSet>


### PR DESCRIPTION
The _update_extension_object function used`instanceof Object` to decide whether to recurse
into a field. Since all non-primitive types satisfy this check (Date, Buffer, NodeId, QualifiedName,
LocalizedText, DiagnosticInfo, arrays), the function recursed into them instead of assigning directly
through the proxy.

This caused two bugs:
- Date values silently revert to 1601-01-01 because Object.keys(date) returns [], so nothing is set.
- All terminal object types bypass the proxy set trap, so child variable value_changed events are never emitted and OPC UA subscriptions silently miss changes.

The fix replaces `instanceof Object` with two whitelist functions:
- _shouldRecurseIntoExisting: uses isProxy() to identify sub-structures installed by bindExtensionObject
- _shouldRecurseIntoNew: uses plain-object check plus constructor name exclusions for QualifiedName, LocalizedText, DiagnosticInfo (which have schema but are terminal types)

