### PR TITLE
fix(nodeid): coerceExpandedNodeId no longer drops namespaceUri and serverIndex

### DIFF
--- a/packages/node-opcua-nodeid/source/expanded_nodeid.ts
+++ b/packages/node-opcua-nodeid/source/expanded_nodeid.ts
@@ -86,8 +86,13 @@ export class ExpandedNodeId extends NodeId {
 }
 
 export function coerceExpandedNodeId(value: unknown): ExpandedNodeId {
+    if (value instanceof ExpandedNodeId) {
+        return new ExpandedNodeId(value.identifierType, value.value, value.namespace, value.namespaceUri, value.serverIndex);
+    }
     const n = coerceNodeId(value);
-    return new ExpandedNodeId(n.identifierType, n.value, n.namespace, /*namespaceUri*/ null, /*serverIndex*/ 0);
+    // a NodeId-like literal may also carry namespaceUri/serverIndex, which coerceNodeId ignores
+    const { namespaceUri, serverIndex } = (value as Partial<ExpandedNodeId>) ?? {};
+    return new ExpandedNodeId(n.identifierType, n.value, n.namespace, namespaceUri ?? null, serverIndex ?? 0);
 }
 /**
  * create an expanded nodeId

--- a/packages/node-opcua-nodeid/test/test_expanded_nodeid.js
+++ b/packages/node-opcua-nodeid/test/test_expanded_nodeid.js
@@ -78,6 +78,28 @@ describe("testing ExpandedNodeId", function() {
         exNodeId2.toString().should.eql("ns=0;i=10");
 
     });
+    it("coerceExpandedNodeId should preserve namespaceUri and serverIndex of an ExpandedNodeId", function() {
+
+        const exNodeId = new ExpandedNodeId(NodeIdType.STRING, "Temp1", 2, "urn:some:namespace", 3);
+        const exNodeId2 = coerceExpandedNodeId(exNodeId);
+        exNodeId2.should.not.equal(exNodeId);
+        should(exNodeId2.namespaceUri).eql("urn:some:namespace");
+        should(exNodeId2.serverIndex).eql(3);
+        exNodeId2.toString().should.eql("ns=2;s=Temp1;namespaceUri:urn:some:namespace;serverIndex:3");
+
+    });
+    it("coerceExpandedNodeId should preserve namespaceUri and serverIndex of a NodeId-like literal", function() {
+
+        const exNodeId = coerceExpandedNodeId({
+            identifierType: NodeIdType.STRING,
+            value: "Temp1",
+            namespace: 2,
+            namespaceUri: "urn:some:namespace",
+            serverIndex: 3
+        });
+        exNodeId.toString().should.eql("ns=2;s=Temp1;namespaceUri:urn:some:namespace;serverIndex:3");
+
+    });
 
 
     it("ExpandedNodeId.fromNodeId", () => {

--- a/packages/node-opcua-types/test/test_alias_name_data_type.ts
+++ b/packages/node-opcua-types/test/test_alias_name_data_type.ts
@@ -1,6 +1,6 @@
 import { BinaryStream } from "node-opcua-binary-stream";
 import { QualifiedName } from "node-opcua-data-model";
-import { ExpandedNodeId, NodeId, coerceExpandedNodeId, resolveNodeId } from "node-opcua-nodeid";
+import { ExpandedNodeId, NodeId, NodeIdType, coerceExpandedNodeId, resolveNodeId } from "node-opcua-nodeid";
 import { AliasNameDataType, AliasNameVerboseDataType } from "..";
 import "should";
 
@@ -49,6 +49,24 @@ describe("OPC 10000-17: AliasName DataTypes", () => {
             reloaded.referencedNodes!.length.should.eql(2);
             reloaded.referencedNodes![0].toString().should.eql(value.referencedNodes![0].toString());
             reloaded.referencedNodes![1].toString().should.eql(value.referencedNodes![1].toString());
+        });
+
+        it("should preserve namespaceUri and serverIndex of referencedNodes at construction and through the binary encoding", () => {
+            // Annex C.2: an aggregating server disambiguates alias targets with
+            // serverIndex (against ServerArray) and namespaceUri - losing either
+            // makes FindAlias results unresolvable for remote servers.
+            const remote = new ExpandedNodeId(NodeIdType.STRING, "Temp1", 2, "urn:remote:pub1:ns", 1);
+            const value = new AliasNameDataType({
+                aliasName: { namespaceIndex: 1, name: "TI101" },
+                referencedNodes: [remote]
+            });
+
+            value.referencedNodes![0].toString().should.eql("ns=2;s=Temp1;namespaceUri:urn:remote:pub1:ns;serverIndex:1");
+
+            const reloaded = binaryRoundTrip(value, AliasNameDataType);
+            reloaded.referencedNodes![0].namespaceUri!.should.eql("urn:remote:pub1:ns");
+            reloaded.referencedNodes![0].serverIndex.should.eql(1);
+            reloaded.referencedNodes![0].toString().should.eql(remote.toString());
         });
 
         it("should expose the standard DataType and encoding NodeIds", () => {

--- a/packages/node-opcua-types/test/test_expanded_nodeid_field_preservation.ts
+++ b/packages/node-opcua-types/test/test_expanded_nodeid_field_preservation.ts
@@ -1,0 +1,44 @@
+import { BinaryStream } from "node-opcua-binary-stream";
+import { ExpandedNodeId, NodeIdType } from "node-opcua-nodeid";
+import { AddNodesItem, AddReferencesItem, BrowsePathTarget, ReferenceDescription } from "..";
+import "should";
+
+/**
+ * Generated structure constructors coerce every ExpandedNodeId field through
+ * coerceExpandedNodeId, which used to rebuild only identifierType/value/namespace
+ * and silently drop namespaceUri and serverIndex (github issue: field loss at
+ * construction, before any encoding). These tests pin the fix for a scalar
+ * field, an array field being covered by test_alias_name_data_type.ts.
+ */
+describe("ExpandedNodeId fields of generated structures preserve namespaceUri and serverIndex", () => {
+    const remote = new ExpandedNodeId(NodeIdType.STRING, "Temp1", 2, "urn:remote:server:ns", 3);
+    const expected = "ns=2;s=Temp1;namespaceUri:urn:remote:server:ns;serverIndex:3";
+
+    it("BrowsePathTarget#targetId", () => {
+        const obj = new BrowsePathTarget({ targetId: remote, remainingPathIndex: 0 });
+        obj.targetId.toString().should.eql(expected);
+    });
+
+    it("AddReferencesItem#targetNodeId", () => {
+        const obj = new AddReferencesItem({ targetNodeId: remote });
+        obj.targetNodeId.toString().should.eql(expected);
+    });
+
+    it("AddNodesItem#parentNodeId, #requestedNewNodeId and #typeDefinition", () => {
+        const obj = new AddNodesItem({ parentNodeId: remote, requestedNewNodeId: remote, typeDefinition: remote });
+        obj.parentNodeId.toString().should.eql(expected);
+        obj.requestedNewNodeId.toString().should.eql(expected);
+        obj.typeDefinition.toString().should.eql(expected);
+    });
+
+    it("ReferenceDescription#nodeId survives a binary round trip", () => {
+        const value = new ReferenceDescription({ nodeId: remote, typeDefinition: remote });
+        const stream = new BinaryStream(value.binaryStoreSize());
+        value.encode(stream);
+        stream.rewind();
+        const reloaded = new ReferenceDescription();
+        reloaded.decode(stream);
+        reloaded.nodeId.toString().should.eql(expected);
+        reloaded.typeDefinition.toString().should.eql(expected);
+    });
+});


