### PR TITLE
fix(server): drop oldest retransmission entry on overflow

### DIFF
--- a/packages/node-opcua-server/source/server_subscription.ts
+++ b/packages/node-opcua-server/source/server_subscription.ts
@@ -1851,9 +1851,12 @@ export class Subscription extends EventEmitter {
         // case of a retransmission queue overflow, the oldest sent NotificationMessage gets deleted. If a
         // Subscription is transferred to another Session, the queued NotificationMessages for this
         // Subscription are moved from the old to the new Session.
-        if (maxNotificationMessagesInQueue <= this._sent_notification_messages.length) {
+        if (maxNotificationMessagesInQueue < this._sent_notification_messages.length) {
             doDebug && debugLog("discardOldSentNotifications = ", this._sent_notification_messages.length);
-            this._sent_notification_messages.splice(this._sent_notification_messages.length - maxNotificationMessagesInQueue);
+            this._sent_notification_messages.splice(
+                0,
+                this._sent_notification_messages.length - maxNotificationMessagesInQueue
+            );
         }
     }
 

--- a/packages/node-opcua-server/test/test_subscription.ts
+++ b/packages/node-opcua-server/test/test_subscription.ts
@@ -983,6 +983,44 @@ describe("Subscriptions", function (this: any) {
             // TODO
         });
 
+        it("should drop the oldest sent NotificationMessage when the retransmission queue overflows", () => {
+            const subscription = makeSubscription({
+                id: 1234,
+                publishingInterval: 1000,
+                lifeTimeCount: 1000,
+                maxKeepAliveCount: 20,
+                publishEngine: fake_publish_engine,
+                globalCounter: { totalMonitoredItemCount: 0 },
+                serverCapabilities: { maxMonitoredItems: 10000, maxMonitoredItemsPerSubscription: 1000 }
+            });
+
+            (subscription as any)._sent_notification_messages = Array.from({ length: 100 }, (_, index) => ({
+                sequenceNumber: index + 1
+            }));
+
+            subscription.sentNotificationMessageCount.should.equal(100);
+            (subscription as any).discardOldSentNotifications();
+            subscription.sentNotificationMessageCount.should.equal(100);
+            ((subscription as any)._sent_notification_messages[0].sequenceNumber as number).should.equal(1);
+
+            (subscription as any)._sent_notification_messages.push({
+                sequenceNumber: 101
+            });
+
+            subscription.sentNotificationMessageCount.should.equal(101);
+            (subscription as any).discardOldSentNotifications();
+            subscription.sentNotificationMessageCount.should.equal(100);
+
+            const availableSequenceNumbers = subscription.getAvailableSequenceNumbers();
+            availableSequenceNumbers[0].should.equal(2);
+            availableSequenceNumbers[availableSequenceNumbers.length - 1].should.equal(101);
+            should(subscription.getMessageForSequenceNumber(1)).eql(null);
+            should(subscription.getMessageForSequenceNumber(101)).not.eql(null);
+
+            subscription.terminate();
+            subscription.dispose();
+        });
+
         // xit("T12-4 - 1.01 a NotificationMessage is retained until it has been in the queue for a minimum of one keep-alive interval.", function () {
         //     // this conforms to OPC UA specification 1.01 and is now obsolete as behavior has been changed in 1.02
 

--- a/packages/node-opcua-server/test/test_subscription.ts
+++ b/packages/node-opcua-server/test/test_subscription.ts
@@ -52,6 +52,11 @@ interface SubscriptionInternal extends Subscription {
     dispose: () => void;
 }
 
+interface ISubscriptionPrivate {
+    _sent_notification_messages: Array<{ sequenceNumber: number }>;
+    discardOldSentNotifications(): void;
+}
+
 function makeSubscription(options: SubscriptionOptions): SubscriptionInternal {
     const subscription1 = new Subscription(options);
     (subscription1 as any).$session = {
@@ -994,21 +999,27 @@ describe("Subscriptions", function (this: any) {
                 serverCapabilities: { maxMonitoredItems: 10000, maxMonitoredItemsPerSubscription: 1000 }
             });
 
-            (subscription as any)._sent_notification_messages = Array.from({ length: 100 }, (_, index) => ({
+            const subscriptionInternal = subscription as unknown as ISubscriptionPrivate;
+
+            should(subscriptionInternal).have.property("_sent_notification_messages");
+            subscriptionInternal._sent_notification_messages.should.be.instanceOf(Array);
+            should(subscriptionInternal.discardOldSentNotifications).be.instanceOf(Function);
+
+            subscriptionInternal._sent_notification_messages = Array.from({ length: 100 }, (_, index) => ({
                 sequenceNumber: index + 1
             }));
 
             subscription.sentNotificationMessageCount.should.equal(100);
-            (subscription as any).discardOldSentNotifications();
+            subscriptionInternal.discardOldSentNotifications();
             subscription.sentNotificationMessageCount.should.equal(100);
-            ((subscription as any)._sent_notification_messages[0].sequenceNumber as number).should.equal(1);
+            subscriptionInternal._sent_notification_messages[0].sequenceNumber.should.equal(1);
 
-            (subscription as any)._sent_notification_messages.push({
+            subscriptionInternal._sent_notification_messages.push({
                 sequenceNumber: 101
             });
 
             subscription.sentNotificationMessageCount.should.equal(101);
-            (subscription as any).discardOldSentNotifications();
+            subscriptionInternal.discardOldSentNotifications();
             subscription.sentNotificationMessageCount.should.equal(100);
 
             const availableSequenceNumbers = subscription.getAvailableSequenceNumbers();


### PR DESCRIPTION
### Summary
This PR fixes retransmission queue overflow handling for sent `NotificationMessage`.

OPC UA Part 4 says that when a retransmission queue overflows, the oldest sent `NotificationMessage` gets deleted. The current implementation trims the queue from the wrong side and can remove newer messages instead of the oldest retained one.

### Bug
`discardOldSentNotifications()` currently uses `splice(length - maxNotificationMessagesInQueue)` once the queue reaches its limit. That does not remove the oldest sent message. Instead, it starts deleting entries from the tail of the array, which is where newer sent notifications are stored.

### Changes
- Only trim the retransmission queue when it actually exceeds the configured maximum
- Remove the excess entries from the head of the queue so that the oldest sent messages are discarded first
- Add a regression test covering the overflow case and verifying that newer sequence numbers remain available
