### PR TITLE
fix(address-space): correct two-state fallback texts

### DIFF
--- a/packages/node-opcua-address-space/src/state_machine/ua_two_state_variable.ts
+++ b/packages/node-opcua-address-space/src/state_machine/ua_two_state_variable.ts
@@ -216,18 +216,18 @@ export class UATwoStateVariableImpl extends UAVariableImplT<LocalizedText, DataT
             assert(typeof options.trueState === "string");
             assert(typeof options.falseState === "string");
 
-            if (this.falseState) {
-                this.falseState.setValueFromSource({
-                    dataType: DataType.LocalizedText,
-                    value: coerceLocalizedText(options.falseState)
-                });
-            } else {
-                this._trueState = coerceLocalizedText(options.trueState)?.text!;
-            }
             if (this.trueState) {
                 this.trueState.setValueFromSource({
                     dataType: DataType.LocalizedText,
                     value: coerceLocalizedText(options.trueState)
+                });
+            } else {
+                this._trueState = coerceLocalizedText(options.trueState)?.text!;
+            }
+            if (this.falseState) {
+                this.falseState.setValueFromSource({
+                    dataType: DataType.LocalizedText,
+                    value: coerceLocalizedText(options.falseState)
                 });
             } else {
                 this._falseState = coerceLocalizedText(options.falseState)?.text!;

--- a/packages/node-opcua-address-space/test/test_address_space_add_two_state_variable.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_add_two_state_variable.ts
@@ -6,6 +6,7 @@ import should from "should";
 import sinon from "sinon";
 import { AddressSpace, type BaseNode, type Namespace } from "..";
 import { generateAddressSpace } from "../nodeJS";
+import { UATwoStateVariableImpl } from "../src/state_machine/ua_two_state_variable";
 
 let clock: any = null;
 
@@ -91,6 +92,43 @@ describe("testing add TwoStateVariable ", function (this: any) {
 
         node.setValue(false);
         node.readValue().value.value.text?.should.eql("Disabled");
+    });
+
+    it("should keep the fallback text for the missing state property", () => {
+        const trueStateNode = {
+            readValue() {
+                return {
+                    value: {
+                        value: { text: "Enabled" }
+                    }
+                };
+            },
+            setValueFromSource: sinon.spy()
+        };
+        const node = Object.create(UATwoStateVariableImpl.prototype) as UATwoStateVariableImpl & {
+            _falseState?: string;
+            _postInitialize: sinon.SinonSpy;
+            addReference: sinon.SinonSpy;
+            falseState?: undefined;
+            id: { setValueFromSource: sinon.SinonSpy };
+            trueState: typeof trueStateNode;
+        };
+        node.trueState = trueStateNode;
+        node.falseState = undefined;
+        node.addReference = sinon.spy();
+        node.id = { setValueFromSource: sinon.spy() };
+        node._postInitialize = sinon.spy();
+
+        node.initialize({
+            falseState: "Disabled",
+            trueState: "Enabled",
+            value: false
+        });
+
+        trueStateNode.setValueFromSource.calledOnce.should.eql(true);
+        node.getTrueState().text?.should.eql("Enabled");
+        node.getFalseState().text?.should.eql("Disabled");
+        node._falseState.should.eql("Disabled");
     });
 
     it("should add a TwoStateVariableType with transitionTime", function (this: any) {


### PR DESCRIPTION
### Summary
This PR fixes the fallback state text initialization for `UATwoStateVariable`. When a `TrueState` or `FalseState` property is not exposed, the implementation stores the configured text in internal fallback fields and later uses them from `getTrueState()` and `getFalseState()`. The current code writes these fallback values to the wrong internal fields.

### Bug
`initialize()` currently assigns the fallback text for a missing `FalseState` property to `_trueState`, and the fallback text for a missing `TrueState` property to `_falseState`.

As a result, instances with only one exposed state property can return the wrong human-readable state text when the missing side is resolved through the internal fallback path.

### Changes
- Assign the fallback `trueState` text to `_trueState`
- Assign the fallback `falseState` text to `_falseState`
- Add a regression test covering the case where only one state property is exposed
