### PR TITLE
feat(client-browser): WebSocket transport + unit tests

### DIFF
--- a/packages/node-opcua-client-browser/.mocharc.yml
+++ b/packages/node-opcua-client-browser/.mocharc.yml
@@ -1,0 +1,8 @@
+require:
+  - should
+  - tsx
+timeout: 30000
+exit: true
+extension:
+  - .ts
+  - .js

--- a/packages/node-opcua-client-browser/package.json
+++ b/packages/node-opcua-client-browser/package.json
@@ -19,15 +19,23 @@
         "build": "tsc -b && tsc -p tsconfig.esm.json",
         "build:test-page": "node build-test-page.mjs",
         "lint": "eslint source test",
+        "test:unit": "mocha 'test/unit/**/*.ts'",
         "test:e2e": "playwright test",
-        "test": "pnpm test:e2e",
+        "test": "pnpm test:unit && pnpm test:e2e",
         "test:check": "tsc --noEmit -p test/tsconfig.json",
         "clean": "npx rimraf -g node_modules dist dist-esm test/page/dist *.tsbuildinfo test-results playwright-report"
     },
-    "dependencies": {},
+    "dependencies": {
+        "node-opcua-assert": "2.164.0",
+        "node-opcua-debug": "2.171.0",
+        "node-opcua-status-code": "2.171.0",
+        "node-opcua-transport": "2.171.0"
+    },
     "devDependencies": {
         "@playwright/test": "^1.60.0",
-        "esbuild": "^0.28.0"
+        "@types/ws": "^8.5.13",
+        "esbuild": "^0.28.0",
+        "ws": "^8.18.0"
     },
     "author": "Sterfive SAS",
     "license": "MIT",

