### PR TITLE
feat(common): in-memory certificate provider for OPCUASecureObject

### DIFF
--- a/packages/node-opcua-common/source/opcua_secure_object.ts
+++ b/packages/node-opcua-common/source/opcua_secure_object.ts
@@ -172,6 +172,24 @@ export function getPartialCertificateChain(certificateChain?: Certificate | Cert
 export interface IOPCUASecureObjectOptions {
     certificateFile?: string;
     privateKeyFile?: string;
+    /**
+     * Optional pre-built certificate + private-key provider. When supplied,
+     * `OPCUASecureObject.getCertificate()` / `.getCertificateChain()` /
+     * `.getPrivateKey()` delegate to this object verbatim, and the disk-backed
+     * `SecretHolder` path (`fs.existsSync` + `readCertificateChain` +
+     * `readPrivateKey`) is not used.
+     *
+     * Intended for browser builds (bundled via esbuild) and test fixtures that
+     * want to stage a cert+key pair without staging PKI folders on disk. A
+     * caller that wants in-memory semantics simply passes an implementation of
+     * {@link ICertificateKeyPairProvider} whose methods return values from
+     * memory.
+     *
+     * When present, `certificateFile` / `privateKeyFile` become optional and
+     * may be omitted (internal placeholders are used for toJSON output).
+     * When absent, those two fields remain required strings.
+     */
+    certificateKeyPairProvider?: ICertificateKeyPairProvider;
 }
 
 /**
@@ -187,24 +205,39 @@ export class OPCUASecureObject<T extends Record<string | symbol, any> = any>
 {
     public readonly certificateFile: string;
     public readonly privateKeyFile: string;
+    readonly #certificateKeyPairProvider?: ICertificateKeyPairProvider;
 
     constructor(options: IOPCUASecureObjectOptions) {
         super();
-        assert(typeof options.certificateFile === "string");
-        assert(typeof options.privateKeyFile === "string");
-        this.certificateFile = options.certificateFile || "invalid certificate file";
-        this.privateKeyFile = options.privateKeyFile || "invalid private key file";
+        if (options.certificateKeyPairProvider) {
+            // When a provider is supplied, the file paths become diagnostic
+            // placeholders only — `SecretHolder` is never consulted.
+            this.certificateFile = options.certificateFile ?? "<in-memory>";
+            this.privateKeyFile = options.privateKeyFile ?? "<in-memory>";
+            this.#certificateKeyPairProvider = options.certificateKeyPairProvider;
+        } else {
+            assert(typeof options.certificateFile === "string");
+            assert(typeof options.privateKeyFile === "string");
+            this.certificateFile = options.certificateFile || "invalid certificate file";
+            this.privateKeyFile = options.privateKeyFile || "invalid private key file";
+        }
     }
 
     public getCertificate(): Certificate {
-        return getSecretHolder(this).getCertificate();
+        return this.#certificateKeyPairProvider
+            ? this.#certificateKeyPairProvider.getCertificate()
+            : getSecretHolder(this).getCertificate();
     }
 
     public getCertificateChain(): Certificate[] {
-        return getSecretHolder(this).getCertificateChain();
+        return this.#certificateKeyPairProvider
+            ? this.#certificateKeyPairProvider.getCertificateChain()
+            : getSecretHolder(this).getCertificateChain();
     }
 
     public getPrivateKey(): PrivateKey {
-        return getSecretHolder(this).getPrivateKey();
+        return this.#certificateKeyPairProvider
+            ? this.#certificateKeyPairProvider.getPrivateKey()
+            : getSecretHolder(this).getPrivateKey();
     }
 }

--- a/packages/node-opcua-common/test/test_opcua_secure_object_in_memory.ts
+++ b/packages/node-opcua-common/test/test_opcua_secure_object_in_memory.ts
@@ -1,0 +1,39 @@
+import "mocha";
+import should from "should";
+import { OPCUASecureObject, type ICertificateKeyPairProvider } from "../source/opcua_secure_object";
+
+describe("OPCUASecureObject + injected ICertificateKeyPairProvider", () => {
+    const cert = Buffer.from("FAKE-CERT");
+    const pk = { hidden: "FAKE-KEY" } as unknown as import("node-opcua-crypto/web").PrivateKey;
+    const provider: ICertificateKeyPairProvider = {
+        getCertificate: () => cert,
+        getCertificateChain: () => [cert],
+        getPrivateKey: () => pk
+    };
+
+    it("constructs without certificateFile/privateKeyFile strings when a provider is supplied", () => {
+        const obj = new OPCUASecureObject({ certificateKeyPairProvider: provider });
+        obj.certificateFile.should.equal("<in-memory>");
+        obj.privateKeyFile.should.equal("<in-memory>");
+    });
+
+    it("delegates getCertificate() / getCertificateChain() / getPrivateKey() to the provider without touching fs", () => {
+        const obj = new OPCUASecureObject({ certificateKeyPairProvider: provider });
+        obj.getCertificate().should.equal(cert);
+        obj.getCertificateChain()[0].should.equal(cert);
+        obj.getPrivateKey().should.equal(pk);
+    });
+
+    it("without a provider, the original string-path assertions still reject empty options", () => {
+        (() => new OPCUASecureObject({})).should.throw();
+    });
+
+    it("without a provider, a constructed object still has the file paths", () => {
+        const obj = new OPCUASecureObject({
+            certificateFile: "/fake/cert.pem",
+            privateKeyFile: "/fake/key.pem"
+        });
+        obj.certificateFile.should.equal("/fake/cert.pem");
+        obj.privateKeyFile.should.equal("/fake/key.pem");
+    });
+});


### PR DESCRIPTION
Adds an optional in-memory path for OPCUASecureObject to get its identity certificate chain and private key, bypassing the disk-backed readCertificateChain / readPrivateKey calls. This unblocks browser clients (which have no fs) and simplifies test fixtures that would otherwise have to stage PKI folders on disk.

PR 6 from https://github.com/node-opcua/node-opcua/issues/1496