### PR TITLE
fix(address-space): support self-referencing structures in nodeset extension objects

### DIFF
--- a/packages/node-opcua-address-space/source/loader/make_xml_extension_object_parser.ts
+++ b/packages/node-opcua-address-space/source/loader/make_xml_extension_object_parser.ts
@@ -12,7 +12,7 @@ import {
     type UInt64
 } from "node-opcua-basic-types";
 import { make_debugLog, make_warningLog } from "node-opcua-debug";
-import { coerceNodeId, type INodeId, type NodeId, NodeIdType } from "node-opcua-nodeid";
+import { coerceNodeId, ExpandedNodeId, type INodeId, type NodeId, NodeIdType } from "node-opcua-nodeid";
 import { EnumDefinition, StructureDefinition } from "node-opcua-types";
 import { lowerFirstLetter } from "node-opcua-utils";
 import { DataType, Variant, type VariantOptions } from "node-opcua-variant";
@@ -30,6 +30,30 @@ import { makeVariantReader } from "./parsers/variant_parser";
 
 const warningLog = make_warningLog(__filename);
 const debugLog = make_debugLog(__filename);
+
+// textual form of an ExpandedNodeId, as found in <ExpandedNodeId><Identifier>...</Identifier></ExpandedNodeId>:
+// an optional server index, an optional namespace uri, then a plain nodeId. see OPC UA part 6.
+const regexServerIndex = /^svr=([0-9]+);(.*)$/;
+const regexNamespaceUri = /^nsu=(.*?);(.*)$/;
+
+function parseExpandedNodeId(text: string): ExpandedNodeId {
+    let remaining = text.trim();
+    let serverIndex = 0;
+    let namespaceUri: string | null = null;
+
+    const serverIndexMatch = remaining.match(regexServerIndex);
+    if (serverIndexMatch) {
+        serverIndex = parseInt(serverIndexMatch[1], 10);
+        remaining = serverIndexMatch[2];
+    }
+    const namespaceUriMatch = remaining.match(regexNamespaceUri);
+    if (namespaceUriMatch) {
+        namespaceUri = namespaceUriMatch[1];
+        remaining = namespaceUriMatch[2];
+    }
+    const nodeId = coerceNodeId(remaining);
+    return new ExpandedNodeId(nodeId.identifierType, nodeId.value, nodeId.namespace, namespaceUri, serverIndex);
+}
 
 function clamp(value: number, minValue: number, maxValue: number) {
     if (value < minValue) {
@@ -169,6 +193,13 @@ const partials = {
             // to do check Local or GMT
             this.value = coerceNodeId(this.text);
         }
+    },
+
+    // <ExpandedNodeId><Identifier>svr=1;nsu=http://acme.com/UA/;i=42</Identifier></ExpandedNodeId>
+    ExpandedNodeId: <Parser<ExpandedNodeId>>{
+        finish(this: Parser<ExpandedNodeId>) {
+            this.value = parseExpandedNodeId(this.text);
+        }
     }
 };
 
