### PR TITLE
fix(debug): tolerate missing __filename in setDebugFlag

### DIFF
--- a/packages/node-opcua-debug/source/make_loggers.ts
+++ b/packages/node-opcua-debug/source/make_loggers.ts
@@ -137,7 +137,10 @@ export function setDebugFlag(scriptFullPath: string, flag: boolean): void {
         const decoratedFilename = chalk.yellow(w(filename, 60));
         loggers.debugLogger(
             {
-                filename: __filename,
+                // `__filename` is undefined in ESM and in browser bundles; fall back to
+                // a stable placeholder so `setDebugFlag()` can be called safely from any
+                // runtime. The value is only ever used as a log label.
+                filename: typeof __filename === "undefined" ? "<browser>" : __filename,
                 callerline: -1
             },
             " Setting debug for ",


### PR DESCRIPTION
'__filename' is a CommonJS-only global. Under ESM and under browser bundles (esbuild, webpack, Vite) it is undefined. When setDebugFlag(filename, true) is called on a non-Node runtime with debug tracing enabled (process.env.DEBUG set), the old 'filename: __filename' dereferences undefined and the following debugLogger call throws ReferenceError.

In practice this rarely fires because the surrounding guard short-circuits on sTraceFlag (process.env.DEBUG) being unset, which is the common browser case. But any consumer that does enable debug tracing from a non-Node runtime hits this. The guard substitutes '<browser>' as a log-label fallback when __filename is missing; the value is only ever used as a log label, so no functional information is lost.

PR#1 from https://github.com/node-opcua/node-opcua/issues/1496