### PR TITLE
feat(client): propagate transportFactory option to ClientSecureChannelLayer

### DIFF
--- a/packages/node-opcua-client/package.json
+++ b/packages/node-opcua-client/package.json
@@ -53,6 +53,7 @@
         "node-opcua-service-translate-browse-path": "2.170.0",
         "node-opcua-service-write": "2.170.0",
         "node-opcua-status-code": "2.169.0",
+        "node-opcua-transport": "2.170.0",
         "node-opcua-types": "2.170.0",
         "node-opcua-utils": "2.169.0",
         "node-opcua-variant": "2.170.0",

--- a/packages/node-opcua-client/source/client_base.ts
+++ b/packages/node-opcua-client/source/client_base.ts
@@ -18,6 +18,7 @@ import type { FindServersOnNetworkRequestOptions, FindServersRequestOptions, Ser
 import type { ApplicationDescription, EndpointDescription } from "node-opcua-service-endpoints";
 import type { ChannelSecurityToken, MessageSecurityMode } from "node-opcua-service-secure-channel";
 import type { ErrorCallback } from "node-opcua-status-code";
+import type { IClientTransportFactory } from "node-opcua-transport";
 import type { Request, Response } from "./common";
 
 export type FindServersRequestLike = FindServersRequestOptions;
@@ -203,6 +204,15 @@ export interface OPCUAClientBaseOptions {
      * path resolution and uses the provider directly.
      */
     certificateKeyPairProvider?: ICertificateKeyPairProvider;
+
+    /**
+     * Optional factory for the underlying client transport. When omitted, the
+     * secure-channel layer uses `defaultClientTransportFactory` (a Node-only
+     * TCP transport). Consumers that need a different transport — browser
+     * WebSocket, in-process stub, tracing wrapper — pass a factory here and
+     * it is threaded through to `ClientSecureChannelLayer`.
+     */
+    transportFactory?: IClientTransportFactory;
 }
 
 export interface GetEndpointsOptions {

--- a/packages/node-opcua-client/source/private/client_base_impl.ts
+++ b/packages/node-opcua-client/source/private/client_base_impl.ts
@@ -27,6 +27,7 @@ import {
     type Response as Response1,
     type SecurityPolicy
 } from "node-opcua-secure-channel";
+import type { IClientTransportFactory } from "node-opcua-transport";
 import {
     FindServersOnNetworkRequest,
     type FindServersOnNetworkRequestOptions,
@@ -387,6 +388,7 @@ export class ClientBaseImpl<Events extends OPCUAClientBaseEvents = OPCUAClientBa
     private _instanceNumber: number;
     private _transportSettings: TransportSettings;
     private _transportTimeout?: number;
+    private _transportFactory?: IClientTransportFactory;
 
     public clientCertificateManager: ICertificateStore;
 
@@ -513,6 +515,7 @@ export class ClientBaseImpl<Events extends OPCUAClientBaseEvents = OPCUAClientBa
 
         this._transportSettings = options.transportSettings || {};
         this._transportTimeout = options.transportTimeout;
+        this._transportFactory = options.transportFactory;
     }
 
     private _cancel_reconnection(callback: ErrorCallback) {
@@ -706,6 +709,7 @@ export class ClientBaseImpl<Events extends OPCUAClientBaseEvents = OPCUAClientBa
             tokenRenewalInterval: this.tokenRenewalInterval,
             transportSettings: this._transportSettings,
             transportTimeout: this._transportTimeout,
+            transportFactory: this._transportFactory,
             defaultTransactionTimeout: this.defaultTransactionTimeout
         });
         secureChannel.on("backoff", (count: number, delay: number) => {

--- a/packages/node-opcua-client/test/test_transport_factory_option.ts
+++ b/packages/node-opcua-client/test/test_transport_factory_option.ts
@@ -1,0 +1,20 @@
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import should from "should";
+import sinon from "sinon";
+
+import { OPCUAClient } from "..";
+
+describe("OPCUAClient + transportFactory option", () => {
+    it("accepts a transportFactory option on OPCUAClientOptions", () => {
+        const factory = { create: sinon.stub() };
+        // Construction alone is the assertion — previously the option was
+        // not a member of OPCUAClientBaseOptions and would be a compile error.
+        const client = OPCUAClient.create({ transportFactory: factory });
+        should.exist(client);
+    });
+
+    it("does not require a transportFactory (default is Node TCP transport)", () => {
+        const client = OPCUAClient.create({});
+        should.exist(client);
+    });
+});

--- a/packages/node-opcua-client/tsconfig.json
+++ b/packages/node-opcua-client/tsconfig.json
@@ -117,6 +117,9 @@
             "path": "../node-opcua-status-code"
         },
         {
+            "path": "../node-opcua-transport"
+        },
+        {
             "path": "../node-opcua-types"
         },
         {


### PR DESCRIPTION
Threads the optional `transportFactory` added to
`ClientSecureChannelLayerOptions` in #1503 up to `OPCUAClientBaseOptions`, so callers that construct clients through the standard `OPCUAClient.create({...})` surface can substitute the transport (e.g. a browser WebSocket transport) without reaching into the secure-channel layer directly.

PR#7 from https://github.com/node-opcua/node-opcua/issues/1496