### PR TITLE
fix(secure-channel): module-load safety on non-Node runtimes

### DIFF
--- a/packages/node-opcua-secure-channel/source/client/client_secure_channel_layer.ts
+++ b/packages/node-opcua-secure-channel/source/client/client_secure_channel_layer.ts
@@ -1352,7 +1352,11 @@ export class ClientSecureChannelLayer extends EventEmitter<ClientSecureChannelLa
             this.#_on_transport_closed(new Error("Connection Break"));
         });
 
-        setImmediate(() => {
+        // `setImmediate` is Node-only; fall back to a queued microtask in browsers.
+        const scheduleNext = typeof setImmediate === "function"
+            ? setImmediate
+            : (cb: () => void) => Promise.resolve().then(cb);
+        scheduleNext(() => {
             doDebug && debugLog(chalk.red("Client now sending OpenSecureChannel"));
             const isInitial = true;
             this.#_send_open_secure_channel_request(isInitial, callback);

--- a/packages/node-opcua-secure-channel/source/verify_pcks1.ts
+++ b/packages/node-opcua-secure-channel/source/verify_pcks1.ts
@@ -15,7 +15,14 @@ function myCreatePrivateKey(rawKey: string | Buffer): any {
 }
 
 export async function testRSAPKCS1V15_EncryptDecrypt() {
-
+    // Skip on non-Node runtimes (browser / Deno / etc.). This diagnostic
+    // only makes sense for Node versions in the narrow range affected by
+    // CVE-2023-46809; in the browser `process.version` is an empty string
+    // under the standard `process` polyfill and the regex below would
+    // throw, breaking module load for every downstream consumer.
+    if (typeof process === "undefined" || !process.version) {
+        return;
+    }
     const version = process.version.match(/v([0-9]+)\.([0-9]+)\.([0-9]+)/);
     if (!version) {
         throw new Error("Invalid version");


### PR DESCRIPTION
Two small independent defensive changes for consumers that load the package in runtimes where process.version is unset / setImmediate isn't present (browsers, Deno, sandboxed Node).

1. verify_pcks1.ts: early-return from testRSAPKCS1V15_EncryptDecrypt when process.version is absent or falsy. The function runs unconditionally at module load (called from source/index.ts); the regex process.version.match(/v([0-9]+)\.([0-9]+)\.([0-9]+)/) previously threw Error("Invalid version") if process.version was empty, blocking module load.

2. client_secure_channel_layer.ts: replace one setImmediate(...) call with typeof setImmediate === "function" ? setImmediate : (cb) => Promise.resolve().then(cb). In Node, this is a no-op (native setImmediate is always present). In browsers, the microtask fallback replaces the Node-only timer.

Why `verify_pcks1.ts`:

testRSAPKCS1V15_EncryptDecrypt is a startup diagnostic that warns users about CVE-2023-46809 in certain Node 20.x builds. It's invoked at module load, so every consumer of node-opcua-secure-channel runs it on import — including any consumer that imports the package from a non-Node runtime.

Why `client_secure_channel_layer.ts`:

One call site uses setImmediate(() => this.#_send_open_secure_channel_request(...)) to defer the first OpenSecureChannel send to the next tick after transport connect. setImmediate is Node-only; browsers (which don't have it) throw ReferenceError at that line when the channel actually tries to open.

PR#3 from https://github.com/node-opcua/node-opcua/issues/1496