### PR TITLE
fix(transport): harden HEL/ACK handshake against malformed responses

### DIFF
--- a/packages/node-opcua-transport/source/client_transport_base.ts
+++ b/packages/node-opcua-transport/source/client_transport_base.ts
@@ -212,7 +212,15 @@ export abstract class ClientTransportBase extends TCP_transport {
         if (messageHeader.msgType === "ERR") {
             responseClass = TCPErrorMessage;
             _stream.rewind();
-            response = decodeMessage(_stream, responseClass) as TCPErrorMessage;
+            try {
+                response = decodeMessage(_stream, responseClass) as TCPErrorMessage;
+            } catch {
+                // the chunk advertised a self-consistent length but does not carry a
+                // complete TCPErrorMessage payload (StatusCode + Reason). Treat it as a
+                // protocol violation rather than letting the decoder read past the buffer.
+                callback(new Error("ACK: failed to decode ERR response (malformed or truncated)"));
+                return;
+            }
 
             err = new Error(`ACK: ERR received ${response.statusCode.toString()} : ${response.reason}`);
             // biome-ignore lint/suspicious/noExplicitAny: legacy diagnostic field tacked onto Error
@@ -224,7 +232,15 @@ export abstract class ClientTransportBase extends TCP_transport {
         } else {
             responseClass = AcknowledgeMessage;
             _stream.rewind();
-            response = decodeMessage(_stream, responseClass) as AcknowledgeMessage;
+            try {
+                response = decodeMessage(_stream, responseClass) as AcknowledgeMessage;
+            } catch {
+                // the chunk advertised a self-consistent length but is too short to hold a
+                // complete AcknowledgeMessage payload. Report it instead of letting the
+                // decoder read past the end of the buffer.
+                callback(new Error("ACK: failed to decode Acknowledge response (malformed or truncated)"));
+                return;
+            }
 
             this.parameters = response;
             this.setLimits(response);

--- a/packages/node-opcua-transport/source/client_transport_base.ts
+++ b/packages/node-opcua-transport/source/client_transport_base.ts
@@ -184,14 +184,20 @@ export abstract class ClientTransportBase extends TCP_transport {
         this._counter += 1;
 
         if (err || !data) {
-            if (this._socket) {
-                const s = this._socket;
-                this._socket = null;
-                s.destroy();
-            }
+            this._destroySocket();
             externalCallback(err || new Error("no data"));
         } else {
             this._handle_ACK_response(data, externalCallback);
+        }
+    }
+
+    // tear down the underlying socket so that a failed handshake does not leave a
+    // half-open, unusable connection alive if the peer does not close it promptly.
+    private _destroySocket(): void {
+        if (this._socket) {
+            const s = this._socket;
+            this._socket = null;
+            s.destroy();
         }
     }
 
@@ -218,6 +224,7 @@ export abstract class ClientTransportBase extends TCP_transport {
                 // the chunk advertised a self-consistent length but does not carry a
                 // complete TCPErrorMessage payload (StatusCode + Reason). Treat it as a
                 // protocol violation rather than letting the decoder read past the buffer.
+                this._destroySocket();
                 callback(new Error("ACK: failed to decode ERR response (malformed or truncated)"));
                 return;
             }
@@ -238,6 +245,7 @@ export abstract class ClientTransportBase extends TCP_transport {
                 // the chunk advertised a self-consistent length but is too short to hold a
                 // complete AcknowledgeMessage payload. Report it instead of letting the
                 // decoder read past the end of the buffer.
+                this._destroySocket();
                 callback(new Error("ACK: failed to decode Acknowledge response (malformed or truncated)"));
                 return;
             }

--- a/packages/node-opcua-transport/test/test_client_tcp_transport.ts
+++ b/packages/node-opcua-transport/test/test_client_tcp_transport.ts
@@ -201,9 +201,9 @@ describe("testing ClientTCP_transport", function (this: any) {
     it("TCS-4b should report an error (and not crash) on a truncated ACK response", (done) => {
         const spyOnServerWrite = sinon.spy((socket, _data) => {
             // ACK/F chunk whose advertised length (8) carries no payload at all, instead
-            // of the mandatory 20 bytes of Acknowledge fields.
+            // of the mandatory 20 bytes of Acknowledge fields. Note: the server deliberately
+            // keeps the connection open so that the client is responsible for closing it.
             socket.write(makeRawChunk("ACK", Buffer.alloc(0)));
-            setImmediate(() => socket.end());
         });
         fakeServer.pushResponse(spyOnServerWrite);
 
@@ -213,6 +213,8 @@ describe("testing ClientTCP_transport", function (this: any) {
             if (err) {
                 err.message.should.match(/malformed or truncated/);
                 spyOnConnect.callCount.should.eql(0);
+                // the failed handshake must not leave a half-open socket behind
+                should.not.exist((clientTransport as any)._socket);
                 done();
             } else {
                 done(new Error("transport.connect should have raised a connection error"));
@@ -222,11 +224,11 @@ describe("testing ClientTCP_transport", function (this: any) {
 
     it("TCS-4c should report an error (and not crash) on a truncated ERR response", (done) => {
         const spyOnServerWrite = sinon.spy((socket, _data) => {
-            // ERR/F chunk carrying a StatusCode but no Reason string.
+            // ERR/F chunk carrying a StatusCode but no Reason string. The server keeps the
+            // connection open so that the client is responsible for closing it.
             const payload = Buffer.alloc(4);
-            payload.writeUInt32LE(0x80000000, 0);
+            payload.writeUInt32LE(StatusCodes.BadCommunicationError.value, 0);
             socket.write(makeRawChunk("ERR", payload));
-            setImmediate(() => socket.end());
         });
         fakeServer.pushResponse(spyOnServerWrite);
 
@@ -236,6 +238,8 @@ describe("testing ClientTCP_transport", function (this: any) {
             if (err) {
                 err.message.should.match(/malformed or truncated/);
                 spyOnConnect.callCount.should.eql(0);
+                // the failed handshake must not leave a half-open socket behind
+                should.not.exist((clientTransport as any)._socket);
                 done();
             } else {
                 done(new Error("transport.connect should have raised a connection error"));

--- a/packages/node-opcua-transport/test/test_client_tcp_transport.ts
+++ b/packages/node-opcua-transport/test/test_client_tcp_transport.ts
@@ -214,7 +214,7 @@ describe("testing ClientTCP_transport", function (this: any) {
                 err.message.should.match(/malformed or truncated/);
                 spyOnConnect.callCount.should.eql(0);
                 // the failed handshake must not leave a half-open socket behind
-                should.not.exist((clientTransport as any)._socket);
+                should.not.exist((clientTransport as unknown as { _socket: net.Socket | null })._socket);
                 done();
             } else {
                 done(new Error("transport.connect should have raised a connection error"));
@@ -239,7 +239,7 @@ describe("testing ClientTCP_transport", function (this: any) {
                 err.message.should.match(/malformed or truncated/);
                 spyOnConnect.callCount.should.eql(0);
                 // the failed handshake must not leave a half-open socket behind
-                should.not.exist((clientTransport as any)._socket);
+                should.not.exist((clientTransport as unknown as { _socket: net.Socket | null })._socket);
                 done();
             } else {
                 done(new Error("transport.connect should have raised a connection error"));
@@ -512,7 +512,7 @@ describe("testing ClientTCP_transport", function (this: any) {
                 try {
                     should.exist(err);
                     err!.message.should.containEql("Timeout");
-                    should.not.exist((clientTransport as any)._socket, "_socket reference must be cleared after failure");
+                    should.not.exist((clientTransport as unknown as { _socket: net.Socket | null })._socket, "_socket reference must be cleared after failure");
                     endCalled.should.eql(false, "socket.end() must not be called");
                     destroyCalled.should.eql(true, "socket.destroy() must be called");
                     spyOnConnect.callCount.should.eql(0);

--- a/packages/node-opcua-transport/test/test_client_tcp_transport.ts
+++ b/packages/node-opcua-transport/test/test_client_tcp_transport.ts
@@ -187,6 +187,62 @@ describe("testing ClientTCP_transport", function (this: any) {
         });
     });
 
+    // build a TCP message header (msgType + chunkType 'F' + total length) followed by
+    // `payload`, but force the advertised total length so that the chunk is self-consistent
+    // for the packet assembler yet shorter than what the message decoder expects.
+    function makeRawChunk(msgType: "ACK" | "ERR", payload: Buffer) {
+        const buffer = Buffer.alloc(8 + payload.length);
+        const stream = new BinaryStream(buffer);
+        writeTCPMessageHeader(msgType, "F", buffer.length, stream);
+        payload.copy(buffer, 8);
+        return buffer;
+    }
+
+    it("TCS-4b should report an error (and not crash) on a truncated ACK response", (done) => {
+        const spyOnServerWrite = sinon.spy((socket, _data) => {
+            // ACK/F chunk whose advertised length (8) carries no payload at all, instead
+            // of the mandatory 20 bytes of Acknowledge fields.
+            socket.write(makeRawChunk("ACK", Buffer.alloc(0)));
+            setImmediate(() => socket.end());
+        });
+        fakeServer.pushResponse(spyOnServerWrite);
+
+        clientTransport.timeout = 1000;
+
+        clientTransport.connect(endpointUrl, (err) => {
+            if (err) {
+                err.message.should.match(/malformed or truncated/);
+                spyOnConnect.callCount.should.eql(0);
+                done();
+            } else {
+                done(new Error("transport.connect should have raised a connection error"));
+            }
+        });
+    });
+
+    it("TCS-4c should report an error (and not crash) on a truncated ERR response", (done) => {
+        const spyOnServerWrite = sinon.spy((socket, _data) => {
+            // ERR/F chunk carrying a StatusCode but no Reason string.
+            const payload = Buffer.alloc(4);
+            payload.writeUInt32LE(0x80000000, 0);
+            socket.write(makeRawChunk("ERR", payload));
+            setImmediate(() => socket.end());
+        });
+        fakeServer.pushResponse(spyOnServerWrite);
+
+        clientTransport.timeout = 1000;
+
+        clientTransport.connect(endpointUrl, (err) => {
+            if (err) {
+                err.message.should.match(/malformed or truncated/);
+                spyOnConnect.callCount.should.eql(0);
+                done();
+            } else {
+                done(new Error("transport.connect should have raised a connection error"));
+            }
+        });
+    });
+
     it("TCS-5 should connect and forward subsequent message chunks after a valid HEL/ACK transaction", (done) => {
         // lets build the subsequent message
         const message1 = Buffer.alloc(10);


### PR DESCRIPTION
Report a connection error instead of throwing when an ACK/F or ERR/F response is self-consistent for the packet assembler but too short to hold a complete message payload. Adds robustness tests for truncated Acknowledge and Error responses.