### PR TITLE
fix(keepalive): treat BadInvalidTimestamp as session-alive, not keepalive failure

### DIFF
--- a/packages/node-opcua-client/source/client_session_keepalive_manager.ts
+++ b/packages/node-opcua-client/source/client_session_keepalive_manager.ts
@@ -182,6 +182,33 @@ export class ClientSessionKeepAliveManager extends EventEmitter implements Clien
                                 terminateConnection(session._client);
                                 resolve(0);
                             } else {
+                                if (sc?.equals(StatusCodes.BadInvalidTimestamp)) {
+                                    // BadInvalidTimestamp (OPC UA Part 4 7.38.2, Table 178:
+                                    // "The timestamp is outside the range allowed by the Server")
+                                    // refers to the timestamp field of the RequestHeader
+                                    // (OPC UA Part 4 7.32), which the spec states is used
+                                    // "only for diagnostic and logging purposes in the Server".
+                                    //
+                                    // The server responded at the OPC UA application layer:
+                                    // the SecureChannel and Session are intact. The cause is
+                                    // clock skew between client and server; this is an
+                                    // infrastructure concern outside the scope of the keepalive
+                                    // manager.
+                                    //
+                                    // Treating this as a keepalive failure is semantically
+                                    // incorrect: the round-trip succeeded. Incrementing
+                                    // consecutiveFailures leads to unbounded exponential backoff
+                                    // and eventual session expiry server-side, triggering an
+                                    // unnecessary reconnect loop.
+                                    //
+                                    // See: https://reference.opcfoundation.org/Core/Part4/v105/docs/7.38.2
+                                    //      https://reference.opcfoundation.org/Core/Part4/v105/docs/7.32
+                                    this.consecutiveFailures = 0;
+                                    debugLog("emit keepalive (BadInvalidTimestamp: session alive, clock skew on request timestamp)");
+                                    this.emit("keepalive", this.lastKnownState ?? ServerState.Unknown, this.count);
+                                    resolve(0);
+                                    return;
+                                }
                                 this.consecutiveFailures++;
                                 warningLog("Keep alive received ServiceFault from server (session intact):", sc?.toString());
                                 this.emit("keepalive_failure");

--- a/packages/node-opcua-client/test/test_keepalive_manager.ts
+++ b/packages/node-opcua-client/test/test_keepalive_manager.ts
@@ -58,16 +58,23 @@ describe("ClientSessionKeepAliveManager", function (this: Mocha.Suite) {
         mgr.stop();
     });
 
-    it("KAL-2 should emit keepalive_failure (not failure) when session.read returns a generic ServiceFault", () => {
+    it("KAL-2 should emit keepalive (not keepalive_failure) when session.read returns BadInvalidTimestamp due to clock skew", () => {
+        // BadInvalidTimestamp means the server responded at the OPC UA application layer:
+        // the session is alive, only the request timestamp was outside the server tolerance.
+        // The keepalive round-trip succeeded — treat it as a successful keepalive.
         const serviceFaultErr = makeServiceFaultError(StatusCodes.BadInvalidTimestamp);
         const session = makeSession((_n, cb) => cb(serviceFaultErr, undefined));
         const terminateSpy = (session._client as any)._secureChannel.forceConnectionBreak as sinon.SinonSpy;
 
         const mgr = new ClientSessionKeepAliveManager(session);
         let failureFired = false;
+        let keepaliveFired = false;
         let keepaliveFailureFired = false;
         mgr.on("failure", () => {
             failureFired = true;
+        });
+        mgr.on("keepalive", () => {
+            keepaliveFired = true;
         });
         mgr.on("keepalive_failure", () => {
             keepaliveFailureFired = true;
@@ -76,9 +83,10 @@ describe("ClientSessionKeepAliveManager", function (this: Mocha.Suite) {
         mgr.start(1000);
         clock.tick(600);
 
-        keepaliveFailureFired.should.eql(true, "keepalive_failure event must fire for ServiceFault");
-        failureFired.should.eql(false, "failure must NOT fire for a recoverable ServiceFault");
-        terminateSpy.callCount.should.eql(0, "forceConnectionBreak must NOT be called for a recoverable ServiceFault");
+        keepaliveFired.should.eql(true, "keepalive must fire: BadInvalidTimestamp means session is alive (clock skew)");
+        keepaliveFailureFired.should.eql(false, "keepalive_failure must NOT fire: clock skew is not a session failure");
+        failureFired.should.eql(false, "failure must NOT fire");
+        terminateSpy.callCount.should.eql(0, "forceConnectionBreak must NOT be called for clock skew");
         mgr.stop();
     });
 
@@ -107,7 +115,9 @@ describe("ClientSessionKeepAliveManager", function (this: Mocha.Suite) {
     });
 
     it("KAL-4 should apply exponential backoff after consecutive ServiceFaults", async () => {
-        const serviceFaultErr = makeServiceFaultError(StatusCodes.BadInvalidTimestamp);
+        // Use BadInternalError as a generic ServiceFault that goes through the backoff path.
+        // BadInvalidTimestamp has dedicated handling (treated as session-alive, no backoff).
+        const serviceFaultErr = makeServiceFaultError(StatusCodes.BadInternalError);
         const session = makeSession((_n, cb) => cb(serviceFaultErr, undefined));
 
         const mgr = new ClientSessionKeepAliveManager(session);
@@ -132,6 +142,38 @@ describe("ClientSessionKeepAliveManager", function (this: Mocha.Suite) {
         failureTimes.length.should.eql(3, "third failure at t=6500");
 
         // only 3 failures in ~6.5s — without backoff at checkInterval=1000ms there would be ~6
+        mgr.stop();
+    });
+
+    it("KAL-5 should treat BadInvalidTimestamp as a successful keepalive (clock skew must not trigger reconnect)", async () => {
+        // Simulate a server with persistent clock skew: every keepalive returns BadInvalidTimestamp.
+        // The session is alive — the server responded at the OPC UA application layer.
+        // Expected: "keepalive" is emitted, no backoff accumulates, no reconnect ever fires.
+        const clockSkewErr = makeServiceFaultError(StatusCodes.BadInvalidTimestamp);
+        const session = makeSession((_n, cb) => cb(clockSkewErr, undefined));
+        const terminateSpy = (session._client as any)._secureChannel.forceConnectionBreak as sinon.SinonSpy;
+
+        const mgr = new ClientSessionKeepAliveManager(session);
+        let keepaliveCount = 0;
+        let keepaliveFailureCount = 0;
+        let failureCount = 0;
+
+        mgr.on("keepalive", () => { keepaliveCount++; });
+        mgr.on("keepalive_failure", () => { keepaliveFailureCount++; });
+        mgr.on("failure", () => { failureCount++; });
+
+        // checkInterval=1000ms, pingTimeout=500ms → pings at t=500, 1500, 2500, 3500, 4500
+        mgr.start(1000);
+        await clock.tickAsync(5000);
+
+        keepaliveCount.should.be.greaterThan(0, "keepalive must fire: BadInvalidTimestamp means session is alive");
+        keepaliveFailureCount.should.eql(0, "keepalive_failure must NOT fire: clock skew is not a session failure");
+        failureCount.should.eql(0, "failure must NOT fire");
+        terminateSpy.callCount.should.eql(0, "forceConnectionBreak must never be called for clock skew");
+        // Without the fix, backoff would reach 60s cap after a few cycles and only 1 ping
+        // would fire in 5000ms. With the fix, pings continue at normal checkInterval rate.
+        keepaliveCount.should.be.greaterThanOrEqual(4, "pings must continue at normal rate with no backoff");
+
         mgr.stop();
     });
 });


### PR DESCRIPTION
### Problem
When an OPC UA server has a persistent clock skew relative to the client, every keepalive
read returns BadInvalidTimestamp. Since v2.170.0, _ping_server no longer calls
terminateConnection() for this case — it instead emits keepalive_failure and applies
exponential backoff via consecutiveFailures.

However, consecutiveFailures is never reset because BadInvalidTimestamp arrives on every
cycle. The backoff reaches maxBackoffInterval (60s) and stays there. Eventually the session
timeout expires server-side -> BadSessionIdInvalid -> terminateConnection() -> reconnect -> repeat.

The net result is an infinite reconnect loop at ~1 reconnect/minute.

### Root cause
BadInvalidTimestamp (OPC UA Part 4 §7.38.2, Table 178) refers to the `RequestHeader.timestamp`
field, which §7.32 states is used "only for diagnostic and logging purposes in the Server".
The session is alive. Treating it as keepalive_failure is semantically incorrect.

- https://reference.opcfoundation.org/Core/Part4/v105/docs/7.38.2
- https://reference.opcfoundation.org/Core/Part4/v105/docs/7.32

### Fix
In `_ping_server`, when ServiceFault is BadInvalidTimestamp, reset `consecutiveFailures = 0`
and emit `keepalive` (not `keepalive_failure`).

### Tests
- KAL-2: updated to assert `keepalive` fires for BadInvalidTimestamp
- KAL-4: updated to use BadInternalError as generic ServiceFault test case
- KAL-5 (new): persistent BadInvalidTimestamp emits keepalive at normal cadence, no backoff, no reconnect

### Related
Follows up on #1497. Reported by @Velluso.