### PR TITLE
fix(server): avoid double counting session timeouts

### DIFF
--- a/packages/node-opcua-server/source/server_engine.ts
+++ b/packages/node-opcua-server/source/server_engine.ts
@@ -1635,7 +1635,6 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
         session.on("timeout", () => {
             // the session hasn't been active for a while , probably because the client has disconnected abruptly
             // it is now time to close the session completely
-            this.serverDiagnosticsSummary.sessionTimeoutCount += 1;
             session.sessionName = session.sessionName || "";
 
             const channel = session.channel;

--- a/packages/node-opcua-server/test/test_server_engine.ts
+++ b/packages/node-opcua-server/test/test_server_engine.ts
@@ -2139,6 +2139,23 @@ describe("ServerEngine advanced", () => {
         await engine.shutdown();
         // leaks will be detected if engine failed to dispose session
     });
+
+    it("ServerEngine should increment sessionTimeoutCount only once per timeout event", async () => {
+        const engine = new ServerEngine({
+            applicationUri: "application:uri"
+        });
+        const session = engine.createSession({ server: {} });
+
+        engine.sessionTimeoutCount.should.equal(0);
+        engine.currentSessionCount.should.equal(1);
+
+        session.emit("timeout");
+
+        engine.sessionTimeoutCount.should.equal(1);
+        engine.currentSessionCount.should.equal(0);
+
+        await engine.shutdown();
+    });
 });
 
 describe("ServerEngine ServerStatus & ServerCapabilities", function (this: Mocha.Suite) {


### PR DESCRIPTION
### Summary
This change fixes the server diagnostics counter for timed out sessions.

At the moment, a single session timeout increments `ServerDiagnosticsSummary.sessionTimeoutCount` twice. This makes the published diagnostics value larger than the number of actual timeout events observed by the server.

### Bug
When a session times out, the timeout handler in `ServerEngine#createSession()` currently increments `sessionTimeoutCount` directly and then calls `incrementSessionTimeoutCount()`:

```ts
this.serverDiagnosticsSummary.sessionTimeoutCount += 1;
...
this.incrementSessionTimeoutCount();
```

Since `incrementSessionTimeoutCount()` already updates the same counter, one real timeout event is counted twice.

As a result, clients and monitoring systems reading `ServerDiagnosticsSummary.sessionTimeoutCount` may observe inflated timeout statistics that do not match the actual session lifecycle events.

### Changes
- Remove the direct `sessionTimeoutCount += 1` update from the session timeout handler
- Keep `incrementSessionTimeoutCount()` as the single path that updates the timeout diagnostic counter
