### PR TITLE
feat(transport): add IClientTransport interface and default factory

### DIFF
--- a/packages/node-opcua-transport/source/default_client_transport_factory.ts
+++ b/packages/node-opcua-transport/source/default_client_transport_factory.ts
@@ -1,0 +1,19 @@
+/**
+ * @module node-opcua-transport
+ */
+
+import { ClientTCP_transport, type TransportSettingsOptions } from "./client_tcp_transport";
+import type { IClientTransport, IClientTransportFactory } from "./i_client_transport";
+
+/**
+ * The default client-transport factory, which returns a {@link ClientTCP_transport}.
+ *
+ * This is the implicit factory used by {@link ClientSecureChannelLayer} when no
+ * `transportFactory` option is provided, preserving the historical (Node-only)
+ * behavior byte-for-byte.
+ */
+export const defaultClientTransportFactory: IClientTransportFactory = {
+    create(settings?: TransportSettingsOptions): IClientTransport {
+        return new ClientTCP_transport(settings) as IClientTransport;
+    }
+};

--- a/packages/node-opcua-transport/source/i_client_transport.ts
+++ b/packages/node-opcua-transport/source/i_client_transport.ts
@@ -1,0 +1,124 @@
+/**
+ * @module node-opcua-transport
+ */
+
+import type { AcknowledgeMessage } from "./AcknowledgeMessage";
+import type { TransportSettingsOptions } from "./client_tcp_transport";
+
+/**
+ * The minimal surface that {@link ClientSecureChannelLayer} (and anything else acting as
+ * a secure-channel client) uses from a transport. {@link ClientTCP_transport} already
+ * satisfies this interface; browser transports (e.g. a WebSocket-based one) must also
+ * satisfy it to be pluggable via {@link IClientTransportFactory}.
+ *
+ * This interface is intentionally the smallest superset of what the existing
+ * `ClientTCP_transport` exposes and that the secure-channel layer actually consumes,
+ * so adding new transports does not require replicating Node-specific machinery.
+ */
+export interface IClientTransport {
+    // ──────────────────────────────────────────────────────────────
+    // mutable configuration / runtime state
+    // ──────────────────────────────────────────────────────────────
+
+    /** diagnostic name, useful in debug logs */
+    readonly name: string;
+
+    /** OPC UA UACP protocol version advertised in HEL */
+    protocolVersion: number;
+
+    /** overall timeout applied to the underlying socket / connection lifecycle */
+    timeout: number;
+
+    /** number of times the owning channel has retried. Advisory; bumped by callers. */
+    numberOfRetry: number;
+
+    /** endpoint URL the transport was connected to (set by `connect`) */
+    endpointUrl: string;
+
+    /** URI reported by the local application to the peer */
+    serverUri: string;
+
+    // ──────────────────────────────────────────────────────────────
+    // HEL/ACK negotiated values (populated after successful connect)
+    // ──────────────────────────────────────────────────────────────
+
+    readonly parameters?: AcknowledgeMessage;
+
+    readonly receiveBufferSize: number;
+    readonly sendBufferSize: number;
+    readonly maxChunkCount: number;
+    readonly maxMessageSize: number;
+
+    // ──────────────────────────────────────────────────────────────
+    // diagnostics
+    // ──────────────────────────────────────────────────────────────
+
+    readonly bytesRead: number;
+    readonly bytesWritten: number;
+    readonly chunkReadCount: number;
+    readonly chunkWrittenCount: number;
+
+    // ──────────────────────────────────────────────────────────────
+    // lifecycle
+    // ──────────────────────────────────────────────────────────────
+
+    /** connect to `endpointUrl` and perform the UACP HEL/ACK handshake */
+    connect(endpointUrl: string, callback: (err?: Error | null) => void): void;
+
+    /** gracefully disconnect; invokes `callback` when the underlying connection is closed */
+    disconnect(callback: (err?: Error | null) => void): void;
+
+    /** forcibly release resources (close the connection if still open) */
+    dispose(): void;
+
+    /** write a single UACP chunk to the transport */
+    write(chunk: Buffer, callback?: (err?: Error | null) => undefined): void;
+
+    /** emit an ERR back to the peer and destroy the underlying connection */
+    prematureTerminate(err: Error, statusCode: import("node-opcua-status-code").StatusCode): void;
+
+    /** simulate a connection break (used by reconnection logic in tests) */
+    forceConnectionBreak(): void;
+
+    /** `true` when the underlying connection is open and usable */
+    isValid(): boolean;
+
+    /** `true` when `disconnect()` has started or the connection is gone */
+    isDisconnecting(): boolean;
+
+    /** return the effective transport settings (`maxChunkCount` etc.) */
+    getTransportSettings(): TransportSettingsOptions;
+
+    // ──────────────────────────────────────────────────────────────
+    // typed events (mirrors ClientTCP_transport's declaration merge)
+    // ──────────────────────────────────────────────────────────────
+
+    on(eventName: "chunk", eventHandler: (messageChunk: Buffer) => void): this;
+    on(eventName: "close", eventHandler: (err: Error | null) => void): this;
+    on(eventName: "connection_break", eventHandler: (err: Error | null) => void): this;
+    on(eventName: "connect", eventHandler: () => void): this;
+
+    once(eventName: "chunk", eventHandler: (messageChunk: Buffer) => void): this;
+    once(eventName: "close", eventHandler: (err: Error | null) => void): this;
+    once(eventName: "connection_break", eventHandler: (err: Error | null) => void): this;
+    once(eventName: "connect", eventHandler: () => void): this;
+
+    removeListener(eventName: "chunk", eventHandler: (messageChunk: Buffer) => void): this;
+    removeListener(eventName: "close", eventHandler: (err: Error | null) => void): this;
+    removeListener(eventName: "connection_break", eventHandler: (err: Error | null) => void): this;
+    removeListener(eventName: "connect", eventHandler: () => void): this;
+}
+
+/**
+ * A factory that produces an {@link IClientTransport}. Injected into
+ * {@link ClientSecureChannelLayerOptions.transportFactory} to swap the default Node TCP
+ * transport for an alternative (for example, a browser WebSocket transport or a tracing
+ * proxy wrapped around the default).
+ */
+export interface IClientTransportFactory {
+    /**
+     * Create a new transport. Called once per secure-channel open; the factory must not
+     * return the same instance twice.
+     */
+    create(settings?: TransportSettingsOptions): IClientTransport;
+}

