### PR TITLE
fix(server-configuration): give each TrustList a real, unique backing file

### DIFF
--- a/packages/node-opcua-server-configuration/source/server/promote_trust_list.ts
+++ b/packages/node-opcua-server-configuration/source/server/promote_trust_list.ts
@@ -643,6 +643,29 @@ export async function promoteTrustList(trustList: UATrustList) {
         MemFs.writeFileSync(filename, Buffer.alloc(0));
     }
 
+    // `memfs` exports one volume for the whole process and nothing here ever
+    // released these paths. Each Open rewrites the full serialized TrustList
+    // (every trusted cert, issuer cert and CRL) and it then stays resident
+    // for the lifetime of the process. That was masked while the filename
+    // came from a module counter, because a second address space reused
+    // `/tmpFile0` and overwrote the first one's bytes; now that the paths are
+    // distinct, a process that builds and tears down servers repeatedly (test
+    // suites, an in-process restart) would accumulate one blob per TrustList
+    // per server. Release them with the address space.
+    //
+    // Registering once per TrustList is bounded: the $$promoted guard above
+    // means this runs once per node, and registerShutdownTask has no
+    // unregister counterpart.
+    trustList.addressSpace.registerShutdownTask(() => {
+        try {
+            if (MemFs.existsSync(filename)) {
+                MemFs.unlinkSync(filename);
+            }
+        } catch (err) {
+            debugLog("could not release trust list backing file", filename, (err as Error).message);
+        }
+    });
+
     // Store filename for use in _closeAndUpdate
     trustListEx.$$filename = filename;
     // Initialize write lock flag

--- a/packages/node-opcua-server-configuration/source/server/promote_trust_list.ts
+++ b/packages/node-opcua-server-configuration/source/server/promote_trust_list.ts
@@ -2,6 +2,7 @@
  * @module node-opcua-server-configuration
  */
 
+import { randomBytes } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -592,11 +593,35 @@ async function _removeCertificate(
     }
 }
 
