### PR TITLE
fix(server-session): add null guard to resendMonitoredItemInitialValues

### DIFF
--- a/packages/node-opcua-server/source/server_session.ts
+++ b/packages/node-opcua-server/source/server_session.ts
@@ -846,6 +846,7 @@ export class ServerSession extends EventEmitter implements ISubscriber, ISession
     }
 
     public async resendMonitoredItemInitialValues(): Promise<void> {
+        if (!this.publishEngine) return;
         for (const subscription of this.publishEngine.subscriptions) {
             await subscription.resendInitialValues();
         }


### PR DESCRIPTION
## Bug

`resendMonitoredItemInitialValues` in `packages/node-opcua-server/source/server_session.ts` dereferences `this.publishEngine` without a null guard:

```ts
public async resendMonitoredItemInitialValues(): Promise<void> {
    for (const subscription of this.publishEngine.subscriptions) {
        await subscription.resendInitialValues();
    }
}
```

`publishEngine` is explicitly set to `null` during session disposal (line ~210):

```ts
if (this.publishEngine) {
    this.publishEngine.dispose();
    (this as any).publishEngine = null;
}
```

## How to reproduce

1. Start an OPC-UA server with multiple connected clients.
2. Restart the server.
3. Have multiple clients reconnect concurrently.

Under concurrent reconnect load, some sessions can be in a partially-disposed state when `resendMonitoredItemInitialValues` fires via the `session_activated` event. The result is:

```
TypeError: null is not an object (evaluating 'this.publishEngine.subscriptions')
```

The session dies and the affected client stays disconnected.

## Fix

Add a one-line early return, consistent with the null-guard pattern used by every other method in `ServerSession` that accesses `publishEngine`:

```ts
public async resendMonitoredItemInitialValues(): Promise<void> {
    if (!this.publishEngine) return;
    for (const subscription of this.publishEngine.subscriptions) {
        await subscription.resendInitialValues();
    }
}
```

Existing guards in the same class using the same pattern:
- `getSubscription` — `if (!this.publishEngine) return null;`
- `_deleteSubscriptions` — `if (!this.publishEngine) return;`
- `currentPublishRequestInQueue` — ternary null-check
- `currentSubscriptionCount` — ternary null-check
- `currentMonitoredItemCount` — ternary null-check

This is a one-line defensive fix with no behavioural change for the normal path.