--- a/packages/node-opcua-transport/source/index.ts
+++ b/packages/node-opcua-transport/source/index.ts
@@ -25,7 +25,9 @@
  */
 export * from "./AcknowledgeMessage";
 export * from "./client_tcp_transport";
+export * from "./default_client_transport_factory";
 export * from "./HelloMessage";
+export * from "./i_client_transport";
 export * from "./i_hello_ack_limits";
 export * from "./message_builder_base";
 export * from "./server_tcp_transport";

--- a/packages/node-opcua-transport/test/test_default_client_transport_factory.ts
+++ b/packages/node-opcua-transport/test/test_default_client_transport_factory.ts
@@ -1,0 +1,50 @@
+import should from "should";
+
+import {
+    ClientTCP_transport,
+    defaultClientTransportFactory,
+    type IClientTransport,
+    type IClientTransportFactory
+} from "..";
+
+describe("defaultClientTransportFactory / IClientTransport", () => {
+    it("returns a ClientTCP_transport instance", () => {
+        const t = defaultClientTransportFactory.create({});
+        t.should.be.instanceof(ClientTCP_transport);
+        // sanity: a new factory call must not re-use the same instance
+        const t2 = defaultClientTransportFactory.create({});
+        (t !== t2).should.be.true();
+        t.dispose();
+        t2.dispose();
+    });
+
+    it("factory honours TransportSettingsOptions", () => {
+        const t = defaultClientTransportFactory.create({
+            maxChunkCount: 7,
+            maxMessageSize: 987_654,
+            receiveBufferSize: 8192,
+            sendBufferSize: 8192
+        }) as ClientTCP_transport;
+        // the constructor copies settings into a private _helloSettings object; it is
+        // surfaced via getTransportSettings() which is part of IClientTransport
+        const s = t.getTransportSettings();
+        s.maxChunkCount!.should.equal(7);
+        s.maxMessageSize!.should.equal(987_654);
+        s.receiveBufferSize!.should.equal(8192);
+        s.sendBufferSize!.should.equal(8192);
+        t.dispose();
+    });
+
+    it("ClientTCP_transport is assignable to IClientTransport (compile-time check)", () => {
+        // If this file compiles, ClientTCP_transport satisfies IClientTransport.
+        const t = new ClientTCP_transport({});
+        const asIface: IClientTransport = t; // no cast
+        asIface.name.should.be.a.String();
+        asIface.dispose();
+    });
+
+    it("defaultClientTransportFactory conforms to IClientTransportFactory", () => {
+        const f: IClientTransportFactory = defaultClientTransportFactory;
+        f.create.should.be.a.Function();
+    });
+});


### PR DESCRIPTION
Adds two new files to node-opcua-transport plus two re-exports from source/index.ts. No behaviour change; no edits to ClientTCP_transport or any other existing file.

- source/i_client_transport.ts — new interface IClientTransport. Codifies the surface that ClientSecureChannelLayer already duck-types against ClientTCP_transport: lifecycle (connect, disconnect, dispose, write, prematureTerminate, forceConnectionBreak, isValid, isDisconnecting), diagnostic fields (bytesRead, bytesWritten, chunkReadCount, chunkWrittenCount, name), HEL/ACK negotiated values (parameters, receiveBufferSize, sendBufferSize, maxChunkCount, maxMessageSize), mutable config (protocolVersion, timeout, numberOfRetry, endpointUrl, serverUri), and the typed EventEmitter events (chunk, close, connect, connection_break). ClientTCP_transport satisfies this interface structurally; no changes to the class are required.

- source/default_client_transport_factory.ts — new interface IClientTransportFactory with a single create(settings?): IClientTransport method, plus a concrete defaultClientTransportFactory whose create() returns new ClientTCP_transport(opts). Preserves every Node-side code path that currently constructs ClientTCP_transport directly.

On its own, this commit adds two unused public exports. A follow-up PR will consumes them.

PR#4 from https://github.com/node-opcua/node-opcua/issues/1496