### PR TITLE
fix(reconnection): resume publishing after Republish returns BadMessa…

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -84,7 +84,25 @@ jobs:
       - run: pnpm run pretest
       - name: Run tests
         shell: bash
-        run: cd packages && node --expose-gc --max-old-space-size=2048 run_all_mocha_tests.js
+        run: |
+          cd packages
+          # Run the suite without letting a non-zero exit abort the step yet,
+          # so we can surface the *raw* exit code. GitHub's "exit code 127"
+          # message is misleading: bash reports codes mod 256, and a native
+          # crash / loader-thread fault exits before run_all_mocha_tests.js's
+          # own clamped process.exit() ever runs.
+          set +e
+          node --expose-gc --max-old-space-size=2048 run_all_mocha_tests.js
+          code=$?
+          set -e
+          echo "::notice::run_all_mocha_tests.js exited with code ${code}"
+          case "${code}" in
+            0) ;;
+            1) echo "::error::test runner reported a test failure (exit 1)" ;;
+            2) echo "::error::unhandled rejection / uncaught exception during run (exit 2) — look for the [FATAL] line above" ;;
+            *) echo "::error::abnormal exit ${code}: node died before the runner's clean exit path. No [FATAL] line above => native/loader-thread crash (not a counted test failure)." ;;
+          esac
+          exit ${code}
 
   build:
     runs-on: ubuntu-latest

--- a/packages/node-opcua-client/source/private/reconnection/client_publish_engine_reconnection.ts
+++ b/packages/node-opcua-client/source/private/reconnection/client_publish_engine_reconnection.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import assert from "node-opcua-assert";
 import { checkDebugFlag, make_debugLog } from "node-opcua-debug";
-import { StatusCodes } from "node-opcua-status-code";
+import { type StatusCode, StatusCodes } from "node-opcua-status-code";
 import { RepublishRequest, type RepublishResponse } from "node-opcua-types";
 import type { ClientSidePublishEngine } from "../client_publish_engine";
 import type { ClientSessionImpl } from "../client_session_impl";
@@ -11,6 +11,33 @@ import { _shouldNotContinue2 } from "./reconnection";
 
 const debugLog = make_debugLog("RECONNECTION");
 const doDebug = checkDebugFlag("RECONNECTION");
