### PR TITLE
add function to set default certificate subject for ESM compatibility

### DIFF
--- a/packages/node-opcua-common/source/make_subject.ts
+++ b/packages/node-opcua-common/source/make_subject.ts
@@ -9,6 +9,7 @@
  *
  * @module node-opcua-common
  */
+import { Subject } from "node-opcua-crypto";
 
 /**
  * The default organisation / location portion appended to every
@@ -51,14 +52,13 @@ export function setDefaultCertificateSubject(value: string): void {
     // 2. Ensure there is a leading slash.
     const normalised = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
 
-    // 3. Validate the overall shape: one or more /KEY=VALUE segments.
-    //    Keys are one or more word characters; values may be anything except a raw slash
-    //    (nested values would need quoting, which is out of scope here).
-    const subjectPattern = /^(?:\/[A-Za-z][A-Za-z0-9]*=[^/]+)+$/;
-    if (!subjectPattern.test(normalised)) {
+    // 3. Delegate validation to existing Subject.parse() method
+    try {
+        Subject.parse(normalised);
+    } catch (err) {
         throw new Error(
-            `setDefaultCertificateSubject: "${value}" does not match the expected ` +
-            '"/KEY=VALUE/KEY=VALUE/…" pattern (e.g. "/O=MyOrg/L=MyCity/C=US").'
+            `setDefaultCertificateSubject: "${value}" is not a valid subject string. ` +
+            (err as Error).message
         );
     }
 

--- a/packages/node-opcua-common/source/make_subject.ts
+++ b/packages/node-opcua-common/source/make_subject.ts
@@ -19,8 +19,8 @@
 export let defaultCertificateSubject = "/O=Sterfive/L=Orleans/C=FR";
 
 /**
- * Set the default organisation / location portion appended to every
- * auto-generated certificate subject.
+ * Set the default DN suffix (Distinguished Name components such as O, L, C, …)
+ * appended to every auto-generated certificate subject.
  *
  * Use this function instead of directly assigning to `defaultCertificateSubject`
  * when consuming the library as an ESM module, because ESM namespace bindings
@@ -29,6 +29,8 @@ export let defaultCertificateSubject = "/O=Sterfive/L=Orleans/C=FR";
  *
  * @param value - e.g. "/O=MyOrg/L=MyCity/C=US"
  *
+ * @throws {Error} if the value is empty or does not match the expected `/KEY=VALUE/…` pattern.
+ *
  * @example
  * ```ts
  * import { setDefaultCertificateSubject } from "node-opcua-common";
@@ -36,7 +38,31 @@ export let defaultCertificateSubject = "/O=Sterfive/L=Orleans/C=FR";
  * ```
  */
 export function setDefaultCertificateSubject(value: string): void {
-    defaultCertificateSubject = value;
+    // 1. Remove surrounding whitespace that would silently corrupt the subject string.
+    const trimmed = value.trim();
+
+    if (trimmed.length === 0) {
+        throw new Error(
+            'setDefaultCertificateSubject: value must not be empty. ' +
+            'Expected a string like "/O=MyOrg/L=MyCity/C=US".'
+        );
+    }
+
+    // 2. Ensure there is a leading slash.
+    const normalised = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+
+    // 3. Validate the overall shape: one or more /KEY=VALUE segments.
+    //    Keys are one or more word characters; values may be anything except a raw slash
+    //    (nested values would need quoting, which is out of scope here).
+    const subjectPattern = /^(?:\/[A-Za-z][A-Za-z0-9]*=[^/]+)+$/;
+    if (!subjectPattern.test(normalised)) {
+        throw new Error(
+            `setDefaultCertificateSubject: "${value}" does not match the expected ` +
+            '"/KEY=VALUE/KEY=VALUE/…" pattern (e.g. "/O=MyOrg/L=MyCity/C=US").'
+        );
+    }
+
+    defaultCertificateSubject = normalised;
 }
 
 export function makeSubject(applicationName: string, hostname: string): string {

--- a/packages/node-opcua-common/source/make_subject.ts
+++ b/packages/node-opcua-common/source/make_subject.ts
@@ -18,6 +18,27 @@
  */
 export let defaultCertificateSubject = "/O=Sterfive/L=Orleans/C=FR";
 
+/**
+ * Set the default organisation / location portion appended to every
+ * auto-generated certificate subject.
+ *
+ * Use this function instead of directly assigning to `defaultCertificateSubject`
+ * when consuming the library as an ESM module, because ESM namespace bindings
+ * are read-only from the outside and can only be mutated from within the module
+ * that declared them.
+ *
+ * @param value - e.g. "/O=MyOrg/L=MyCity/C=US"
+ *
+ * @example
+ * ```ts
+ * import { setDefaultCertificateSubject } from "node-opcua-common";
+ * setDefaultCertificateSubject("/O=MyOrg/L=MyCity/C=US");
+ * ```
+ */
+export function setDefaultCertificateSubject(value: string): void {
+    defaultCertificateSubject = value;
+}
+
 export function makeSubject(applicationName: string, hostname: string): string {
     const commonName = `${applicationName}@${hostname}`.substring(0, 63);
     const dc = `${hostname}`.substring(63);

--- a/packages/node-opcua-common/source/make_subject.ts
+++ b/packages/node-opcua-common/source/make_subject.ts
@@ -39,6 +39,13 @@ export let defaultCertificateSubject = "/O=Sterfive/L=Orleans/C=FR";
  * ```
  */
 export function setDefaultCertificateSubject(value: string): void {
+    // 0. Guard against non-string values from plain-JS callers.
+    if (typeof value !== "string") {
+        throw new TypeError(
+            'Example: "/O=MyOrg/L=MyCity/C=US".'
+        );
+    }
+
     // 1. Remove surrounding whitespace that would silently corrupt the subject string.
     const trimmed = value.trim();
 
@@ -56,9 +63,10 @@ export function setDefaultCertificateSubject(value: string): void {
     try {
         Subject.parse(normalised);
     } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
         throw new Error(
-            `setDefaultCertificateSubject: "${value}" is not a valid subject string. ` +
-            (err as Error).message
+            `setDefaultCertificateSubject: "${value}" is not a valid subject string. ${reason}`,
+            { cause: err }
         );
     }
 


### PR DESCRIPTION
The "export let" in "node-opcua-common/make_subject.ts" is technically mutable from within the module, but ESM module namespace objects are frozen from the outside. The cleanest short-term fix is using require() in a CJS context. The real fix needs to come from the library itself by exposing a setter function.

The library should expose a setter function like "setDefaultCertificateSubject(value: string)" that mutates the internal variable from within the module (which is always allowed). This is the proper fix. The current design is broken for ESM consumers.