@@ -231,10 +262,16 @@ function _makeTypeReader(
     let reader: ReaderStateParserLike = readerMap.get(dataTypeName)!;
 
     if (reader) {
-        return { name, reader: reader.parser! };
+        return { name, reader };
     }
 
     reader = {
+        init(this: any) {
+            // the same reader instance is used for every element of that data type: the value must be
+            // reset here, or the element being read would inherit the fields of the previously read one
+            // ( or of the enclosing one, when the structure refers to itself ).
+            this.value = undefined;
+        },
         finish(this: any) {
             /** empty  */
         },
@@ -244,6 +281,12 @@ function _makeTypeReader(
     };
 
     if (definition instanceof StructureDefinition) {
+        // the reader must be registered *before* its fields are explored: a structure may refer to
+        // itself, directly or through one of its fields, and the recursion below would never end.
+        // `reader` and `reader.parser` keep their identity while being filled, so a nested reference
+        // that picks the reader up from the map ends up pointing at the completed reader.
+        readerMap.set(dataTypeName, reader);
+
         for (const field of definition.fields || []) {
             const typeReader = _makeTypeReader(field.dataType, definitionMap, readerMap, translateNodeId);
             const fieldParser = typeReader.reader;
@@ -301,7 +344,6 @@ function _makeTypeReader(
                 throw new Error("Unsupported ValueRank !");
             }
         }
-        readerMap.set(dataTypeName, reader);
         return { name, reader };
     } else if (definition instanceof EnumDefinition) {
         const turnToInt = (value: any) => {

--- a/packages/node-opcua-address-space/test/test_xml_decode.ts
+++ b/packages/node-opcua-address-space/test/test_xml_decode.ts
@@ -1,6 +1,6 @@
 import util from "node:util";
 import "should";
-import { coerceNodeId, type NodeId, resolveNodeId } from "node-opcua-nodeid";
+import { coerceNodeId, type NodeId, NodeIdType, resolveNodeId } from "node-opcua-nodeid";
 import { nodesets } from "node-opcua-nodesets";
 import { StructureDefinition } from "node-opcua-types";
 import { DataType } from "node-opcua-variant";
@@ -74,5 +74,161 @@ describe("test xml decode", () => {
         (pojo.certificates as Buffer[])[0]?.toString("utf-8").should.eql("Hello");
         (pojo.certificates as Buffer[])[1]?.toString("utf-8").should.eql("World");
         (pojo.url as string).should.eql("http://10.0.19.124");
+    });
+
+    // see https://github.com/node-opcua/node-opcua/issues/1543
+    // some companion specifications (for instance http://opcfoundation.org/UA/TMC/v2/) define
+    // structures that directly or indirectly refer to themselves. The reader construction used
+    // to recurse forever on those, ending with a `RangeError: Maximum call stack size exceeded`.
+    it("XMLDEC-1 should xml decode a self referencing structure without blowing the stack", () => {
+        // struct TreeNode { String Name; TreeNode[] Children; }
+        const treeNodeDataTypeNodeId = coerceNodeId("ns=1;i=1000");
+        const definition = new StructureDefinition({
+            fields: [
+                { dataType: resolveNodeId(DataType.String), name: "Name", valueRank: -1 },
+                { dataType: treeNodeDataTypeNodeId, name: "Children", valueRank: 1 }
+            ]
+        });
+        const definitionMap = {
+            findDefinition(dataTypeNodeId: NodeId): { name: string; definition: StructureDefinition } {
+                if (dataTypeNodeId.toString() === treeNodeDataTypeNodeId.toString()) {
+                    return { name: "TreeNode", definition };
+                }
+                throw new Error(`not implemented ${dataTypeNodeId.toString()}`);
+            }
+        };
+        // the nesting is deep enough for the readers of TreeNode and Children to be re-entered
+        const xmlBody = `
+<TreeNode xmlns="http://sterfive.com/Small_model/Types.xsd">
+    <Name>root</Name>
+    <Children>
+        <TreeNode>
+            <Name>child1</Name>
+            <Children>
+                <TreeNode>
+                    <Name>grandChild1</Name>
+                    <Children></Children>
+                </TreeNode>
+                <TreeNode>
+                    <Name>grandChild2</Name>
+                    <Children></Children>
+                </TreeNode>
+            </Children>
+        </TreeNode>
+        <TreeNode>
+            <Name>child2</Name>
+            <Children></Children>
+        </TreeNode>
+    </Children>
+</TreeNode>
+`;
+        const translateNodeId = (nodeId: string) => resolveNodeId(nodeId);
+        const reader = makeXmlExtensionObjectReader(treeNodeDataTypeNodeId, definitionMap, new Map(), translateNodeId);
+        const parser2 = new Xml2Json(reader);
+        const pojo = parser2.parseString(xmlBody);
+
+        // note: the decoded pojo has a null prototype, hence the round trip through JSON
+        JSON.parse(JSON.stringify(pojo)).should.eql({
+            name: "root",
+            children: [
+                {
+                    name: "child1",
+                    children: [
+                        { name: "grandChild1", children: [] },
+                        { name: "grandChild2", children: [] }
+                    ]
+                },
+                { name: "child2", children: [] }
+            ]
+        });
+    });
+
+    it("XMLDEC-2 should xml decode a structure reusing the same nested structure twice", () => {
+        // struct Pair { Inner A; Inner B; }  struct Inner { String Value; }
+        const innerDataTypeNodeId = coerceNodeId("ns=1;i=2000");
+        const pairDataTypeNodeId = coerceNodeId("ns=1;i=2001");
+        const innerDefinition = new StructureDefinition({
+            fields: [{ dataType: resolveNodeId(DataType.String), name: "Value", valueRank: -1 }]
+        });
+        const pairDefinition = new StructureDefinition({
+            fields: [
+                { dataType: innerDataTypeNodeId, name: "A", valueRank: -1 },
+                { dataType: innerDataTypeNodeId, name: "B", valueRank: -1 }
+            ]
+        });
+        const definitionMap = {
+            findDefinition(dataTypeNodeId: NodeId): { name: string; definition: StructureDefinition } {
+                switch (dataTypeNodeId.toString()) {
+                    case innerDataTypeNodeId.toString():
+                        return { name: "Inner", definition: innerDefinition };
+                    case pairDataTypeNodeId.toString():
+                        return { name: "Pair", definition: pairDefinition };
+                    default:
+                        throw new Error(`not implemented ${dataTypeNodeId.toString()}`);
+                }
+            }
+        };
+        const xmlBody = `
+<Pair xmlns="http://sterfive.com/Small_model/Types.xsd">
+    <A><Value>hello</Value></A>
+    <B><Value>world</Value></B>
+</Pair>
+`;
+        const translateNodeId = (nodeId: string) => resolveNodeId(nodeId);
+        const reader = makeXmlExtensionObjectReader(pairDataTypeNodeId, definitionMap, new Map(), translateNodeId);
+        const parser2 = new Xml2Json(reader);
+        const pojo = parser2.parseString(xmlBody);
+        (pojo.a as any).value.should.eql("hello");
+        (pojo.b as any).value.should.eql("world");
+    });
+
+    // the TMC nodeset of issue #1543 has a `MaterialPointType` structure with an ExpandedNodeId field,
+    // a data type that had no entry at all in the `partials` table.
+    it("XMLDEC-3 should xml decode a structure with an ExpandedNodeId field", () => {
+        const dataTypeNodeId = coerceNodeId("ns=1;i=3000");
+        const definition = new StructureDefinition({
+            fields: [
+                { dataType: resolveNodeId(DataType.ExpandedNodeId), name: "ConnectedMaterialPoint", valueRank: -1 },
+                { dataType: resolveNodeId(DataType.ExpandedNodeId), name: "PlainOne", valueRank: -1 }
+            ]
+        });
+        const definitionMap = {
+            findDefinition(): { name: string; definition: StructureDefinition } {
+                return { name: "MaterialPointType", definition };
+            }
+        };
+        const xmlBody = `
+<MaterialPointType xmlns="http://sterfive.com/Small_model/Types.xsd">
+    <ConnectedMaterialPoint>
+        <Identifier>svr=1;nsu=http://sterfive.com/UA/;i=42</Identifier>
+    </ConnectedMaterialPoint>
+    <PlainOne>
+        <Identifier>ns=2;s=Boiler</Identifier>
+    </PlainOne>
+</MaterialPointType>
+`;
+        const translateNodeId = (nodeId: string) => resolveNodeId(nodeId);
+        const reader = makeXmlExtensionObjectReader(dataTypeNodeId, definitionMap, new Map(), translateNodeId);
+        const parser2 = new Xml2Json(reader);
+        const pojo = parser2.parseString(xmlBody);
+
+        // note: like the NodeId parser, the decoded value is a plain pojo (see _clone), which
+        // constructExtensionObject then coerces back into a real ExpandedNodeId.
+        JSON.parse(JSON.stringify(pojo)).should.eql({
+            connectedMaterialPoint: {
+                identifierType: NodeIdType.NUMERIC,
+                value: 42,
+                namespace: 0,
+                namespaceUri: "http://sterfive.com/UA/",
+                serverIndex: 1
+            },
+            plainOne: {
+                identifierType: NodeIdType.STRING,
+                value: "Boiler",
+                namespace: 2,
+                namespaceUri: null,
+                serverIndex: 0
+            }
+        });
     });
 });

--- a/packages/node-opcua-xml2json/source/xml2json.ts
+++ b/packages/node-opcua-xml2json/source/xml2json.ts
@@ -255,6 +255,7 @@ export class Xml2Json {
     public currentLevel = 0;
     private state_stack: any[] = [];
     private current_state: IReaderState | null = null;
+    private activation_count: Map<IReaderState, number> = new Map();
 
     constructor(options: ReaderStateParser) {
         const state = options instanceof ReaderStateBase ? (options as ReaderState) : new ReaderState(options);
@@ -274,8 +275,16 @@ export class Xml2Json {
      */
     public _promote(new_state: IReaderState, level: number, name?: string, attr?: XmlAttributes): void {
         attr = attr || {};
+
+        // a reader state carries the state of the element being read, so the same instance cannot be
+        // active at two levels at once. This happens when a data type refers to itself, directly or
+        // indirectly: the reader of the nested element is then the very same object as the outer one.
+        // In that case only, take a copy of the outer activation and restore it in _demote.
+        const isReentrant = this.activation_count.has(new_state);
+        this.activation_count.set(new_state, (this.activation_count.get(new_state) || 0) + 1);
+
         this.state_stack.push({
-            backup: {},
+            backup: isReentrant ? { ...(new_state as unknown as Record<string, unknown>) } : null,
             state: this.current_state
         });
 
@@ -294,6 +303,23 @@ export class Xml2Json {
         this.current_state = state;
         if (this.current_state) {
             this.current_state._on_endElement2(level, elementName);
+        }
+
+        const count = (this.activation_count.get(cur_state) || 1) - 1;
+        if (count === 0) {
+            this.activation_count.delete(cur_state);
+        } else {
+            this.activation_count.set(cur_state, count);
+        }
+        if (backup) {
+            // cur_state was a nested activation of a state that is still active at an outer level:
+            // put the outer element back the way it was. The parent has already consumed the nested
+            // value in _on_endElement2 above, so nothing is lost here.
+            const state_as_object = cur_state as unknown as Record<string, unknown>;
+            for (const key of Object.keys(state_as_object)) {
+                delete state_as_object[key];
+            }
+            Object.assign(state_as_object, backup);
         }
     }
 

--- a/packages/playground/issue1543/.gitignore
+++ b/packages/playground/issue1543/.gitignore
@@ -1,0 +1,1 @@
+Opc.Ua.TMC.NodeSet2.xml

--- a/packages/playground/issue1543/main.mjs
+++ b/packages/playground/issue1543/main.mjs
@@ -1,0 +1,66 @@
+import { access, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { OPCUAServer, nodesets } from 'node-opcua';
+
+// the official TMC nodeset. note: this is the raw form of
+// https://github.com/OPCFoundation/UA-Nodeset/blob/latest/TMC/Opc.Ua.TMC.NodeSet2.xml
+// ( the /blob/ url serves a HTML page, not the xml )
+const nodesetUrl =
+  'https://raw.githubusercontent.com/OPCFoundation/UA-Nodeset/latest/TMC/Opc.Ua.TMC.NodeSet2.xml';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const nodesetFilename = path.join(here, 'Opc.Ua.TMC.NodeSet2.xml');
+
+// the server loads nodesets from disk, so download the file once and keep it next to this script
+async function downloadNodesetIfNeeded() {
+  try {
+    await access(nodesetFilename);
+    console.log(`using already downloaded ${nodesetFilename}`);
+    return;
+  } catch {
+    // not downloaded yet
+  }
+
+  console.log(`downloading ${nodesetUrl} ...`);
+  const response = await fetch(nodesetUrl);
+  if (!response.ok) {
+    throw new Error(`cannot download ${nodesetUrl} : ${response.status} ${response.statusText}`);
+  }
+  const xml = await response.text();
+  await writeFile(nodesetFilename, xml, 'utf-8');
+  console.log(`downloaded ${xml.length} bytes to ${nodesetFilename}`);
+}
+
+(async () => {
+  try {
+    await downloadNodesetIfNeeded();
+
+    // Let create an instance of OPCUAServer
+    const server = new OPCUAServer({
+      port: 26543, // the port of the listening socket of the server
+
+      nodeset_filename: [
+        nodesets.standard,
+        nodesets.di,
+        nodesets.packML,
+        nodesetFilename
+      ],
+    });
+
+    await server.initialize();
+
+    // we can now start the server
+    await server.start();
+
+    console.log('Server is now listening ... ( press CTRL+C to stop) ');
+
+    await new Promise((resolve) => process.once('SIGINT', resolve));
+
+    await server.shutdown();
+    console.log('server shutdown completed !');
+  } catch (err) {
+    console.log(err.message);
+    process.exit(-1);
+  }
+})();


### PR DESCRIPTION
Fixes #1543.

Loading the [TMC v2](http://opcfoundation.org/UA/TMC/v2/) nodeset ends with `RangeError: Maximum call stack size exceeded` in `performPostLoadingTasks`. The nodeset is only the messenger: any structure that refers to itself, directly or through one of its fields, triggers it.

## What was wrong

`_makeTypeReader` registered the reader it builds in the `readerMap` only *after* walking all the fields. A field pointing back at the enclosing structure therefore restarted the construction from scratch, forever. Registering the reader before the fields are walked breaks the cycle: `reader` and `reader.parser` keep their identity while being filled, so a nested reference resolves to the completed reader.

Fixing the recursion uncovered three more bugs on the same path, each of which had to be fixed for a recursive structure to actually decode:

1. **The cache hit returned the wrong object.** A `readerMap` hit returned `reader.parser` where a miss returned `reader`. Any structure reused by two fields decoded to nothing — silently. Covered by `XMLDEC-2`, which fails on master.
2. **Readers never reset their value.** A reader instance is shared by every element of its data type, so an element inherited the fields of the previously read one. With a self-referencing structure the nested element inherited — and corrupted — the value of the enclosing one.
3. **`ReaderState` is not re-entrant.** It carries the state of the element being read, which is exactly what a self-referencing reader needs at two levels at once. `Xml2Json` already had an unused `backup` slot in its state stack; it now saves the outer activation and restores it on demote — **only when a state is genuinely re-entered**, so the ordinary case is untouched.

## ExpandedNodeId

With the overflow gone, TMC hit `Cannot find reader for dataType ns=0;i=18` — `ExpandedNodeId` had no entry in the `partials` table, and TMC's `MaterialPointType` has such a field. Added, including the `svr=` / `nsu=` prefixes of the textual form, which `coerceExpandedNodeId` does not handle.

Two known gaps are deliberately left out of this PR, as neither is needed by TMC and both are pre-existing: `StatusCode` and `XmlElement` are still absent from `partials`. `StatusCode` in particular cannot be done properly without revisiting `_clone`, which strips prototypes and would turn it into an uncoercible `{_value, _description, _name}` pojo.

## Verification

- The reporter's exact repro (`nodesets.standard` + `di` + `packML` + `Opc.Ua.TMC.NodeSet2.xml`) now loads with **zero errors**; on master it dies with the RangeError.
- Three new unit tests in `test_xml_decode.ts`, each failing on master:
  - `XMLDEC-1` — self-referencing `TreeNode { String Name; TreeNode[] Children; }`, nested deeply enough to re-enter both readers (this is the minimal repro of the stack overflow)
  - `XMLDEC-2` — a structure reusing the same nested structure twice
  - `XMLDEC-3` — a structure with `ExpandedNodeId` fields, plain and with `svr=`/`nsu=`
- Full suites green: **node-opcua-address-space 1007 passing**, node-opcua-schemas 44, node-opcua-xml2json 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