--- a/packages/node-opcua-client-browser/source/client_ws_transport.ts
+++ b/packages/node-opcua-client-browser/source/client_ws_transport.ts
@@ -1,0 +1,251 @@
+/**
+ * @module node-opcua-client-browser
+ *
+ * `ClientWS_transport` — OPC UA WebSocket client transport (Part 6 §7.5).
+ *
+ * Subclasses `ClientTCP_transport` and reuses its HEL/ACK + chunk-reassembly
+ * machinery unchanged. The only swap is the socket-creation step: instead of
+ * opening a TCP connection, we open a `WebSocket` and hand a
+ * {@link WsSocketAdapter} to `TCP_transport._install_socket`.
+ *
+ * OPC UA WebSocket framing:
+ *   - One UACP chunk per outgoing binary WebSocket frame (handled naturally —
+ *     each `write(chunk)` call invokes `ws.send(chunk)` once).
+ *   - Incoming bytes are fed into `TCP_transport`'s packet-assembler, which
+ *     re-combines split chunks.
+ *   - Subprotocol `opcua+uacp` is requested on the handshake. If the server
+ *     echoes it back we record that; if not (common with a `websockify`
+ *     bridge) we continue without failing — browsers still accept the
+ *     connection provided the server's bytes are valid UACP.
+ */
+
+/* global WebSocket */
+
+import { assert } from "node-opcua-assert";
+import { checkDebugFlag, make_debugLog, make_warningLog } from "node-opcua-debug";
+import type { ErrorCallback } from "node-opcua-status-code";
+import {
+    ClientTCP_transport,
+    type IClientTransport,
+    type IClientTransportFactory,
+    type ISocketLike,
+    type TransportSettingsOptions
+} from "node-opcua-transport";
+
+import { type WebSocketLike, WsSocketAdapter } from "./ws_socket_adapter";
+
+const debugLog = make_debugLog("ClientWS_transport");
+const warningLog = make_warningLog("ClientWS_transport");
+const doDebug = checkDebugFlag("ClientWS_transport");
+
+/** WebSocket subprotocol name defined by OPC UA Part 6 §7.5 */
+export const OPCUA_UACP_SUBPROTOCOL = "opcua+uacp";
+
+/**
+ * A tiny WebSocket-constructor type. In the browser this is `globalThis.WebSocket`;
+ * in Node-side unit tests this is the `ws` package's `default` export. Either works.
+ */
+export type WebSocketConstructor = new (url: string, protocols?: string | string[]) => WebSocketLike;
+
+/** Options specific to the browser WebSocket transport. */
+export interface ClientWSTransportOptions extends TransportSettingsOptions {
+    /**
+     * The WebSocket constructor to use. Defaults to `globalThis.WebSocket`.
+     * Override this from Node-side unit tests to inject the `ws` package.
+     */
+    webSocketCtor?: WebSocketConstructor;
+
+    /**
+     * When `true`, `connect()` fails if the peer does not echo back the
+     * `opcua+uacp` subprotocol on the WebSocket opening handshake. Defaults to
+     * `false` because `websockify` bridges do not negotiate subprotocols; the
+     * OPC UA bytes that follow will fail the HEL/ACK step anyway if the peer
+     * isn't actually speaking UACP.
+     */
+    strictSubprotocol?: boolean;
+}
+
+/**
+ * Parsed endpoint URL, normalised for the browser `WebSocket` constructor.
+ */
+export interface ParsedWsEndpoint {
+    /** The URL to pass to `new WebSocket(url, …)` — always starts with `ws://` or `wss://`. */
+    wsUrl: string;
+    /** `true` if the original URL used `opc.wss://` or `wss://`. */
+    secure: boolean;
+}
+
+/**
+ * Parse and normalise an OPC UA WebSocket endpoint URL. Accepts all four
+ * forms: `opc.ws://`, `opc.wss://`, `ws://`, `wss://`. Anything else throws.
+ *
+ * @throws {Error} if the scheme is not one of the four accepted forms.
+ */
+export function parseWsEndpointUrl(endpointUrl: string): ParsedWsEndpoint {
+    const m = /^(opc\.ws|opc\.wss|ws|wss):\/\/(.+)$/i.exec(endpointUrl);
+    if (!m) {
+        throw new Error(
+            `[node-opcua-client-browser] unsupported endpoint URL scheme for WebSocket transport: ${endpointUrl} ` +
+                `(expected one of opc.ws://, opc.wss://, ws://, wss://)`
+        );
+    }
+    const scheme = m[1].toLowerCase();
+    const secure = scheme === "opc.wss" || scheme === "wss";
+    const wsUrl = `${secure ? "wss" : "ws"}://${m[2]}`;
+    return { wsUrl, secure };
+}
+
+/**
+ * WebSocket-backed client transport. Instances satisfy {@link IClientTransport}
+ * by inheritance from {@link ClientTCP_transport}; the only overridden method
+ * is `connect`, which constructs a WebSocket and adapts it to `ISocketLike`.
+ */
+// biome-ignore lint/suspicious/noUnsafeDeclarationMerging: typed EventEmitter mirror of ClientTCP_transport
+export interface ClientWS_transport {
+    on(eventName: "chunk", eventHandler: (messageChunk: Buffer) => void): this;
+    on(eventName: "close", eventHandler: (err: Error | null) => void): this;
+    on(eventName: "connection_break", eventHandler: (err: Error | null) => void): this;
+    on(eventName: "connect", eventHandler: () => void): this;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class ClientWS_transport extends ClientTCP_transport {
+    private readonly _webSocketCtor: WebSocketConstructor;
+    private readonly _strictSubprotocol: boolean;
+
+    constructor(options?: ClientWSTransportOptions) {
+        super(options);
+        const resolvedCtor =
+            options?.webSocketCtor ??
+            ((typeof globalThis !== "undefined" ? (globalThis as { WebSocket?: WebSocketConstructor }).WebSocket : undefined) as
+                | WebSocketConstructor
+                | undefined);
+        if (!resolvedCtor) {
+            throw new Error(
+                "[ClientWS_transport] no WebSocket constructor available: pass `webSocketCtor` explicitly or run in a browser / Node 22+"
+            );
+        }
+        this._webSocketCtor = resolvedCtor;
+        this._strictSubprotocol = !!options?.strictSubprotocol;
+    }
+
+    /**
+     * Opens a WebSocket to `endpointUrl`, adapts it to `ISocketLike`, and
+     * defers to `ClientTCP_transport`'s HEL/ACK transaction.
+     */
+    public override connect(endpointUrl: string, callback: ErrorCallback): void {
+        this.endpointUrl = endpointUrl;
+
+        /* c8 ignore next */
+        doDebug && debugLog(`ClientWS_transport#connect(endpointUrl = ${endpointUrl})`);
+
+        let parsed: ParsedWsEndpoint;
+        try {
+            parsed = parseWsEndpointUrl(endpointUrl);
+        } catch (err) {
+            callback(err as Error);
+            return;
+        }
+
+        let ws: WebSocketLike;
+        try {
+            ws = new this._webSocketCtor(parsed.wsUrl, OPCUA_UACP_SUBPROTOCOL);
+        } catch (err) {
+            /* c8 ignore next */
+            doDebug && debugLog("WebSocket construction failed", (err as Error).message);
+            callback(err as Error);
+            return;
+        }
+
+        const socket: ISocketLike = new WsSocketAdapter(ws, parsed.wsUrl);
+
+        const onEarlyError = (err: Error) => {
+            callback(err);
+        };
+        socket.once("error", onEarlyError);
+
+        socket.once("connect", () => {
+            socket.removeListener("error", onEarlyError);
+
+            // Subprotocol negotiation check. Browser WS exposes `protocol` on the
+            // instance; `ws` package exposes it too. When the peer doesn't
+            // negotiate (e.g. a websockify bridge), `protocol` is an empty
+            // string. Only fail in strict mode.
+            const negotiated: string | undefined = (ws as unknown as { protocol?: string }).protocol;
+            if (negotiated && negotiated !== OPCUA_UACP_SUBPROTOCOL) {
+                const msg = `unexpected WebSocket subprotocol negotiated: "${negotiated}" (expected "${OPCUA_UACP_SUBPROTOCOL}")`;
+                if (this._strictSubprotocol) {
+                    callback(new Error(`[ClientWS_transport] ${msg}`));
+                    socket.destroy();
+                    return;
+                }
+                warningLog(msg);
+            } else if (!negotiated) {
+                /* c8 ignore next */
+                doDebug &&
+                    debugLog(
+                        `peer did not echo the "${OPCUA_UACP_SUBPROTOCOL}" subprotocol; continuing ` +
+                            `(set strictSubprotocol=true to reject this)`
+                    );
+            }
+
+            // Defer to TCP_transport's install path + ClientTCP_transport's
+            // HEL/ACK handshake by installing the socket directly.
+            assert(!this._socket, "transport should not have a socket yet");
+            // _install_socket is protected; subclassing grants access.
+            (this as unknown as { _install_socket(s: ISocketLike): void })._install_socket(socket);
+
+            // Kick off HEL/ACK. _perform_HEL_ACK_transaction is private on the
+            // parent, so we reuse the public behaviour by invoking the parent
+            // `connect` again — but that would loop. Instead, the parent's
+            // `_on_socket_connect` handler is wired to perform HEL/ACK and then
+            // emit "connect" on `this`. We trigger it by emitting "connect" on
+            // the freshly-installed socket; but the parent attached its
+            // `once("connect", _on_socket_connect)` via its own `connect()`,
+            // which we're overriding. So we call the HEL/ACK sequence directly.
+            const parentAny = this as unknown as {
+                _perform_HEL_ACK_transaction(cb: ErrorCallback): void;
+            };
+            parentAny._perform_HEL_ACK_transaction((err) => {
+                if (!err) {
+                    /* c8 ignore next */
+                    if (!this._socket) {
+                        return callback(new Error("Abandoned"));
+                    }
+                    // Install the connection-break detector that ClientTCP_transport's
+                    // success path installs.
+                    this._socket.on("error", (e: Error) => {
+                        if (e.message.match(/ECONNRESET|EPIPE|premature socket termination/)) {
+                            /* c8 ignore next */
+                            doDebug && debugLog("connection_break after reconnection", endpointUrl);
+                            this.emit("connection_break", e);
+                        }
+                    });
+                    this.emit("connect");
+                } else {
+                    debugLog("_perform_HEL_ACK_transaction has failed with err=", err.message);
+                }
+                callback(err);
+            });
+        });
+    }
+}
+
+/**
+ * A factory that produces {@link ClientWS_transport} instances. Pass to
+ * `ClientSecureChannelLayerOptions.transportFactory` to route all channel
+ * traffic through a WebSocket.
+ *
+ * @example
+ *   const ws = browserWsTransportFactory.create({});
+ *   // or, on Node:
+ *   import WebSocket from "ws";
+ *   const factory: IClientTransportFactory = {
+ *       create(s) { return new ClientWS_transport({ ...s, webSocketCtor: WebSocket as any }); }
+ *   };
+ */
+export const browserWsTransportFactory: IClientTransportFactory = {
+    create(settings?: TransportSettingsOptions): IClientTransport {
+        return new ClientWS_transport(settings as ClientWSTransportOptions | undefined);
+    }
+};

--- a/packages/node-opcua-client-browser/source/index.ts
+++ b/packages/node-opcua-client-browser/source/index.ts
@@ -22,18 +22,18 @@
 /**
  * @module node-opcua-client-browser
  *
- * Browser entry point for `node-opcua-client`. This initial scaffold ships the
- * package layout, build toolchain, and Playwright smoke harness. Later PRs add:
- *
- *   - The WebSocket transport (`ClientWS_transport`,
- *     `browserWsTransportFactory`) over OPC UA Part 6 §7.5 framing.
- *   - `createBrowserClient(...)` pre-wired with in-memory credentials and a
- *     browser-safe trust store.
- *   - Re-exports of the full `OPCUAClient` / `ClientSession` /
- *     `ClientSubscription` / `ClientMonitoredItem` surface.
- *   - An `esbuild`-produced standalone browser bundle.
+ * Browser entry point for `node-opcua-client`. Currently exposes the OPC UA
+ * WebSocket transport (`ClientWS_transport`, `browserWsTransportFactory`,
+ * `parseWsEndpointUrl`). Later PRs add a `createBrowserClient()` helper and a
+ * prebuilt standalone browser bundle.
  *
  * Target environments: modern evergreen browsers (Chromium, Firefox, WebKit).
+ * The transport uses the OPC UA WebSocket mapping per Part 6 §7.5
+ * (`opcua+uacp` subprotocol, one UACP chunk per binary frame).
  */
 
-export const VERSION = "2.170.1";
+export * from "./client_ws_transport";
+export * as uacp from "./uacp";
+export { WsSocketAdapter, type WebSocketLike } from "./ws_socket_adapter";
+
+export const VERSION = "2.171.0";

--- a/packages/node-opcua-client-browser/source/uacp.ts
+++ b/packages/node-opcua-client-browser/source/uacp.ts
@@ -1,0 +1,22 @@
+/**
+ * @module node-opcua-client-browser
+ * @internal
+ *
+ * UACP primitives usable in the browser.
+ *
+ * These are thin re-exports of the byte-level encoders/decoders from
+ * `node-opcua-transport`. Those modules are pure-JS (only `node:events` is
+ * pulled in, which Vite polyfills automatically) and are therefore safe to
+ * bundle for the browser. Consolidating them here gives us a single point of
+ * audit if a future release of `node-opcua-transport` introduces a Node-only
+ * import.
+ */
+
+export {
+    AcknowledgeMessage,
+    HelloMessage,
+    TCPErrorMessage,
+    packTcpMessage,
+    readRawMessageHeader,
+    type TransportSettingsOptions
+} from "node-opcua-transport";

--- a/packages/node-opcua-client-browser/source/ws_socket_adapter.ts
+++ b/packages/node-opcua-client-browser/source/ws_socket_adapter.ts
@@ -1,0 +1,219 @@
+/**
+ * @module node-opcua-client-browser
+ * @internal
+ *
+ * WebSocket → {@link ISocketLike} adapter.
+ *
+ * {@link TCP_transport} in `node-opcua-transport` expects an `ISocketLike` that
+ * emits `data`, `close`, `end`, `error`, `timeout` events and provides
+ * `write`, `end`, `destroy`, `setKeepAlive`, `setNoDelay`, `setTimeout`.
+ *
+ * This adapter turns a browser `WebSocket` (or the `ws` package used during
+ * unit tests) into that shape so the full HEL/ACK + chunk-assembly machinery
+ * in `TCP_transport` can be reused without change.
+ *
+ * Framing per OPC UA Part 6 §7.5: each outgoing UACP chunk is sent as exactly
+ * one binary WebSocket message. Incoming binary messages are concatenated via
+ * the `TCP_transport` packet-assembler, so even if a peer (e.g. `websockify`)
+ * splits a chunk across multiple frames, the assembler re-combines them.
+ * Text frames are ignored with a warning.
+ */
+
+import { EventEmitter } from "events";
+import type { ISocketLike } from "node-opcua-transport";
+
+/**
+ * Minimal structural type that matches both the browser `WebSocket` global and
+ * the `ws` package's Node implementation.
+ */
+export interface WebSocketLike {
+    readonly readyState: number;
+    binaryType: string;
+    send(data: ArrayBuffer | ArrayBufferView): void;
+    close(code?: number, reason?: string): void;
+
+    // Browser event model (setter-based)
+    onopen: ((this: WebSocketLike, ev: unknown) => void) | null;
+    onclose: ((this: WebSocketLike, ev: { code?: number; reason?: string }) => void) | null;
+    onerror: ((this: WebSocketLike, ev: unknown) => void) | null;
+    onmessage: ((this: WebSocketLike, ev: { data: unknown }) => void) | null;
+}
+
+// WebSocket readyState constants (avoid importing the DOM lib to stay Node-side compatible)
+const WS_OPEN = 1;
+const WS_CLOSING = 2;
+const WS_CLOSED = 3;
+
+function toBuffer(data: unknown): Buffer | null {
+    if (!data) return null;
+    if (typeof Buffer !== "undefined" && Buffer.isBuffer(data)) return data as Buffer;
+    if (data instanceof ArrayBuffer) return Buffer.from(new Uint8Array(data));
+    if (ArrayBuffer.isView(data)) {
+        const view = data as ArrayBufferView;
+        return Buffer.from(view.buffer, view.byteOffset, view.byteLength);
+    }
+    // Blob path: the transport's HEL/ACK uses `binaryType = "arraybuffer"`,
+    // so this should never hit. Fail loud if it does.
+    return null;
+}
+
+/**
+ * Wrap a {@link WebSocketLike} as an {@link ISocketLike}. The returned socket
+ * forwards `data` events once the WS is open, and cleans up the WS listeners
+ * on `destroy` or `end`.
+ *
+ * The WebSocket must already be instantiated (i.e. `new WebSocket(url, protocols)`).
+ * The caller drives this by the time `_install_socket` is called; we just bind.
+ */
+export class WsSocketAdapter extends EventEmitter implements ISocketLike {
+    public remoteAddress?: string;
+    public remotePort?: number;
+    public destroyed = false;
+
+    private _timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+    private _timeoutMs = 0;
+    private _timeoutCb: (() => void) | null = null;
+
+    constructor(private readonly ws: WebSocketLike, url?: string) {
+        super();
+
+        if (url) {
+            try {
+                const u = new URL(url);
+                this.remoteAddress = u.hostname;
+                this.remotePort = u.port ? Number(u.port) : undefined;
+            } catch {
+                /* ignore – URL parse already happened in connect() */
+            }
+        }
+
+        ws.binaryType = "arraybuffer";
+
+        const emitError = (err: Error) => {
+            this.emit("error", err);
+        };
+
+        ws.onopen = () => {
+            this.emit("connect");
+        };
+
+        ws.onmessage = (ev: { data: unknown }) => {
+            // Reset inactivity timer if any
+            this._resetTimeout();
+
+            const buf = toBuffer(ev.data);
+            if (!buf) {
+                // Text frame or unknown type: ignore with a warning, per spec
+                // eslint-disable-next-line no-console
+                console.warn("[ClientWS_transport] ignoring non-binary WebSocket frame");
+                return;
+            }
+            this.emit("data", buf);
+        };
+
+        ws.onerror = () => {
+            // Browser WebSocket errors carry no useful detail. Translate into a
+            // generic Error so downstream log messages still make sense.
+            emitError(new Error("WebSocket error"));
+        };
+
+        ws.onclose = (ev: { code?: number; reason?: string }) => {
+            this._clearTimeout();
+            // `hadError` is best-effort: anything other than 1000 (normal) is
+            // treated as an error path.
+            const hadError = !!ev && typeof ev.code === "number" && ev.code !== 1000;
+            this.emit("end");
+            this.emit("close", hadError);
+        };
+    }
+
+    public write(data: string | Buffer, callback?: (err?: Error | null) => undefined | undefined): void {
+        if (this.destroyed || this.ws.readyState >= WS_CLOSING) {
+            callback?.(new Error("WebSocket is not open"));
+            return;
+        }
+        try {
+            if (typeof data === "string") {
+                // UACP chunks are always binary; if we somehow got a string,
+                // encode to UTF-8.
+                this.ws.send(new TextEncoder().encode(data));
+            } else {
+                // Send as ArrayBufferView so the WS layer keeps it as one binary frame.
+                const u8 = data instanceof Uint8Array ? data : new Uint8Array(data);
+                // `send()` accepts ArrayBuffer or ArrayBufferView; use the view so the
+                // underlying buffer isn't copied unnecessarily.
+                this.ws.send(u8);
+            }
+            callback?.();
+        } catch (err) {
+            callback?.(err as Error);
+        }
+    }
+
+    public end(): void {
+        this._clearTimeout();
+        if (this.ws.readyState === WS_OPEN) {
+            try {
+                this.ws.close(1000, "normal closure");
+            } catch {
+                /* swallow */
+            }
+        }
+    }
+
+    public destroy(_err?: Error): void {
+        this.destroyed = true;
+        this._clearTimeout();
+        if (this.ws.readyState < WS_CLOSED) {
+            try {
+                this.ws.close(1001, "going away");
+            } catch {
+                /* swallow */
+            }
+        }
+        // Detach handlers so no late events fire into a destroyed transport.
+        try {
+            this.ws.onopen = null;
+            this.ws.onclose = null;
+            this.ws.onerror = null;
+            this.ws.onmessage = null;
+        } catch {
+            /* swallow */
+        }
+    }
+
+    // These three are no-ops for WebSocket – keep-alive and nodelay are handled
+    // by the browser / underlying TCP stack; we expose them so TCP_transport's
+    // setup sequence runs unchanged.
+    public setKeepAlive(_enable?: boolean, _initialDelay?: number): this {
+        return this;
+    }
+    public setNoDelay(_noDelay?: boolean): this {
+        return this;
+    }
+
+    public setTimeout(timeout: number, callback?: () => void): this {
+        this._timeoutMs = timeout;
+        this._timeoutCb = callback ?? null;
+        this._resetTimeout();
+        return this;
+    }
+
+    private _resetTimeout(): void {
+        this._clearTimeout();
+        if (this._timeoutMs > 0 && this._timeoutCb) {
+            const cb = this._timeoutCb;
+            this._timeoutHandle = setTimeout(() => {
+                this.emit("timeout");
+                cb();
+            }, this._timeoutMs);
+        }
+    }
+
+    private _clearTimeout(): void {
+        if (this._timeoutHandle !== null) {
+            clearTimeout(this._timeoutHandle);
+            this._timeoutHandle = null;
+        }
+    }
+}

--- a/packages/node-opcua-client-browser/test/tsconfig.json
+++ b/packages/node-opcua-client-browser/test/tsconfig.json
@@ -8,6 +8,7 @@
     },
     "include": [
         "e2e/**/*.ts",
-        "page/**/*.ts"
+        "page/**/*.ts",
+        "unit/**/*.ts"
     ]
 }

