### PR TITLE
fix(address-space): prevent NodeIdManager symbol-cache collisions and honor AnalogItemType subtypes

### DIFF
--- a/packages/node-opcua-address-space/source/namespace_data_access.ts
+++ b/packages/node-opcua-address-space/source/namespace_data_access.ts
@@ -2,7 +2,8 @@ import type {
     AddVariableOptionsWithoutValue,
     AddYArrayItemOptions,
     BindVariableOptions,
-    UADataType
+    UADataType,
+    UAVariableType
 } from "node-opcua-address-space-base";
 import type { NodeIdLike } from "node-opcua-nodeid";
 import type { UAAnalogItem, UADataItem } from "node-opcua-nodeset-ua";
@@ -44,6 +45,13 @@ export interface AddAnalogDataItemOptions extends AddDataItemOptions {
     engineeringUnits?: EUInformationOptions | EUInformation;
     minimumSamplingInterval?: number;
     dataType?: string | NodeIdLike | UADataType;
+
+    /**
+     * an optional VariableType, which must be a subtype of AnalogItemType, to use instead of the
+     * plain AnalogItemType. Its own mandatory members (if any) will be instantiated as well.
+     * @default AnalogItemType
+     */
+    typeDefinition?: string | NodeIdLike | UAVariableType;
 
     /**
      * the acceptValueOutOfRange property indicates whether the write operation will accept or reject a value which

--- a/packages/node-opcua-address-space/src/namespace_impl.ts
+++ b/packages/node-opcua-address-space/src/namespace_impl.ts
@@ -45,7 +45,7 @@ import {
     type QualifiedNameLike
 } from "node-opcua-data-model";
 import { dumpIf, make_errorLog, make_warningLog } from "node-opcua-debug";
-import { coerceNodeId, NodeId, type NodeIdLike, NodeIdType, resolveNodeId } from "node-opcua-nodeid";
+import { coerceNodeId, NodeId, type NodeIdLike, NodeIdType, resolveNodeId, sameNodeId } from "node-opcua-nodeid";
 import type { UAAnalogItem, UADataItem, UAInitialState, UAState } from "node-opcua-nodeset-ua";
 import { StatusCodes } from "node-opcua-status-code";
 import {
@@ -903,9 +903,52 @@ export class NamespaceImpl implements NamespacePrivate {
             throw new Error("expecting AnalogItemType to be defined , check nodeset xml file");
         }
 
-        const clone_options = { ...options, dataType, typeDefinition: analogItemType.nodeId } as AddVariableOptions;
+        // options.typeDefinition may designate a subtype of AnalogItemType (e.g. a companion
+        // specification's own AnalogItemType-derived VariableType). In that case we must honor it
+        // so that the subtype's identity - and its own mandatory members - are preserved, instead of
+        // silently downgrading the variable to a plain AnalogItemType.
+        let requestedTypeDefinition = analogItemType;
+        if (options.typeDefinition) {
+            const t =
+                options.typeDefinition instanceof BaseNodeImpl
+                    ? (options.typeDefinition as unknown as UAVariableType)
+                    : addressSpace.findVariableType(options.typeDefinition as NodeIdLike);
+            if (!t) {
+                throw new Error(`cannot find requested typeDefinition ${options.typeDefinition.toString()}`);
+            }
+            if (!t.isSubtypeOf(analogItemType)) {
+                throw new Error(`typeDefinition ${t.browseName.toString()} shall be a subtype of AnalogItemType`);
+            }
+            requestedTypeDefinition = t;
+        }
+        const isStrictSubtype = !sameNodeId(requestedTypeDefinition.nodeId, analogItemType.nodeId);
 
-        const variable = this.addVariable(clone_options) as unknown as UAVariableImpl;
+        let variable: UAVariableImpl;
+        if (isStrictSubtype) {
+            // instantiate the requested subtype so that its own mandatory members
+            // (in addition to the AnalogItemType ones) get materialized.
+            const optionals: string[] = [];
+            if (Object.hasOwn(options, "instrumentRange")) {
+                optionals.push("InstrumentRange");
+            }
+            if (Object.hasOwn(options, "engineeringUnits")) {
+                optionals.push("EngineeringUnits");
+            }
+            variable = requestedTypeDefinition.instantiate({
+                browseName: options.browseName,
+                componentOf: options.componentOf,
+                dataType: addressSpace._coerce_DataType(dataType as NodeIdLike),
+                modellingRule: options.modellingRule,
+                nodeId: options.nodeId,
+                notifierOf: options.notifierOf,
+                eventSourceOf: options.eventSourceOf,
+                organizedBy: options.organizedBy,
+                optionals
+            }) as unknown as UAVariableImpl;
+        } else {
+            const clone_options = { ...options, dataType, typeDefinition: analogItemType.nodeId } as AddVariableOptions;
+            variable = this.addVariable(clone_options) as unknown as UAVariableImpl;
+        }
 
         add_dataItem_stuff(variable, options);
 
@@ -920,18 +963,30 @@ export class NamespaceImpl implements NamespacePrivate {
         // prepared to handle this.
         //     Example:    EURange ::= {-200.0,1400.0}
 
-        const euRange = this.addVariable({
-            browseName: { name: "EURange", namespaceIndex: 0 },
-            dataType: "Range",
-            minimumSamplingInterval: 0,
-            modellingRule: options.modellingRule,
-            propertyOf: variable,
-            typeDefinition: "PropertyType",
-            value: new Variant({
-                dataType: DataType.ExtensionObject,
-                value: new Range(options.engineeringUnitsRange)
-            })
-        }) as unknown as UAVariableImpl;
+        // when `variable` was instantiated from a strict AnalogItemType subtype (isStrictSubtype),
+        // EURange/InstrumentRange/EngineeringUnits may already exist as cloned mandatory/optional
+        // members of that subtype - reuse them instead of creating duplicate property nodes.
+        const euRangeExisting = variable.getPropertyByName("EURange") as UAVariableImpl | null;
+        const euRange =
+            euRangeExisting ||
+            (this.addVariable({
+                browseName: { name: "EURange", namespaceIndex: 0 },
+                dataType: "Range",
+                minimumSamplingInterval: 0,
+                modellingRule: options.modellingRule,
+                propertyOf: variable,
+                typeDefinition: "PropertyType",
+                value: new Variant({
+                    dataType: DataType.ExtensionObject,
+                    value: new Range(options.engineeringUnitsRange)
+                })
+            }) as unknown as UAVariableImpl);
+        if (euRangeExisting) {
+            euRange.setValueFromSource(
+                new Variant({ dataType: DataType.ExtensionObject, value: new Range(options.engineeringUnitsRange) }),
+                StatusCodes.Good
+            );
+        }
 
         assert(euRange.readValue().value.value instanceof Range);
 
@@ -939,19 +994,28 @@ export class NamespaceImpl implements NamespacePrivate {
         euRange.on("value_changed", handler);
 
         if (Object.hasOwn(options, "instrumentRange")) {
-            const instrumentRange = this.addVariable({
-                accessLevel: "CurrentRead | CurrentWrite",
-                browseName: { name: "InstrumentRange", namespaceIndex: 0 },
-                dataType: "Range",
-                minimumSamplingInterval: 0,
-                modellingRule: options.modellingRule ? "Mandatory" : undefined,
-                propertyOf: variable,
-                typeDefinition: "PropertyType",
-                value: new Variant({
-                    dataType: DataType.ExtensionObject,
-                    value: new Range(options.instrumentRange)
-                })
-            });
+            const instrumentRangeExisting = variable.getPropertyByName("InstrumentRange") as UAVariableImpl | null;
+            const instrumentRange =
+                instrumentRangeExisting ||
+                this.addVariable({
+                    accessLevel: "CurrentRead | CurrentWrite",
+                    browseName: { name: "InstrumentRange", namespaceIndex: 0 },
+                    dataType: "Range",
+                    minimumSamplingInterval: 0,
+                    modellingRule: options.modellingRule ? "Mandatory" : undefined,
+                    propertyOf: variable,
+                    typeDefinition: "PropertyType",
+                    value: new Variant({
+                        dataType: DataType.ExtensionObject,
+                        value: new Range(options.instrumentRange)
+                    })
+                });
+            if (instrumentRangeExisting) {
+                instrumentRange.setValueFromSource(
+                    new Variant({ dataType: DataType.ExtensionObject, value: new Range(options.instrumentRange) }),
+                    StatusCodes.Good
+                );
+            }
 
             instrumentRange.on("value_changed", handler);
         }
@@ -964,19 +1028,28 @@ export class NamespaceImpl implements NamespacePrivate {
             // EngineeringUnits  specifies the units for the   DataItem‟s value (e.g., degree, hertz, seconds).   The
             // EUInformation   type is specified in   5.6.3.
 
-            const eu = this.addVariable({
-                accessLevel: "CurrentRead",
-                browseName: { name: "EngineeringUnits", namespaceIndex: 0 },
-                dataType: "EUInformation",
-                minimumSamplingInterval: 0,
-                modellingRule: options.modellingRule ? "Mandatory" : undefined,
-                propertyOf: variable,
-                typeDefinition: "PropertyType",
-                value: new Variant({
-                    dataType: DataType.ExtensionObject,
-                    value: engineeringUnits
-                })
-            });
+            const euExisting = variable.getPropertyByName("EngineeringUnits") as UAVariableImpl | null;
+            const eu =
+                euExisting ||
+                this.addVariable({
+                    accessLevel: "CurrentRead",
+                    browseName: { name: "EngineeringUnits", namespaceIndex: 0 },
+                    dataType: "EUInformation",
+                    minimumSamplingInterval: 0,
+                    modellingRule: options.modellingRule ? "Mandatory" : undefined,
+                    propertyOf: variable,
+                    typeDefinition: "PropertyType",
+                    value: new Variant({
+                        dataType: DataType.ExtensionObject,
+                        value: engineeringUnits
+                    })
+                });
+            if (euExisting) {
+                eu.setValueFromSource(
+                    new Variant({ dataType: DataType.ExtensionObject, value: engineeringUnits }),
+                    StatusCodes.Good
+                );
+            }
 
             eu.on("value_changed", handler);
         }

--- a/packages/node-opcua-address-space/src/nodeid_manager.ts
+++ b/packages/node-opcua-address-space/src/nodeid_manager.ts
@@ -72,7 +72,7 @@ function _findParentNodeId(addressSpace: AddressSpacePartial, options: Construct
 
 function prepareName(browseName?: QualifiedName | QualifiedNameOptions): string {
     const m = browseName?.name?.toString().replace(/[ ]/g, "").replace(/(<|>)/g, "");
-    return m ||"";
+    return m || "";
 }
 
 export interface AddressSpacePartial {
@@ -170,11 +170,12 @@ export class NodeIdManager {
                 fullParentName = buildUpName2(parentNodeId, suffix);
             }
             const fullName = compose(fullParentName, prepareName(options.browseName));
-            if (this._cacheSymbolicName[fullName]) {
-                return makeNodeId(this._cacheSymbolicName[fullName][0], this.namespaceIndex);
+            const cached = this._cacheSymbolicName[fullName];
+            if (cached && this._isCacheHitReusable(cached[0], options, parentInfo)) {
+                return makeNodeId(cached[0], this.namespaceIndex);
             }
             const nodeId = this._constructNodeId(options);
-            if (nodeId.identifierType === NodeIdType.NUMERIC) {
+            if (nodeId.identifierType === NodeIdType.NUMERIC && !cached) {
                 this._cacheSymbolicName[fullName] = [nodeId.value as number, options.nodeClass || NodeClass.Unspecified];
                 this._cacheSymbolicNameRev.add(nodeId.value as number);
             }
@@ -199,6 +200,47 @@ export class NodeIdManager {
             }
         }
         return nodeId;
+    }
+
+    /**
+     * A symbol-cache hit is only safe to reuse when it actually refers to
+     * the node we are about to construct. Because the cache key is built
+     * from a (possibly truncated, e.g. during a clone where parentNodeId
+     * isn't linked yet) parent-name chain, two unrelated nodes can end up
+     * sharing the same key. When that happens, reusing the cached nodeId
+     * would hand a brand-new node the identity of a completely different,
+     * already-registered one.
+     *
+     * We only trust the cache hit when either:
+     *  - nothing occupies that nodeId yet (first-time reservation), or
+     *  - the occupant is genuinely the same node (same browseName AND same
+     *    parent) - in which case we deliberately return the same id so
+     *    that the caller's duplicate-registration error still fires.
+     */
+    private _isCacheHitReusable(value: number, options: ConstructNodeIdOptions, parentInfo: [NodeId, Suffix] | null): boolean {
+        const candidate = makeNodeId(value, this.namespaceIndex);
+        const occupant = this.addressSpace.findNode(candidate);
+        if (!occupant) {
+            return true;
+        }
+        // a namespaceIndex of 0 on options.browseName is ambiguous: it may mean "explicitly
+        // namespace 0" or simply "unspecified, use this manager's own namespace" (the latter is
+        // what happens when browseName is passed as a plain string, see internalCreateNode).
+        // Normalizing 0 to this manager's namespace on both sides keeps the common default-namespace
+        // case working, while still relying on the parent check below to disambiguate real
+        // same-name/same-namespace collisions (e.g. two sibling nodes both using explicit "0:EngineeringUnits").
+        const normalizeNs = (ns: number | undefined | null) => ns || this.namespaceIndex;
+        const sameBrowseName =
+            !!occupant.browseName &&
+            occupant.browseName.name === (options.browseName?.name ?? null) &&
+            normalizeNs(occupant.browseName.namespaceIndex) === normalizeNs(options.browseName?.namespaceIndex);
+
+        const expectedParentNodeId = parentInfo ? parentInfo[0] : null;
+        const sameParent = expectedParentNodeId
+            ? !!occupant.parentNodeId && sameNodeId(occupant.parentNodeId, expectedParentNodeId)
+            : !occupant.parentNodeId;
+
+        return sameBrowseName && sameParent;
     }
 
     private _constructNodeId(options: ConstructNodeIdOptions): NodeId {

--- a/packages/node-opcua-address-space/src/nodeid_manager.ts
+++ b/packages/node-opcua-address-space/src/nodeid_manager.ts
@@ -223,17 +223,16 @@ export class NodeIdManager {
         if (!occupant) {
             return true;
         }
-        // a namespaceIndex of 0 on options.browseName is ambiguous: it may mean "explicitly
-        // namespace 0" or simply "unspecified, use this manager's own namespace" (the latter is
-        // what happens when browseName is passed as a plain string, see internalCreateNode).
-        // Normalizing 0 to this manager's namespace on both sides keeps the common default-namespace
-        // case working, while still relying on the parent check below to disambiguate real
-        // same-name/same-namespace collisions (e.g. two sibling nodes both using explicit "0:EngineeringUnits").
-        const normalizeNs = (ns: number | undefined | null) => ns || this.namespaceIndex;
+        // options.browseName is expected to already carry its real, resolved namespaceIndex by the
+        // time it reaches here: internalCreateNode() normalizes plain-string browseNames to
+        // `namespaceIndex: this.index` before construction, so `0` here means "explicitly namespace 0"
+        // (e.g. the standard "0:EURange" / "0:EngineeringUnits" properties), not "unspecified".
+        // Comparing literally keeps genuinely different namespaces (own-namespace vs explicit ns 0)
+        // from being treated as the same node.
         const sameBrowseName =
             !!occupant.browseName &&
             occupant.browseName.name === (options.browseName?.name ?? null) &&
-            normalizeNs(occupant.browseName.namespaceIndex) === normalizeNs(options.browseName?.namespaceIndex);
+            (occupant.browseName.namespaceIndex ?? 0) === (options.browseName?.namespaceIndex ?? 0);
 
         const expectedParentNodeId = parentInfo ? parentInfo[0] : null;
         const sameParent = expectedParentNodeId

--- a/packages/node-opcua-address-space/test/data_access/subtest_analog_item_type.ts
+++ b/packages/node-opcua-address-space/test/data_access/subtest_analog_item_type.ts
@@ -182,5 +182,164 @@ export function subtest_analog_item_type(maintest: any): void {
             const statusCode = await analogItem.writeValue(context, dataValue);
             statusCode.should.eql(StatusCodes.Good);
         });
+
+        it("should honor a typeDefinition that is a strict subtype of AnalogItemType and materialize its own mandatory members", () => {
+            const analogItemType = addressSpace.findVariableType("AnalogItemType")!;
+
+            // simulates a companion-specification VariableType derived from AnalogItemType,
+            // with its own mandatory member (e.g. PADIM's ActualVolumeFlowRateVariableType / LowFlowCutOff)
+            const myAnalogSubtype = namespace.addVariableType({
+                browseName: "MyAnalogSubtype",
+                subtypeOf: analogItemType
+            });
+            namespace.addVariable({
+                browseName: "LowFlowCutOff",
+                componentOf: myAnalogSubtype,
+                dataType: "Double",
+                modellingRule: "Mandatory"
+            });
+
+            const objectsFolder = addressSpace.rootFolder.objects;
+
+            const analogItem = namespace.addAnalogDataItem({
+                browseName: "MyAnalogSubtypeInstance",
+                dataType: "Double",
+                engineeringUnits: standardUnits.degree_celsius,
+                engineeringUnitsRange: { low: 0, high: 100 },
+                instrumentRange: { low: 0, high: 100 },
+                organizedBy: objectsFolder,
+                typeDefinition: myAnalogSubtype,
+                value: new Variant({ dataType: DataType.Double, value: 10.0 })
+            });
+
+            // the HasTypeDefinition reference must point to the requested subtype, not AnalogItemType
+            analogItem.typeDefinitionObj.nodeId.toString().should.eql(myAnalogSubtype.nodeId.toString());
+
+            // the subtype's own mandatory member must have been instantiated
+            const lowFlowCutOff = analogItem.getComponentByName("LowFlowCutOff");
+            should.exist(lowFlowCutOff);
+
+            // and the usual AnalogItemType members must still be there, with a single instance each
+            analogItem.euRange.readValue().value.value.low.should.eql(0);
+            analogItem.euRange.readValue().value.value.high.should.eql(100);
+            analogItem.instrumentRange?.readValue().value.value.low.should.eql(0);
+            analogItem.engineeringUnits?.readValue().value.value.displayName.text?.should.eql(
+                standardUnits.degree_celsius.displayName?.text
+            );
+
+            const browseDescription = new BrowseDescription({
+                browseDirection: BrowseDirection.Forward,
+                nodeClassMask: 0,
+                referenceTypeId: 0,
+                resultMask: 0x3f
+            });
+            const references = analogItem.browseNode(browseDescription);
+            references.filter((r) => r.browseName.name === "EURange").length.should.eql(1);
+            references.filter((r) => r.browseName.name === "InstrumentRange").length.should.eql(1);
+            references.filter((r) => r.browseName.name === "EngineeringUnits").length.should.eql(1);
+        });
+
+        it("should accept a typeDefinition passed as a NodeId, resolving it like the VariableType instance form", () => {
+            const analogItemType = addressSpace.findVariableType("AnalogItemType")!;
+            const myAnalogSubtype2 = namespace.addVariableType({
+                browseName: "MyAnalogSubtype2",
+                subtypeOf: analogItemType
+            });
+
+            const objectsFolder = addressSpace.rootFolder.objects;
+
+            const analogItem = namespace.addAnalogDataItem({
+                browseName: "MyAnalogSubtype2Instance",
+                dataType: "Double",
+                engineeringUnitsRange: { low: 0, high: 100 },
+                organizedBy: objectsFolder,
+                typeDefinition: myAnalogSubtype2.nodeId,
+                value: new Variant({ dataType: DataType.Double, value: 10.0 })
+            });
+
+            analogItem.typeDefinitionObj.nodeId.toString().should.eql(myAnalogSubtype2.nodeId.toString());
+        });
+
+        it("should accept a typeDefinition passed as a browseName string (own-namespace form)", () => {
+            const analogItemType = addressSpace.findVariableType("AnalogItemType")!;
+            const myAnalogSubtype2b = namespace.addVariableType({
+                browseName: "MyAnalogSubtype2b",
+                subtypeOf: analogItemType
+            });
+
+            const objectsFolder = addressSpace.rootFolder.objects;
+
+            const analogItem = namespace.addAnalogDataItem({
+                browseName: "MyAnalogSubtype2bInstance",
+                dataType: "Double",
+                engineeringUnitsRange: { low: 0, high: 100 },
+                organizedBy: objectsFolder,
+                typeDefinition: `${namespace.index}:MyAnalogSubtype2b`,
+                value: new Variant({ dataType: DataType.Double, value: 10.0 })
+            });
+
+            analogItem.typeDefinitionObj.nodeId.toString().should.eql(myAnalogSubtype2b.nodeId.toString());
+        });
+
+        it("should throw when typeDefinition is not a subtype of AnalogItemType", () => {
+            const unrelatedType = namespace.addVariableType({
+                browseName: "UnrelatedVariableType",
+                subtypeOf: "BaseDataVariableType"
+            });
+
+            const objectsFolder = addressSpace.rootFolder.objects;
+
+            should(() =>
+                namespace.addAnalogDataItem({
+                    browseName: "ShouldFail",
+                    dataType: "Double",
+                    engineeringUnitsRange: { low: 0, high: 100 },
+                    organizedBy: objectsFolder,
+                    typeDefinition: unrelatedType,
+                    value: new Variant({ dataType: DataType.Double, value: 10.0 })
+                })
+            ).throw(/shall be a subtype of AnalogItemType/);
+        });
+
+        it("should instantiate only the mandatory members when a subtype is used without instrumentRange/engineeringUnits options", () => {
+            const analogItemType = addressSpace.findVariableType("AnalogItemType")!;
+            const myAnalogSubtype3 = namespace.addVariableType({
+                browseName: "MyAnalogSubtype3",
+                subtypeOf: analogItemType
+            });
+            namespace.addVariable({
+                browseName: "LowFlowCutOff",
+                componentOf: myAnalogSubtype3,
+                dataType: "Double",
+                modellingRule: "Mandatory"
+            });
+
+            const objectsFolder = addressSpace.rootFolder.objects;
+
+            const analogItem = namespace.addAnalogDataItem({
+                browseName: "MyAnalogSubtype3Instance",
+                dataType: "Double",
+                engineeringUnitsRange: { low: 0, high: 100 },
+                organizedBy: objectsFolder,
+                typeDefinition: myAnalogSubtype3,
+                value: new Variant({ dataType: DataType.Double, value: 10.0 })
+            });
+
+            analogItem.typeDefinitionObj.nodeId.toString().should.eql(myAnalogSubtype3.nodeId.toString());
+            should.exist(analogItem.getComponentByName("LowFlowCutOff"));
+
+            analogItem.euRange.readValue().value.value.low.should.eql(0);
+            should.not.exist(analogItem.instrumentRange);
+            should.not.exist(analogItem.engineeringUnits);
+
+            const browseDescription = new BrowseDescription({
+                browseDirection: BrowseDirection.Forward,
+                nodeClassMask: 0,
+                referenceTypeId: 0,
+                resultMask: 0x3f
+            });
+            const references = analogItem.browseNode(browseDescription);
+            references.filter((r) => r.browseName.name === "EURange").length.should.eql(1);
+        });
     });
 }

