### PR TITLE
feat(client-browser): scaffold package + Playwright E2E harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ CTTA/
 CTT/Node-OPCUA-Client
 demo/
 dist/
+dist-browser-bundle/
+dist-esm/
 dist-test/
 distHelpers/
 distNodeJS/

--- a/packages/node-opcua-client-browser/LICENSE
+++ b/packages/node-opcua-client-browser/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2022-2024  Sterfive SAS - 833264583 RCS ORLEANS - France (https://www.sterfive.com)
+
+Copyright (c) 2014-2022 Etienne Rossignon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/node-opcua-client-browser/README.md
+++ b/packages/node-opcua-client-browser/README.md
@@ -1,0 +1,42 @@
+# node-opcua-client-browser
+
+OPC UA client SDK for modern browsers, using the **WebSocket transport mapping**
+defined in OPC UA Part 6, §7.5.
+
+> **Status — scaffold only.**
+> This initial drop establishes the package layout, build toolchain, and
+> Playwright E2E harness. The WebSocket transport, the `createBrowserClient`
+> helper, and the prebuilt browser bundle arrive in follow-up PRs. Consult
+> `openspec/changes/add-browser-client-wsopcua/` for the canonical scope and
+> roadmap.
+
+## Planned scope (upcoming PRs)
+
+- Endpoint URL schemes: `opc.ws://`, `opc.wss://`, `ws://`, `wss://`
+- Security policies: `None`, `Basic256Sha256` (SignAndEncrypt)
+- User identity tokens: Anonymous, UserName/Password (password encrypted under
+  `Basic256Sha256` when applicable)
+- Services: Read / Write / CreateSubscription / CreateMonitoredItems / Publish
+
+## What is in this scaffold PR
+
+- Package skeleton (`package.json`, `tsconfig*.json`).
+- An empty `source/index.ts` that just exports a `VERSION` string; subsequent
+  PRs add the actual transport implementation.
+- A Playwright test harness that builds a minimal test page with esbuild,
+  serves it over a local HTTP server, and loads it headless in Chromium.
+- One smoke spec (`test/e2e/smoke.spec.ts`) that asserts the test page loads
+  and the `node-opcua-client-browser` module evaluates. Later PRs replace
+  this with full OPC UA Read / Write / Subscribe flows over `opc.ws` and
+  `opc.wss` against a demo server.
+
+## Running the smoke test
+
+```bash
+pnpm exec playwright install chromium   # first time only
+pnpm test:e2e                           # runs the smoke spec headless
+```
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/packages/node-opcua-client-browser/build-test-page.mjs
+++ b/packages/node-opcua-client-browser/build-test-page.mjs
@@ -1,0 +1,44 @@
+/**
+ * Build the smoke-test page for the Playwright harness.
+ *
+ * Produces `test/page/dist/{index.html, main.js}` from `test/page/main.ts`
+ * using a minimal esbuild config. The smoke page only verifies the bundler
+ * wiring end-to-end; later PRs will introduce a fuller build configuration
+ * (shared with the production browser bundle) in `esbuild-config.mjs`.
+ */
+
+import * as esbuild from "esbuild";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdirSync, copyFileSync } from "node:fs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pageDir = resolve(__dirname, "test", "page");
+const outDir = resolve(pageDir, "dist");
+
+export async function buildTestPage(opts = {}) {
+    mkdirSync(outDir, { recursive: true });
+
+    // index.html references `./main.js`; emit the bundle under that name.
+    copyFileSync(resolve(pageDir, "index.html"), resolve(outDir, "index.html"));
+
+    await esbuild.build({
+        entryPoints: [resolve(pageDir, "main.ts")],
+        outfile: resolve(outDir, "main.js"),
+        bundle: true,
+        format: "esm",
+        platform: "browser",
+        target: "es2022",
+        minify: false,
+        sourcemap: opts.sourcemap ?? true,
+        logLevel: opts.logLevel ?? "warning"
+    });
+
+    return outDir;
+}
+
+// CLI entry: `node build-test-page.mjs`
+if (import.meta.url === `file://${process.argv[1]}`) {
+    await buildTestPage({ logLevel: "info" });
+    console.log(`Built test page at ${outDir}`);
+}

