### PR TITLE
fix(variant): never put inconsistent empty Matrix on the wire

### DIFF
--- a/packages/node-opcua-address-space/source/loader/load_nodeset2.ts
+++ b/packages/node-opcua-address-space/source/loader/load_nodeset2.ts
@@ -133,6 +133,28 @@ function makeDefaultVariant(
     }
     return variant;
 }
+
+/**
+ * a Matrix variant is "uninitialized" when it carries no element (value=[]) but declares
+ * non-zero dimensions (e.g. ArrayDimensions="256,128"). Such a variant is internally inconsistent
+ * (value.length !== product(dimensions)) and, if serialized, produces a spec-violating wire form.
+ */
+function isUninitializedMatrix(value: VariantOptions): boolean {
+    if (value.arrayType !== VariantArrayType.Matrix) {
+        return false;
+    }
+    const length = Array.isArray(value.value) ? value.value.length : 0;
+    if (length !== 0) {
+        return false;
+    }
+    const dimensions = value.dimensions;
+    if (!dimensions || dimensions.length === 0) {
+        return false;
+    }
+    const product = dimensions.reduce((n, p) => n * p, 1);
+    return product > 0;
+}
+
 export interface NodeSet2ParserEngine {
     addNodeSet: (xmlData: string) => Promise<void>;
     terminate: () => Promise<void>;
@@ -731,7 +753,12 @@ function makeNodeSetParserEngine(addressSpace: IAddressSpace, options: NodeSetLo
                         if (false && doDebug) {
                             debugLog("2 setting value to ", cv.nodeId.toString(), value);
                         }
-                        if (value.dataType === DataType.Null) {
+                        // a Matrix variable declared with fixed ArrayDimensions but no <Value> is built with
+                        // an empty value (value=[]) yet non-zero declared dimensions. This is an *uninitialized*
+                        // and internally inconsistent matrix (value.length !== product(dimensions)). Advertising
+                        // it as Good would put a spec-violating matrix on the wire (ArraySize 0 + non-empty
+                        // ArrayDimensions), so flag it as BadWaitingForInitialData like any other missing value.
+                        if (value.dataType === DataType.Null || isUninitializedMatrix(value)) {
                             cv.setValueFromSource(value, StatusCodes.BadWaitingForInitialData);
                         } else {
                             cv.setValueFromSource(value, StatusCodes.Good);

--- a/packages/node-opcua-address-space/test/test_loadnodeset_edge_cases.ts
+++ b/packages/node-opcua-address-space/test/test_loadnodeset_edge_cases.ts
@@ -1,7 +1,11 @@
 import path from "node:path";
 import { nodesets } from "node-opcua-nodesets";
 import should from "should";
+import { encodeVariant, decodeVariant } from "node-opcua-variant";
+import { BinaryStream } from "node-opcua-binary-stream";
+import { StatusCodes } from "node-opcua-status-code";
 import { AddressSpace } from "..";
+import type { UAVariable } from "..";
 import { generateAddressSpace } from "../nodeJS";
 
 describe("Testing loadNodeSet - edge cases", async function (this: any) {
@@ -72,6 +76,37 @@ describe("Testing loadNodeSet - edge cases", async function (this: any) {
         const nodeset = path.join(__dirname, "../test_helpers/test_fixtures/nodeset_with_matrix_variable_and_missing_values.xml");
 
         await generateAddressSpace(addressSpace, [nodesets.standard, nodeset]);
+    });
+
+    it("LNSEC-5b -  a Matrix variable loaded with no <Value> must encode to a spec-consistent (decodable) Variant", async () => {
+        // see customer report (Mika Karaila / AO21): a Matrix UAVariable declared with fixed
+        // ArrayDimensions but no <Value> in the nodeset is loaded with value=[] and the *declared*
+        // dimensions. When read and serialized on the wire, encodeVariant() emits
+        //   encodingByte 0xcc | ArraySize 0 | ArrayDimensions [11,1]
+        // which violates the OPC UA spec (ArrayLength must equal product(dimensions)). node-opcua's
+        // own decoder rejects it with "inconsistent matrix", and strict clients stall on it.
+        const nodeset = path.join(__dirname, "../test_helpers/test_fixtures/nodeset_with_matrix_variable_and_missing_values.xml");
+        await generateAddressSpace(addressSpace, [nodesets.standard, nodeset]);
+
+        const uaVariable = addressSpace.findNode("ns=1;i=1250") as UAVariable;
+        should.exist(uaVariable, "expected the matrix variable ns=1;i=1250 to be loaded");
+
+        const dataValue = uaVariable.readValue();
+        const variant = dataValue.value;
+
+        // loader fix: an uninitialized matrix (no <Value> for fixed dimensions) must not advertise Good
+        dataValue.statusCode.should.eql(StatusCodes.BadWaitingForInitialData);
+
+        // encoder fix: the value actually put on the wire must be self-consistent: re-decoding the
+        // encoded Variant must succeed. Before the fix this threw "inconsistent matrix".
+        const stream = new BinaryStream(4096);
+        encodeVariant(variant, stream);
+        const buffer = stream.buffer.subarray(0, stream.length);
+
+        (function roundTrip() {
+            const v2 = decodeVariant(new BinaryStream(buffer));
+            should.exist(v2);
+        }).should.not.throw();
     });
     it("LNSEC-6-  should load a nodeset2.xml  with recursive DataType", async () => {
         const nodeset = path.join(__dirname, "../test_helpers/test_fixtures/datatype_recursive.xml");

--- a/packages/node-opcua-variant/source/variant.ts
+++ b/packages/node-opcua-variant/source/variant.ts
@@ -260,11 +260,23 @@ export function encodeVariant(variant: Variant | undefined | null, stream: Outpu
     }
     let encodingByte = variant.dataType;
 
+    let dimensions = variant.dimensions;
+    if (variant.arrayType === VariantArrayType.Matrix && dimensions && dimensions.length > 0) {
+        // Defensive guard: an empty Matrix value (value.length === 0) combined with non-zero declared
+        // dimensions would encode as a spec-violating wire form (ArraySize 0 followed by non-empty
+        // ArrayDimensions whose product !== 0), which strict clients - including node-opcua's own
+        // decoder - reject with "inconsistent matrix". Emit a self-consistent empty matrix instead.
+        const valueLength = (variant.value as ArrayLike<unknown> | null | undefined)?.length ?? 0;
+        if (valueLength === 0) {
+            dimensions = [];
+        }
+    }
+
     if (variant.arrayType === VariantArrayType.Array || variant.arrayType === VariantArrayType.Matrix) {
         encodingByte |= VARIANT_ARRAY_MASK;
     }
-    if (variant.dimensions && variant.arrayType === VariantArrayType.Matrix) {
-        assert(variant.dimensions.length >= 0);
+    if (dimensions && variant.arrayType === VariantArrayType.Matrix) {
+        assert(dimensions.length >= 0);
         encodingByte |= VARIANT_ARRAY_DIMENSIONS_MASK;
     }
     encodeUInt8(encodingByte, stream);
@@ -276,8 +288,8 @@ export function encodeVariant(variant: Variant | undefined | null, stream: Outpu
         encode(variant.value, stream);
     }
 
-    if ((encodingByte & VARIANT_ARRAY_DIMENSIONS_MASK) === VARIANT_ARRAY_DIMENSIONS_MASK && variant.dimensions) {
-        encodeDimension(variant.dimensions, stream);
+    if ((encodingByte & VARIANT_ARRAY_DIMENSIONS_MASK) === VARIANT_ARRAY_DIMENSIONS_MASK && dimensions) {
+        encodeDimension(dimensions, stream);
     }
 }
 


### PR DESCRIPTION
A Matrix UAVariable declared with fixed ArrayDimensions but no <Value> in the nodeset was loaded with value=[] and the declared (non-zero) dimensions, and advertised with status Good. When read and serialized, encodeVariant() emitted a spec-violating Variant: encodingByte 0xcc | ArraySize 0 | non-empty ArrayDimensions (ArrayLength != product(dimensions)). node-opcua's own decoder rejects this with "inconsistent matrix", and strict third-party clients stall on it. Reported by a customer (Mika Karaila / AO21 build, node-opcua 2.153.0).

The inconsistent state was legalised by 093ac7d08 (v2.134.0, the value.length != 0 escape hatch in constructHook) on top of aacd2c86c (v2.121.0, which started propagating the declared dimensions into makeDefaultVariant).

Two complementary fixes:

- loader: flag an uninitialized Matrix (empty value + non-zero declared dimensions) as BadWaitingForInitialData instead of Good, mirroring the existing DataType.Null handling.
- encoder: defensively emit a self-consistent empty matrix (empty ArrayDimensions, the pre-2.121 wire form) whenever a Matrix value is empty, so a stray inconsistent variant can never reach the wire.

Adds LNSEC-5b covering both the status code and the encode->decode round-trip.

Note: 1-D Arrays are not affected - they encode ArraySize 0 with no dimensions field, which is always a self-consistent empty array on the wire.