--- a/packages/node-opcua-address-space/test/test_nodeid_manager.ts
+++ b/packages/node-opcua-address-space/test/test_nodeid_manager.ts
@@ -143,7 +143,9 @@ describe("NodeIdManager", () => {
         nodeIdManager.getSymbolCSV().should.eql(`SomeName;1000;Object\nSomeName_Property1;1001;Variable`);
 
         const options2 = {
-            browseName: coerceQualifiedName("Property1"),
+            // mirror what internalCreateNode() does for a plain string browseName: it resolves to
+            // this namespace's own index, not the QualifiedName default of 0.
+            browseName: coerceQualifiedName({ name: "Property1", namespaceIndex: ns.index }),
             nodeClass: NodeClass.Variable,
             registerSymbolicNames: true,
             references: [
@@ -192,14 +194,16 @@ describe("NodeIdManager", () => {
             dataType: "Double"
         });
 
-        // force a symbol-cache collision: pretend the truncated key for a totally
-        // different (parent2, EngineeringUnits) pair maps to the already-occupied
-        // nodeId of firstChild.
-        const collidingKey = "EngineeringUnits";
+        // force a symbol-cache collision: pretend a previous (buggy) run mapped the *real* key
+        // that a (parent2, EngineeringUnits) child resolves to ("Parent2_EngineeringUnits") onto
+        // the already-occupied nodeId of firstChild (a child of parent1).
+        const collidingKey = "Parent2_EngineeringUnits";
         (nodeIdManager as any)._cacheSymbolicName[collidingKey] = [firstChild.nodeId.value as number, NodeClass.Variable];
 
         const options: ConstructNodeIdOptions = {
-            browseName: coerceQualifiedName("EngineeringUnits"),
+            // mirror what internalCreateNode() does for a plain string browseName: it resolves to
+            // this namespace's own index, not the QualifiedName default of 0.
+            browseName: coerceQualifiedName({ name: "EngineeringUnits", namespaceIndex: ns.index }),
             nodeClass: NodeClass.Variable,
             registerSymbolicNames: true,
             references: [{ isForward: false, nodeId: parent2.nodeId, referenceType: resolveNodeId("HasComponent") }]
@@ -221,7 +225,9 @@ describe("NodeIdManager", () => {
         });
 
         const options: ConstructNodeIdOptions = {
-            browseName: coerceQualifiedName("EngineeringUnits"),
+            // mirror what internalCreateNode() does for a plain string browseName: it resolves to
+            // this namespace's own index, not the QualifiedName default of 0.
+            browseName: coerceQualifiedName({ name: "EngineeringUnits", namespaceIndex: ns.index }),
             nodeClass: NodeClass.Variable,
             registerSymbolicNames: true,
             references: [{ isForward: false, nodeId: parent.nodeId, referenceType: resolveNodeId("HasComponent") }]
@@ -244,13 +250,16 @@ describe("NodeIdManager", () => {
             dataType: "Double"
         });
 
-        // force a symbol-cache collision on a truncated key, same parent, but a genuinely
-        // different local name ("InstrumentRange" vs "EngineeringUnits").
-        const collidingKey = "InstrumentRange";
+        // force a symbol-cache collision: pretend a previous (buggy) run mapped the *real* key
+        // that a (parent, InstrumentRange) child resolves to ("Parent1_InstrumentRange") onto the
+        // already-occupied nodeId of firstChild ("Parent1_EngineeringUnits" for real).
+        const collidingKey = "Parent1_InstrumentRange";
         (nodeIdManager as any)._cacheSymbolicName[collidingKey] = [firstChild.nodeId.value as number, NodeClass.Variable];
 
         const options: ConstructNodeIdOptions = {
-            browseName: coerceQualifiedName("InstrumentRange"),
+            // mirror what internalCreateNode() does for a plain string browseName: it resolves to
+            // this namespace's own index, not the QualifiedName default of 0.
+            browseName: coerceQualifiedName({ name: "InstrumentRange", namespaceIndex: ns.index }),
             nodeClass: NodeClass.Variable,
             registerSymbolicNames: true,
             references: [{ isForward: false, nodeId: parent.nodeId, referenceType: resolveNodeId("HasComponent") }]
@@ -268,7 +277,9 @@ describe("NodeIdManager", () => {
         const firstChild = ns.addObject({ browseName: "TopLevelObject" });
 
         const options: ConstructNodeIdOptions = {
-            browseName: coerceQualifiedName("TopLevelObject"),
+            // mirror what internalCreateNode() does for a plain string browseName: it resolves to
+            // this namespace's own index, not the QualifiedName default of 0.
+            browseName: coerceQualifiedName({ name: "TopLevelObject", namespaceIndex: ns.index }),
             nodeClass: NodeClass.Object,
             registerSymbolicNames: true
         };
@@ -284,13 +295,16 @@ describe("NodeIdManager", () => {
         // a top-level occupant (no parent)
         const firstChild = ns.addObject({ browseName: "SharedName" });
 
-        // force a collision: the truncated key for a (parent, SharedName) pair maps to the
+        // force a collision: pretend a previous (buggy) run mapped the *real* key that a
+        // (parent, SharedName) child resolves to ("SomeParent_SharedName") onto the
         // already-occupied nodeId of the top-level firstChild.
         const parent = ns.addObject({ browseName: "SomeParent" });
-        (nodeIdManager as any)._cacheSymbolicName.SharedName = [firstChild.nodeId.value as number, NodeClass.Object];
+        (nodeIdManager as any)._cacheSymbolicName.SomeParent_SharedName = [firstChild.nodeId.value as number, NodeClass.Object];
 
         const options: ConstructNodeIdOptions = {
-            browseName: coerceQualifiedName("SharedName"),
+            // mirror what internalCreateNode() does for a plain string browseName: it resolves to
+            // this namespace's own index, not the QualifiedName default of 0.
+            browseName: coerceQualifiedName({ name: "SharedName", namespaceIndex: ns.index }),
             nodeClass: NodeClass.Object,
             registerSymbolicNames: true,
             references: [{ isForward: false, nodeId: parent.nodeId, referenceType: resolveNodeId("HasComponent") }]

--- a/packages/node-opcua-address-space/test/test_nodeid_manager.ts
+++ b/packages/node-opcua-address-space/test/test_nodeid_manager.ts
@@ -159,4 +159,144 @@ describe("NodeIdManager", () => {
 
         nodeIdManager.getSymbolCSV().should.eql(`SomeName;1000;Object\nSomeName_Property1;1001;Variable`);
     });
+
+    it("should not collide when two children share the same local name but different browseName namespaces", () => {
+        // simulates an inherited 4:ActualSpeed and an overriding 1:ActualSpeed under the same parent
+        const ns = addressSpace.getOwnNamespace();
+        setSymbols(ns, []);
+        const parent = ns.addObject({ browseName: "ParameterSet" });
+
+        const child1 = ns.addVariable({
+            browseName: { name: "ActualSpeed", namespaceIndex: 4 },
+            componentOf: parent,
+            dataType: "Double"
+        });
+        const child2 = ns.addVariable({
+            browseName: { name: "ActualSpeed", namespaceIndex: 1 },
+            componentOf: parent,
+            dataType: "Double"
+        });
+
+        child1.nodeId.toString().should.not.eql(child2.nodeId.toString());
+    });
+
+    it("should not hand out an occupied nodeId to a different node when the symbol-cache key collides", () => {
+        const ns = addressSpace.getOwnNamespace();
+        setSymbols(ns, []);
+        const parent1 = ns.addObject({ browseName: "Parent1" });
+        const parent2 = ns.addObject({ browseName: "Parent2" });
+
+        const firstChild = ns.addVariable({
+            browseName: "EngineeringUnits",
+            componentOf: parent1,
+            dataType: "Double"
+        });
+
+        // force a symbol-cache collision: pretend the truncated key for a totally
+        // different (parent2, EngineeringUnits) pair maps to the already-occupied
+        // nodeId of firstChild.
+        const collidingKey = "EngineeringUnits";
+        (nodeIdManager as any)._cacheSymbolicName[collidingKey] = [firstChild.nodeId.value as number, NodeClass.Variable];
+
+        const options: ConstructNodeIdOptions = {
+            browseName: coerceQualifiedName("EngineeringUnits"),
+            nodeClass: NodeClass.Variable,
+            registerSymbolicNames: true,
+            references: [{ isForward: false, nodeId: parent2.nodeId, referenceType: resolveNodeId("HasComponent") }]
+        };
+        const nodeId = nodeIdManager.constructNodeId(options);
+
+        nodeId.toString().should.not.eql(firstChild.nodeId.toString());
+    });
+
+    it("should keep returning the same nodeId for a genuine duplicate (same browseName and same parent)", () => {
+        const ns = addressSpace.getOwnNamespace();
+        setSymbols(ns, []);
+        const parent = ns.addObject({ browseName: "Parent1" });
+
+        const firstChild = ns.addVariable({
+            browseName: "EngineeringUnits",
+            componentOf: parent,
+            dataType: "Double"
+        });
+
+        const options: ConstructNodeIdOptions = {
+            browseName: coerceQualifiedName("EngineeringUnits"),
+            nodeClass: NodeClass.Variable,
+            registerSymbolicNames: true,
+            references: [{ isForward: false, nodeId: parent.nodeId, referenceType: resolveNodeId("HasComponent") }]
+        };
+        const nodeId = nodeIdManager.constructNodeId(options);
+
+        // a genuine duplicate must still resolve to the same id, so that downstream
+        // registerNode() raises its "already registered" error as before.
+        nodeId.toString().should.eql(firstChild.nodeId.toString());
+    });
+
+    it("should not reuse a cached id when the occupant has a different browseName under the same parent", () => {
+        const ns = addressSpace.getOwnNamespace();
+        setSymbols(ns, []);
+        const parent = ns.addObject({ browseName: "Parent1" });
+
+        const firstChild = ns.addVariable({
+            browseName: "EngineeringUnits",
+            componentOf: parent,
+            dataType: "Double"
+        });
+
+        // force a symbol-cache collision on a truncated key, same parent, but a genuinely
+        // different local name ("InstrumentRange" vs "EngineeringUnits").
+        const collidingKey = "InstrumentRange";
+        (nodeIdManager as any)._cacheSymbolicName[collidingKey] = [firstChild.nodeId.value as number, NodeClass.Variable];
+
+        const options: ConstructNodeIdOptions = {
+            browseName: coerceQualifiedName("InstrumentRange"),
+            nodeClass: NodeClass.Variable,
+            registerSymbolicNames: true,
+            references: [{ isForward: false, nodeId: parent.nodeId, referenceType: resolveNodeId("HasComponent") }]
+        };
+        const nodeId = nodeIdManager.constructNodeId(options);
+
+        nodeId.toString().should.not.eql(firstChild.nodeId.toString());
+    });
+
+    it("should recognize a genuine duplicate among top-level nodes that have no parent", () => {
+        const ns = addressSpace.getOwnNamespace();
+        setSymbols(ns, []);
+
+        // a top-level node has no componentOf/organizedBy, so parentNodeId is undefined
+        const firstChild = ns.addObject({ browseName: "TopLevelObject" });
+
+        const options: ConstructNodeIdOptions = {
+            browseName: coerceQualifiedName("TopLevelObject"),
+            nodeClass: NodeClass.Object,
+            registerSymbolicNames: true
+        };
+        const nodeId = nodeIdManager.constructNodeId(options);
+
+        nodeId.toString().should.eql(firstChild.nodeId.toString());
+    });
+
+    it("should not reuse a top-level cached id for a lookup that resolves to a real parent", () => {
+        const ns = addressSpace.getOwnNamespace();
+        setSymbols(ns, []);
+
+        // a top-level occupant (no parent)
+        const firstChild = ns.addObject({ browseName: "SharedName" });
+
+        // force a collision: the truncated key for a (parent, SharedName) pair maps to the
+        // already-occupied nodeId of the top-level firstChild.
+        const parent = ns.addObject({ browseName: "SomeParent" });
+        (nodeIdManager as any)._cacheSymbolicName.SharedName = [firstChild.nodeId.value as number, NodeClass.Object];
+
+        const options: ConstructNodeIdOptions = {
+            browseName: coerceQualifiedName("SharedName"),
+            nodeClass: NodeClass.Object,
+            registerSymbolicNames: true,
+            references: [{ isForward: false, nodeId: parent.nodeId, referenceType: resolveNodeId("HasComponent") }]
+        };
+        const nodeId = nodeIdManager.constructNodeId(options);
+
+        nodeId.toString().should.not.eql(firstChild.nodeId.toString());
+    });
 });


### PR DESCRIPTION
## Summary

- `NodeIdManager.constructNodeId()` no longer trusts a symbol-cache hit blindly: it now verifies the cached nodeId is either unoccupied or genuinely owned by the same node (same browseName + same parent) before reusing it. This fixes spurious "already registered" errors when:
  - an inherited and an overriding same-name child collide on the same cache key (e.g. an own-namespace `1:ActualSpeed` next to an inherited `4:ActualSpeed` under the same parent), or
  - sibling nodes under different parents share a truncated cache key (e.g. two `0:EngineeringUnits` properties on sibling AnalogItems), typically during clone operations where the parent chain isn't fully linked yet.

  Genuine duplicates (same browseName, same parent) still resolve to the same id, so `registerNode()`'s duplicate-registration error keeps firing as before.

- `Namespace.addAnalogDataItem()` now honors an explicit `options.typeDefinition` when it is a strict subtype of `AnalogItemType`, instead of unconditionally forcing `AnalogItemType`. The subtype is instantiated so its own mandatory members materialize (e.g. a companion specification's extra property such as PADIM's `LowFlowCutOff`), and the `EURange`/`InstrumentRange`/`EngineeringUnits` handling reuses any properties already cloned by that instantiation instead of creating duplicates.

## Test plan

- [x] `packages/node-opcua-address-space` full test suite passes (1015 passing, 1 pre-existing pending)
- [x] New unit tests in `test/test_nodeid_manager.ts` cover: cross-namespace same-local-name siblings, colliding-key-with-different-occupant (different name, different parent), genuine-duplicate-still-throws, and the no-parent (top-level node) comparison branches
- [x] New unit tests in `test/data_access/subtest_analog_item_type.ts` cover: subtype `typeDefinition` honored + mandatory member materialized, `typeDefinition` passed as `NodeId` / browseName string, invalid (non-AnalogItemType-subtype) `typeDefinition` throws, and subtype used without `instrumentRange`/`engineeringUnits` options
- [x] Full monorepo `tsc -b` build passes with no type errors