--- a/packages/node-opcua-client-browser/package.json
+++ b/packages/node-opcua-client-browser/package.json
@@ -1,0 +1,53 @@
+{
+    "name": "node-opcua-client-browser",
+    "version": "2.170.1",
+    "description": "OPC UA SDK - browser WebSocket client (opc.ws / opc.wss)",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "browser": "./dist-esm/index.js",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "browser": "./dist-esm/index.js",
+            "import": "./dist-esm/index.js",
+            "require": "./dist/index.js",
+            "default": "./dist/index.js"
+        }
+    },
+    "sideEffects": false,
+    "scripts": {
+        "build": "tsc -b && tsc -p tsconfig.esm.json",
+        "build:test-page": "node build-test-page.mjs",
+        "lint": "eslint source test",
+        "test:e2e": "playwright test",
+        "test": "pnpm test:e2e",
+        "test:check": "tsc --noEmit -p test/tsconfig.json",
+        "clean": "npx rimraf -g node_modules dist dist-esm test/page/dist *.tsbuildinfo test-results playwright-report"
+    },
+    "dependencies": {},
+    "devDependencies": {
+        "@playwright/test": "^1.49.0",
+        "esbuild": "^0.25.0"
+    },
+    "author": "Sterfive SAS",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/node-opcua/node-opcua.git"
+    },
+    "keywords": [
+        "OPCUA",
+        "opcua",
+        "browser",
+        "websocket",
+        "wsopc-ua",
+        "opc.ws",
+        "opc.wss"
+    ],
+    "homepage": "http://node-opcua.github.io/",
+    "files": [
+        "dist",
+        "dist-esm",
+        "source"
+    ]
+}

--- a/packages/node-opcua-client-browser/playwright.config.ts
+++ b/packages/node-opcua-client-browser/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from "@playwright/test";
+
+/**
+ * Playwright config for node-opcua-client-browser E2E.
+ *
+ * Runs only the Chromium project to keep the install footprint minimal.
+ * Each spec owns its own harness (server + bridge + vite) to avoid any
+ * cross-spec state leakage; `fullyParallel: false` keeps port usage tidy.
+ */
+export default defineConfig({
+    testDir: "./test/e2e",
+    testMatch: /.*\.spec\.ts$/,
+    fullyParallel: false,
+    workers: 1,
+    retries: 0,
+    timeout: 60_000,
+    expect: { timeout: 10_000 },
+    reporter: [["list"]],
+    use: {
+        headless: true,
+        ignoreHTTPSErrors: true
+    },
+    projects: [
+        {
+            name: "chromium",
+            use: {
+                browserName: "chromium",
+                // Reuse the repo's local Chromium cache (already populated)
+                launchOptions: {}
+            }
+        }
+    ]
+});

--- a/packages/node-opcua-client-browser/source/index.ts
+++ b/packages/node-opcua-client-browser/source/index.ts
@@ -1,0 +1,39 @@
+/*!
+ * The MIT License (MIT)
+ * Copyright (c) 2022-2025  Sterfive SAS - 833264583 RCS ORLEANS - France (https://www.sterfive.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in all
+ *   copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @module node-opcua-client-browser
+ *
+ * Browser entry point for `node-opcua-client`. This initial scaffold ships the
+ * package layout, build toolchain, and Playwright smoke harness. Later PRs add:
+ *
+ *   - The WebSocket transport (`ClientWS_transport`,
+ *     `browserWsTransportFactory`) over OPC UA Part 6 §7.5 framing.
+ *   - `createBrowserClient(...)` pre-wired with in-memory credentials and a
+ *     browser-safe trust store.
+ *   - Re-exports of the full `OPCUAClient` / `ClientSession` /
+ *     `ClientSubscription` / `ClientMonitoredItem` surface.
+ *   - An `esbuild`-produced standalone browser bundle.
+ *
+ * Target environments: modern evergreen browsers (Chromium, Firefox, WebKit).
+ */
+
+export const VERSION = "2.170.1";

