### PR TITLE
fix(file-transfer): invalidate file handle on close

### DIFF
--- a/packages/node-opcua-file-transfer/source/server/file_type_helpers.ts
+++ b/packages/node-opcua-file-transfer/source/server/file_type_helpers.ts
@@ -295,7 +295,7 @@ function _getFileInfo(addressSpace: IAddressSpace, context: ISessionContext, fil
 
 function _close(addressSpace: IAddressSpace, context: ISessionContext, fileData: FileAccessData) {
     const _context = _prepare(addressSpace, context);
-    delete _context.$$files[fileData.fd];
+    delete _context.$$files[fileData.handle];
 }
 
 function toNodeJSMode(opcuaMode: OpenFileMode): string {


### PR DESCRIPTION
### Summary
This change fixes the server-side file handle lifecycle for FileType operations.

### Bug
`_addFile()` stores file access state in `$$files[fileHandle]`, and `_getFileInfo()` also resolves file state by `fileHandle`.

However, `_close()` currently removes the entry with:

```ts
delete _context.$$files[fileData.fd];
```

This uses the OS file descriptor instead of the OPC UA `fileHandle`. As a result, `Close` releases the underlying file descriptor but does not actually invalidate the corresponding `fileHandle` entry in the FileType session state. Later calls such as `Read`, `Write`, `GetPosition`, or `SetPosition` may still pass `_getFileInfo()` and fall through to lower-level file-descriptor error paths instead of being rejected as invalid handle usage.

### Changes
- Remove closed file entries from `$$files` by `fileData.handle` instead of `fileData.fd`
- Keep FileType handle invalidation aligned with the same key used by `_addFile()` and `_getFileInfo()`
