### PR TITLE
fix: preserve cross-namespace references in toNodeset2XML

### DIFF
--- a/packages/node-opcua-address-space/src/nodeset_tools/construct_namespace_dependency.ts
+++ b/packages/node-opcua-address-space/src/nodeset_tools/construct_namespace_dependency.ts
@@ -209,12 +209,13 @@ export function _getCompleteRequiredModelsFromValuesAndReferences(
         }
     };
 
+    const addressSpace = namespace.addressSpace;
+    const nonHierarchicalReferencesType = addressSpace.findReferenceType("NonHierarchicalReferences");
+
     //const maxIndex = Math.max(...requiredNamespaceIndexes);
     for (const node of namespace_.nodeIterator()) {
         const references = (<BaseNodeImpl>node).allReferences();
         for (const reference of references) {
-            // if (reference.isForward) continue;
-            // only look at backward reference
             // check referenceId
             const namespaceIndexOfReferenceType = getReferenceType(reference)?.nodeId.namespace;
             if (namespaceIndexOfReferenceType !== 0 && namespaceIndexOfReferenceType !== namespace.index) {
@@ -228,6 +229,18 @@ export function _getCompleteRequiredModelsFromValuesAndReferences(
                 const refPriority = priorityList[namespaceIndexOfTargetNode];
                 if (refPriority <= thisPriority) {
                     consider(namespaceIndexOfTargetNode);
+                } else {
+                    // For forward NonHierarchicalReferences (e.g. HasInterface),
+                    // always include the target namespace as a dependency
+                    // regardless of priority, since the current node owns
+                    // this relationship.
+                    const referenceType = getReferenceType(reference);
+                    if (reference.isForward
+                        && referenceType
+                        && nonHierarchicalReferencesType
+                        && referenceType.isSubtypeOf(nonHierarchicalReferencesType)) {
+                        consider(namespaceIndexOfTargetNode);
+                    }
                 }
             }
         }

--- a/packages/node-opcua-address-space/src/nodeset_tools/nodeset_to_xml.ts
+++ b/packages/node-opcua-address-space/src/nodeset_tools/nodeset_to_xml.ts
@@ -133,11 +133,6 @@ function _dumpReferences(xw: XmlWriter, node: BaseNode) {
     function referenceToKeep(reference: UAReference): boolean {
         const referenceType = (reference as ReferenceImpl)._referenceType!;
         const targetedNamespaceIndex = reference.nodeId.namespace;
-        if (_hasHigherPriorityThan(xw, targetedNamespaceIndex, node.nodeId.namespace)) {
-            // this reference has nothing to do here ! drop it
-            // because the target namespace is higher in the hierarchy
-            return false;
-        }
 
         // get the direct backward reference to a external namespace
         if (referenceType.isSubtypeOf(aggregateReferenceType) && !reference.isForward) {
@@ -152,14 +147,19 @@ function _dumpReferences(xw: XmlWriter, node: BaseNode) {
         }
         // only keep
         if (referenceType.isSubtypeOf(aggregateReferenceType) && reference.isForward) {
+            if (_hasHigherPriorityThan(xw, targetedNamespaceIndex, node.nodeId.namespace)) {
+                return false;
+            }
             return true;
         } else if (referenceType.isSubtypeOf(hasSubtypeReferenceType) && !reference.isForward) {
             return true;
         } else if (referenceType.isSubtypeOf(hasTypeDefinitionReferenceType) && reference.isForward) {
             return true;
         } else if (referenceType.isSubtypeOf(nonHierarchicalReferencesType) && reference.isForward) {
+            // e.g. HasInterface — always keep, the current node owns this reference
             return true;
         } else if (referenceType.isSubtypeOf(organizesReferencesType) && !reference.isForward) {
+            // Organizes inverse — the current node is organized by an external folder
             return true;
         } else if (connectsToReferenceType && referenceType.isSubtypeOf(connectsToReferenceType) && reference.isForward) {
             return true;

--- a/packages/node-opcua-address-space/test/test_nodeset_to_xml.ts
+++ b/packages/node-opcua-address-space/test/test_nodeset_to_xml.ts
@@ -1007,3 +1007,88 @@ describe("nodeset2.xml with more than one referenced namespace", function (this:
         match?.length.should.eql(4); // 2 of input and output argument in Type and 2 for instance
     });
 });
+
+describe("toNodeset2XML - cross-namespace references with types and instances", function (this: any) {
+    this.timeout(Math.max(40000, this.timeout()));
+
+    let addressSpace: AddressSpace;
+    let namespace: Namespace;
+
+    beforeEach(async () => {
+        addressSpace = AddressSpace.create();
+
+        const xml_files = [nodesets.standard, nodesets.di];
+        fs.existsSync(xml_files[0]).should.be.eql(true);
+        fs.existsSync(xml_files[1]).should.be.eql(true);
+
+        addressSpace.registerNamespace("http://my-namespace/UA/test/");
+        addressSpace.getNamespaceArray().length.should.eql(2);
+
+        await generateAddressSpace(addressSpace, xml_files);
+
+        namespace = addressSpace.getOwnNamespace();
+    });
+    afterEach(async () => {
+        if (addressSpace) {
+            addressSpace.dispose();
+        }
+    });
+
+    it("NSXML-PRIO-1 should preserve HasInterface and Organizes refs when namespace has both types and instances", () => {
+        // Step 1: Add an ObjectType to our namespace — this makes nbTypes > 0,
+        // which causes our namespace to be sorted BEFORE the DI namespace
+        // in the priority table.
+        const myObjectType = namespace.addObjectType({
+            browseName: "MyCustomObjectType",
+            subtypeOf: "BaseObjectType",
+        });
+
+        // Step 2: Find the DI interface and folder
+        const diNamespace = addressSpace.getNamespace("http://opcfoundation.org/UA/DI/");
+        should.exist(diNamespace);
+
+        const iVendorNameplateType = diNamespace.findObjectType("IVendorNameplateType");
+        should.exist(iVendorNameplateType);
+
+        const deviceSet = diNamespace.findNode(`ns=${diNamespace.index};i=5001`);
+        should.exist(deviceSet);
+
+        // Step 3: Create an instance that is:
+        //   - organized by di:DeviceSet  (Organizes inverse ref to DI namespace)
+        //   - implements di:IVendorNameplateType (HasInterface forward ref to DI namespace)
+        const myInstance = namespace.addObject({
+            browseName: "MyMachine",
+            organizedBy: deviceSet,
+        });
+
+        myInstance.addReference({
+            referenceType: "HasInterface",
+            nodeId: iVendorNameplateType!.nodeId,
+        });
+
+        // Step 4: Generate XML
+        const xml = namespace.toNodeset2XML();
+
+        // Step 5: Verify that the DI namespace is included as a dependency
+        xml.should.match(/http:\/\/opcfoundation\.org\/UA\/DI\//,
+            "DI namespace URI must be in NamespaceUris");
+
+        // Step 6: Verify HasInterface reference is present in the XML
+        xml.should.match(/HasInterface/,
+            "HasInterface reference must be serialized");
+
+        // Step 7: Verify Organizes inverse reference is present in the XML
+        xml.should.match(/Organizes/,
+            "Organizes inverse reference must be serialized");
+
+        // Extract the MyMachine section and verify both references are on it
+        const machineSection = xml.substring(
+            xml.indexOf("MyMachine {{{{"),
+            xml.indexOf("MyMachine }}}}")
+        );
+        machineSection.should.match(/HasInterface/,
+            "MyMachine must have HasInterface reference");
+        machineSection.should.match(/Organizes.*IsForward="false"/,
+            "MyMachine must have Organizes inverse reference to DeviceSet");
+    });
+});


### PR DESCRIPTION
When a namespace defines both types (nbTypes>0) and instances with cross-namespace references (HasInterface, Organizes), the priority table would sort the user namespace before companion specs. This caused referenceToKeep() to drop HasInterface and Organizes references, and the dependency detection to exclude companion spec namespaces from the NamespaceUris manifest.

Changes:
- nodeset_to_xml.ts: remove blanket priority filter from referenceToKeep(). Priority check now only applies to forward Aggregates refs. NonHierarchicalReferences (HasInterface) and inverse Organizes are always kept.
- construct_namespace_dependency.ts: bypass priority filter for forward NonHierarchicalReferences targets so that companion specs are correctly listed as dependencies.
- test_nodeset_to_xml.ts: add NSXML-PRIO-1 test that reproduces the bug with a namespace containing both an ObjectType and an instance with HasInterface + Organizes refs to DI namespace.