+
+/**
+ * Recover the StatusCode carried by a Republish reply, whether it came back as a regular
+ * RepublishResponse (operation-level serviceResult) or as a ServiceFault.
+ *
+ * Precedence:
+ *   1. the explicit `response` argument, when the server answered with a regular RepublishResponse
+ *      (the operation-level serviceResult, e.g. CoDeSys);
+ *   2. otherwise `err.response` — the secure channel layer turns a ServiceFault into an Error and
+ *      attaches the original response there;
+ *   3. otherwise fall back to parsing the error message.
+ */
+function extractStatusCode(err: Error | null | undefined, response?: RepublishResponse): StatusCode {
+    if (response) {
+        return response.responseHeader.serviceResult;
+    }
+    if (err) {
+        const faultResponse = (err as { response?: { responseHeader?: { serviceResult?: StatusCode } } }).response;
+        if (faultResponse?.responseHeader?.serviceResult) {
+            return faultResponse.responseHeader.serviceResult;
+        }
+        if (/BadMessageNotAvailable/.test(err.message)) {
+            return StatusCodes.BadMessageNotAvailable;
+        }
+    }
+    return StatusCodes.Bad;
+}
 
 function _sendRepublish(
     session: ClientSessionImpl,
@@ -41,16 +68,22 @@ function _sendRepublish(
         }
 
         session.republish(request, (err: Error | null, response?: RepublishResponse) => {
+            // BadMessageNotAvailable signals the end of the republish loop: there are no more
+            // queued NotificationMessages to replay and the client must now resume normal Publish
+            // handling (OPC UA Part 4 §6.5/§6.7). A server may report it either as a ServiceFault
+            // (err set, no response) or as the serviceResult of a regular RepublishResponse
+            // (operation-level result, e.g. CoDeSys). Both cases must terminate the loop.
+            const statusCode = extractStatusCode(err, response);
+            if (statusCode.equals(StatusCodes.BadMessageNotAvailable)) {
+                return resolve({ isDone: true });
+            }
             if (!response) {
                 reject(err);
                 return;
             }
-            const statusCode = err ? StatusCodes.Bad : response.responseHeader.serviceResult;
-            if (!err && (statusCode.equals(StatusCodes.Good) || statusCode.equals(StatusCodes.BadMessageNotAvailable))) {
+            if (!err && statusCode.equals(StatusCodes.Good)) {
                 // reprocess notification message and keep going
-                if (statusCode.equals(StatusCodes.Good)) {
-                    subscription.onNotificationMessage(response.notificationMessage);
-                }
+                subscription.onNotificationMessage(response.notificationMessage);
                 return resolve({ isDone: false });
             }
             if (!err) {
@@ -120,8 +153,10 @@ async function __askSubscriptionRepublish(
             await recreateSubscriptionAndMonitoredItem(subscription);
             return;
         }
-        if (error.message.match(/|MessageNotAvailable/)) {
-            // start engine and start monitoring
+        if (error.message.match(/BadMessageNotAvailable/)) {
+            // End of the republish loop: no more queued messages to replay.
+            // Nothing else to do here, the caller will resume normal Publish handling.
+            return;
         }
     }
     // check after successful republish too

--- a/packages/node-opcua-client/source/private/reconnection/reconnection.ts
+++ b/packages/node-opcua-client/source/private/reconnection/reconnection.ts
@@ -162,6 +162,19 @@ function _ask_for_subscription_republish(session: ClientSessionImpl, callback: (
             return repair_client_session_by_recreating_a_new_session(session._client!, session, callback);
         }
 
+        // Republish has completed: resume normal Publish handling. During the connection break the
+        // in-flight PublishRequests have failed and the publish-request queue has drained, so we must
+        // replenish it now, otherwise the client would stop sending PublishRequests and never receive
+        // live notifications again. (https://github.com/node-opcua/node-opcua/issues/1524)
+        // Note: on the new-session repair path the engine is still suspended here, so this is a no-op
+        // there and the queue is replenished later by suspend(false).
+        // Guard on subscriptionCount: with no subscription, send_publish_request() would still emit
+        // spurious PublishRequests (it does not check the subscription count itself), adding useless
+        // round-trips on every reconnection of a subscription-less session.
+        if (engine.subscriptionCount > 0) {
+            engine.replenish_publish_request_queue();
+        }
+
         callback(err);
     });
 }

--- a/packages/node-opcua-client/test/test_issue_1524.ts
+++ b/packages/node-opcua-client/test/test_issue_1524.ts
@@ -1,0 +1,87 @@
+// Regression test for https://github.com/node-opcua/node-opcua/issues/1524
+//
+// "Client does not recover subscriptions after Republish/BadMessageNotAvailable"
+//
+// After re-establishing a connection, the client calls Republish in a loop until the server
+// answers with BadMessageNotAvailable. As soon as that status is received, the client must stop
+// the Republish loop and resume normal Publish handling (OPC UA Part 4 §6.5/§6.7).
+//
+// Some servers (e.g. CoDeSys) return BadMessageNotAvailable as the *serviceResult* of a regular
+// RepublishResponse (operation-level result) rather than as a ServiceFault. In that case the client
+// used to treat the status as "keep going", spinning forever on the same sequence number and never
+// resuming the publish engine.
+import "mocha";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { StatusCodes } from "node-opcua-status-code";
+import { type RepublishRequest, RepublishResponse } from "node-opcua-types";
+import "should";
+import type { ClientSidePublishEngine } from "../source/private/client_publish_engine";
+import { republish } from "../source/private/reconnection/client_publish_engine_reconnection";
+
+describe("issue #1524 - client must resume publishing after Republish returns BadMessageNotAvailable", function (this: Mocha.Suite) {
+    this.timeout(10 * 1000);
+
+    it("should stop the republish loop and complete when the server returns BadMessageNotAvailable", async () => {
+        let republishCallCount = 0;
+        let stopResponding = false;
+
+        // minimal session/subscription/engine doubles, just enough to drive republish()
+        const session = {
+            _closeEventHasBeenEmitted: false,
+            hasBeenClosed: () => false,
+            _client: {
+                _secureChannel: {},
+                isUnusable: () => false
+            },
+            republish(_request: RepublishRequest, cb: (err: Error | null, response?: RepublishResponse) => void) {
+                if (stopResponding) {
+                    // halt the production loop if the test has already concluded
+                    return;
+                }
+                republishCallCount += 1;
+                // BadMessageNotAvailable returned as an operation-level result (not a ServiceFault)
+                const response = new RepublishResponse({
+                    responseHeader: { serviceResult: StatusCodes.BadMessageNotAvailable }
+                });
+                setImmediate(() => {
+                    if (!stopResponding) cb(null, response);
+                });
+            }
+        };
+
+        const subscription = {
+            subscriptionId: 1,
+            lastSequenceNumber: 0,
+            hasSession: true,
+            session,
+            onNotificationMessage() {
+                /* no notification message expected in this scenario */
+            }
+        };
+
+        const engine = {
+            session,
+            subscriptionMap: { "1": subscription },
+            nbPendingPublishRequests: 0
+        } as unknown as ClientSidePublishEngine;
+
+        const completed = await new Promise<boolean>((resolve) => {
+            const timer = setTimeout(() => {
+                stopResponding = true;
+                resolve(false);
+            }, 3000);
+            republish(engine, () => {
+                clearTimeout(timer);
+                stopResponding = true;
+                resolve(true);
+            });
+        });
+
+        // Without the fix, the client loops forever on BadMessageNotAvailable: the callback never
+        // fires and the publish engine is never resumed.
+        completed.should.eql(true, "republish() must complete so that the publish engine can resume normal publishing");
+
+        // A single Republish round-trip is enough to learn there is nothing left to replay.
+        republishCallCount.should.be.lessThanOrEqual(2, "republish must not spin on BadMessageNotAvailable");
+    });
+});

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_connection_reconnection_republish_BadMessageNotAvailable_1524.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_connection_reconnection_republish_BadMessageNotAvailable_1524.ts
@@ -1,0 +1,230 @@
+/* eslint-disable max-statements */
+// e2e regression test for https://github.com/node-opcua/node-opcua/issues/1524
+//
+// "Client does not recover subscriptions after Republish/BadMessageNotAvailable"
+//
+// After a transient connection break the client reactivates its session and calls Republish in a
+// loop until the server answers with BadMessageNotAvailable. As soon as that status is received the
+// client must stop the Republish loop and resume normal Publish handling (OPC UA Part 4 §6.5/§6.7).
+//
+// Two defects used to break this recovery:
+//   1. some servers (e.g. CoDeSys) return BadMessageNotAvailable as the *serviceResult* of a regular
+//      RepublishResponse (operation-level result) rather than as a ServiceFault. The client treated
+//      that status as "keep going" and spun forever on the same sequence number.
+//   2. on the session-reactivation repair path the publish-request queue was never replenished after
+//      republish, so the client stopped sending PublishRequests and never received live data again.
+//
+// This test installs the CoDeSys-like behaviour on an in-process server, breaks the connection
+// without losing the server-side session, and verifies that data-change notifications resume after
+// the reconnection.
+import type { Socket } from "node:net";
+import {
+    AttributeIds,
+    type ClientMonitoredItem,
+    type ClientSession,
+    type ClientSubscription,
+    DataType,
+    OPCUAClient,
+    type OPCUAServer,
+    RepublishResponse,
+    StatusCodes,
+    TimestampsToReturn,
+    type UAVariable,
+    Variant
+} from "node-opcua";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import "should";
+import { build_server_with_temperature_device } from "../../test_helpers/build_server_with_temperature_device";
+
+// 2027: free in this package's port map (2025 is taken by test_issue_1442.ts;
+// 2024/2025 used, next free slot before 2030)
+const port = 2027;
+
+describe("issue #1524 - e2e - client must resume publishing after Republish returns BadMessageNotAvailable", function (this: Mocha.Suite) {
+    this.timeout(Math.max(60 * 1000, this.timeout()));
+
+    let server: OPCUAServer | undefined;
+    let client: OPCUAClient | undefined;
+    let session: ClientSession | undefined;
+    let subscription: ClientSubscription | undefined;
+    let monitoredItem: ClientMonitoredItem | undefined;
+    let counterNode: UAVariable;
+    let timerId: NodeJS.Timeout | undefined;
+    let republishRequestCount = 0;
+    let changeCount = 0;
+
+    async function start_server() {
+        server = await build_server_with_temperature_device({ port });
+
+        // Make the server answer every Republish with BadMessageNotAvailable carried as the
+        // operation-level serviceResult of a regular RepublishResponse (the CoDeSys behaviour).
+        (server as unknown as { _on_RepublishRequest: unknown })._on_RepublishRequest = (
+            message: unknown,
+            channel: { send_response: (msgType: string, response: RepublishResponse, message: unknown) => void }
+        ) => {
+            republishRequestCount += 1;
+            const response = new RepublishResponse({
+                responseHeader: { serviceResult: StatusCodes.BadMessageNotAvailable }
+            });
+            return channel.send_response("MSG", response, message);
+        };
+
+        const namespace = server.engine.addressSpace?.getOwnNamespace();
+        if (!namespace) {
+            throw new Error("namespace not found");
+        }
+        let c = 0;
+        counterNode = namespace.addVariable({
+            browseName: "Counter",
+            organizedBy: server.engine.addressSpace?.rootFolder.objects,
+            dataType: "UInt32",
+            value: new Variant({ dataType: DataType.UInt32, value: c })
+        });
+        timerId = setInterval(() => {
+            c += 1;
+            counterNode.setValueFromSource(new Variant({ dataType: "UInt32", value: c }), StatusCodes.Good);
+        }, 100);
+    }
+
+    async function stop_server() {
+        if (timerId) {
+            clearInterval(timerId);
+            timerId = undefined;
+        }
+        await server?.shutdown();
+        server = undefined;
+    }
+
+    async function start_client_with_subscription() {
+        const _client = OPCUAClient.create({
+            // keep retrying so the client reconnects after the transient break
+            connectionStrategy: { maxRetry: 1000, initialDelay: 10, maxDelay: 200, randomisationFactor: 0 },
+            endpointMustExist: false,
+            keepSessionAlive: true,
+            // session and subscription must outlive the connection break
+            requestedSessionTimeout: 60_000
+        });
+        client = _client;
+        if (!server) throw new Error("server not started");
+        await _client.connect(server.getEndpointUrl());
+        session = await _client.createSession();
+
+        subscription = await session.createSubscription2({
+            requestedPublishingInterval: 100,
+            requestedLifetimeCount: 1000,
+            requestedMaxKeepAliveCount: 12,
+            maxNotificationsPerPublish: 10,
+            publishingEnabled: true,
+            priority: 10
+        });
+
+        monitoredItem = await subscription.monitor(
+            { nodeId: counterNode.nodeId, attributeId: AttributeIds.Value },
+            { samplingInterval: 50, discardOldest: true, queueSize: 10 },
+            TimestampsToReturn.Both
+        );
+        monitoredItem.on("changed", () => {
+            changeCount += 1;
+        });
+    }
+
+    async function stop_client() {
+        try {
+            await session?.close();
+        } catch {
+            /* ignore */
+        }
+        await client?.disconnect();
+        client = undefined;
+        session = undefined;
+    }
+
+    async function wait_for_n_changes(n: number, timeout: number): Promise<number> {
+        const start = changeCount;
+        return await new Promise<number>((resolve, reject) => {
+            const timer = setTimeout(() => {
+                clearInterval(poll);
+                reject(new Error(`timeout: only ${changeCount - start} change(s) received in ${timeout} ms (expected ${n})`));
+            }, timeout);
+            const poll = setInterval(() => {
+                if (changeCount - start >= n) {
+                    clearTimeout(timer);
+                    clearInterval(poll);
+                    resolve(changeCount - start);
+                }
+            }, 50);
+        });
+    }
+
+    async function simulate_transient_connection_break(breakDuration: number) {
+        // suspend the server endpoints so the client cannot reconnect during the break,
+        // but the server keeps the session/subscription alive
+        await server?.suspendEndPoints();
+        const clientSocket: Socket = (
+            client as unknown as { _secureChannel: { getTransport(): { _socket: Socket } } }
+        )._secureChannel.getTransport()._socket;
+        clientSocket.end();
+        clientSocket.destroy();
+        clientSocket.emit("error", new Error("ECONNRESET"));
+        await new Promise((resolve) => setTimeout(resolve, breakDuration));
+        await server?.resumeEndPoints();
+    }
+
+    // Arm the connection_reestablished listener and return a promise that resolves when it fires.
+    // The listener must be attached *before* the break is triggered, otherwise a fast reconnection
+    // could emit connection_reestablished before we start listening and the test would hang.
+    // The timeout makes a missed event / failed reconnection fail fast with a clear message instead
+    // of stalling until the suite timeout.
+    function arm_reconnection(timeout: number): Promise<void> {
+        return new Promise<void>((resolve, reject) => {
+            const onReestablished = () => {
+                clearTimeout(timer);
+                resolve();
+            };
+            const timer = setTimeout(() => {
+                client?.removeListener("connection_reestablished", onReestablished);
+                reject(new Error(`timeout: connection_reestablished was not emitted within ${timeout} ms`));
+            }, timeout);
+            client?.once("connection_reestablished", onReestablished);
+        });
+    }
+
+    beforeEach(async () => {
+        republishRequestCount = 0;
+        changeCount = 0;
+        await start_server();
+    });
+
+    afterEach(async () => {
+        if (monitoredItem) {
+            monitoredItem.removeAllListeners();
+            monitoredItem = undefined;
+        }
+        subscription = undefined;
+        await stop_client();
+        await stop_server();
+    });
+
+    it("should resume data-change notifications after a reconnection where the server replies BadMessageNotAvailable to Republish", async () => {
+        await start_client_with_subscription();
+
+        // 1) verify the subscription works before the break
+        (await wait_for_n_changes(3, 5_000)).should.be.greaterThanOrEqual(3);
+
+        // 2) transient connection break (server keeps the session alive).
+        //    Arm the reconnection wait before triggering the break so we cannot miss the event.
+        //    The 3 s break is suspended-endpoint time, so the timeout must comfortably exceed it.
+        const reconnected = arm_reconnection(30_000);
+        await simulate_transient_connection_break(3_000);
+        await reconnected;
+
+        // 3) the client must reactivate the session, call Republish (server -> BadMessageNotAvailable),
+        //    then resume normal publishing. Without the fix the client either spins on Republish forever
+        //    or stops sending PublishRequests, and the following wait times out.
+        const received = await wait_for_n_changes(3, 15_000);
+        received.should.be.greaterThanOrEqual(3, "data-change notifications must resume after reconnection");
+
+        // sanity: the server really did exercise the Republish path with BadMessageNotAvailable
+        republishRequestCount.should.be.greaterThanOrEqual(1, "the Republish path should have been exercised");
+    });
+});


### PR DESCRIPTION
…geNotAvailable (#1524)

Two defects prevented subscription recovery after a reconnection when the server answered Republish with BadMessageNotAvailable:

1. The republish loop treated BadMessageNotAvailable as "keep going". When a server (e.g. CoDeSys) returns it as the operation-level serviceResult of a regular RepublishResponse, the client spun forever on the same sequence number and never resumed publishing. It now terminates the loop whether the status arrives as a ServiceFault or as an operation-level result, and the dead /|MessageNotAvailable/ regex is fixed to /BadMessageNotAvailable/.

2. The session-reactivation repair path never replenished the publish-request queue after republish (unlike the new-session path). Since the queue drains during the connection break, the client stopped sending PublishRequests and never received live notifications again. We now replenish it once republish completes.

Adds a fast unit regression test and an in-process e2e test that reproduces the CoDeSys behaviour, breaks the connection without losing the server-side session, and verifies data-change notifications resume after reconnection.