### PR TITLE
fix(server): evict oldest inactive session at maxSessions

### DIFF
--- a/packages/node-opcua-server/source/server_engine.ts
+++ b/packages/node-opcua-server/source/server_engine.ts
@@ -1580,7 +1580,7 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
         let session = tmp[0];
         for (let i = 1; i < tmp.length; i++) {
             const c = tmp[i];
-            if (session.creationDate.getTime() < c.creationDate.getTime()) {
+            if (session.creationDate.getTime() > c.creationDate.getTime()) {
                 session = c;
             }
         }


### PR DESCRIPTION
### Summary
This PR fixes the session eviction order used when the server reaches `serverCapabilities.maxSessions`.

OPC UA Part 4 requires a server to close the oldest Session that is not activated before reaching the maximum number of supported Sessions. The current implementation does the opposite and selects the newest inactive session instead.

### Bug
`OPCUAServer::_on_CreateSessionRequest()` calls `ServerEngine#getOldestInactiveSession()` when the server is about to exceed `maxSessions`. However, `getOldestInactiveSession()` currently updates the candidate with:

```ts
if (session.creationDate.getTime() < c.creationDate.getTime()) {
    session = c;
}
```

This keeps the session with the latest `creationDate`, so the helper returns the newest inactive session rather than the oldest one. As a result, when multiple non-activated sessions exist near the session limit, a new `CreateSession` request may evict the most recently created inactive session instead of the oldest one, which is inconsistent with both the helper name and the OPC UA requirement.

### Changes
Reverse the comparison in `ServerEngine#getOldestInactiveSession()` so the helper keeps the earliest `creationDate`.
