### PR TITLE
 feat(role-set): pluggable password hashing (scrypt + bcrypt), async credentials

### DIFF
--- a/documentation/role_based_security.md
+++ b/documentation/role_based_security.md
@@ -75,8 +75,8 @@ import { createRoleBasedSecurity } from "node-opcua-role-set-server";
 
 async function main() {
     // 1. Build the shared stores and the userManager bridge.
-    // Seeds initial users and maps them to standard Roles.
-    const security = createRoleBasedSecurity({
+    // Seeds initial users and maps them to standard Roles (async — hashes seeds).
+    const security = await createRoleBasedSecurity({
         policy: { minLength: 8, requireDigit: true },
         users: [
             {
@@ -131,11 +131,15 @@ Creates the user and identity mapping stores, builds the `userManager` bridge, a
     * `requireSpecialCharacters?: boolean`
   * `users?: RoleBasedUser[]`: List of users to seed.
     * `userName: string`
-    * `password: string`
+    * `password?: string`: clear-text seed (hashed with scrypt), **or**
+    * `passwordHash?: SerializedUserRecord`: a pre-hashed credential record (from
+      `serializeUser` / `credentialRecord`), so no clear text lives in config.
     * `roles?: NodeId[]`
     * `userConfiguration?: UserConfigurationMask`
     * `description?: string`
-* **Returns**: `RoleBasedSecurity`
+  * `registry?: HasherRegistry`: override the password-hashing schemes (default:
+    scrypt hashes, bcrypt verifies legacy credentials and upgrades on login).
+* **Returns**: `Promise<RoleBasedSecurity>` (async — seed passwords are hashed)
   * `userStore: InMemoryUserManagementStore`
   * `identityStore: InMemoryIdentityMappingStore`
   * `userManager: IManagedUserManager`

--- a/packages/node-opcua-role-set-common/README.md
+++ b/packages/node-opcua-role-set-common/README.md
@@ -28,6 +28,9 @@ $ npm install node-opcua-role-set-common
 | `WellKnownRoleIds` | Pre-built `NodeId` objects for each well-known role. |
 | `saveToBinaryFile` / `loadFromBinaryFile` | Persist / restore a store to / from a binary file. |
 | `encodeIdentityStore` / `decodeIdentityStore` / `identityStoreBinaryStoreSize` | Lower-level binary (de)serialization helpers. |
+| `InMemoryUserManagementStore` | Local user list + password lifecycle (OPC 10000-18 §5). |
+| `serializeUser` / `credentialRecord` | Build a persisted user record offline (scrypt hash, or wrap an existing credential) — no clear text at rest. |
+| `PasswordHasher` / `HasherRegistry` / `ScryptHasher` / `BcryptHasher` / `defaultHasherRegistry` | Pluggable password hashing (scrypt default; bcrypt coexists). |
 
 ## The identity mapping store
 
@@ -95,6 +98,51 @@ WellKnownRoleIds.Supervisor;
 WellKnownRoleIds.ConfigureAdmin;
 WellKnownRoleIds.SecurityAdmin;
 ```
+
+## Users & password hashing
+
+`InMemoryUserManagementStore` keeps the local user list and implements the
+AddUser / ModifyUser / RemoveUser / ChangePassword behaviour (§5.2), the password
+policy, and `authenticate`. **Passwords are never stored in clear**: each user
+holds a single self-describing **PHC credential string**, so multiple hashing
+schemes coexist and are told apart by prefix:
+
+```
+scrypt:  $scrypt$ln=14,r=8,p=1$<b64 salt>$<b64 hash>     (default — Node core, no extra dependency)
+bcrypt:  $2b$10$<salt><hash>                             (verified for interop/migration)
+```
+
+New and changed passwords are hashed with **scrypt**. A legacy **bcrypt**
+credential still verifies and is transparently re-hashed to scrypt on the next
+successful login (*upgrade-on-login*, driven by `HasherRegistry.needsRehash`).
+Inject a custom `HasherRegistry` to add schemes (e.g. an external verifier).
+
+> Credential operations (`authenticate` / `addUser` / `changePassword` /
+> `modifyUser`) are **async** so an external verifier can be plugged in.
+
+### Seeding without clear text
+
+Generate a persisted record **offline** and commit that instead of a password:
+
+```ts
+import { InMemoryUserManagementStore, serializeUser, credentialRecord } from "node-opcua-role-set-common";
+import { UserConfigurationMask } from "node-opcua-types";
+
+// scrypt record from a clear password (run once at deploy time)
+const rec = await serializeUser("admin", "admin-pw1", { userConfiguration: UserConfigurationMask.None });
+
+// or wrap an already-hashed credential you hold (e.g. a legacy bcrypt hash)
+const legacy = credentialRecord("legacy", "$2b$10$……");
+
+const store = new InMemoryUserManagementStore();
+store.importUsers([rec, legacy]);          // no clear text involved
+await store.authenticate("admin", "admin-pw1"); // -> Good
+```
+
+`serializeUser` / `exportUsers` records are interchangeable and, together with
+`importUsers`, back the consolidated archive (see below). Records written by an
+older release (raw `{salt, hash}`, archive **v1**) are migrated to a `$scrypt$`
+credential on read — **no forced password resets**.
 
 ## Persistence
 

--- a/packages/node-opcua-role-set-common/package.json
+++ b/packages/node-opcua-role-set-common/package.json
@@ -16,7 +16,7 @@
         "npm": ">=10.x"
     },
     "dependencies": {
-        "bcryptjs": "^3.0.3",
+        "bcryptjs": "3.0.3",
         "node-opcua-basic-types": "2.174.0",
         "node-opcua-binary-stream": "2.173.0",
         "node-opcua-constants": "2.174.0",

--- a/packages/node-opcua-role-set-common/package.json
+++ b/packages/node-opcua-role-set-common/package.json
@@ -16,6 +16,7 @@
         "npm": ">=10.x"
     },
     "dependencies": {
+        "bcryptjs": "^3.0.3",
         "node-opcua-basic-types": "2.174.0",
         "node-opcua-binary-stream": "2.173.0",
         "node-opcua-constants": "2.174.0",

--- a/packages/node-opcua-role-set-common/source/archive.ts
+++ b/packages/node-opcua-role-set-common/source/archive.ts
@@ -25,9 +25,15 @@ import { BinaryStream } from "node-opcua-binary-stream";
 import { decodeIdentityStore, encodeIdentityStore, identityStoreBinaryStoreSize } from "./binary_persistence.js";
 import type { IIdentityMappingStore } from "./identity_mapping_store.js";
 import type { SerializedRoleRestriction } from "./role_restriction_store.js";
-import type { SerializedUserRecord } from "./user_management_store.js";
+import type { LegacySerializedUserRecord, SerializedUserRecord } from "./user_management_store.js";
 
-export const ROLE_SET_ARCHIVE_VERSION = 1;
+/**
+ * v1: users stored as raw scrypt `{salt, hash}`.
+ * v2: users stored as a self-describing PHC `credential` string (scrypt/bcrypt/…).
+ * v1 archives are still read (records are migrated on import); v2 archives are
+ * rejected by a v1 reader via the version check.
+ */
+export const ROLE_SET_ARCHIVE_VERSION = 2;
 
 /** Persisted definition of a custom Role (so its GUID NodeId survives a restart). */
 export interface PersistedCustomRole {
@@ -43,8 +49,12 @@ export interface RoleSetArchive {
     identities?: string;
     roles?: PersistedCustomRole[];
     restrictions?: SerializedRoleRestriction[];
-    /** UserManagement users with salted scrypt hashes (never clear passwords). */
-    users?: SerializedUserRecord[];
+    /**
+     * UserManagement users, credentials only (never clear passwords). v2 writes
+     * PHC {@link SerializedUserRecord}s; v1 archives are read as
+     * {@link LegacySerializedUserRecord}s and migrated on import.
+     */
+    users?: (SerializedUserRecord | LegacySerializedUserRecord)[];
 }
 
 /** Encode the identity store as a base64 string (reuses the binary encoder). */

--- a/packages/node-opcua-role-set-common/source/index.ts
+++ b/packages/node-opcua-role-set-common/source/index.ts
@@ -23,6 +23,14 @@ export {
 export type { AnyUserIdentityToken, IIdentityMappingStore } from "./identity_mapping_store.js";
 export { InMemoryIdentityMappingStore } from "./in_memory_store.js";
 export {
+    BcryptHasher,
+    defaultHasherRegistry,
+    HasherRegistry,
+    type PasswordHasher,
+    ScryptHasher,
+    scryptPhc
+} from "./password_hasher.js";
+export {
     applicationComplies,
     deserializeRestrictions,
     type EndpointCriteria,
@@ -37,11 +45,14 @@ export {
 } from "./role_restriction_store.js";
 export {
     type AuthenticationResult,
+    credentialRecord,
     InMemoryUserManagementStore,
     type IUserManagementStore,
+    type LegacySerializedUserRecord,
     type ModifyUserOptions,
     type PasswordPolicy,
     type SerializedUserRecord,
+    serializeUser,
     type UserRecord
 } from "./user_management_store.js";
 export { WellKnownRoleIds, WellKnownRoles } from "./well_known_role_ids.js";

--- a/packages/node-opcua-role-set-common/source/index.ts
+++ b/packages/node-opcua-role-set-common/source/index.ts
@@ -53,7 +53,8 @@ export {
     type PasswordPolicy,
     type SerializedUserRecord,
     serializeUser,
-    type UserRecord
+    type UserRecord,
+    validateUserConfiguration
 } from "./user_management_store.js";
 export { WellKnownRoleIds, WellKnownRoles } from "./well_known_role_ids.js";
 export {

--- a/packages/node-opcua-role-set-common/source/password_hasher.ts
+++ b/packages/node-opcua-role-set-common/source/password_hasher.ts
@@ -1,0 +1,183 @@
+/**
+ * @module node-opcua-role-set-common
+ *
+ * Pluggable password hashing (OPC 10000-18 §5 credentials).
+ *
+ * Each stored credential is a single self-describing **PHC / modular-crypt
+ * string** so multiple schemes can coexist and be told apart by prefix:
+ *
+ * ```
+ * scrypt:  $scrypt$ln=<log2N>,r=<r>,p=<p>$<b64 salt>$<b64 hash>
+ * bcrypt:  $2b$<cost>$<22-char salt><31-char hash>       (bcrypt's native format)
+ * ```
+ *
+ * A {@link HasherRegistry} verifies a credential by routing on its prefix and
+ * always *hashes* new credentials with the configured default (scrypt — Node
+ * core, zero extra dependency). Because non-default schemes report
+ * {@link PasswordHasher.needsRehash}=true, a store can transparently migrate a
+ * legacy credential to the default algorithm on the next successful login
+ * ("upgrade-on-login"). Additional schemes (bcrypt today, LDAP/argon2 later)
+ * are just more {@link PasswordHasher}s in the registry.
+ */
+import { randomBytes, scryptSync, timingSafeEqual } from "node:crypto";
+import bcrypt from "bcryptjs";
+
+/** A single password-hashing scheme. All operations are async (LDAP/argon2-ready). */
+export interface PasswordHasher {
+    /** Canonical scheme id, e.g. `"scrypt"`, `"bcrypt"`. */
+    readonly id: string;
+    /** PHC prefixes this hasher verifies, e.g. `["$scrypt$"]` or `["$2a$", "$2b$", "$2y$"]`. */
+    readonly prefixes: readonly string[];
+    /** Hash a clear-text password into a full PHC string. */
+    hash(password: string): Promise<string>;
+    /** Verify a clear-text password against a PHC string produced by this scheme. */
+    verify(password: string, phc: string): Promise<boolean>;
+    /** True when a credential should be re-hashed after a successful login (e.g. cost drifted). */
+    needsRehash?(phc: string): boolean;
+}
+
+// ---------------------------------------------------------------------------
+// scrypt (default — Node core, no extra dependency)
+// ---------------------------------------------------------------------------
+
+const SCRYPT_N = 16384; // ln = 14
+const SCRYPT_R = 8;
+const SCRYPT_P = 1;
+const SCRYPT_KEYLEN = 64;
+const SCRYPT_SALT_BYTES = 16;
+const SCRYPT_LN = Math.log2(SCRYPT_N);
+
+interface ParsedScrypt {
+    ln: number;
+    r: number;
+    p: number;
+    salt: Buffer;
+    hash: Buffer;
+}
+
+/** Build the canonical scrypt PHC string from a base64 salt + hash. */
+export function scryptPhc(saltB64: string, hashB64: string, params?: { ln?: number; r?: number; p?: number }): string {
+    const ln = params?.ln ?? SCRYPT_LN;
+    const r = params?.r ?? SCRYPT_R;
+    const p = params?.p ?? SCRYPT_P;
+    return `$scrypt$ln=${ln},r=${r},p=${p}$${saltB64}$${hashB64}`;
+}
+
+function parseScrypt(phc: string): ParsedScrypt | null {
+    // $scrypt$ln=14,r=8,p=1$<salt>$<hash>
+    const m = /^\$scrypt\$ln=(\d+),r=(\d+),p=(\d+)\$([^$]+)\$([^$]+)$/.exec(phc);
+    if (!m) return null;
+    return {
+        ln: Number(m[1]),
+        r: Number(m[2]),
+        p: Number(m[3]),
+        salt: Buffer.from(m[4], "base64"),
+        hash: Buffer.from(m[5], "base64")
+    };
+}
+
+export class ScryptHasher implements PasswordHasher {
+    public readonly id = "scrypt";
+    public readonly prefixes = ["$scrypt$"] as const;
+
+    public async hash(password: string): Promise<string> {
+        const salt = randomBytes(SCRYPT_SALT_BYTES);
+        const hash = scryptSync(password, salt, SCRYPT_KEYLEN, { N: SCRYPT_N, r: SCRYPT_R, p: SCRYPT_P });
+        return scryptPhc(salt.toString("base64"), hash.toString("base64"));
+    }
+
+    public async verify(password: string, phc: string): Promise<boolean> {
+        const parsed = parseScrypt(phc);
+        if (!parsed) return false;
+        const candidate = scryptSync(password, parsed.salt, parsed.hash.length, {
+            N: 2 ** parsed.ln,
+            r: parsed.r,
+            p: parsed.p
+        });
+        return candidate.length === parsed.hash.length && timingSafeEqual(candidate, parsed.hash);
+    }
+
+    public needsRehash(phc: string): boolean {
+        const parsed = parseScrypt(phc);
+        // Re-hash if unparsable or the work factors drifted below the current defaults.
+        return !parsed || parsed.ln !== SCRYPT_LN || parsed.r !== SCRYPT_R || parsed.p !== SCRYPT_P;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// bcrypt (verify-only default: migrated to scrypt on next login)
+// ---------------------------------------------------------------------------
+
+export class BcryptHasher implements PasswordHasher {
+    public readonly id = "bcrypt";
+    public readonly prefixes = ["$2a$", "$2b$", "$2y$"] as const;
+
+    public constructor(private readonly _cost = 10) {}
+
+    public async hash(password: string): Promise<string> {
+        return bcrypt.hash(password, this._cost);
+    }
+
+    public async verify(password: string, phc: string): Promise<boolean> {
+        return bcrypt.compare(password, phc);
+    }
+
+    // bcrypt is only kept for interop/migration — always upgrade to the default.
+    public needsRehash(): boolean {
+        return true;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Registry — hash with the default, verify by routing on the PHC prefix
+// ---------------------------------------------------------------------------
+
+export class HasherRegistry {
+    private readonly _all: PasswordHasher[];
+
+    public constructor(
+        private readonly _default: PasswordHasher,
+        others: readonly PasswordHasher[] = []
+    ) {
+        this._all = [_default, ...others];
+    }
+
+    public get defaultId(): string {
+        return this._default.id;
+    }
+
+    /** Hash a new/changed password with the configured default scheme. */
+    public hash(password: string): Promise<string> {
+        return this._default.hash(password);
+    }
+
+    /** Verify against whichever registered scheme owns the credential's prefix. */
+    public async verify(password: string, phc: string): Promise<boolean> {
+        const hasher = this._find(phc);
+        return hasher ? hasher.verify(password, phc) : false;
+    }
+
+    /**
+     * True when the credential should be re-hashed with the default after a
+     * successful login: a different scheme than the default, or the same scheme
+     * reporting drifted parameters.
+     */
+    public needsRehash(phc: string): boolean {
+        const hasher = this._find(phc);
+        if (!hasher) return false;
+        if (hasher !== this._default) return true;
+        return hasher.needsRehash ? hasher.needsRehash(phc) : false;
+    }
+
+    private _find(phc: string): PasswordHasher | undefined {
+        return this._all.find((h) => h.prefixes.some((prefix) => phc.startsWith(prefix)));
+    }
+}
+
+/**
+ * Default registry: **scrypt** hashes and verifies (Node core), **bcrypt**
+ * verifies legacy credentials and is upgraded to scrypt on next login.
+ */
+export function defaultHasherRegistry(): HasherRegistry {
+    return new HasherRegistry(new ScryptHasher(), [new BcryptHasher()]);
+}

--- a/packages/node-opcua-role-set-common/source/password_hasher.ts
+++ b/packages/node-opcua-role-set-common/source/password_hasher.ts
@@ -47,6 +47,15 @@ const SCRYPT_KEYLEN = 64;
 const SCRYPT_SALT_BYTES = 16;
 const SCRYPT_LN = Math.log2(SCRYPT_N);
 
+// Upper bounds on the work factors accepted from a stored credential string.
+// A tampered/poisoned credential (e.g. an edited archive) must not be able to
+// set huge parameters and cause resource exhaustion during login, so anything
+// out of range is rejected (parseScrypt returns null → verify() fails closed).
+// The default (ln=14, r=8, p=1) sits comfortably below these limits.
+const SCRYPT_LN_MAX = 20; // N = 2^20 (~1M) — beyond any legitimate configuration here
+const SCRYPT_R_MAX = 32;
+const SCRYPT_P_MAX = 16;
+
 interface ParsedScrypt {
     ln: number;
     r: number;
@@ -67,10 +76,18 @@ function parseScrypt(phc: string): ParsedScrypt | null {
     // $scrypt$ln=14,r=8,p=1$<salt>$<hash>
     const m = /^\$scrypt\$ln=(\d+),r=(\d+),p=(\d+)\$([^$]+)\$([^$]+)$/.exec(phc);
     if (!m) return null;
+    const ln = Number(m[1]);
+    const r = Number(m[2]);
+    const p = Number(m[3]);
+    // Reject out-of-range work factors so a tampered credential can't force an
+    // absurd scryptSync cost. Fails closed: verify() treats null as "no match".
+    if (ln < 1 || ln > SCRYPT_LN_MAX || r < 1 || r > SCRYPT_R_MAX || p < 1 || p > SCRYPT_P_MAX) {
+        return null;
+    }
     return {
-        ln: Number(m[1]),
-        r: Number(m[2]),
-        p: Number(m[3]),
+        ln,
+        r,
+        p,
         salt: Buffer.from(m[4], "base64"),
         hash: Buffer.from(m[5], "base64")
     };

--- a/packages/node-opcua-role-set-common/source/user_management_store.ts
+++ b/packages/node-opcua-role-set-common/source/user_management_store.ts
@@ -360,7 +360,7 @@ export class InMemoryUserManagementStore implements IUserManagementStore {
  *
  * @returns a `Bad_ConfigurationError` StatusCode, or `null` if valid.
  */
-function validateUserConfiguration(mask: UserConfigurationMask): StatusCode | null {
+export function validateUserConfiguration(mask: UserConfigurationMask): StatusCode | null {
     if (has(mask, UserConfigurationMask.MustChangePassword) && has(mask, UserConfigurationMask.NoChangeByUser)) {
         return StatusCodes.BadConfigurationError;
     }

--- a/packages/node-opcua-role-set-common/source/user_management_store.ts
+++ b/packages/node-opcua-role-set-common/source/user_management_store.ts
@@ -6,12 +6,16 @@
  *
  * The store implements the behaviour of the AddUser / ModifyUser / RemoveUser
  * / ChangePassword Methods and the password policy (PasswordLength range and
- * the password-option requirements). Passwords are never stored in clear:
- * each is salted and hashed with scrypt.
+ * the password-option requirements). Passwords are never stored in clear: each
+ * is kept as a self-describing PHC credential string (scrypt by default; other
+ * schemes such as bcrypt coexist and are migrated on login — see
+ * {@link HasherRegistry}). Credential operations are **async** so an external
+ * verifier (LDAP/argon2) can be plugged in without another interface change.
  */
-import { randomBytes, scryptSync, timingSafeEqual } from "node:crypto";
 import { type StatusCode, StatusCodes } from "node-opcua-status-code";
 import { UserConfigurationMask } from "node-opcua-types";
+
+import { defaultHasherRegistry, type HasherRegistry, ScryptHasher, scryptPhc } from "./password_hasher.js";
 
 /**
  * Password requirements (OPC 10000-18 §5.2.1-2: PasswordLength range and
@@ -34,10 +38,25 @@ export interface UserRecord {
 }
 
 /**
- * Persisted user record — includes the salted scrypt hash (base64), never the
- * clear password. Suitable for storing in the consolidated archive.
+ * Persisted user record (archive v2) — the credential is a self-describing PHC
+ * string (e.g. `$scrypt$…` / `$2b$…`), never a clear password. Suitable for
+ * storing in the consolidated archive.
  */
 export interface SerializedUserRecord {
+    userName: string;
+    /** PHC / modular-crypt credential string (scheme self-described by its prefix). */
+    credential: string;
+    userConfiguration: UserConfigurationMask;
+    description: string;
+}
+
+/**
+ * Legacy (archive v1) persisted record — raw scrypt `salt`+`hash` (base64).
+ * Accepted by {@link IUserManagementStore.importUsers} and read-migrated to a
+ * `$scrypt$…` {@link SerializedUserRecord} credential, so old archives keep
+ * working with **no forced password resets**.
+ */
+export interface LegacySerializedUserRecord {
     userName: string;
     salt: string; // base64
     hash: string; // base64
@@ -63,28 +82,84 @@ export interface ModifyUserOptions {
 }
 
 export interface IUserManagementStore {
-    addUser(userName: string, password: string, userConfiguration: UserConfigurationMask, description: string): StatusCode;
-    modifyUser(userName: string, options: ModifyUserOptions, callerUserName?: string): StatusCode;
+    addUser(userName: string, password: string, userConfiguration: UserConfigurationMask, description: string): Promise<StatusCode>;
+    modifyUser(userName: string, options: ModifyUserOptions, callerUserName?: string): Promise<StatusCode>;
     removeUser(userName: string, callerUserName?: string): StatusCode;
-    changePassword(userName: string, oldPassword: string, newPassword: string): StatusCode;
-    authenticate(userName: string, password: string): AuthenticationResult;
+    changePassword(userName: string, oldPassword: string, newPassword: string): Promise<StatusCode>;
+    authenticate(userName: string, password: string): Promise<AuthenticationResult>;
     getUsers(): UserRecord[];
     hasUser(userName: string): boolean;
-    /** Export every user (with salted hash) for persistence. Optional: only stores that support persistence. */
+    /** Export every user (with its PHC credential) for persistence. Optional: only stores that support persistence. */
     exportUsers?(): SerializedUserRecord[];
-    /** Load persisted users (with salted hash), replacing any existing entry of the same name. */
-    importUsers?(records: SerializedUserRecord[]): void;
+    /** Load persisted users (v2 credential or legacy v1 salt+hash), replacing any existing entry of the same name. */
+    importUsers?(records: readonly (SerializedUserRecord | LegacySerializedUserRecord)[]): void;
+    /**
+     * Optional: register a callback fired when a credential is transparently
+     * re-hashed during {@link authenticate} (upgrade-on-login), so a persistence
+     * layer can flush the new hash.
+     */
+    setOnCredentialUpgraded?(fn: (userName: string) => void): void;
 }
 
 interface InternalUser {
     userName: string;
-    salt: Buffer;
-    hash: Buffer;
+    /** PHC credential string. */
+    credential: string;
     userConfiguration: UserConfigurationMask;
     description: string;
 }
 
 const has = (mask: UserConfigurationMask, bit: UserConfigurationMask): boolean => (mask & bit) === bit;
+
+/** A record is legacy (v1) when it carries raw `salt`+`hash` instead of a `credential`. */
+function isLegacyRecord(r: SerializedUserRecord | LegacySerializedUserRecord): r is LegacySerializedUserRecord {
+    return typeof (r as SerializedUserRecord).credential !== "string";
+}
+
+/** Shared default scrypt hasher used by the offline {@link serializeUser} helper. */
+const offlineScrypt = new ScryptHasher();
+
+/**
+ * Produce a {@link SerializedUserRecord} (scrypt PHC credential) from a
+ * clear-text password — **offline**, without a store.
+ *
+ * Use this to keep clear-text passwords out of version control / config: run it
+ * once at deploy time and commit only the returned record, then seed it through
+ * `importUsers` (or `createRoleBasedSecurity`'s `passwordHash`). The record is
+ * interchangeable with what {@link InMemoryUserManagementStore.exportUsers}
+ * produces, so `authenticate` accepts the original clear-text password.
+ */
+export async function serializeUser(
+    userName: string,
+    password: string,
+    options?: { userConfiguration?: UserConfigurationMask; description?: string }
+): Promise<SerializedUserRecord> {
+    return {
+        userName,
+        credential: await offlineScrypt.hash(password),
+        userConfiguration: options?.userConfiguration ?? UserConfigurationMask.None,
+        description: options?.description ?? ""
+    };
+}
+
+/**
+ * Wrap an **already-hashed** PHC credential string (e.g. a legacy `$2b$…`
+ * bcrypt hash) into a {@link SerializedUserRecord} — no clear text, no
+ * re-hashing. The credential is verified by whichever registered scheme owns
+ * its prefix, and (for non-default schemes) upgraded on next login.
+ */
+export function credentialRecord(
+    userName: string,
+    credential: string,
+    options?: { userConfiguration?: UserConfigurationMask; description?: string }
+): SerializedUserRecord {
+    return {
+        userName,
+        credential,
+        userConfiguration: options?.userConfiguration ?? UserConfigurationMask.None,
+        description: options?.description ?? ""
+    };
+}
 
 /**
  * In-memory implementation of {@link IUserManagementStore}.
@@ -94,13 +169,20 @@ const has = (mask: UserConfigurationMask, bit: UserConfigurationMask): boolean =
 export class InMemoryUserManagementStore implements IUserManagementStore {
     private readonly _users = new Map<string, InternalUser>();
     private readonly _policy: PasswordPolicy;
+    private readonly _registry: HasherRegistry;
+    private _onCredentialUpgraded?: (userName: string) => void;
 
-    constructor(policy?: PasswordPolicy) {
+    constructor(policy?: PasswordPolicy, options?: { registry?: HasherRegistry }) {
         this._policy = policy ?? {};
+        this._registry = options?.registry ?? defaultHasherRegistry();
     }
 
     public get policy(): PasswordPolicy {
         return this._policy;
+    }
+
+    public setOnCredentialUpgraded(fn: (userName: string) => void): void {
+        this._onCredentialUpgraded = fn;
     }
 
     public hasUser(userName: string): boolean {
@@ -118,26 +200,32 @@ export class InMemoryUserManagementStore implements IUserManagementStore {
     public exportUsers(): SerializedUserRecord[] {
         return [...this._users.values()].map((u) => ({
             userName: u.userName,
-            salt: u.salt.toString("base64"),
-            hash: u.hash.toString("base64"),
+            credential: u.credential,
             userConfiguration: u.userConfiguration,
             description: u.description
         }));
     }
 
-    public importUsers(records: SerializedUserRecord[]): void {
+    public importUsers(records: readonly (SerializedUserRecord | LegacySerializedUserRecord)[]): void {
         for (const r of records) {
+            // v1 archives stored raw scrypt salt+hash — migrate to a $scrypt$ PHC
+            // credential on read (lossless: same algorithm and parameters).
+            const credential = isLegacyRecord(r) ? scryptPhc(r.salt, r.hash) : r.credential;
             this._users.set(r.userName, {
                 userName: r.userName,
-                salt: Buffer.from(r.salt, "base64"),
-                hash: Buffer.from(r.hash, "base64"),
+                credential,
                 userConfiguration: r.userConfiguration,
                 description: r.description
             });
         }
     }
 
-    public addUser(userName: string, password: string, userConfiguration: UserConfigurationMask, description: string): StatusCode {
+    public async addUser(
+        userName: string,
+        password: string,
+        userConfiguration: UserConfigurationMask,
+        description: string
+    ): Promise<StatusCode> {
         if (this._users.has(userName)) {
             return StatusCodes.BadAlreadyExists;
         }
@@ -148,11 +236,12 @@ export class InMemoryUserManagementStore implements IUserManagementStore {
         if (!this.isPasswordValid(password)) {
             return StatusCodes.BadOutOfRange;
         }
-        this._users.set(userName, { userName, ...this.hashPassword(password), userConfiguration, description });
+        const credential = await this._registry.hash(password);
+        this._users.set(userName, { userName, credential, userConfiguration, description });
         return StatusCodes.Good;
     }
 
-    public modifyUser(userName: string, options: ModifyUserOptions, callerUserName?: string): StatusCode {
+    public async modifyUser(userName: string, options: ModifyUserOptions, callerUserName?: string): Promise<StatusCode> {
         const user = this._users.get(userName);
         if (!user) {
             return StatusCodes.BadNotFound;
@@ -181,9 +270,7 @@ export class InMemoryUserManagementStore implements IUserManagementStore {
 
         // All checks passed — apply the changes
         if (options.modifyPassword) {
-            const { salt, hash } = this.hashPassword(options.password ?? "");
-            user.salt = salt;
-            user.hash = hash;
+            user.credential = await this._registry.hash(options.password ?? "");
         }
         if (options.modifyUserConfiguration) {
             user.userConfiguration = nextConfig;
@@ -209,7 +296,7 @@ export class InMemoryUserManagementStore implements IUserManagementStore {
         return StatusCodes.Good;
     }
 
-    public changePassword(userName: string, oldPassword: string, newPassword: string): StatusCode {
+    public async changePassword(userName: string, oldPassword: string, newPassword: string): Promise<StatusCode> {
         const user = this._users.get(userName);
         // Unknown user is treated as an invalid old password (§5.2.8)
         if (!user) {
@@ -218,7 +305,7 @@ export class InMemoryUserManagementStore implements IUserManagementStore {
         if (has(user.userConfiguration, UserConfigurationMask.NoChangeByUser)) {
             return StatusCodes.BadNotSupported;
         }
-        if (!this.verify(user, oldPassword)) {
+        if (!(await this._registry.verify(oldPassword, user.credential))) {
             return StatusCodes.BadIdentityTokenInvalid;
         }
         if (oldPassword === newPassword) {
@@ -227,22 +314,26 @@ export class InMemoryUserManagementStore implements IUserManagementStore {
         if (!this.isPasswordValid(newPassword)) {
             return StatusCodes.BadOutOfRange;
         }
-        const { salt, hash } = this.hashPassword(newPassword);
-        user.salt = salt;
-        user.hash = hash;
+        user.credential = await this._registry.hash(newPassword);
         // A successful change clears the MustChangePassword flag (§5.2.8)
         user.userConfiguration &= ~UserConfigurationMask.MustChangePassword;
         return StatusCodes.Good;
     }
 
-    public authenticate(userName: string, password: string): AuthenticationResult {
+    public async authenticate(userName: string, password: string): Promise<AuthenticationResult> {
         const user = this._users.get(userName);
         // A disabled user behaves like a user that does not exist (§5.2.3)
         if (!user || has(user.userConfiguration, UserConfigurationMask.Disabled)) {
             return { statusCode: StatusCodes.BadUserAccessDenied, mustChangePassword: false };
         }
-        if (!this.verify(user, password)) {
+        if (!(await this._registry.verify(password, user.credential))) {
             return { statusCode: StatusCodes.BadUserAccessDenied, mustChangePassword: false };
+        }
+        // Upgrade-on-login: transparently re-hash a legacy/drifted credential with
+        // the default scheme (e.g. bcrypt → scrypt) now that we hold the clear text.
+        if (this._registry.needsRehash(user.credential)) {
+            user.credential = await this._registry.hash(password);
+            this._onCredentialUpgraded?.(userName);
         }
         if (has(user.userConfiguration, UserConfigurationMask.MustChangePassword)) {
             return { statusCode: StatusCodes.GoodPasswordChangeRequired, mustChangePassword: true };
@@ -260,17 +351,6 @@ export class InMemoryUserManagementStore implements IUserManagementStore {
         if (p.requireDigit && !/[0-9]/.test(password)) return false;
         if (p.requireSpecial && !/[^A-Za-z0-9]/.test(password)) return false;
         return true;
-    }
-
-    private hashPassword(password: string): { salt: Buffer; hash: Buffer } {
-        const salt = randomBytes(16);
-        const hash = scryptSync(password, salt, 64);
-        return { salt, hash };
-    }
-
-    private verify(user: InternalUser, password: string): boolean {
-        const candidate = scryptSync(password, user.salt, 64);
-        return candidate.length === user.hash.length && timingSafeEqual(candidate, user.hash);
     }
 }
 

--- a/packages/node-opcua-role-set-common/test/test_archive.ts
+++ b/packages/node-opcua-role-set-common/test/test_archive.ts
@@ -110,7 +110,7 @@ describe("RoleSet consolidated archive", () => {
                 new IdentityMappingRuleType({ criteriaType: IdentityCriteriaType.UserName, criteria: "joe" })
             );
             const users = new InMemoryUserManagementStore();
-            users.addUser("alice", "Sekret123!", UserConfigurationMask.None, "");
+            await users.addUser("alice", "Sekret123!", UserConfigurationMask.None, "");
 
             const store = new ArchiveStore(filePath);
             store.setIdentitiesProvider(() => identitiesToBase64(ids));
@@ -125,7 +125,7 @@ describe("RoleSet consolidated archive", () => {
             // the salted scrypt hash round-trips: the password still verifies
             const users2 = new InMemoryUserManagementStore();
             users2.importUsers(back?.users ?? []);
-            users2.authenticate("alice", "Sekret123!").statusCode.should.equal(StatusCodes.Good);
+            (await users2.authenticate("alice", "Sekret123!")).statusCode.should.equal(StatusCodes.Good);
         });
 
         it("preserves a section that has no provider yet (install-order independence)", async () => {
@@ -137,7 +137,7 @@ describe("RoleSet consolidated archive", () => {
 
             // a coordinator that ONLY knows about users (e.g. user mgmt installed first)
             const users = new InMemoryUserManagementStore();
-            users.addUser("carol", "Sekret123!", UserConfigurationMask.None, "");
+            await users.addUser("carol", "Sekret123!", UserConfigurationMask.None, "");
             const store = new ArchiveStore(filePath);
             await store.load(); // remembers the on-disk roles
             store.setUsersProvider(() => users.exportUsers());
@@ -151,7 +151,7 @@ describe("RoleSet consolidated archive", () => {
 
         it("persists encrypted when a secret is configured", async () => {
             const users = new InMemoryUserManagementStore();
-            users.addUser("bob", "Sekret123!", UserConfigurationMask.None, "");
+            await users.addUser("bob", "Sekret123!", UserConfigurationMask.None, "");
             const store = new ArchiveStore(filePath, { secret: "k" });
             store.setUsersProvider(() => users.exportUsers());
             await store.save();

--- a/packages/node-opcua-role-set-common/test/test_password_hasher.ts
+++ b/packages/node-opcua-role-set-common/test/test_password_hasher.ts
@@ -1,0 +1,39 @@
+import "mocha";
+import should from "should";
+import { HasherRegistry, ScryptHasher, defaultHasherRegistry, scryptPhc } from "../source/password_hasher.js";
+
+describe("ScryptHasher — credential parsing hardening", () => {
+    const hasher = new ScryptHasher();
+
+    it("hashes and verifies a normal password round-trip", async () => {
+        const phc = await hasher.hash("s3cret");
+        phc.should.match(/^\$scrypt\$ln=14,r=8,p=1\$/);
+        (await hasher.verify("s3cret", phc)).should.be.true();
+        (await hasher.verify("wrong", phc)).should.be.false();
+    });
+
+    it("fails closed (no scryptSync) on an out-of-range work factor ln", async () => {
+        // A tampered/poisoned credential setting a huge N must be rejected rather
+        // than driving scryptSync into resource exhaustion during login.
+        const poisoned = "$scrypt$ln=30,r=8,p=1$c2FsdA==$aGFzaA==";
+        (await hasher.verify("whatever", poisoned)).should.be.false();
+    });
+
+    it("fails closed on out-of-range r and p", async () => {
+        (await hasher.verify("x", "$scrypt$ln=14,r=9999,p=1$c2FsdA==$aGFzaA==")).should.be.false();
+        (await hasher.verify("x", "$scrypt$ln=14,r=8,p=9999$c2FsdA==$aGFzaA==")).should.be.false();
+    });
+
+    it("fails closed on a zero work factor", async () => {
+        (await hasher.verify("x", "$scrypt$ln=0,r=8,p=1$c2FsdA==$aGFzaA==")).should.be.false();
+    });
+
+    it("still verifies a legitimately-parametrised credential", async () => {
+        // Build a valid credential at a non-default-but-in-range cost and confirm
+        // the bounds check does not reject well-formed records.
+        const phc = await hasher.hash("pw-in-range");
+        should(scryptPhc("c2FsdA==", "aGFzaA==").startsWith("$scrypt$")).be.true();
+        (await new HasherRegistry(hasher).verify("pw-in-range", phc)).should.be.true();
+        (await defaultHasherRegistry().verify("pw-in-range", phc)).should.be.true();
+    });
+});

--- a/packages/node-opcua-role-set-common/test/test_user_management_store.ts
+++ b/packages/node-opcua-role-set-common/test/test_user_management_store.ts
@@ -1,7 +1,15 @@
+import { randomBytes, scryptSync } from "node:crypto";
 import "should";
 import { StatusCodes } from "node-opcua-status-code";
 import { UserConfigurationMask } from "node-opcua-types";
-import { InMemoryUserManagementStore, type PasswordPolicy } from "../source/user_management_store.js";
+import { BcryptHasher } from "../source/password_hasher.js";
+import {
+    credentialRecord,
+    InMemoryUserManagementStore,
+    type LegacySerializedUserRecord,
+    type PasswordPolicy,
+    serializeUser
+} from "../source/user_management_store.js";
 
 const STRONG_POLICY: PasswordPolicy = {
     minLength: 8,
@@ -13,9 +21,9 @@ const STRONG_POLICY: PasswordPolicy = {
 };
 
 describe("InMemoryUserManagementStore — AddUser (OPC 10000-18 §5.2.5)", () => {
-    it("should add a user and report it in getUsers / hasUser", () => {
+    it("should add a user and report it in getUsers / hasUser", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "secret", UserConfigurationMask.None, "Joe").should.equal(StatusCodes.Good);
+        (await store.addUser("joe", "secret", UserConfigurationMask.None, "Joe")).should.equal(StatusCodes.Good);
         store.hasUser("joe").should.be.true();
         const users = store.getUsers();
         users.should.have.length(1);
@@ -23,165 +31,169 @@ describe("InMemoryUserManagementStore — AddUser (OPC 10000-18 §5.2.5)", () =>
         users[0].description.should.equal("Joe");
     });
 
-    it("should return BadAlreadyExists for a duplicate user", () => {
+    it("should return BadAlreadyExists for a duplicate user", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "secret", UserConfigurationMask.None, "");
-        store.addUser("joe", "other", UserConfigurationMask.None, "").should.equal(StatusCodes.BadAlreadyExists);
+        await store.addUser("joe", "secret", UserConfigurationMask.None, "");
+        (await store.addUser("joe", "other", UserConfigurationMask.None, "")).should.equal(StatusCodes.BadAlreadyExists);
     });
 
-    it("should return BadOutOfRange when the password violates the policy", () => {
+    it("should return BadOutOfRange when the password violates the policy", async () => {
         const store = new InMemoryUserManagementStore(STRONG_POLICY);
-        store.addUser("joe", "weak", UserConfigurationMask.None, "").should.equal(StatusCodes.BadOutOfRange);
-        store.addUser("joe", "alllowercase1!", UserConfigurationMask.None, "").should.equal(StatusCodes.BadOutOfRange);
-        store.addUser("joe", "Secret123!", UserConfigurationMask.None, "").should.equal(StatusCodes.Good);
+        (await store.addUser("joe", "weak", UserConfigurationMask.None, "")).should.equal(StatusCodes.BadOutOfRange);
+        (await store.addUser("joe", "alllowercase1!", UserConfigurationMask.None, "")).should.equal(StatusCodes.BadOutOfRange);
+        (await store.addUser("joe", "Secret123!", UserConfigurationMask.None, "")).should.equal(StatusCodes.Good);
     });
 
-    it("should return BadConfigurationError for MustChangePassword + NoChangeByUser", () => {
+    it("should return BadConfigurationError for MustChangePassword + NoChangeByUser", async () => {
         const store = new InMemoryUserManagementStore();
         const bad = UserConfigurationMask.MustChangePassword | UserConfigurationMask.NoChangeByUser;
-        store.addUser("joe", "secret", bad, "").should.equal(StatusCodes.BadConfigurationError);
+        (await store.addUser("joe", "secret", bad, "")).should.equal(StatusCodes.BadConfigurationError);
     });
 });
 
 describe("InMemoryUserManagementStore — authenticate (OPC 10000-18 §5.2.8 / §5.2.3)", () => {
-    it("should authenticate a valid user", () => {
+    it("should authenticate a valid user", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "secret", UserConfigurationMask.None, "");
-        const r = store.authenticate("joe", "secret");
+        await store.addUser("joe", "secret", UserConfigurationMask.None, "");
+        const r = await store.authenticate("joe", "secret");
         r.statusCode.should.equal(StatusCodes.Good);
         r.mustChangePassword.should.be.false();
     });
 
-    it("should reject a wrong password", () => {
+    it("should reject a wrong password", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "secret", UserConfigurationMask.None, "");
-        store.authenticate("joe", "wrong").statusCode.should.equal(StatusCodes.BadUserAccessDenied);
+        await store.addUser("joe", "secret", UserConfigurationMask.None, "");
+        (await store.authenticate("joe", "wrong")).statusCode.should.equal(StatusCodes.BadUserAccessDenied);
     });
 
-    it("should reject an unknown user", () => {
+    it("should reject an unknown user", async () => {
         const store = new InMemoryUserManagementStore();
-        store.authenticate("ghost", "secret").statusCode.should.equal(StatusCodes.BadUserAccessDenied);
+        (await store.authenticate("ghost", "secret")).statusCode.should.equal(StatusCodes.BadUserAccessDenied);
     });
 
-    it("should treat a disabled user like a non-existent one", () => {
+    it("should treat a disabled user like a non-existent one", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "secret", UserConfigurationMask.Disabled, "");
-        store.authenticate("joe", "secret").statusCode.should.equal(StatusCodes.BadUserAccessDenied);
+        await store.addUser("joe", "secret", UserConfigurationMask.Disabled, "");
+        (await store.authenticate("joe", "secret")).statusCode.should.equal(StatusCodes.BadUserAccessDenied);
     });
 
-    it("should return GoodPasswordChangeRequired when MustChangePassword is set", () => {
+    it("should return GoodPasswordChangeRequired when MustChangePassword is set", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "secret", UserConfigurationMask.MustChangePassword, "");
-        const r = store.authenticate("joe", "secret");
+        await store.addUser("joe", "secret", UserConfigurationMask.MustChangePassword, "");
+        const r = await store.authenticate("joe", "secret");
         r.statusCode.should.equal(StatusCodes.GoodPasswordChangeRequired);
         r.mustChangePassword.should.be.true();
     });
 });
 
 describe("InMemoryUserManagementStore — ChangePassword (OPC 10000-18 §5.2.8)", () => {
-    it("should change the password — old fails afterwards, new works", () => {
+    it("should change the password — old fails afterwards, new works", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "OldPass123!", UserConfigurationMask.None, "");
+        await store.addUser("joe", "OldPass123!", UserConfigurationMask.None, "");
 
-        store.changePassword("joe", "OldPass123!", "NewPass456!").should.equal(StatusCodes.Good);
+        (await store.changePassword("joe", "OldPass123!", "NewPass456!")).should.equal(StatusCodes.Good);
 
-        store.authenticate("joe", "OldPass123!").statusCode.should.equal(StatusCodes.BadUserAccessDenied);
-        store.authenticate("joe", "NewPass456!").statusCode.should.equal(StatusCodes.Good);
+        (await store.authenticate("joe", "OldPass123!")).statusCode.should.equal(StatusCodes.BadUserAccessDenied);
+        (await store.authenticate("joe", "NewPass456!")).statusCode.should.equal(StatusCodes.Good);
     });
 
-    it("should reject a wrong old password with BadIdentityTokenInvalid", () => {
+    it("should reject a wrong old password with BadIdentityTokenInvalid", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "OldPass123!", UserConfigurationMask.None, "");
-        store.changePassword("joe", "WRONG", "NewPass456!").should.equal(StatusCodes.BadIdentityTokenInvalid);
+        await store.addUser("joe", "OldPass123!", UserConfigurationMask.None, "");
+        (await store.changePassword("joe", "WRONG", "NewPass456!")).should.equal(StatusCodes.BadIdentityTokenInvalid);
         // unchanged
-        store.authenticate("joe", "OldPass123!").statusCode.should.equal(StatusCodes.Good);
+        (await store.authenticate("joe", "OldPass123!")).statusCode.should.equal(StatusCodes.Good);
     });
 
-    it("should reject a new password equal to the old with BadAlreadyExists", () => {
+    it("should reject a new password equal to the old with BadAlreadyExists", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "OldPass123!", UserConfigurationMask.None, "");
-        store.changePassword("joe", "OldPass123!", "OldPass123!").should.equal(StatusCodes.BadAlreadyExists);
+        await store.addUser("joe", "OldPass123!", UserConfigurationMask.None, "");
+        (await store.changePassword("joe", "OldPass123!", "OldPass123!")).should.equal(StatusCodes.BadAlreadyExists);
     });
 
-    it("should reject a new password that violates the policy", () => {
+    it("should reject a new password that violates the policy", async () => {
         const store = new InMemoryUserManagementStore(STRONG_POLICY);
-        store.addUser("joe", "OldPass123!", UserConfigurationMask.None, "");
-        store.changePassword("joe", "OldPass123!", "weak").should.equal(StatusCodes.BadOutOfRange);
+        await store.addUser("joe", "OldPass123!", UserConfigurationMask.None, "");
+        (await store.changePassword("joe", "OldPass123!", "weak")).should.equal(StatusCodes.BadOutOfRange);
     });
 
-    it("should reject when the user has NoChangeByUser set", () => {
+    it("should reject when the user has NoChangeByUser set", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "OldPass123!", UserConfigurationMask.NoChangeByUser, "");
-        store.changePassword("joe", "OldPass123!", "NewPass456!").should.equal(StatusCodes.BadNotSupported);
+        await store.addUser("joe", "OldPass123!", UserConfigurationMask.NoChangeByUser, "");
+        (await store.changePassword("joe", "OldPass123!", "NewPass456!")).should.equal(StatusCodes.BadNotSupported);
     });
 
-    it("should clear the MustChangePassword flag after a successful change", () => {
+    it("should clear the MustChangePassword flag after a successful change", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "OldPass123!", UserConfigurationMask.MustChangePassword, "");
-        store.authenticate("joe", "OldPass123!").statusCode.should.equal(StatusCodes.GoodPasswordChangeRequired);
+        await store.addUser("joe", "OldPass123!", UserConfigurationMask.MustChangePassword, "");
+        (await store.authenticate("joe", "OldPass123!")).statusCode.should.equal(StatusCodes.GoodPasswordChangeRequired);
 
-        store.changePassword("joe", "OldPass123!", "NewPass456!").should.equal(StatusCodes.Good);
-        store.authenticate("joe", "NewPass456!").statusCode.should.equal(StatusCodes.Good);
+        (await store.changePassword("joe", "OldPass123!", "NewPass456!")).should.equal(StatusCodes.Good);
+        (await store.authenticate("joe", "NewPass456!")).statusCode.should.equal(StatusCodes.Good);
     });
 
-    it("should treat ChangePassword on an unknown user as an invalid old password", () => {
+    it("should treat ChangePassword on an unknown user as an invalid old password", async () => {
         const store = new InMemoryUserManagementStore();
-        store.changePassword("ghost", "x", "NewPass456!").should.equal(StatusCodes.BadIdentityTokenInvalid);
+        (await store.changePassword("ghost", "x", "NewPass456!")).should.equal(StatusCodes.BadIdentityTokenInvalid);
     });
 });
 
 describe("InMemoryUserManagementStore — ModifyUser (OPC 10000-18 §5.2.6)", () => {
-    it("should return BadNotFound for an unknown user", () => {
+    it("should return BadNotFound for an unknown user", async () => {
         const store = new InMemoryUserManagementStore();
-        store.modifyUser("ghost", { modifyDescription: true, description: "x" }).should.equal(StatusCodes.BadNotFound);
+        (await store.modifyUser("ghost", { modifyDescription: true, description: "x" })).should.equal(StatusCodes.BadNotFound);
     });
 
-    it("should change the description", () => {
+    it("should change the description", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "secret", UserConfigurationMask.None, "old");
-        store.modifyUser("joe", { modifyDescription: true, description: "new" }).should.equal(StatusCodes.Good);
+        await store.addUser("joe", "secret", UserConfigurationMask.None, "old");
+        (await store.modifyUser("joe", { modifyDescription: true, description: "new" })).should.equal(StatusCodes.Good);
         store.getUsers()[0].description.should.equal("new");
     });
 
-    it("should change the password (old fails, new works)", () => {
+    it("should change the password (old fails, new works)", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "secret", UserConfigurationMask.None, "");
-        store.modifyUser("joe", { modifyPassword: true, password: "brandnew" }).should.equal(StatusCodes.Good);
-        store.authenticate("joe", "secret").statusCode.should.equal(StatusCodes.BadUserAccessDenied);
-        store.authenticate("joe", "brandnew").statusCode.should.equal(StatusCodes.Good);
+        await store.addUser("joe", "secret", UserConfigurationMask.None, "");
+        (await store.modifyUser("joe", { modifyPassword: true, password: "brandnew" })).should.equal(StatusCodes.Good);
+        (await store.authenticate("joe", "secret")).statusCode.should.equal(StatusCodes.BadUserAccessDenied);
+        (await store.authenticate("joe", "brandnew")).statusCode.should.equal(StatusCodes.Good);
     });
 
-    it("should disable a user via configuration", () => {
+    it("should disable a user via configuration", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "secret", UserConfigurationMask.None, "");
-        store
-            .modifyUser("joe", { modifyUserConfiguration: true, userConfiguration: UserConfigurationMask.Disabled })
-            .should.equal(StatusCodes.Good);
-        store.authenticate("joe", "secret").statusCode.should.equal(StatusCodes.BadUserAccessDenied);
+        await store.addUser("joe", "secret", UserConfigurationMask.None, "");
+        (
+            await store.modifyUser("joe", { modifyUserConfiguration: true, userConfiguration: UserConfigurationMask.Disabled })
+        ).should.equal(StatusCodes.Good);
+        (await store.authenticate("joe", "secret")).statusCode.should.equal(StatusCodes.BadUserAccessDenied);
     });
 
-    it("should refuse to let a caller disable themselves", () => {
+    it("should refuse to let a caller disable themselves", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("admin", "secret", UserConfigurationMask.None, "");
-        store
-            .modifyUser("admin", { modifyUserConfiguration: true, userConfiguration: UserConfigurationMask.Disabled }, "admin")
-            .should.equal(StatusCodes.BadInvalidSelfReference);
+        await store.addUser("admin", "secret", UserConfigurationMask.None, "");
+        (
+            await store.modifyUser(
+                "admin",
+                { modifyUserConfiguration: true, userConfiguration: UserConfigurationMask.Disabled },
+                "admin"
+            )
+        ).should.equal(StatusCodes.BadInvalidSelfReference);
     });
 
-    it("should reject an invalid configuration combination", () => {
+    it("should reject an invalid configuration combination", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "secret", UserConfigurationMask.None, "");
+        await store.addUser("joe", "secret", UserConfigurationMask.None, "");
         const bad = UserConfigurationMask.MustChangePassword | UserConfigurationMask.NoChangeByUser;
-        store
-            .modifyUser("joe", { modifyUserConfiguration: true, userConfiguration: bad })
-            .should.equal(StatusCodes.BadConfigurationError);
+        (await store.modifyUser("joe", { modifyUserConfiguration: true, userConfiguration: bad })).should.equal(
+            StatusCodes.BadConfigurationError
+        );
     });
 });
 
 describe("InMemoryUserManagementStore — RemoveUser (OPC 10000-18 §5.2.7)", () => {
-    it("should remove a user", () => {
+    it("should remove a user", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "secret", UserConfigurationMask.None, "");
+        await store.addUser("joe", "secret", UserConfigurationMask.None, "");
         store.removeUser("joe").should.equal(StatusCodes.Good);
         store.hasUser("joe").should.be.false();
     });
@@ -191,15 +203,97 @@ describe("InMemoryUserManagementStore — RemoveUser (OPC 10000-18 §5.2.7)", ()
         store.removeUser("ghost").should.equal(StatusCodes.BadNotFound);
     });
 
-    it("should refuse to remove the calling user (BadInvalidSelfReference)", () => {
+    it("should refuse to remove the calling user (BadInvalidSelfReference)", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("admin", "secret", UserConfigurationMask.None, "");
+        await store.addUser("admin", "secret", UserConfigurationMask.None, "");
         store.removeUser("admin", "admin").should.equal(StatusCodes.BadInvalidSelfReference);
     });
 
-    it("should refuse to remove a NoDelete user (BadNotSupported)", () => {
+    it("should refuse to remove a NoDelete user (BadNotSupported)", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("service", "secret", UserConfigurationMask.NoDelete, "");
+        await store.addUser("service", "secret", UserConfigurationMask.NoDelete, "");
         store.removeUser("service").should.equal(StatusCodes.BadNotSupported);
+    });
+});
+
+describe("serializeUser — offline pre-hashing (no clear text at rest)", () => {
+    it("should produce a scrypt PHC record that authenticates with the original clear-text password", async () => {
+        const rec = await serializeUser("admin", "s3cret-init");
+        rec.userName.should.equal("admin");
+        rec.credential.should.be.a.String();
+        rec.credential.startsWith("$scrypt$").should.be.true();
+
+        const store = new InMemoryUserManagementStore();
+        store.importUsers([rec]);
+        (await store.authenticate("admin", "s3cret-init")).statusCode.should.equal(StatusCodes.Good);
+        (await store.authenticate("admin", "wrong")).statusCode.should.equal(StatusCodes.BadUserAccessDenied);
+    });
+
+    it("should carry userConfiguration and description into the store", async () => {
+        const rec = await serializeUser("admin", "s3cret-init", {
+            userConfiguration: UserConfigurationMask.MustChangePassword,
+            description: "seed"
+        });
+        rec.userConfiguration.should.equal(UserConfigurationMask.MustChangePassword);
+
+        const store = new InMemoryUserManagementStore();
+        store.importUsers([rec]);
+        const [user] = store.getUsers();
+        user.userName.should.equal("admin");
+        user.userConfiguration.should.equal(UserConfigurationMask.MustChangePassword);
+        user.description.should.equal("seed");
+        (await store.authenticate("admin", "s3cret-init")).statusCode.should.equal(StatusCodes.GoodPasswordChangeRequired);
+    });
+
+    it("should round-trip with exportUsers (same shape)", async () => {
+        const store = new InMemoryUserManagementStore();
+        await store.addUser("joe", "secret", UserConfigurationMask.None, "Joe");
+        const exported = store.exportUsers();
+        exported.should.have.length(1);
+        Object.keys(await serializeUser("joe", "secret"))
+            .sort()
+            .should.eql(Object.keys(exported[0]).sort());
+    });
+});
+
+describe("password hashing — coexistence, upgrade-on-login, legacy migration", () => {
+    it("should verify a bcrypt credential and upgrade it to scrypt on login", async () => {
+        // a legacy bcrypt hash, wrapped as a credential (no clear text at rest)
+        const bcryptCredential = await new BcryptHasher().hash("s3cret-init");
+        bcryptCredential.startsWith("$2").should.be.true();
+
+        const store = new InMemoryUserManagementStore();
+        const upgraded: string[] = [];
+        store.setOnCredentialUpgraded((u) => upgraded.push(u));
+        store.importUsers([credentialRecord("admin", bcryptCredential)]);
+
+        // first login: verifies against bcrypt AND transparently re-hashes to scrypt
+        (await store.authenticate("admin", "s3cret-init")).statusCode.should.equal(StatusCodes.Good);
+        upgraded.should.eql(["admin"]);
+        store.exportUsers()[0].credential.startsWith("$scrypt$").should.be.true();
+
+        // still authenticates after the upgrade; wrong password still rejected
+        (await store.authenticate("admin", "s3cret-init")).statusCode.should.equal(StatusCodes.Good);
+        (await store.authenticate("admin", "nope")).statusCode.should.equal(StatusCodes.BadUserAccessDenied);
+    });
+
+    it("should read a legacy v1 record (raw scrypt salt+hash) with no password reset", async () => {
+        // synthesize a v1 record exactly as the old store produced it
+        const salt = randomBytes(16);
+        const hash = scryptSync("legacy-pw", salt, 64);
+        const v1: LegacySerializedUserRecord = {
+            userName: "old",
+            salt: salt.toString("base64"),
+            hash: hash.toString("base64"),
+            userConfiguration: UserConfigurationMask.None,
+            description: ""
+        };
+
+        const store = new InMemoryUserManagementStore();
+        store.importUsers([v1]);
+        (await store.authenticate("old", "legacy-pw")).statusCode.should.equal(StatusCodes.Good);
+        (await store.authenticate("old", "wrong")).statusCode.should.equal(StatusCodes.BadUserAccessDenied);
+        // migrated to a PHC credential on import
+        store.exportUsers()[0].credential.startsWith("$scrypt$").should.be.true();
     });
 });

--- a/packages/node-opcua-role-set-server/README.md
+++ b/packages/node-opcua-role-set-server/README.md
@@ -75,13 +75,50 @@ in short:
 import { createRoleBasedSecurity } from "node-opcua-role-set-server";
 import { WellKnownRoleIds } from "node-opcua-role-set-common";
 
-const security = createRoleBasedSecurity({
+const security = await createRoleBasedSecurity({
     users: [{ userName: "admin", password: "admin-pw1", roles: [WellKnownRoleIds.SecurityAdmin] }]
 });
 const server = new OPCUAServer({ /* … */ userManager: security.userManager });
 await server.start();
 await security.install(server, { persistencePath: "./config/role-set.json" });
 ```
+
+`createRoleBasedSecurity` is **async** (it hashes any clear-text seed passwords)
+and returns the shared stores plus the `userManager` bridge.
+
+### Seeding without clear text, and password hashing
+
+Each seeded user provides **one** of:
+
+- `password` — clear text (hashed with scrypt on seed); or
+- `passwordHash` — a pre-hashed credential record, so **no clear text lives in
+  config / version control**.
+
+Build a record offline with the `node-opcua-role-set-common` helpers:
+
+```ts
+import { serializeUser, credentialRecord } from "node-opcua-role-set-common";
+
+// scrypt record from a clear password (run once at deploy time, commit the result)
+const admin = await serializeUser("admin", "admin-pw1", { /* userConfiguration, description */ });
+
+// or wrap an already-hashed credential you already hold (e.g. a legacy $2b$ bcrypt hash)
+const legacy = credentialRecord("legacy", "$2b$10$……");
+
+const security = await createRoleBasedSecurity({
+    users: [
+        { userName: "admin",  passwordHash: admin,  roles: [WellKnownRoleIds.SecurityAdmin] },
+        { userName: "legacy", passwordHash: legacy, roles: [WellKnownRoleIds.Operator] }
+    ]
+});
+```
+
+Credentials are stored as self-describing PHC strings (`$scrypt$…` / `$2b$…`), so
+schemes coexist: new/changed passwords hash with **scrypt** (Node core), while a
+legacy **bcrypt** credential still verifies and is transparently re-hashed to
+scrypt on the next successful login (*upgrade-on-login*). Pass a custom
+`registry` to `createRoleBasedSecurity` to add schemes (e.g. an external
+verifier). See [`node-opcua-role-set-common`](../node-opcua-role-set-common#users--password-hashing).
 
 ## Exports
 

--- a/packages/node-opcua-role-set-server/package.json
+++ b/packages/node-opcua-role-set-server/package.json
@@ -20,6 +20,7 @@
         "node-opcua-address-space-base": "2.174.0",
         "node-opcua-constants": "2.174.0",
         "node-opcua-data-model": "2.174.0",
+        "node-opcua-debug": "2.172.0",
         "node-opcua-nodeid": "2.174.0",
         "node-opcua-role-set-common": "2.174.0",
         "node-opcua-service-call": "2.174.0",

--- a/packages/node-opcua-role-set-server/source/bind_user_management.ts
+++ b/packages/node-opcua-role-set-server/source/bind_user_management.ts
@@ -73,7 +73,7 @@ export function makeAddUserHandler(options: BindUserManagementOptions) {
         const userConfiguration = asMask(inputArguments[2]);
         const description = asString(inputArguments[3]) ?? "";
 
-        const statusCode = store.addUser(userName, password, userConfiguration, description);
+        const statusCode = await store.addUser(userName, password, userConfiguration, description);
         if (statusCode === StatusCodes.Good && onMutation) {
             await onMutation();
         }
@@ -107,7 +107,7 @@ export function makeModifyUserHandler(options: BindUserManagementOptions) {
         }
         const modifyUserConfiguration = asBoolean(inputArguments[3]);
         const userConfiguration = asMask(inputArguments[4]);
-        const statusCode = store.modifyUser(
+        const statusCode = await store.modifyUser(
             userName,
             {
                 modifyPassword: asBoolean(inputArguments[1]),
@@ -199,7 +199,7 @@ export function makeChangePasswordHandler(options: BindUserManagementOptions) {
             return { statusCode: StatusCodes.BadInvalidArgument };
         }
 
-        const statusCode = store.changePassword(userName, oldPassword, newPassword);
+        const statusCode = await store.changePassword(userName, oldPassword, newPassword);
         if (statusCode === StatusCodes.Good && onMutation) {
             await onMutation();
         }

--- a/packages/node-opcua-role-set-server/source/install_role_based_security.ts
+++ b/packages/node-opcua-role-set-server/source/install_role_based_security.ts
@@ -12,7 +12,7 @@
  * **after** `server.start()`, this comes in two phases:
  *
  * ```ts
- * const security = createRoleBasedSecurity({
+ * const security = await createRoleBasedSecurity({
  *     users: [{ userName: "admin", password: "pw", roles: [WellKnownRoleIds.SecurityAdmin] }]
  * });
  * const server = new OPCUAServer({ ..., userManager: security.userManager });
@@ -27,9 +27,11 @@
 import type { NodeId } from "node-opcua-nodeid";
 import {
     ArchiveStore,
+    type HasherRegistry,
     InMemoryIdentityMappingStore,
     InMemoryUserManagementStore,
-    type PasswordPolicy
+    type PasswordPolicy,
+    type SerializedUserRecord
 } from "node-opcua-role-set-common";
 import { IdentityCriteriaType, IdentityMappingRuleType, UserConfigurationMask } from "node-opcua-types";
 import { type InstallRoleSetResult, type IServerForRoleSet, installRoleSet } from "./install_role_set.js";
@@ -40,10 +42,23 @@ import {
 } from "./install_user_management.js";
 import { createUserManager, type IManagedUserManager } from "./user_management_user_manager.js";
 
-/** A user to seed, with the well-known/custom Roles it holds. */
+/**
+ * A user to seed, with the well-known/custom Roles it holds.
+ *
+ * Provide **either** a clear-text {@link password} **or** a pre-hashed
+ * {@link passwordHash} (salted scrypt record from `serializeUser`) — the latter
+ * lets you seed users without any clear text in config/version control.
+ */
 export interface RoleBasedUser {
     userName: string;
-    password: string;
+    /** Clear-text seed password. Provide this or {@link passwordHash}. */
+    password?: string;
+    /**
+     * Pre-hashed seed (salted scrypt record produced offline by `serializeUser`
+     * / `exportUsers`). Provide this or {@link password} — never both. Seeded
+     * verbatim via `importUsers`, so no clear text is required.
+     */
+    passwordHash?: SerializedUserRecord;
     /** Role NodeIds granted to this user (e.g. `WellKnownRoleIds.Operator`). */
     roles?: NodeId[];
     userConfiguration?: UserConfigurationMask;
@@ -55,6 +70,12 @@ export interface CreateRoleBasedSecurityOptions {
     policy?: PasswordPolicy;
     /** Users to seed up front (more can be added later via the Methods). */
     users?: RoleBasedUser[];
+    /**
+     * Password-hashing registry. Omit for the default (scrypt hashes; bcrypt
+     * verifies legacy credentials and is upgraded to scrypt on login). Inject a
+     * custom {@link HasherRegistry} to add schemes (e.g. an external verifier).
+     */
+    registry?: HasherRegistry;
 }
 
 export interface InstallRoleBasedSecurityOptions {
@@ -92,17 +113,33 @@ const userNameRule = (userName: string): IdentityMappingRuleType =>
  * users and their Roles. Pass `userManager` to the `OPCUAServer` constructor,
  * then call {@link RoleBasedSecurity.install} after `server.start()`.
  */
-export function createRoleBasedSecurity(options?: CreateRoleBasedSecurityOptions): RoleBasedSecurity {
-    const userStore = new InMemoryUserManagementStore(options?.policy);
+export async function createRoleBasedSecurity(options?: CreateRoleBasedSecurityOptions): Promise<RoleBasedSecurity> {
+    const userStore = new InMemoryUserManagementStore(options?.policy, options?.registry ? { registry: options.registry } : undefined);
     const identityStore = new InMemoryIdentityMappingStore();
 
     for (const user of options?.users ?? []) {
-        userStore.addUser(
-            user.userName,
-            user.password,
-            user.userConfiguration ?? UserConfigurationMask.None,
-            user.description ?? ""
-        );
+        if (user.passwordHash) {
+            // Pre-hashed seed: import the credential record verbatim — no clear
+            // text involved. `userName`/`userConfiguration`/`description` on the
+            // RoleBasedUser take precedence over the record's own fields.
+            userStore.importUsers?.([
+                {
+                    ...user.passwordHash,
+                    userName: user.userName,
+                    userConfiguration: user.userConfiguration ?? user.passwordHash.userConfiguration,
+                    description: user.description ?? user.passwordHash.description
+                }
+            ]);
+        } else if (user.password !== undefined) {
+            await userStore.addUser(
+                user.userName,
+                user.password,
+                user.userConfiguration ?? UserConfigurationMask.None,
+                user.description ?? ""
+            );
+        } else {
+            throw new Error(`RoleBasedUser "${user.userName}": provide either "password" (clear text) or "passwordHash" (pre-hashed record).`);
+        }
         for (const role of user.roles ?? []) {
             identityStore.addIdentity(role, userNameRule(user.userName));
         }
@@ -121,6 +158,14 @@ export function createRoleBasedSecurity(options?: CreateRoleBasedSecurityOptions
                 (installOptions?.persistencePath
                     ? new ArchiveStore(installOptions.persistencePath, { secret: installOptions.persistenceSecret })
                     : undefined);
+
+            // Persist upgrade-on-login re-hashes (e.g. bcrypt → scrypt) so the
+            // migration sticks across restarts.
+            if (persistence) {
+                userStore.setOnCredentialUpgraded?.(() => {
+                    void persistence.save();
+                });
+            }
 
             const roleSet = await installRoleSet(server, { store: identityStore, persistence });
             const userManagement = await installUserManagement(server, { store: userStore, persistence });

--- a/packages/node-opcua-role-set-server/source/install_role_based_security.ts
+++ b/packages/node-opcua-role-set-server/source/install_role_based_security.ts
@@ -24,6 +24,7 @@
  * Methods, persistence) is backed by the same two stores, so the "legacy"
  * (userManager) and "modern" (RoleSet Methods) views can never drift apart.
  */
+import { make_errorLog } from "node-opcua-debug";
 import type { NodeId } from "node-opcua-nodeid";
 import {
     ArchiveStore,
@@ -31,7 +32,8 @@ import {
     InMemoryIdentityMappingStore,
     InMemoryUserManagementStore,
     type PasswordPolicy,
-    type SerializedUserRecord
+    type SerializedUserRecord,
+    validateUserConfiguration
 } from "node-opcua-role-set-common";
 import { IdentityCriteriaType, IdentityMappingRuleType, UserConfigurationMask } from "node-opcua-types";
 import { type InstallRoleSetResult, type IServerForRoleSet, installRoleSet } from "./install_role_set.js";
@@ -41,6 +43,8 @@ import {
     installUserManagement
 } from "./install_user_management.js";
 import { createUserManager, type IManagedUserManager } from "./user_management_user_manager.js";
+
+const errorLog = make_errorLog("RoleBasedSecurity");
 
 /**
  * A user to seed, with the well-known/custom Roles it holds.
@@ -118,15 +122,33 @@ export async function createRoleBasedSecurity(options?: CreateRoleBasedSecurityO
     const identityStore = new InMemoryIdentityMappingStore();
 
     for (const user of options?.users ?? []) {
+        // Exactly one of password / passwordHash — reject the ambiguous case up
+        // front rather than silently preferring one (the docstring says "never
+        // both"), so a misconfiguration is loud instead of a silent surprise.
+        if (user.password !== undefined && user.passwordHash) {
+            throw new Error(
+                `RoleBasedUser "${user.userName}": provide either "password" (clear text) or "passwordHash" (pre-hashed record), not both.`
+            );
+        }
         if (user.passwordHash) {
             // Pre-hashed seed: import the credential record verbatim — no clear
             // text involved. `userName`/`userConfiguration`/`description` on the
             // RoleBasedUser take precedence over the record's own fields.
+            const userConfiguration = user.userConfiguration ?? user.passwordHash.userConfiguration;
+            // importUsers bypasses addUser's validation, so apply the same
+            // UserConfigurationMask check here (e.g. MustChangePassword +
+            // NoChangeByUser is an illegal combination — §5.2.3).
+            const configError = validateUserConfiguration(userConfiguration);
+            if (configError) {
+                throw new Error(
+                    `RoleBasedUser "${user.userName}": invalid userConfiguration (${configError.name}).`
+                );
+            }
             userStore.importUsers?.([
                 {
                     ...user.passwordHash,
                     userName: user.userName,
-                    userConfiguration: user.userConfiguration ?? user.passwordHash.userConfiguration,
+                    userConfiguration,
                     description: user.description ?? user.passwordHash.description
                 }
             ]);
@@ -163,7 +185,17 @@ export async function createRoleBasedSecurity(options?: CreateRoleBasedSecurityO
             // migration sticks across restarts.
             if (persistence) {
                 userStore.setOnCredentialUpgraded?.(() => {
-                    void persistence.save();
+                    // Background flush: a failed save must not surface as a
+                    // process-level unhandled rejection. The upgraded credential
+                    // is already live in memory; it will be re-persisted on the
+                    // next login/mutation, so log and move on.
+                    persistence.save().catch((err) => {
+                        // Log the message only — a minified/obfuscated stack is noise.
+                        errorLog(
+                            "createRoleBasedSecurity: failed to persist credential upgrade:",
+                            err instanceof Error ? err.message : err
+                        );
+                    });
                 });
             }
 

--- a/packages/node-opcua-role-set-server/source/user_management_user_manager.ts
+++ b/packages/node-opcua-role-set-server/source/user_management_user_manager.ts
@@ -23,16 +23,23 @@ import type { AnyUserIdentityToken, IIdentityMappingStore, IUserManagementStore 
 import { type StatusCode, StatusCodes } from "node-opcua-status-code";
 import { type IdentityMappingRuleType, UserConfigurationMask, UserNameIdentityToken } from "node-opcua-types";
 
-/** The subset of the ServerSession that `isValidUser` is bound to (`this`). */
+/** The subset of the ServerSession that `isValidUserAsync` is bound to (`this`). */
 interface SessionThis {
     getSessionId?(): NodeId;
     /** Set so ActivateSession returns Good_PasswordChangeRequired (node-opcua-server). */
     passwordChangeRequired?: boolean;
 }
 
+/** node-opcua's callback-style credential check (`ValidUserAsyncFunc`). */
+type ValidUserCallback = (err: Error | null, isAuthorized?: boolean) => void;
+
 export interface IManagedUserManager {
-    /** Validate credentials (sync). Returns true for Good and Good_PasswordChangeRequired. */
-    isValidUser(this: SessionThis, userName: string, password: string): boolean;
+    /**
+     * Validate credentials (async, callback-style — the shape node-opcua's
+     * `isValidUserAsync` option expects, so an external verifier can be plugged
+     * in). Invokes the callback with `true` for Good and Good_PasswordChangeRequired.
+     */
+    isValidUserAsync(this: SessionThis, userName: string, password: string, callback: ValidUserCallback): void;
     /** Resolve the Roles granted to a user (only Anonymous while a change is required). */
     getUserRoles(userName: string): NodeId[];
     /**
@@ -70,20 +77,29 @@ export function createUserManager(userStore: IUserManagementStore, identityStore
             return statusBySession.get(sessionId.toString());
         },
 
-        isValidUser(this: SessionThis, userName: string, password: string): boolean {
-            const result = userStore.authenticate(userName, password);
-            lastAuthStatus.set(userName, result.statusCode);
-            // `this` is the ServerSession; key the status by the SessionId the
-            // client also holds, so the outcome can be observed per session.
-            const sessionId = this?.getSessionId?.();
-            if (sessionId) {
-                statusBySession.set(sessionId.toString(), result.statusCode);
-            }
-            // flag the session so ActivateSession returns Good_PasswordChangeRequired
-            if (this) {
-                this.passwordChangeRequired = result.statusCode === StatusCodes.GoodPasswordChangeRequired;
-            }
-            return result.statusCode === StatusCodes.Good || result.statusCode === StatusCodes.GoodPasswordChangeRequired;
+        isValidUserAsync(this: SessionThis, userName: string, password: string, callback: ValidUserCallback): void {
+            // `this` is the ServerSession; the arrow callbacks below preserve it
+            // across the async boundary.
+            userStore.authenticate(userName, password).then(
+                (result) => {
+                    lastAuthStatus.set(userName, result.statusCode);
+                    // key the status by the SessionId the client also holds, so the
+                    // outcome can be observed per session.
+                    const sessionId = this?.getSessionId?.();
+                    if (sessionId) {
+                        statusBySession.set(sessionId.toString(), result.statusCode);
+                    }
+                    // flag the session so ActivateSession returns Good_PasswordChangeRequired
+                    if (this) {
+                        this.passwordChangeRequired = result.statusCode === StatusCodes.GoodPasswordChangeRequired;
+                    }
+                    callback(
+                        null,
+                        result.statusCode === StatusCodes.Good || result.statusCode === StatusCodes.GoodPasswordChangeRequired
+                    );
+                },
+                (err: unknown) => callback(err instanceof Error ? err : new Error(String(err)))
+            );
         },
 
         getUserRoles(userName: string): NodeId[] {

--- a/packages/node-opcua-role-set-server/test/test_bind_user_management.ts
+++ b/packages/node-opcua-role-set-server/test/test_bind_user_management.ts
@@ -94,39 +94,39 @@ describe("bind_user_management — AddUser (§5.2.5)", () => {
 });
 
 describe("bind_user_management — ChangePassword (§5.2.8)", () => {
-    function seed(): InMemoryUserManagementStore {
+    async function seed(): Promise<InMemoryUserManagementStore> {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "OldPass123!", UserConfigurationMask.None, "");
+        await store.addUser("joe", "OldPass123!", UserConfigurationMask.None, "");
         return store;
     }
     const joeToken = () => new UserNameIdentityToken({ userName: "joe" });
 
     it("should change the password — old fails, new works", async () => {
-        const store = seed();
+        const store = await seed();
         const handler = makeChangePasswordHandler({ store });
         const result = await handler.call(method, [str("OldPass123!"), str("NewPass456!")], makeContext({ token: joeToken() }));
         result.statusCode?.should.equal(StatusCodes.Good);
 
-        store.authenticate("joe", "OldPass123!").statusCode.should.equal(StatusCodes.BadUserAccessDenied);
-        store.authenticate("joe", "NewPass456!").statusCode.should.equal(StatusCodes.Good);
+        (await store.authenticate("joe", "OldPass123!")).statusCode.should.equal(StatusCodes.BadUserAccessDenied);
+        (await store.authenticate("joe", "NewPass456!")).statusCode.should.equal(StatusCodes.Good);
     });
 
     it("should reject a wrong old password", async () => {
-        const store = seed();
+        const store = await seed();
         const handler = makeChangePasswordHandler({ store });
         const result = await handler.call(method, [str("WRONG"), str("NewPass456!")], makeContext({ token: joeToken() }));
         result.statusCode?.should.equal(StatusCodes.BadIdentityTokenInvalid);
     });
 
     it("should require a USERNAME token (BadInvalidState)", async () => {
-        const store = seed();
+        const store = await seed();
         const handler = makeChangePasswordHandler({ store });
         const result = await handler.call(method, [str("OldPass123!"), str("NewPass456!")], makeContext({ token: undefined }));
         result.statusCode?.should.equal(StatusCodes.BadInvalidState);
     });
 
     it("should require an encrypted channel", async () => {
-        const store = seed();
+        const store = await seed();
         const handler = makeChangePasswordHandler({ store });
         const ctx = makeContext({ token: joeToken(), securityMode: MessageSecurityMode.None });
         const result = await handler.call(method, [str("OldPass123!"), str("NewPass456!")], ctx);
@@ -134,7 +134,7 @@ describe("bind_user_management — ChangePassword (§5.2.8)", () => {
     });
 
     it("should not require SecurityAdmin (self-service)", async () => {
-        const store = seed();
+        const store = await seed();
         const handler = makeChangePasswordHandler({ store });
         // caller has no roles, but is changing their own password
         const ctx = makeContext({ token: joeToken(), roles: [] });
@@ -144,15 +144,15 @@ describe("bind_user_management — ChangePassword (§5.2.8)", () => {
 });
 
 describe("bind_user_management — ModifyUser / RemoveUser (§5.2.6-7)", () => {
-    function seeded(): InMemoryUserManagementStore {
+    async function seeded(): Promise<InMemoryUserManagementStore> {
         const store = new InMemoryUserManagementStore();
-        store.addUser("joe", "secret", UserConfigurationMask.None, "old");
-        store.addUser("admin", "secret", UserConfigurationMask.None, "");
+        await store.addUser("joe", "secret", UserConfigurationMask.None, "old");
+        await store.addUser("admin", "secret", UserConfigurationMask.None, "");
         return store;
     }
 
     it("ModifyUser should change the description", async () => {
-        const store = seeded();
+        const store = await seeded();
         const handler = makeModifyUserHandler({ store });
         const args = [str("joe"), bool(false), str(""), bool(false), mask(UserConfigurationMask.None), bool(true), str("new")];
         (await handler.call(method, args, makeContext())).statusCode?.should.equal(StatusCodes.Good);
@@ -163,14 +163,14 @@ describe("bind_user_management — ModifyUser / RemoveUser (§5.2.6-7)", () => {
     });
 
     it("RemoveUser should remove another user", async () => {
-        const store = seeded();
+        const store = await seeded();
         const handler = makeRemoveUserHandler({ store });
         (await handler.call(method, [str("joe")], makeContext())).statusCode?.should.equal(StatusCodes.Good);
         store.hasUser("joe").should.be.false();
     });
 
     it("RemoveUser should refuse to remove the calling user", async () => {
-        const store = seeded();
+        const store = await seeded();
         const handler = makeRemoveUserHandler({ store });
         const result = await handler.call(method, [str("admin")], makeContext({ userName: "admin" }));
         result.statusCode?.should.equal(StatusCodes.BadInvalidSelfReference);
@@ -197,7 +197,7 @@ describe("bind_user_management — audit (AuditUpdateMethodEventType)", () => {
 
     it("ChangePassword audits the session user without either password", async () => {
         const store = new InMemoryUserManagementStore();
-        store.addUser("kim", "OldPass1", UserConfigurationMask.None, "");
+        await store.addUser("kim", "OldPass1", UserConfigurationMask.None, "");
         const audits: UserManagementAudit[] = [];
         const handler = makeChangePasswordHandler({ store, onAudit: (a) => audits.push(a) });
         const ctx = makeContext({ token: new UserNameIdentityToken({ userName: "kim" }) });

--- a/packages/node-opcua-role-set-server/test/test_install_role_based_security.ts
+++ b/packages/node-opcua-role-set-server/test/test_install_role_based_security.ts
@@ -97,4 +97,41 @@ describe("createRoleBasedSecurity — one store behind the userManager bridge", 
             }
         );
     });
+
+    it("rejects when a seed user provides BOTH password and passwordHash", async () => {
+        const passwordHash = await serializeUser("admin", "s3cret-init");
+        await createRoleBasedSecurity({
+            users: [{ userName: "admin", password: "admin-pw1", passwordHash, roles: [WellKnownRoleIds.Operator] }]
+        }).then(
+            () => {
+                throw new Error("expected rejection");
+            },
+            (err: Error) => {
+                err.message.should.match(/not both/);
+            }
+        );
+    });
+
+    it("rejects an invalid userConfiguration on a pre-hashed (passwordHash) seed", async () => {
+        const passwordHash = await serializeUser("admin", "s3cret-init");
+        // MustChangePassword + NoChangeByUser is an illegal combination (§5.2.3);
+        // importUsers bypasses addUser, so createRoleBasedSecurity must catch it.
+        await createRoleBasedSecurity({
+            users: [
+                {
+                    userName: "admin",
+                    passwordHash,
+                    userConfiguration: UserConfigurationMask.MustChangePassword | UserConfigurationMask.NoChangeByUser,
+                    roles: [WellKnownRoleIds.Operator]
+                }
+            ]
+        }).then(
+            () => {
+                throw new Error("expected rejection");
+            },
+            (err: Error) => {
+                err.message.should.match(/invalid userConfiguration/);
+            }
+        );
+    });
 });

--- a/packages/node-opcua-role-set-server/test/test_install_role_based_security.ts
+++ b/packages/node-opcua-role-set-server/test/test_install_role_based_security.ts
@@ -1,14 +1,14 @@
 import "mocha";
 import { sameNodeId } from "node-opcua-nodeid";
-import { WellKnownRoleIds } from "node-opcua-role-set-common";
+import { serializeUser, WellKnownRoleIds } from "node-opcua-role-set-common";
 import { StatusCodes } from "node-opcua-status-code";
 import { UserConfigurationMask } from "node-opcua-types";
 import should from "should";
 import { createRoleBasedSecurity } from "../source/install_role_based_security.js";
 
 describe("createRoleBasedSecurity — one store behind the userManager bridge", () => {
-    it("seeds users + roles and exposes them through getUserRoles AND getIdentitiesForRole", () => {
-        const security = createRoleBasedSecurity({
+    it("seeds users + roles and exposes them through getUserRoles AND getIdentitiesForRole", async () => {
+        const security = await createRoleBasedSecurity({
             users: [
                 {
                     userName: "admin",
@@ -39,12 +39,12 @@ describe("createRoleBasedSecurity — one store behind the userManager bridge", 
             .should.eql(["joe"]);
 
         // authentication goes through the same user store
-        security.userStore.authenticate("admin", "admin-pw1").statusCode.should.equal(StatusCodes.Good);
-        security.userStore.authenticate("admin", "nope").statusCode.should.equal(StatusCodes.BadUserAccessDenied);
+        (await security.userStore.authenticate("admin", "admin-pw1")).statusCode.should.equal(StatusCodes.Good);
+        (await security.userStore.authenticate("admin", "nope")).statusCode.should.equal(StatusCodes.BadUserAccessDenied);
     });
 
-    it("grants only Anonymous while a user must change the password", () => {
-        const security = createRoleBasedSecurity({
+    it("grants only Anonymous while a user must change the password", async () => {
+        const security = await createRoleBasedSecurity({
             users: [
                 {
                     userName: "newhire",
@@ -58,5 +58,43 @@ describe("createRoleBasedSecurity — one store behind the userManager bridge", 
         roles.should.have.length(1);
         sameNodeId(roles[0], WellKnownRoleIds.Anonymous).should.be.true();
         should(roles.some((r) => sameNodeId(r, WellKnownRoleIds.Operator))).be.false();
+    });
+
+    it("seeds a user from a pre-hashed record (passwordHash) with no clear text", async () => {
+        // record generated offline (would be committed instead of a clear password)
+        const passwordHash = await serializeUser("admin", "s3cret-init", {
+            userConfiguration: UserConfigurationMask.MustChangePassword
+        });
+
+        const security = await createRoleBasedSecurity({
+            users: [
+                { userName: "admin", passwordHash, roles: [WellKnownRoleIds.SecurityAdmin] },
+                { userName: "joe", password: "joe-pw1", roles: [WellKnownRoleIds.Operator] }
+            ]
+        });
+
+        // the original clear-text password authenticates against the imported hash
+        (await security.userStore.authenticate("admin", "s3cret-init")).statusCode.should.equal(StatusCodes.GoodPasswordChangeRequired);
+        (await security.userStore.authenticate("admin", "nope")).statusCode.should.equal(StatusCodes.BadUserAccessDenied);
+
+        // roles are seeded exactly like the clear-text path
+        security.userManager
+            .getIdentitiesForRole(WellKnownRoleIds.SecurityAdmin)
+            .map((i) => i.criteria)
+            .should.eql(["admin"]);
+
+        // clear-text path still works alongside
+        (await security.userStore.authenticate("joe", "joe-pw1")).statusCode.should.equal(StatusCodes.Good);
+    });
+
+    it("rejects when a seed user has neither password nor passwordHash", async () => {
+        await createRoleBasedSecurity({ users: [{ userName: "x", roles: [WellKnownRoleIds.Operator] }] }).then(
+            () => {
+                throw new Error("expected rejection");
+            },
+            (err: Error) => {
+                err.message.should.match(/either "password".*"passwordHash"/);
+            }
+        );
     });
 });

--- a/packages/node-opcua-role-set-server/test/test_user_management_user_manager.ts
+++ b/packages/node-opcua-role-set-server/test/test_user_management_user_manager.ts
@@ -17,10 +17,13 @@ function setup() {
     return { userStore, identityStore, um };
 }
 
-/** Promisify the callback-style bridge check (no session bound). */
+/** Promisify the callback-style bridge check with a minimal bound session. */
 function checkUser(um: IManagedUserManager, userName: string, password: string): Promise<boolean> {
     return new Promise((resolve, reject) => {
-        um.isValidUserAsync(userName, password, (err, ok) => (err ? reject(err) : resolve(!!ok)));
+        // node-opcua invokes isValidUserAsync with `this` = ServerSession; bind a
+        // minimal stand-in here (all SessionThis members are optional).
+        const session = {};
+        um.isValidUserAsync.call(session, userName, password, (err, ok) => (err ? reject(err) : resolve(!!ok)));
     });
 }
 

--- a/packages/node-opcua-role-set-server/test/test_user_management_user_manager.ts
+++ b/packages/node-opcua-role-set-server/test/test_user_management_user_manager.ts
@@ -4,7 +4,7 @@ import { makeNodeId, sameNodeId } from "node-opcua-nodeid";
 import { InMemoryIdentityMappingStore, InMemoryUserManagementStore, WellKnownRoleIds } from "node-opcua-role-set-common";
 import { StatusCodes } from "node-opcua-status-code";
 import { IdentityCriteriaType, IdentityMappingRuleType, UserConfigurationMask } from "node-opcua-types";
-import { createUserManager } from "../source/user_management_user_manager.js";
+import { createUserManager, type IManagedUserManager } from "../source/user_management_user_manager.js";
 
 function setup() {
     const userStore = new InMemoryUserManagementStore();
@@ -17,49 +17,56 @@ function setup() {
     return { userStore, identityStore, um };
 }
 
+/** Promisify the callback-style bridge check (no session bound). */
+function checkUser(um: IManagedUserManager, userName: string, password: string): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+        um.isValidUserAsync(userName, password, (err, ok) => (err ? reject(err) : resolve(!!ok)));
+    });
+}
+
 describe("createUserManager", () => {
-    it("should validate a correct password and record Good", () => {
+    it("should validate a correct password and record Good", async () => {
         const { userStore, um } = setup();
-        userStore.addUser("joe", "pass1", UserConfigurationMask.None, "");
-        um.isValidUser("joe", "pass1").should.be.true();
+        await userStore.addUser("joe", "pass1", UserConfigurationMask.None, "");
+        (await checkUser(um, "joe", "pass1")).should.be.true();
         um.lastAuthStatus.get("joe")?.should.equal(StatusCodes.Good);
     });
 
-    it("should reject a wrong password and record BadUserAccessDenied", () => {
+    it("should reject a wrong password and record BadUserAccessDenied", async () => {
         const { userStore, um } = setup();
-        userStore.addUser("joe", "pass1", UserConfigurationMask.None, "");
-        um.isValidUser("joe", "WRONG").should.be.false();
+        await userStore.addUser("joe", "pass1", UserConfigurationMask.None, "");
+        (await checkUser(um, "joe", "WRONG")).should.be.false();
         um.lastAuthStatus.get("joe")?.should.equal(StatusCodes.BadUserAccessDenied);
     });
 
-    it("should accept a must-change user but record GoodPasswordChangeRequired", () => {
+    it("should accept a must-change user but record GoodPasswordChangeRequired", async () => {
         const { userStore, um } = setup();
-        userStore.addUser("joe", "pass1", UserConfigurationMask.MustChangePassword, "");
-        um.isValidUser("joe", "pass1").should.be.true();
+        await userStore.addUser("joe", "pass1", UserConfigurationMask.MustChangePassword, "");
+        (await checkUser(um, "joe", "pass1")).should.be.true();
         um.lastAuthStatus.get("joe")?.should.equal(StatusCodes.GoodPasswordChangeRequired);
     });
 
-    it("should grant the configured roles to a normal user", () => {
+    it("should grant the configured roles to a normal user", async () => {
         const { userStore, um } = setup();
-        userStore.addUser("joe", "pass1", UserConfigurationMask.None, "");
+        await userStore.addUser("joe", "pass1", UserConfigurationMask.None, "");
         const roles = um.getUserRoles("joe");
         roles.some((r) => sameNodeId(r, WellKnownRoleIds.Operator)).should.be.true();
     });
 
-    it("should grant only Anonymous while a password change is required", () => {
+    it("should grant only Anonymous while a password change is required", async () => {
         const { userStore, um } = setup();
-        userStore.addUser("joe", "pass1", UserConfigurationMask.MustChangePassword, "");
+        await userStore.addUser("joe", "pass1", UserConfigurationMask.MustChangePassword, "");
         const roles = um.getUserRoles("joe");
         roles.should.have.length(1);
         sameNodeId(roles[0], makeNodeId(WellKnownRoles.Anonymous)).should.be.true();
     });
 
-    it("should grant the configured roles again after the password is changed", () => {
+    it("should grant the configured roles again after the password is changed", async () => {
         const { userStore, um } = setup();
-        userStore.addUser("joe", "OldPass1", UserConfigurationMask.MustChangePassword, "");
+        await userStore.addUser("joe", "OldPass1", UserConfigurationMask.MustChangePassword, "");
         um.getUserRoles("joe").should.have.length(1); // anonymous only
 
-        userStore.changePassword("joe", "OldPass1", "NewPass2").should.equal(StatusCodes.Good);
+        (await userStore.changePassword("joe", "OldPass1", "NewPass2")).should.equal(StatusCodes.Good);
         um.getUserRoles("joe")
             .some((r) => sameNodeId(r, WellKnownRoleIds.Operator))
             .should.be.true();

--- a/packages/node-opcua-role-set-test/bin/sample_server_with_role_set.ts
+++ b/packages/node-opcua-role-set-test/bin/sample_server_with_role_set.ts
@@ -80,7 +80,7 @@ export async function startSampleServer(options?: SampleServerOptions): Promise<
     // One-call role-based security: a single user store + identity store reached
     // through the userManager bridge, so role resolution, the `Identities`
     // Property and the management Methods all share one source of truth.
-    const security = createRoleBasedSecurity({
+    const security = await createRoleBasedSecurity({
         users: Object.values(SAMPLE_USERS).map((u) => ({
             userName: u.userName,
             password: u.password,

--- a/packages/node-opcua-role-set-test/test/test_user_management_server_e2e.ts
+++ b/packages/node-opcua-role-set-test/test/test_user_management_server_e2e.ts
@@ -59,7 +59,7 @@ describe("User Management E2E over a real OPCUAServer (MustChangePassword §5.2.
 
         // bootstrap: admin is a managed user mapped to SecurityAdmin;
         // newhire (created later) will be mapped to Operator
-        userStore.addUser("admin", "admin-pw1", UserConfigurationMask.None, "");
+        await userStore.addUser("admin", "admin-pw1", UserConfigurationMask.None, "");
         identityStore.addIdentity(WellKnownRoleIds.SecurityAdmin, userRule("admin"));
         identityStore.addIdentity(WellKnownRoleIds.Operator, userRule("newhire"));
 

--- a/packages/node-opcua-role-set-test/test/test_user_persistence_restart.ts
+++ b/packages/node-opcua-role-set-test/test/test_user_persistence_restart.ts
@@ -96,8 +96,8 @@ describe("User Management persistence across restart (shared archive, §5)", fun
         (await admin2.readUsers()).map((u) => u.userName).should.containEql("alice");
 
         // ... and the salted scrypt hash survived, so the password still verifies
-        b2.userStore.authenticate("alice", "Sekret123!").statusCode.should.equal(StatusCodes.Good);
-        b2.userStore.authenticate("alice", "wrong-password").statusCode.should.equal(StatusCodes.BadUserAccessDenied);
+        (await b2.userStore.authenticate("alice", "Sekret123!")).statusCode.should.equal(StatusCodes.Good);
+        (await b2.userStore.authenticate("alice", "wrong-password")).statusCode.should.equal(StatusCodes.BadUserAccessDenied);
 
         b2.addressSpace.dispose();
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2858,6 +2858,9 @@ importers:
       node-opcua-data-model:
         specifier: 2.174.0
         version: link:../node-opcua-data-model
+      node-opcua-debug:
+        specifier: 2.172.0
+        version: link:../node-opcua-debug
       node-opcua-nodeid:
         specifier: 2.174.0
         version: link:../node-opcua-nodeid

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2813,7 +2813,7 @@ importers:
   packages/node-opcua-role-set-common:
     dependencies:
       bcryptjs:
-        specifier: ^3.0.3
+        specifier: 3.0.3
         version: 3.0.3
       node-opcua-basic-types:
         specifier: 2.174.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2812,6 +2812,9 @@ importers:
 
   packages/node-opcua-role-set-common:
     dependencies:
+      bcryptjs:
+        specifier: ^3.0.3
+        version: 3.0.3
       node-opcua-basic-types:
         specifier: 2.174.0
         version: link:../node-opcua-basic-types


### PR DESCRIPTION
- Store credentials as self-describing PHC strings so schemes coexist and are
 told apart by prefix ($scrypt$ / $2b$). A HasherRegistry hashes new credentials
 with the default (scrypt, Node core) and verifies by routing on the prefix;
 non-default schemes report needsRehash, so a legacy credential is transparently
 migrated to crypt on the next successful login (upgrade-on-login). bcrypt ships
 as a verify-only default for interol/migration.

- Credential operations (authenticate/addUser/changePassword/modifyUser) are now
  async so an external versifier (LDAP/argon2) can be added later without another
  interface change. createRoleBasedSecurity is sync and accepts a `registry` for
  injecting schemes; the userManager bridge now exposes isValidUserAsync
  (callback-style, preferred by UAUserManager1).

- Persistence: archive bumped to v2 (credential string); v1 {salt,hash} records
  are read-migrated losslessly, so no forced password resets. New helpers:
  serializeUser (offline crypt record) and credentialRecord (wrap an
  already-hashed credential such as a legacy crypt hash).

