### PR TITLE
fix(server): use typed access for serverDiagnosticsEnabled default

### DIFF
--- a/packages/node-opcua-server/source/server_engine.ts
+++ b/packages/node-opcua-server/source/server_engine.ts
@@ -507,11 +507,10 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
             this._applicationUri = options.applicationUri || "<unset _applicationUri>";
         }
 
-        options.serverDiagnosticsEnabled = Object.hasOwn(options, "serverDiagnosticsEnable")
-            ? options.serverDiagnosticsEnabled
-            : true;
+        options.serverDiagnosticsEnabled =
+            options.serverDiagnosticsEnabled == undefined ? true : options.serverDiagnosticsEnabled;
 
-        this.serverDiagnosticsEnabled = options.serverDiagnosticsEnabled || false;
+        this.serverDiagnosticsEnabled = options.serverDiagnosticsEnabled;
     }
     public isStarted(): boolean {
         return !!this._serverStatus;


### PR DESCRIPTION
Use typed property access when initializing serverDiagnosticsEnabled so the declared option name is honored and misspellings are not hidden by string-based checks.