### PR TITLE
fix(address-space): avoid infinite recursion on self referencing structure dataTypes

### DIFF
--- a/packages/node-opcua-address-space/src/nodeset_tools/construct_namespace_dependency.ts
+++ b/packages/node-opcua-address-space/src/nodeset_tools/construct_namespace_dependency.ts
@@ -71,13 +71,15 @@ export function _recomputeRequiredModelsFromTypes(namespace: INamespace, cache?:
 
         const namespaceIndex = dataType.namespace;
         consider(namespaceIndex);
+        // mark the dataType as visited *before* exploring its fields: a structure may refer to
+        // itself (directly or through a cycle), and marking it afterwards would recurse forever
+        _visitedDataType.add(dataType.toString());
         if (dataTypeNode.isStructure()) {
             const definition = dataTypeNode.getStructureDefinition();
             for (const field of definition.fields || []) {
                 exploreDataTypeField(field);
             }
         }
-        _visitedDataType.add(dataType.toString());
     }
 
     function exploreExtensionObject(e: ExtensionObject) {

--- a/packages/node-opcua-address-space/test/test_construct_namespace_dependencies.ts
+++ b/packages/node-opcua-address-space/test/test_construct_namespace_dependencies.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import "should";
 import { nodesets } from "node-opcua-nodesets";
+import { DataType } from "node-opcua-variant";
 import {
     _constructNamespaceTranslationTable,
     _recomputeRequiredModelsFromTypes,
@@ -191,5 +192,50 @@ describe("constructNamespaceDependency", function () {
         _recomputeRequiredModelsFromTypes2(addressSpace2.getNamespace(3)).requiredNamespaceIndexes.should.eql([0, 2]);
         _recomputeRequiredModelsFromTypes2(addressSpace2.getNamespace(4)).requiredNamespaceIndexes.should.eql([0, 2]);
         await addressSpace2.dispose();
+    });
+});
+
+// see https://github.com/node-opcua/node-opcua/issues/1547
+// exploring the dataTypes of a namespace used to recurse forever when a structure refers to
+// itself: the guard marking a dataType as visited was applied after its fields were explored.
+// ( the TMC nodeset exhibits this with MaterialSublotType, a sublot made of sublots )
+describe("constructNamespaceDependency with self referencing structures", function () {
+    this.timeout(100000);
+
+    let addressSpace: AddressSpace;
+    before(async () => {
+        addressSpace = AddressSpace.create();
+        addressSpace.registerNamespace("Private");
+        // WwMessageArgumentValueDataType owns a field of its own type
+        const recursiveNodeset = path.join(__dirname, "../test_helpers/test_fixtures/dataType_with_recursive_structure.xml");
+        await generateAddressSpace(addressSpace, [nodesets.standard, recursiveNodeset]);
+    });
+    after(() => {
+        addressSpace.dispose();
+    });
+
+    it("RRR-5 should not overflow the stack when a variable holds a self referencing extension object", () => {
+        const nsAcme = addressSpace.getNamespaceIndex("http://acme");
+        nsAcme.should.be.greaterThan(0);
+
+        const dataType = addressSpace.findDataType("WwMessageArgumentValueDataType", nsAcme)!;
+        dataType.isStructure().should.eql(true);
+
+        // the recursion is only entered through the value of a variable, so we need an instance
+        const extObj = addressSpace.constructExtensionObject(dataType, {
+            switchField: 1,
+            array: [{ boolean: 1 }, { uInt16: 16 }]
+        });
+        const namespace = addressSpace.getOwnNamespace();
+        namespace.addVariable({
+            browseName: "RecursiveValue",
+            dataType: dataType.nodeId,
+            organizedBy: addressSpace.rootFolder.objects,
+            value: { dataType: DataType.ExtensionObject, value: extObj }
+        });
+
+        // used to throw RangeError: Maximum call stack size exceeded
+        const { requiredNamespaceIndexes } = _recomputeRequiredModelsFromTypes(namespace);
+        requiredNamespaceIndexes.should.eql([0, nsAcme]);
     });
 });