### PR DESCRIPTION
## Problem

The generated structure constructors coerce every `ExpandedNodeId`-typed field through `coerceExpandedNodeId`, which rebuilt the node id from `identifierType`/`value`/`namespace` only, hardcoding `namespaceUri: null` and `serverIndex: 0`:

```js
const { AliasNameDataType } = require("node-opcua-types");
const { ExpandedNodeId, NodeIdType } = require("node-opcua-nodeid");
const n = new ExpandedNodeId(NodeIdType.STRING, "Temp1", 2, "urn:verify:pub1:ns", 1);
const dt = new AliasNameDataType({ aliasName: { name: "TI101", namespaceIndex: 1 }, referencedNodes: [n] });
// dt.referencedNodes[0].namespaceUri === null, serverIndex === 0  (both lost)
```

The loss happens at construction, before any encoding (the binary codec itself handles both fields correctly). Every generated type with `ExpandedNodeId` fields is affected: `AliasNameDataType`, `AliasNameVerboseDataType`, `AddNodesItem`, `AddReferencesItem`, `DeleteReferencesItem`, `BrowsePathTarget`, `ReferenceDescription`, ...

For OPC UA Part 17 AliasNames this is a conformance problem: `FindAlias`/`FindAliasVerbose` results served by an aggregating server lose the `serverIndex` that makes targets resolvable against `ServerArray` (Part 17 Annex C.2), and the `namespaceUri` disambiguation with it.

## Fix

`coerceExpandedNodeId` now:
- copies `namespaceUri` and `serverIndex` when the input is an `ExpandedNodeId` (still returning a fresh instance, as before);
- picks both fields up from NodeId-like object literals, which `coerceNodeId` ignores.

All other coercion paths (strings, numbers, `NodeId`) are unchanged.

## Tests

- `node-opcua-nodeid`: two new unit tests for field preservation from an `ExpandedNodeId` and from an object literal (13 passing).
- `node-opcua-types`: new construction + binary round-trip test on `AliasNameDataType` with both fields set, and a new file covering the scalar fields of `BrowsePathTarget`, `AddReferencesItem`, `AddNodesItem`, and a `ReferenceDescription` round trip (28 passing).
- Regression sweep: `node-opcua-basic-types`, `node-opcua-factory` (277 passing) and `node-opcua-alias-name-server` (200 passing) suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)