### PR TITLE
feat(secure-channel): add transportFactory option to ClientSecureChanelLayerOptions

### DIFF
--- a/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_connection_reconnection_with_server_that_close_session_too_early.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_connection_reconnection_with_server_that_close_session_too_early.ts
@@ -6,6 +6,7 @@ import {
     type ClientMonitoredItem,
     type ClientSession,
     ClientSubscription,
+    ClientTCP_transport,
     type ConnectionStrategyOptions,
     coerceNodeId,
     DataType,
@@ -79,9 +80,12 @@ async function break_connection(theClient: OPCUAClient, socketError: string): Pr
     const r = await session.call(methodToCall);
     debugLog(r.toString());
 
-    // Brutally destroy underlying socket to emulate abrupt network failure
+    // Brutally destroy underlying socket to emulate abrupt network failure.
+    // `getTransport()` now returns `IClientTransport | undefined`; here we know
+    // we built the client with the default factory so the concrete type is
+    // `ClientTCP_transport` and `._socket` is available.
     const secureChannel = (theClient as OPCUAClientImpl)._secureChannel; // internal
-    const transport = secureChannel?.getTransport();
+    const transport = secureChannel?.getTransport() as ClientTCP_transport | undefined;
     const clientSocket = transport?._socket;
     clientSocket?.end();
     clientSocket?.destroy();

--- a/packages/node-opcua-secure-channel/source/client/client_secure_channel_layer.ts
+++ b/packages/node-opcua-secure-channel/source/client/client_secure_channel_layer.ts
@@ -33,7 +33,13 @@ import {
 } from "node-opcua-service-secure-channel";
 import type { ErrorCallback } from "node-opcua-status-code";
 import { type CallbackT, type StatusCode, StatusCodes } from "node-opcua-status-code";
-import { ClientTCP_transport, doTraceChunk, type TransportSettingsOptions } from "node-opcua-transport";
+import {
+    defaultClientTransportFactory,
+    doTraceChunk,
+    type IClientTransport,
+    type IClientTransportFactory,
+    type TransportSettingsOptions
+} from "node-opcua-transport";
 import { get_clock_tick, timestamp } from "node-opcua-utils";
 import {
     extractFirstCertificateInChain,
@@ -259,6 +265,8 @@ export interface ClientSecureChannelLayerOptions {
     connectionStrategy?: ConnectionStrategyOptions;
 
     transportSettings?: TransportSettingsOptions;
+
+    transportFactory?: IClientTransportFactory;
 }
 
 export interface ClientSecureChannelLayerEvents {
@@ -377,6 +385,7 @@ export class ClientSecureChannelLayer extends EventEmitter<ClientSecureChannelLa
     }
 
     #requestedTransportSettings: TransportSettingsOptions;
+    #transportFactory: IClientTransportFactory;
 
     public protocolVersion: number;
     public readonly securityMode: MessageSecurityMode;
@@ -386,8 +395,8 @@ export class ClientSecureChannelLayer extends EventEmitter<ClientSecureChannelLa
     public activeSecurityToken: ChannelSecurityToken | null;
 
     #_lastRequestId: number;
-    #_transport?: ClientTCP_transport;
-    #_pending_transport?: ClientTCP_transport;
+    #_transport?: IClientTransport;
+    #_pending_transport?: IClientTransport;
     readonly #parent?: ClientSecureChannelParent;
 
     readonly #messageChunker: MessageChunker;
@@ -459,6 +468,7 @@ export class ClientSecureChannelLayer extends EventEmitter<ClientSecureChannelLa
         this.#_securityTokenTimeoutId = null;
         this.#transportTimeout = options.transportTimeout || ClientSecureChannelLayer.defaultTransportTimeout;
         this.#requestedTransportSettings = options.transportSettings || {};
+        this.#transportFactory = options.transportFactory || defaultClientTransportFactory;
         this.#connectionStrategy = coerceConnectionStrategy(options.connectionStrategy);
         this.channelId = 0;
     }
@@ -595,11 +605,11 @@ export class ClientSecureChannelLayer extends EventEmitter<ClientSecureChannelLa
 
         this.endpointUrl = endpointUrl;
 
-        const transport = new ClientTCP_transport(this.#requestedTransportSettings);
+        const transport = this.#transportFactory.create(this.#requestedTransportSettings);
         transport.timeout = this.#transportTimeout;
 
         doDebug &&
-            debugLog("ClientSecureChannelLayer#create creating ClientTCP_transport with  transport.timeout = ", transport.timeout);
+            debugLog("ClientSecureChannelLayer#create creating transport with  transport.timeout = ", transport.timeout);
         assert(!this.#_pending_transport);
         this.#_pending_transport = transport;
         this.#_establish_connection(transport, endpointUrl, (err?: Error | null) => {
@@ -814,7 +824,7 @@ export class ClientSecureChannelLayer extends EventEmitter<ClientSecureChannelLa
     /**
      * @private internal use only : (used for test)
      */
-    getTransport(): ClientTCP_transport | undefined {
+    getTransport(): IClientTransport | undefined {
         return this.#_transport;
     }
     /**
@@ -1329,7 +1339,7 @@ export class ClientSecureChannelLayer extends EventEmitter<ClientSecureChannelLa
     /**
      * install message builder and send first OpenSecureChannelRequest
      */
-    #_on_connection(transport: ClientTCP_transport, callback: ErrorCallback) {
+    #_on_connection(transport: IClientTransport, callback: ErrorCallback) {
         assert(this.#_pending_transport === transport);
         this.#_pending_transport = undefined;
         this.#_transport = transport;
@@ -1366,7 +1376,7 @@ export class ClientSecureChannelLayer extends EventEmitter<ClientSecureChannelLa
     #_backoff_completion(
         err: Error | undefined,
         lastError: Error | undefined,
-        transport: ClientTCP_transport,
+        transport: IClientTransport,
         callback: ErrorCallback
     ) {
         // Node 20.11.1 on windows now reports a AggregateError when a connection is refused
@@ -1401,7 +1411,7 @@ export class ClientSecureChannelLayer extends EventEmitter<ClientSecureChannelLa
         }
     }
 
-    #_connect(transport: ClientTCP_transport, endpointUrl: string, _i_callback: ErrorCallback) {
+    #_connect(transport: IClientTransport, endpointUrl: string, _i_callback: ErrorCallback) {
         const on_connect = (err?: Error | null) => {
             doDebug && debugLog("Connection => err", err ? err.message : "null");
             // force Backoff to fail if err is not ECONNRESET or ECONNREFUSED
@@ -1454,7 +1464,7 @@ export class ClientSecureChannelLayer extends EventEmitter<ClientSecureChannelLa
         transport.connect(endpointUrl, on_connect);
     }
 
-    #_establish_connection(transport: ClientTCP_transport, endpointUrl: string, callback: ErrorCallback) {
+    #_establish_connection(transport: IClientTransport, endpointUrl: string, callback: ErrorCallback) {
         transport.protocolVersion = this.protocolVersion;
 
         this.#lastError = undefined;

--- a/packages/node-opcua-secure-channel/test/20-test_transport_factory_seam.ts
+++ b/packages/node-opcua-secure-channel/test/20-test_transport_factory_seam.ts
@@ -1,0 +1,138 @@
+import should from "should";
+import sinon from "sinon";
+
+import {
+    ClientTCP_transport,
+    defaultClientTransportFactory,
+    type IClientTransport,
+    type IClientTransportFactory,
+    type TransportSettingsOptions
+} from "node-opcua-transport";
+
+import { ClientSecureChannelLayer } from "../dist/source";
+
+/**
+ * Minimal IClientTransport stub whose sole purpose is to prove that
+ * ClientSecureChannelLayer consults the injected transportFactory instead of
+ * new-ing ClientTCP_transport directly.
+ *
+ * We do NOT drive the full HEL/ACK/OPN flow here; that is covered by
+ * `11-test_client_secure_channel_layer.ts` using the MockServerTransport.
+ * This test only asserts the factory-selection branch in
+ * `ClientSecureChannelLayer#create`.
+ */
+class NoopTransportStub {
+    public readonly name = "NoopTransportStub";
+    public protocolVersion = 0;
+    public timeout = 5000;
+    public numberOfRetry = 0;
+    public endpointUrl = "";
+    public serverUri = "";
+    public parameters = undefined;
+    public receiveBufferSize = 0;
+    public sendBufferSize = 0;
+    public maxChunkCount = 0;
+    public maxMessageSize = 0;
+    public bytesRead = 0;
+    public bytesWritten = 0;
+    public chunkReadCount = 0;
+    public chunkWrittenCount = 0;
+
+    public connectSpy = sinon.spy();
+    public disposeSpy = sinon.spy();
+
+    connect(endpointUrl: string, cb: (err?: Error | null) => void) {
+        this.endpointUrl = endpointUrl;
+        this.connectSpy(endpointUrl);
+        // deliberately never call cb – keeps channel in "pending" state.
+    }
+    disconnect(cb: (err?: Error | null) => void) {
+        cb();
+    }
+    dispose() {
+        this.disposeSpy();
+    }
+    write() {
+        /* no-op */
+    }
+    prematureTerminate() {
+        /* no-op */
+    }
+    forceConnectionBreak() {
+        /* no-op */
+    }
+    isValid() {
+        return false;
+    }
+    isDisconnecting() {
+        return false;
+    }
+    getTransportSettings() {
+        return {} as TransportSettingsOptions;
+    }
+
+    on(): this {
+        return this;
+    }
+    once(): this {
+        return this;
+    }
+    removeListener(): this {
+        return this;
+    }
+}
+
+describe("ClientSecureChannelLayer transportFactory seam", () => {
+    it("uses the provided transportFactory instead of ClientTCP_transport", (done) => {
+        const stub = new NoopTransportStub();
+        const factory: IClientTransportFactory = {
+            create(_settings?: TransportSettingsOptions): IClientTransport {
+                return stub as unknown as IClientTransport;
+            }
+        };
+        const createSpy = sinon.spy(factory, "create");
+
+        const channel = new ClientSecureChannelLayer({ transportFactory: factory });
+
+        // Kick off connect. Stub never completes the handshake, but that's fine:
+        // we only want to observe which factory path was taken.
+        (channel as any).create("fake://localhost:1/Fake", () => {
+            /* wrapperCallback - we'll abort before it fires */
+        });
+
+        // Allow microtasks to flush (connect() is sync up to the point where it hands off to transport.connect)
+        setImmediate(() => {
+            try {
+                createSpy.calledOnce.should.be.true();
+                stub.connectSpy.calledOnce.should.be.true();
+                stub.connectSpy.firstCall.args[0].should.equal("fake://localhost:1/Fake");
+
+                // The channel uses our stub. getTransport()'s TypeScript signature is widened
+                // to ClientTCP_transport for backward-compatibility with tests that reach
+                // into `_socket`; at runtime, however, it is still the stub we passed in.
+                const usedTransport = (channel as any).getTransport();
+                // The pending transport path: during an in-flight connect, the stub is the
+                // pending transport and `getTransport()` may still be undefined. We assert
+                // via the factory/connect spies instead, which is sufficient evidence.
+                should(usedTransport === stub || usedTransport === undefined).be.true();
+
+                // Clean up so the test does not leak.
+                channel.abortConnection(() => {
+                    channel.dispose();
+                    done();
+                });
+            } catch (e) {
+                done(e as Error);
+            }
+        });
+    });
+
+    it("falls back to defaultClientTransportFactory when no option is provided", () => {
+        // We can't observe the internal field directly, but we can observe that the
+        // default factory - when called directly - returns a ClientTCP_transport
+        // (i.e. the historical behaviour is preserved byte-for-byte).
+        const t = defaultClientTransportFactory.create({});
+        t.should.be.instanceof(ClientTCP_transport);
+        t.dispose();
+    });
+});


### PR DESCRIPTION
Follow-up to the IClientTransport / IClientTransportFactory / defaultClientTransportFactory exports added in https://github.com/node-opcua/node-opcua/pull/1501. Wires the factory through ClientSecureChannelLayer so consumers can substitute the transport implementation without forking node-opcua-secure-channel.

Changes in client_secure_channel_layer.ts to swap interface and factory
New test `test/20-test_transport_factory_seam.ts`


PR 5 from https://github.com/node-opcua/node-opcua/issues/1496