--- a/packages/playground/issue1543/issue_1547.mjs
+++ b/packages/playground/issue1543/issue_1547.mjs
@@ -1,0 +1,31 @@
+import { nodesets } from "node-opcua-modeler";
+// buildModel is the nodejs flavour of buildModelInner: it already provides the
+// readNodeSet2XmlFile xmlLoader, so the nodeset xml files are read from disk
+import { buildModel } from "node-opcua-modeler/nodeJS.js";
+import { downloadTMCNodesetIfNeeded } from "./tmc-nodeset.mjs";
+
+const tmcNodesetFilename = await downloadTMCNodesetIfNeeded();
+
+const XML_FILES = [
+  nodesets.standard,
+  nodesets.di,
+  nodesets.packML,
+  tmcNodesetFilename,
+];
+
+const { xmlModel, symbols, markdown } = await buildModel({
+  namespaceUri: "namespace",
+  version: "2.0.1",
+  xmlFiles: XML_FILES,
+  presetSymbols: [],
+  createModel: async (addressSpace) => {
+    const ns = addressSpace.getOwnNamespace();
+    ns.addObject({
+      browseName: "line A",
+      typeDefinition: "FolderType",
+      organizedBy: addressSpace.rootFolder.objects,
+    });
+  },
+});
+
+console.log(`model built: ${xmlModel.length} bytes of xml, ${symbols.length} symbols, ${markdown.length} bytes of markdown`);