--- a/packages/node-opcua-client-browser/test/e2e/harness.ts
+++ b/packages/node-opcua-client-browser/test/e2e/harness.ts
@@ -1,0 +1,93 @@
+/**
+ * E2E harness (scaffold).
+ *
+ * Builds the test page with esbuild and serves it over a plain HTTP server
+ * so a Playwright browser can load it. The harness is intentionally minimal:
+ * later PRs will layer on a demo `node-opcua-server` and a TCP↔WebSocket
+ * bridge (`start-ws-bridge.ts`) so specs can drive a full OPC UA session
+ * through the browser. For now the only thing a spec can assert is that
+ * `test/page/main.ts` loaded and reported a `status` back to the page.
+ */
+
+import { readFileSync, statSync } from "node:fs";
+import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
+import { extname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export interface StaticServer {
+    url: string;
+    port: number;
+    close: () => Promise<void>;
+}
+
+export interface HarnessContext {
+    /** The static-server URL hosting the test page. */
+    pageUrl: string;
+    /** Static page server. */
+    pageServer: StaticServer;
+    /** Shut everything down. */
+    stopAll: () => Promise<void>;
+}
+
+const packageDir = resolve(__dirname, "..", "..");
+const pageDistDir = resolve(packageDir, "test", "page", "dist");
+
+const MIME_BY_EXT: Record<string, string> = {
+    ".html": "text/html; charset=utf-8",
+    ".js": "application/javascript; charset=utf-8",
+    ".mjs": "application/javascript; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".map": "application/json; charset=utf-8"
+};
+
+async function startStaticServer(rootDir: string): Promise<StaticServer> {
+    const server: HttpServer = createHttpServer((req, res) => {
+        const urlPath = (req.url || "/").split("?", 1)[0];
+        const safePath = urlPath === "/" ? "/index.html" : urlPath;
+        const filePath = join(rootDir, safePath);
+        try {
+            if (!statSync(filePath).isFile()) throw new Error("not a file");
+            const body = readFileSync(filePath);
+            res.setHeader("content-type", MIME_BY_EXT[extname(filePath)] ?? "application/octet-stream");
+            res.end(body);
+        } catch {
+            res.statusCode = 404;
+            res.end("not found");
+        }
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+    const addr = server.address();
+    if (!addr || typeof addr === "string") {
+        throw new Error("static server address unavailable");
+    }
+    const url = `http://127.0.0.1:${addr.port}`;
+    return {
+        url,
+        port: addr.port,
+        close: () =>
+            new Promise<void>((r, rej) =>
+                server.close((err) => (err ? rej(err) : r()))
+            )
+    };
+}
+
+export async function startHarness(): Promise<HarnessContext> {
+    // Dynamic import — `build-test-page.mjs` is plain JS with no type
+    // declaration and lives outside the test tsconfig scope.
+    const buildModuleUrl = pathToFileURL(resolve(packageDir, "build-test-page.mjs")).href;
+    const { buildTestPage } = (await import(buildModuleUrl)) as {
+        buildTestPage: (opts?: { logLevel?: string; sourcemap?: boolean }) => Promise<string>;
+    };
+    await buildTestPage({ logLevel: "warning" });
+    const pageServer = await startStaticServer(pageDistDir);
+
+    const stopAll = async () => {
+        await pageServer.close();
+    };
+
+    return {
+        pageUrl: pageServer.url,
+        pageServer,
+        stopAll
+    };
+}

--- a/packages/node-opcua-client-browser/test/e2e/smoke.spec.ts
+++ b/packages/node-opcua-client-browser/test/e2e/smoke.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * Smoke spec — verifies the Playwright harness, the esbuild test-page build,
+ * and the browser bundle all wire up end-to-end. Later PRs replace this file
+ * with specs that drive a real OPC UA session over `opc.ws://` / `opc.wss://`.
+ */
+
+import { test, expect } from "@playwright/test";
+
+import { startHarness, type HarnessContext } from "./harness";
+
+let harness: HarnessContext;
+
+test.beforeAll(async () => {
+    harness = await startHarness();
+});
+
+test.afterAll(async () => {
+    await harness?.stopAll();
+});
+
+test("test page loads and node-opcua-client-browser module evaluates", async ({ page }) => {
+    await page.goto(harness.pageUrl);
+
+    // `#status` is set by test/page/main.ts once the module finishes evaluating.
+    await expect(page.locator("#status")).toHaveText("ready");
+
+    const ready = await page.evaluate(() => (window as unknown as { __opcuaReady?: unknown }).__opcuaReady);
+    expect(ready).toMatchObject({ loaded: true });
+    expect(Array.isArray((ready as { exports: unknown }).exports)).toBe(true);
+});

--- a/packages/node-opcua-client-browser/test/page/index.html
+++ b/packages/node-opcua-client-browser/test/page/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>node-opcua-client-browser E2E test page</title>
+    </head>
+    <body>
+        <h1>node-opcua-client-browser E2E</h1>
+        <pre id="status">ready</pre>
+        <script type="module" src="./main.js"></script>
+    </body>
+</html>

--- a/packages/node-opcua-client-browser/test/page/main.ts
+++ b/packages/node-opcua-client-browser/test/page/main.ts
@@ -1,0 +1,23 @@
+/**
+ * Smoke test page for the E2E harness scaffold.
+ *
+ * Imports the browser-client bundle and exposes a tiny
+ * `window.__opcuaReady` marker once the module has loaded. Later PRs will
+ * replace this with a real `window.connect(...)` entry point driving a full
+ * OPC UA session.
+ */
+
+import * as browserModule from "../../source/index";
+
+const status = document.querySelector("#status");
+
+// Expose the loaded module for Playwright to introspect.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(window as any).__opcuaReady = {
+    loaded: true,
+    exports: Object.keys(browserModule).sort()
+};
+
+if (status) {
+    status.textContent = "ready";
+}

--- a/packages/node-opcua-client-browser/test/tsconfig.json
+++ b/packages/node-opcua-client-browser/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "composite": false,
+        "lib": ["es2022", "dom"],
+        "types": ["node"]
+    },
+    "include": [
+        "e2e/**/*.ts",
+        "page/**/*.ts"
+    ]
+}

