### PR TITLE
feat(client-browser): createBrowserClient() helper

### DIFF
--- a/packages/node-opcua-client-browser/package.json
+++ b/packages/node-opcua-client-browser/package.json
@@ -27,6 +27,9 @@
     },
     "dependencies": {
         "node-opcua-assert": "2.164.0",
+        "node-opcua-client": "2.172.0",
+        "node-opcua-common": "2.172.0",
+        "node-opcua-crypto": "5.3.6",
         "node-opcua-debug": "2.172.0",
         "node-opcua-status-code": "2.172.0",
         "node-opcua-transport": "2.172.0"

--- a/packages/node-opcua-client-browser/source/create_browser_client.ts
+++ b/packages/node-opcua-client-browser/source/create_browser_client.ts
@@ -1,0 +1,105 @@
+/**
+ * @module node-opcua-client-browser
+ *
+ * Thin helper that constructs an `OPCUAClient` (from `node-opcua-client`)
+ * pre-wired with the browser WebSocket transport factory and, when no
+ * credentials are supplied, an in-memory certificate/key pair provider so
+ * no disk paths are touched.
+ *
+ * All other `OPCUAClient` configuration passes through unchanged — callers
+ * configure session timeouts, reconnection strategies, security policies,
+ * etc. exactly as they would for the Node client.
+ *
+ * @example
+ * ```ts
+ * import { createBrowserClient, AttributeIds, MessageSecurityMode, SecurityPolicy } from "node-opcua-client-browser";
+ *
+ * const client = createBrowserClient({
+ *     endpointMustExist: false,
+ *     securityMode: MessageSecurityMode.None,
+ *     securityPolicy: SecurityPolicy.None,
+ * });
+ * await client.connect("opc.ws://localhost:4840");
+ * const session = await client.createSession();
+ * const dv = await session.read({ nodeId: "ns=1;s=Counter", attributeId: AttributeIds.Value });
+ * await session.close();
+ * await client.disconnect();
+ * ```
+ */
+
+import { InMemoryCertificateKeyPairProvider, InMemoryCertificateStore } from "node-opcua-common";
+import { OPCUAClient, type OPCUAClientOptions } from "node-opcua-client";
+import type { Certificate, PrivateKey } from "node-opcua-crypto/web";
+
+import { browserWsTransportFactory } from "./client_ws_transport";
+
+/**
+ * Options accepted by {@link createBrowserClient}. Superset of
+ * {@link OPCUAClientOptions}; the browser-specific defaults described above
+ * apply unless the caller overrides them.
+ */
+export interface CreateBrowserClientOptions extends OPCUAClientOptions {
+    /**
+     * Pre-built client certificate chain (DER). When combined with
+     * `clientPrivateKey`, it is loaded into an
+     * `InMemoryCertificateKeyPairProvider` so the owning `OPCUAClient`
+     * needs no disk cert files.
+     *
+     * If you already pass `certificateKeyPairProvider`, this option is
+     * ignored.
+     */
+    clientCertificate?: Certificate | Certificate[];
+
+    /**
+     * Pre-built client private key. Paired with `clientCertificate` to
+     * populate the in-memory provider.
+     *
+     * If you already pass `certificateKeyPairProvider`, this option is
+     * ignored.
+     */
+    clientPrivateKey?: PrivateKey;
+}
+
+/**
+ * Construct an `OPCUAClient` with browser-appropriate defaults.
+ *
+ * - `transportFactory` defaults to `browserWsTransportFactory` so the
+ *   underlying secure channel opens a WebSocket. Callers can override by
+ *   passing a different `transportFactory`.
+ * - `certificateKeyPairProvider` defaults to an
+ *   `InMemoryCertificateKeyPairProvider`, populated with
+ *   `clientCertificate` / `clientPrivateKey` when those are supplied.
+ *   When they are NOT supplied, the provider is constructed empty —
+ *   callers are expected to await `ensureCertificateExists(...)` on the
+ *   returned client's credentials before connecting with a non-None
+ *   security policy.
+ * - `clientCertificateManager` defaults to an `InMemoryCertificateStore`
+ *   (auto-accept unknown peer certs). Callers can override by passing
+ *   their own `clientCertificateManager` (e.g. one backed by IndexedDB
+ *   or OPFS).
+ */
+export function createBrowserClient(options: CreateBrowserClientOptions = {} as CreateBrowserClientOptions): OPCUAClient {
+    const { clientCertificate, clientPrivateKey, ...clientOptions } = options;
+
+    // Default to the browser WS transport factory unless the caller supplies one.
+    if (!clientOptions.transportFactory) {
+        clientOptions.transportFactory = browserWsTransportFactory;
+    }
+
+    // Default to an in-memory cert/key provider unless the caller supplies one.
+    // If the caller provided a client cert + private key, pre-populate the
+    // provider so the owning client can reach them without further async setup.
+    if (!clientOptions.certificateKeyPairProvider) {
+        const chain = clientCertificate
+            ? (Array.isArray(clientCertificate) ? clientCertificate : [clientCertificate])
+            : undefined;
+        clientOptions.certificateKeyPairProvider = new InMemoryCertificateKeyPairProvider(chain, clientPrivateKey);
+    }
+
+    // Default to an in-memory trust store unless the caller supplies one.
+    if (!clientOptions.clientCertificateManager) {
+        clientOptions.clientCertificateManager = new InMemoryCertificateStore({ autoAcceptUnknown: true });
+    }
+
+    return OPCUAClient.create(clientOptions);
+}

--- a/packages/node-opcua-client-browser/source/index.ts
+++ b/packages/node-opcua-client-browser/source/index.ts
@@ -22,10 +22,12 @@
 /**
  * @module node-opcua-client-browser
  *
- * Browser entry point for `node-opcua-client`. Currently exposes the OPC UA
- * WebSocket transport (`ClientWS_transport`, `browserWsTransportFactory`,
- * `parseWsEndpointUrl`). Later PRs add a `createBrowserClient()` helper and a
- * prebuilt standalone browser bundle.
+ * Browser entry point for `node-opcua-client`. Exposes the OPC UA WebSocket
+ * transport (`ClientWS_transport`, `browserWsTransportFactory`,
+ * `parseWsEndpointUrl`) and a `createBrowserClient()` helper that
+ * pre-wires an `OPCUAClient` with browser-appropriate defaults
+ * (in-memory credentials, in-memory trust store, WebSocket transport).
+ * A later PR adds a prebuilt standalone browser bundle.
  *
  * Target environments: modern evergreen browsers (Chromium, Firefox, WebKit).
  * The transport uses the OPC UA WebSocket mapping per Part 6 §7.5
@@ -33,7 +35,8 @@
  */
 
 export * from "./client_ws_transport";
+export * from "./create_browser_client";
 export * as uacp from "./uacp";
 export { WsSocketAdapter, type WebSocketLike } from "./ws_socket_adapter";
 
-export const VERSION = "2.171.0";
+export const VERSION = "2.172.0";

--- a/packages/node-opcua-client-browser/test/unit/test_create_browser_client.ts
+++ b/packages/node-opcua-client-browser/test/unit/test_create_browser_client.ts
@@ -1,0 +1,122 @@
+import should from "should";
+
+import { OPCUAClient } from "node-opcua-client";
+import { InMemoryCertificateStore } from "node-opcua-common";
+import type { IClientTransportFactory } from "node-opcua-transport";
+
+import { browserWsTransportFactory, createBrowserClient } from "../../dist";
+
+describe("createBrowserClient", () => {
+    it("returns a constructed OPCUAClient (no throw)", () => {
+        // `OPCUAClient` is a facade class whose `create()` returns an
+        // `OPCUAClientImpl` cast through `as unknown`; `instanceof OPCUAClient`
+        // would always be false. Assert via duck-typing instead — every
+        // OPCUAClientImpl exposes `connect` / `disconnect` / `createSession`.
+        const client = createBrowserClient();
+        should.exist(client);
+        client.connect.should.be.a.Function();
+        client.disconnect.should.be.a.Function();
+        client.createSession.should.be.a.Function();
+        // Reference OPCUAClient so this import isn't pruned in compiled JS.
+        OPCUAClient.create.should.be.a.Function();
+    });
+
+    it("defaults `transportFactory` to `browserWsTransportFactory` when not supplied", () => {
+        const client = createBrowserClient();
+        // OPCUAClientImpl stores transportFactory as a private field; the cast
+        // exposes it for white-box assertion. There is no public getter today.
+        const tf = (client as unknown as { _transportFactory?: IClientTransportFactory })
+            ._transportFactory;
+        should.exist(tf);
+        tf!.should.equal(browserWsTransportFactory);
+    });
+
+    it("preserves a caller-supplied `transportFactory`", () => {
+        const customFactory: IClientTransportFactory = {
+            // biome-ignore lint/suspicious/noExplicitAny: stub
+            create: (() => null) as any
+        };
+        const client = createBrowserClient({ transportFactory: customFactory });
+        const tf = (client as unknown as { _transportFactory?: IClientTransportFactory })
+            ._transportFactory;
+        tf!.should.equal(customFactory);
+    });
+
+    it("defaults `clientCertificateManager` to an `InMemoryCertificateStore`", () => {
+        const client = createBrowserClient();
+        client.clientCertificateManager.should.be.instanceof(InMemoryCertificateStore);
+    });
+
+    it("preserves a caller-supplied `clientCertificateManager`", () => {
+        const store = new InMemoryCertificateStore({ autoAcceptUnknown: false });
+        const client = createBrowserClient({ clientCertificateManager: store });
+        client.clientCertificateManager.should.equal(store);
+    });
+
+    it("defaults to an in-memory cert/key provider when none supplied", () => {
+        const client = createBrowserClient();
+        // Both file paths come from `InMemoryCertificateKeyPairProvider`'s
+        // `<in-memory>` getters; a disk-backed provider would resolve real
+        // paths under the cert manager's rootDir.
+        client.certificateFile.should.equal("<in-memory>");
+        client.privateKeyFile.should.equal("<in-memory>");
+    });
+
+    it("populates the in-memory cert/key provider with `clientCertificate` + `clientPrivateKey`", () => {
+        // Use a real DER-shaped buffer (Sequence tag + length); the
+        // in-memory provider holds it opaquely so any non-empty buffer
+        // suffices for round-trip verification.
+        const cert = Buffer.from([0x30, 0x82, 0x01, 0x00]) as never;
+        // biome-ignore lint/suspicious/noExplicitAny: opaque PrivateKey shape
+        const key = { hidden: "test-key" } as any;
+        const client = createBrowserClient({
+            clientCertificate: cert,
+            clientPrivateKey: key
+        });
+        // `getCertificateChain` / `getPrivateKey` are inherited from
+        // OPCUASecureObject and delegate to the in-memory provider that
+        // createBrowserClient installed.
+        client.getCertificateChain().should.deepEqual([cert]);
+        client.getPrivateKey().should.equal(key);
+    });
+
+    it("treats `clientCertificate` as a single-cert chain when not an array", () => {
+        const cert = Buffer.from([0x30, 0x01]) as never;
+        // biome-ignore lint/suspicious/noExplicitAny: opaque
+        const key = { hidden: "k" } as any;
+        const client = createBrowserClient({
+            clientCertificate: cert,
+            clientPrivateKey: key
+        });
+        const chain = client.getCertificateChain();
+        chain.should.have.length(1);
+        chain[0].should.equal(cert);
+    });
+
+    it("preserves a caller-supplied `certificateKeyPairProvider`", () => {
+        // When the caller supplies their own provider, createBrowserClient
+        // must NOT replace it with one populated from `clientCertificate`/
+        // `clientPrivateKey`. Verify by inspecting which getter wins.
+        const ownCert = Buffer.from([0xaa]) as never;
+        // biome-ignore lint/suspicious/noExplicitAny: opaque
+        const ownKey = { hidden: "own" } as any;
+        const ignoredCert = Buffer.from([0xbb]) as never;
+        // biome-ignore lint/suspicious/noExplicitAny: opaque
+        const ignoredKey = { hidden: "ignored" } as any;
+
+        const myProvider = {
+            certificateFile: "<test>",
+            privateKeyFile: "<test>",
+            getCertificate: () => ownCert,
+            getCertificateChain: () => [ownCert],
+            getPrivateKey: () => ownKey
+        };
+        const client = createBrowserClient({
+            certificateKeyPairProvider: myProvider,
+            clientCertificate: ignoredCert,
+            clientPrivateKey: ignoredKey
+        });
+        client.getCertificateChain().should.deepEqual([ownCert]);
+        client.getPrivateKey().should.equal(ownKey);
+    });
+});

--- a/packages/node-opcua-client-browser/tsconfig.json
+++ b/packages/node-opcua-client-browser/tsconfig.json
@@ -12,6 +12,8 @@
     ],
     "references": [
         { "path": "../node-opcua-assert" },
+        { "path": "../node-opcua-client" },
+        { "path": "../node-opcua-common" },
         { "path": "../node-opcua-debug" },
         { "path": "../node-opcua-status-code" },
         { "path": "../node-opcua-transport" }


### PR DESCRIPTION
Adds a one-call helper that constructs an `OPCUAClient` pre-wired with browser-appropriate defaults so consumers don't have to assemble the WebSocket transport factory + in-memory cert/key provider + in-memory trust store manually.