--- a/packages/playground/issue1543/main.mjs
+++ b/packages/playground/issue1543/main.mjs
@@ -1,40 +1,9 @@
-import { access, writeFile } from 'node:fs/promises';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { OPCUAServer, nodesets } from 'node-opcua';
-
-// the official TMC nodeset. note: this is the raw form of
-// https://github.com/OPCFoundation/UA-Nodeset/blob/latest/TMC/Opc.Ua.TMC.NodeSet2.xml
-// ( the /blob/ url serves a HTML page, not the xml )
-const nodesetUrl =
-  'https://raw.githubusercontent.com/OPCFoundation/UA-Nodeset/latest/TMC/Opc.Ua.TMC.NodeSet2.xml';
-
-const here = path.dirname(fileURLToPath(import.meta.url));
-const nodesetFilename = path.join(here, 'Opc.Ua.TMC.NodeSet2.xml');
-
-// the server loads nodesets from disk, so download the file once and keep it next to this script
-async function downloadNodesetIfNeeded() {
-  try {
-    await access(nodesetFilename);
-    console.log(`using already downloaded ${nodesetFilename}`);
-    return;
-  } catch {
-    // not downloaded yet
-  }
-
-  console.log(`downloading ${nodesetUrl} ...`);
-  const response = await fetch(nodesetUrl);
-  if (!response.ok) {
-    throw new Error(`cannot download ${nodesetUrl} : ${response.status} ${response.statusText}`);
-  }
-  const xml = await response.text();
-  await writeFile(nodesetFilename, xml, 'utf-8');
-  console.log(`downloaded ${xml.length} bytes to ${nodesetFilename}`);
-}
+import { downloadTMCNodesetIfNeeded } from './tmc-nodeset.mjs';
 
 (async () => {
   try {
-    await downloadNodesetIfNeeded();
+    const tmcNodesetFilename = await downloadTMCNodesetIfNeeded();
 
     // Let create an instance of OPCUAServer
     const server = new OPCUAServer({
@@ -44,7 +13,7 @@ async function downloadNodesetIfNeeded() {
         nodesets.standard,
         nodesets.di,
         nodesets.packML,
-        nodesetFilename
+        tmcNodesetFilename
       ],
     });
 

--- a/packages/playground/issue1543/tmc-nodeset.mjs
+++ b/packages/playground/issue1543/tmc-nodeset.mjs
@@ -1,0 +1,35 @@
+import { access, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// the official TMC nodeset. note: this is the raw form of
+// https://github.com/OPCFoundation/UA-Nodeset/blob/latest/TMC/Opc.Ua.TMC.NodeSet2.xml
+// ( the /blob/ url serves a HTML page, not the xml )
+const nodesetUrl =
+  'https://raw.githubusercontent.com/OPCFoundation/UA-Nodeset/latest/TMC/Opc.Ua.TMC.NodeSet2.xml';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+// keep the file next to this script, so it is found whatever the current working directory is
+export const tmcNodesetFilename = path.join(here, 'Opc.Ua.TMC.NodeSet2.xml');
+
+// the nodeset is loaded from disk, so download the file once and keep it next to this script
+export async function downloadTMCNodesetIfNeeded() {
+  try {
+    await access(tmcNodesetFilename);
+    console.log(`using already downloaded ${tmcNodesetFilename}`);
+    return tmcNodesetFilename;
+  } catch {
+    // not downloaded yet
+  }
+
+  console.log(`downloading ${nodesetUrl} ...`);
+  const response = await fetch(nodesetUrl);
+  if (!response.ok) {
+    throw new Error(`cannot download ${nodesetUrl} : ${response.status} ${response.statusText}`);
+  }
+  const xml = await response.text();
+  await writeFile(tmcNodesetFilename, xml, 'utf-8');
+  console.log(`downloaded ${xml.length} bytes to ${tmcNodesetFilename}`);
+  return tmcNodesetFilename;
+}


### PR DESCRIPTION
## Problem

Loading a nodeset that contains a **self referencing structure dataType** and building a model from it crashes with a stack overflow:

```
RangeError: Maximum call stack size exceeded
    at exploreDataTypeField (construct_namespace_dependency.ts:55)
    at exploreDataTypes     (construct_namespace_dependency.ts:77)
    at exploreDataTypeField (construct_namespace_dependency.ts:55)
    ... repeating
```

This reproduces with the official **TMC** nodeset (`Opc.Ua.TMC.NodeSet2.xml`), whose `MaterialSublotType` is a sublot made of sublots.

## Cause

`exploreDataTypes` in `_recomputeRequiredModelsFromTypes` *does* keep a `_visitedDataType` set, but it only populates it **after** walking the structure fields:

```ts
if (dataTypeNode.isStructure()) {
    const definition = dataTypeNode.getStructureDefinition();
    for (const field of definition.fields || []) {
        exploreDataTypeField(field);        // <-- recurses back into the same node
    }
}
_visitedDataType.add(dataType.toString());  // <-- too late
```

A dataType reachable from its own fields is therefore never in the visited set while its fields are being explored, so the walk never terminates.

Note that the recursion is only entered through `exploreExtensionObject`, i.e. when a `Variable` in the namespace holds an ExtensionObject *value* of the recursive dataType — which is why the existing `dataType_with_recursive_structure.xml` fixture did not previously surface it.

## Fix

Mark the dataType as visited **before** exploring its fields. For acyclic dataTypes the computed dependencies are unchanged; for cyclic ones the walk now terminates.

## Test

Added `RRR-5` to `test_construct_namespace_dependencies.ts`. It reuses the existing minimal `dataType_with_recursive_structure.xml` fixture (`WwMessageArgumentValueDataType` has a field of its own type) and adds a variable holding such an extension object, then calls `_recomputeRequiredModelsFromTypes`.

Verified the test genuinely covers the fix — it fails with `RangeError: Maximum call stack size exceeded` when the one line change is reverted, and passes with it.

- `test_construct_namespace_dependencies.ts` — 6 passing
- neighbouring nodeset/namespace suites (`test_nodeset_to_xml`, `test_namespace`, `test_address_space_namespace`, `test_issue_datype_with_recursive_structure`, `test_nodeset_ordering`, `test_namespace_export_variable_with_extension_object`) — 48 passing, no regressions

## Also in this PR

`packages/playground/issue1543` — a reproduction against the real TMC nodeset:

- new `tmc-nodeset.mjs`, shared by both playground scripts, downloads the TMC nodeset on demand (it is 6.6 MB and gitignored) and resolves it relative to the script rather than the cwd
- `main.mjs` reuses it instead of carrying its own copy of the download logic
- `issue_1547.mjs` reproduces the crash through `buildModel`; it previously could not even start, because it imported `readNodeSet2XmlFile` from `node-opcua-address-space`, which is not a dependency of `playground`. It now uses `buildModel` from `node-opcua-modeler/nodeJS.js`, which already supplies that loader.

closes #1547

🤖 Generated with [Claude Code](https://claude.com/claude-code)