--- a/packages/node-opcua-client-browser/test/unit/test_client_ws_transport.ts
+++ b/packages/node-opcua-client-browser/test/unit/test_client_ws_transport.ts
@@ -1,0 +1,181 @@
+import should from "should";
+import { WebSocket, WebSocketServer } from "ws";
+
+import type { IClientTransport, IClientTransportFactory } from "node-opcua-transport";
+import { browserWsTransportFactory, ClientWS_transport, parseWsEndpointUrl } from "../../dist";
+
+describe("parseWsEndpointUrl", () => {
+    it("accepts opc.ws:// and returns ws:// plus secure=false", () => {
+        const r = parseWsEndpointUrl("opc.ws://host:4840/path");
+        r.wsUrl.should.equal("ws://host:4840/path");
+        r.secure.should.be.false();
+    });
+    it("accepts opc.wss:// and returns wss:// plus secure=true", () => {
+        const r = parseWsEndpointUrl("opc.wss://host:4843/path");
+        r.wsUrl.should.equal("wss://host:4843/path");
+        r.secure.should.be.true();
+    });
+    it("accepts ws:// as-is", () => {
+        const r = parseWsEndpointUrl("ws://host:1234");
+        r.wsUrl.should.equal("ws://host:1234");
+        r.secure.should.be.false();
+    });
+    it("accepts wss:// as-is", () => {
+        const r = parseWsEndpointUrl("wss://host:1234");
+        r.wsUrl.should.equal("wss://host:1234");
+        r.secure.should.be.true();
+    });
+    it("rejects opc.tcp:// with a clear error", () => {
+        (() => parseWsEndpointUrl("opc.tcp://host:4840")).should.throw(/unsupported endpoint URL scheme/);
+    });
+    it("rejects garbage", () => {
+        (() => parseWsEndpointUrl("not-a-url")).should.throw(/unsupported endpoint URL scheme/);
+    });
+});
+
+describe("ClientWS_transport — structural / factory", () => {
+    it("factory returns a ClientWS_transport instance", () => {
+        // Inject the `ws` constructor since no globalThis.WebSocket exists on Node <22.
+        const factory: IClientTransportFactory = {
+            create(s) {
+                // biome-ignore lint/suspicious/noExplicitAny: constructor shape mismatch between dom lib's WebSocket and `ws`
+                return new ClientWS_transport({ ...(s as object), webSocketCtor: WebSocket as any });
+            }
+        };
+        const t = factory.create({});
+        t.should.be.instanceof(ClientWS_transport);
+    });
+
+    it("conforms to IClientTransport (compile-time check)", () => {
+        // biome-ignore lint/suspicious/noExplicitAny: see above
+        const t = new ClientWS_transport({ webSocketCtor: WebSocket as any });
+        const asIface: IClientTransport = t;
+        asIface.name.should.match(/^ClientWS_transport/);
+    });
+
+    it("exports a default factory object (globalThis.WebSocket path only)", () => {
+        // If the host Node has a WebSocket global (22+), the default factory works;
+        // otherwise constructing should throw the "no WebSocket constructor" error.
+        const hasNativeWs = typeof (globalThis as { WebSocket?: unknown }).WebSocket === "function";
+        if (hasNativeWs) {
+            const t = browserWsTransportFactory.create({});
+            t.should.be.instanceof(ClientWS_transport);
+        } else {
+            (() => browserWsTransportFactory.create({})).should.throw(/no WebSocket constructor/);
+        }
+    });
+
+    it("rejects unsupported scheme at connect() time", (done) => {
+        // biome-ignore lint/suspicious/noExplicitAny: see above
+        const t = new ClientWS_transport({ webSocketCtor: WebSocket as any });
+        t.connect("opc.tcp://localhost:4840", (err) => {
+            should.exist(err);
+            (err as Error).message.should.match(/unsupported endpoint URL scheme|opc\.tcp/);
+            done();
+        });
+    });
+});
+
+describe("ClientWS_transport — HEL/ACK over ws://", function () {
+    this.timeout(20000);
+
+    let server: WebSocketServer | undefined;
+    let endpointUrl: string;
+
+    beforeEach((done) => {
+        // Stand up a Node WebSocketServer that speaks UACP: on each binary
+        // message, reply with a canned ACK so the transport's HEL/ACK loop
+        // completes. We parse the HEL just enough to surface meaningful
+        // failures.
+        server = new WebSocketServer({
+            port: 0,
+            handleProtocols: (protocols) => (protocols.has("opcua+uacp") ? "opcua+uacp" : false)
+        });
+        server.on("listening", () => {
+            const addr = server!.address();
+            if (!addr || typeof addr === "string") {
+                return done(new Error("server address unavailable"));
+            }
+            endpointUrl = `ws://127.0.0.1:${addr.port}`;
+            done();
+        });
+        server.on("connection", (ws) => {
+            ws.on("message", (data, isBinary) => {
+                if (!isBinary) return;
+                const buf = data as Buffer;
+                // First 3 bytes should be "HEL"
+                const msgType = buf.slice(0, 3).toString("ascii");
+                if (msgType !== "HEL") {
+                    ws.close(1002, `unexpected msgType=${msgType}`);
+                    return;
+                }
+                // Build a minimal ACK manually rather than pulling encoder deps
+                // in the test — just enough to make the client's ACK handler
+                // succeed. The transport reads: msgType(3)+chr(1)+len(4)+
+                // protocolVersion(4)+receiveBufferSize(4)+sendBufferSize(4)+
+                // maxMessageSize(4)+maxChunkCount(4) = 28 bytes total.
+                const ack = Buffer.alloc(28);
+                ack.write("ACK", 0, 3, "ascii");
+                ack.write("F", 3, 1, "ascii");
+                ack.writeUInt32LE(28, 4);      // length
+                ack.writeUInt32LE(0, 8);       // protocolVersion
+                ack.writeUInt32LE(65535, 12);  // receiveBufferSize
+                ack.writeUInt32LE(65535, 16);  // sendBufferSize
+                ack.writeUInt32LE(0, 20);      // maxMessageSize
+                ack.writeUInt32LE(0, 24);      // maxChunkCount
+                ws.send(ack);
+            });
+        });
+    });
+
+    afterEach((done) => {
+        if (!server) return done();
+        server.close(() => done());
+        server = undefined;
+    });
+
+    it("connects, performs HEL/ACK, and emits 'connect'", (done) => {
+        // biome-ignore lint/suspicious/noExplicitAny: see above
+        const t = new ClientWS_transport({ webSocketCtor: WebSocket as any });
+        let finished = false;
+        const finish = (err?: Error) => {
+            if (finished) return;
+            finished = true;
+            try {
+                t.dispose();
+            } catch {
+                /* ignore */
+            }
+            done(err);
+        };
+        t.on("connect", () => {
+            try {
+                t.isValid().should.be.true();
+                t.receiveBufferSize.should.be.greaterThan(0);
+                finish();
+            } catch (e) {
+                finish(e as Error);
+            }
+        });
+        t.connect(endpointUrl, (err) => {
+            if (err) finish(err);
+            // note: "connect" event fires before this callback in the happy path
+        });
+    });
+
+    it("returns an error if the peer closes without sending ACK", function (done) {
+        this.timeout(10000);
+        // Replace the message handler to just close on HEL
+        server!.removeAllListeners("connection");
+        server!.on("connection", (ws) => {
+            ws.on("message", () => ws.close(1002, "synthetic failure"));
+        });
+        // biome-ignore lint/suspicious/noExplicitAny: see above
+        const t = new ClientWS_transport({ webSocketCtor: WebSocket as any });
+        t.connect(endpointUrl, (err) => {
+            should.exist(err);
+            t.dispose();
+            done();
+        });
+    });
+});

--- a/packages/node-opcua-client-browser/tsconfig.json
+++ b/packages/node-opcua-client-browser/tsconfig.json
@@ -10,7 +10,12 @@
     "include": [
         "source/**/*.ts"
     ],
-    "references": [],
+    "references": [
+        { "path": "../node-opcua-assert" },
+        { "path": "../node-opcua-debug" },
+        { "path": "../node-opcua-status-code" },
+        { "path": "../node-opcua-transport" }
+    ],
     "exclude": [
         "node_modules",
         "dist"


### PR DESCRIPTION
Second slice of the browser-client split. Adds the `node-opcua-client-browser` WebSocket transport implementation that satisfies `IClientTransport` from `node-opcua-transport`, so the upstream `ClientSecureChannelLayer.transportFactory` option (merged as #1503) can route client traffic over `opc.ws://` / `opc.wss://` in addition to `opc.tcp://`.

Part of PR#9 from https://github.com/node-opcua/node-opcua/issues/1496