-let counter = 0;
+/**
+ * Backing path on the in-memory volume for a TrustList's FileType.
+ *
+ * Replaces a module-scoped `counter`. `memfs` exports one process-wide
+ * volume, but the counter is only unique within one *instance* of this
+ * module, and a process can easily load several (duplicated transitive
+ * dependency, a monorepo resolving two versions). Two TrustLists in
+ * different copies then both take `/tmpFile0` on the same volume and
+ * silently serve each other's bytes.
+ *
+ * A NodeId alone does not fix it either: two OPCUAServers in one
+ * process have separate address spaces in which the same TrustList
+ * NodeId occurs, so they would collide too. The path therefore combines
+ * a per-address-space id with the NodeId. The id is stored on the
+ * address space object itself, not in a module-scoped map, so every
+ * copy of this module sees the same value.
+ */
+function trustListBackingPath(trustList: UATrustList): string {
+    const addressSpace = trustList.addressSpace as IAddressSpace & { $$trustListVolumeId?: string };
+    if (!addressSpace.$$trustListVolumeId) {
+        addressSpace.$$trustListVolumeId = randomBytes(6).toString("hex");
+    }
+    const node = trustList.nodeId.toString().replace(/[^A-Za-z0-9]/g, "_");
+    return `/trustlist_${addressSpace.$$trustListVolumeId}_${node}`;
+}
 
 export async function promoteTrustList(trustList: UATrustList) {
     const trustListEx = trustList as UATrustListEx & { $$promoted?: boolean };
-    
+
     // Prevent double-binding if called multiple times testing
     if (trustListEx.$$promoted) {
         await _initializeLastUpdateTimeFromFilesystem(trustListEx);
@@ -604,8 +629,19 @@ export async function promoteTrustList(trustList: UATrustList) {
     }
     trustListEx.$$promoted = true;
 
-    const filename = `/tmpFile${counter}`;
-    counter += 1;
+    const filename = trustListBackingPath(trustList);
+
+    // The file is normally written by _openTrustList, just before the
+    // FileType Open runs. But Size is readable without Open, and Open
+    // itself falls through to the raw implementation when the group has
+    // no certificateManager, so the path has to exist from promotion
+    // time. Without this, both read ENOENT: Size logs and yields no
+    // value, and Open answers Bad_UnexpectedError instead of presenting
+    // an empty TrustList, which is the correct answer for a group that
+    // has nothing to serve.
+    if (!MemFs.existsSync(filename)) {
+        MemFs.writeFileSync(filename, Buffer.alloc(0));
+    }
 
     // Store filename for use in _closeAndUpdate
     trustListEx.$$filename = filename;

--- a/packages/node-opcua-server-configuration/test/test_trust_list_backing_file.ts
+++ b/packages/node-opcua-server-configuration/test/test_trust_list_backing_file.ts
@@ -1,0 +1,128 @@
+import path from "node:path";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import "should";
+import "mocha";
+import {
+    AddressSpace,
+    ContinuationPointManager,
+    type IServerBase,
+    type ISessionBase,
+    makeRoles,
+    PseudoSession,
+    SessionContext,
+    WellKnownRoles
+} from "node-opcua-address-space";
+import { generateAddressSpace } from "node-opcua-address-space/nodeJS.js";
+import { CertificateManager } from "node-opcua-certificate-manager";
+import { OpenFileMode } from "node-opcua-file-transfer";
+import { NodeId } from "node-opcua-nodeid";
+import { nodesets } from "node-opcua-nodesets";
+import { SecurityPolicy } from "node-opcua-secure-channel";
+import { MessageSecurityMode, UserNameIdentityToken } from "node-opcua-types";
+import { ClientPushCertificateManagement, installPushCertificateManagement } from "../dist/index.js";
+import { initializeHelpers } from "./helpers/fake_certificate_authority.js";
+
+/**
+ * installPushCertificateManagement promotes every CertificateGroup it finds
+ * under ServerConfiguration, but binds a certificateManager only to
+ * DefaultApplicationGroup and DefaultUserTokenGroup, and to the latter only
+ * when one was supplied. A group can therefore end up promoted with nothing
+ * to serve.
+ *
+ * promoteTrustList used to point such a group's FileType at a path on the
+ * shared memfs volume without creating it: the file was written by the Open
+ * wrapper, which for an unbound group falls straight through to the raw
+ * implementation. Open then failed with
+ *
+ *   ENOENT: no such file or directory, open '/tmpFile3'
+ *
+ * and the client got Bad_UnexpectedError. An empty TrustList is the correct
+ * answer for a group that has nothing to serve.
+ */
+describe("TrustList backing file", () => {
+    let addressSpace: AddressSpace;
+
+    const opcuaServer: IServerBase = {
+        userManager: {
+            getUserRoles(_userName: string) {
+                return makeRoles([WellKnownRoles.AuthenticatedUser, WellKnownRoles.SecurityAdmin]);
+            }
+        }
+    };
+    const session: ISessionBase = {
+        userIdentityToken: new UserNameIdentityToken({
+            userName: "admin"
+        }),
+        channel: {
+            securityMode: MessageSecurityMode.SignAndEncrypt,
+            securityPolicy: SecurityPolicy.Basic256Sha256,
+            clientCertificate: Buffer.from("dummy", "utf-8"),
+            getTransportSettings() {
+                return { maxMessageSize: 0 };
+            }
+        },
+        getSessionId() {
+            return NodeId.nullNodeId;
+        },
+        continuationPointManager: new ContinuationPointManager()
+    };
+
+    let applicationGroup: CertificateManager;
+
+    before(async () => {
+        const _folder = await initializeHelpers("BACKINGFILE", 0);
+
+        applicationGroup = new CertificateManager({
+            location: path.join(_folder, "application")
+        });
+        await applicationGroup.initialize();
+
+        addressSpace = AddressSpace.create();
+        await generateAddressSpace(addressSpace, [nodesets.standard]);
+        addressSpace.registerNamespace("Private");
+    });
+
+    after(async () => {
+        session.continuationPointManager?.dispose();
+        await addressSpace.shutdown();
+        addressSpace.dispose();
+        await applicationGroup.dispose();
+    });
+
+    it("TLBF-1 should open the TrustList of a group that has no certificateManager", async () => {
+        // no userTokenGroup: DefaultUserTokenGroup is promoted but left unbound
+        await installPushCertificateManagement(addressSpace, {
+            applicationGroup,
+            applicationUri: "SomeUri"
+        });
+
+        const context = new SessionContext({ server: opcuaServer, session });
+        const pseudoSession = new PseudoSession(addressSpace, context);
+
+        const client = new ClientPushCertificateManagement(pseudoSession);
+        const group = await client.getCertificateGroup("DefaultUserTokenGroup");
+        const trustList = await group.getTrustList();
+
+        // used to raise ENOENT on the memfs path and answer Bad_UnexpectedError
+        const fileHandle = await trustList.open(OpenFileMode.Read);
+        fileHandle.should.be.a.Number();
+        fileHandle.should.be.greaterThan(0);
+
+        await trustList.close();
+    });
+
+    it("TLBF-2 should give each TrustList its own backing path", async () => {
+        const serverConfiguration = addressSpace.rootFolder.objects.server.getChildByName("ServerConfiguration")!;
+        const groups = serverConfiguration.getChildByName("CertificateGroups")!;
+
+        const filenames = groups
+            .getComponents()
+            .map((g) => (g as unknown as { getComponentByName(n: string): unknown }).getComponentByName("TrustList"))
+            .filter((t) => !!t)
+            .map((t) => (t as unknown as { $$filename?: string }).$$filename)
+            .filter((f): f is string => !!f);
+
+        filenames.length.should.be.greaterThan(1);
+        new Set(filenames).size.should.eql(filenames.length);
+    });
+});

--- a/packages/node-opcua-server-configuration/test/test_trust_list_backing_file.ts
+++ b/packages/node-opcua-server-configuration/test/test_trust_list_backing_file.ts
@@ -13,6 +13,8 @@ import {
     WellKnownRoles
 } from "node-opcua-address-space";
 import { generateAddressSpace } from "node-opcua-address-space/nodeJS.js";
+import { fs as MemFs } from "memfs";
+import type { UAObject } from "node-opcua-address-space";
 import { CertificateManager } from "node-opcua-certificate-manager";
 import { OpenFileMode } from "node-opcua-file-transfer";
 import { NodeId } from "node-opcua-nodeid";
@@ -111,18 +113,47 @@ describe("TrustList backing file", () => {
         await trustList.close();
     });
 
-    it("TLBF-2 should give each TrustList its own backing path", async () => {
-        const serverConfiguration = addressSpace.rootFolder.objects.server.getChildByName("ServerConfiguration")!;
-        const groups = serverConfiguration.getChildByName("CertificateGroups")!;
-
-        const filenames = groups
-            .getComponents()
-            .map((g) => (g as unknown as { getComponentByName(n: string): unknown }).getComponentByName("TrustList"))
-            .filter((t) => !!t)
-            .map((t) => (t as unknown as { $$filename?: string }).$$filename)
-            .filter((f): f is string => !!f);
+    it("TLBF-2 should give each TrustList its own backing path", () => {
+        const filenames = collectBackingPaths(addressSpace);
 
         filenames.length.should.be.greaterThan(1);
         new Set(filenames).size.should.eql(filenames.length);
     });
+
+    it("TLBF-3 should release the backing files when the address space shuts down", async () => {
+        // memfs is a single process-wide volume, so a server that is built and
+        // torn down repeatedly must not leave its serialized TrustLists behind.
+        const throwaway = AddressSpace.create();
+        await generateAddressSpace(throwaway, [nodesets.standard]);
+        throwaway.registerNamespace("Private");
+
+        await installPushCertificateManagement(throwaway, {
+            applicationGroup,
+            applicationUri: "SomeOtherUri"
+        });
+
+        const filenames = collectBackingPaths(throwaway);
+        filenames.length.should.be.greaterThan(0);
+        filenames.every((f) => MemFs.existsSync(f)).should.eql(true);
+
+        await throwaway.shutdown();
+        throwaway.dispose();
+
+        filenames.some((f) => MemFs.existsSync(f)).should.eql(false);
+    });
 });
+
+function collectBackingPaths(addressSpace: AddressSpace): string[] {
+    const serverConfiguration = addressSpace.rootFolder.objects.server.getChildByName("ServerConfiguration") as UAObject;
+    const groups = serverConfiguration.getChildByName("CertificateGroups") as UAObject;
+
+    const filenames: string[] = [];
+    for (const name of ["DefaultApplicationGroup", "DefaultUserTokenGroup", "DefaultHttpsGroup"]) {
+        const group = groups.getComponentByName(name) as UAObject | null;
+        const trustList = group?.getComponentByName("TrustList") as (UAObject & { $$filename?: string }) | null;
+        if (trustList?.$$filename) {
+            filenames.push(trustList.$$filename);
+        }
+    }
+    return filenames;
+}


### PR DESCRIPTION
## Symptom

Browsing a server's `ServerConfiguration` TrustList with UaExpert logs an
ENOENT against the in-memory backing file and answers `Bad_UnexpectedError`:

```
:file_type_helpers :426  ENOENT: no such file or directory, open '/tmpFile3'
    at _Superblock.getResolvedLinkOrThrow (...)
    at _Superblock.openFile (...)
    at Volume.open (...)
```

## Two independent defects behind it

`promoteTrustList` did:

```ts
let counter = 0;                        // module scope
const filename = `/tmpFile${counter}`;
counter += 1;
installFileType(trustList, { filename, fileSystem: MemFs });
```

**1. The backing file is never created.** It only appears when `_openTrustList`
runs `writeTrustList(...)`, inside the `Open` handler, and only on the branch
where the group has a `$$certificateManager`. Until then the path dangles, and
two readers hit it:

- `file_type_helpers.ts:106`, the `Size` binding calls `statSync(filename)`.
  Simply browsing the TrustList reads `Size`.
- `file_type_helpers.ts:405`, `openFile` calls `abstractFs.open(filename, flags)`
  when `Open` falls through to the raw implementation, which is what happens for
  a certificate group that was promoted without a certificate manager.

An empty file at promotion time makes a group with nothing to serve read as an
empty TrustList, which is the correct answer, rather than an error.

**2. The filename is not unique.** `counter` is unique only within one
*instance* of this module, while `memfs` exports a single process-wide volume.
A process that loads two copies of `node-opcua-server-configuration` (duplicated
transitive dependency, or a monorepo resolving two versions) gives two different
TrustLists the same `/tmpFile0` on the same volume, and they silently overwrite
each other's content on every `Open`.

A NodeId alone does not fix this either: two `OPCUAServer` instances in one
process have separate address spaces containing the same TrustList NodeId. The
path now combines a per-address-space id with the NodeId, and the id is stored
on the address space object rather than in a module-scoped map so that every
duplicate copy of the module observes the same value.

## Tests

`packages/node-opcua-server-configuration`: 133 passing, including
`test_trust_list_file_lock.ts` and the full `test/server/` set. Package and test
tsconfigs both typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