--- a/packages/node-opcua-client-browser/tsconfig.esm.json
+++ b/packages/node-opcua-client-browser/tsconfig.esm.json
@@ -1,0 +1,16 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "module": "ES2022",
+        "moduleResolution": "bundler",
+        "outDir": "dist-esm",
+        "composite": false,
+        "declaration": false,
+        "declarationMap": false,
+        "tsBuildInfoFile": null
+    },
+    "include": [
+        "source/**/*.ts"
+    ],
+    "references": []
+}

--- a/packages/node-opcua-client-browser/tsconfig.json
+++ b/packages/node-opcua-client-browser/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "extends": "../tsconfig.common.json",
+    "compilerOptions": {
+        "rootDir": "source",
+        "outDir": "dist",
+        "types": ["node"],
+        "composite": true,
+        "incremental": true
+    },
+    "include": [
+        "source/**/*.ts"
+    ],
+    "references": [],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -21,6 +21,9 @@
             "path": "node-opcua-client"
         },
         {
+            "path": "node-opcua-client-browser"
+        },
+        {
             "path": "node-opcua-server"
         },
         {


### PR DESCRIPTION
First of several PRs splitting up the browser-client work. This drop establishes:

- The `node-opcua-client-browser` package layout: `package.json`, `tsconfig.json` (+ ESM variant), `LICENSE`, `README.md`.
- A Playwright harness that builds a minimal test page with `esbuild`, serves it over a plain Node HTTP server, and loads it headless in Chromium.
- One smoke spec (`test/e2e/smoke.spec.ts`) that verifies the build toolchain and browser-module evaluation end-to-end.

Part of https://github.com/node-opcua/node-opcua/issues/1496