### PR TITLE
feat(server): supported API for contributing Server_ServerArray entries (Part 17 Annex C.2)

### DIFF
--- a/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_server_array_provider.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_server_array_provider.ts
@@ -1,0 +1,67 @@
+import "should";
+import { AttributeIds, DataType, makeNodeId, OPCUAClient, OPCUAServer, VariableIds } from "node-opcua";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+
+const port = 2263;
+
+// OPC 10000-17 (GDS) Annex C.2: an aggregating server exposes the ServerUri of every
+// aggregated server in its ServerArray, so that ExpandedNodeId.serverIndex values
+// (e.g. in FindAlias results) can be resolved by clients.
+describe("Testing ServerEngine#setServerArrayProvider (Server_ServerArray i=2254)", function (this: Mocha.Suite) {
+    this.timeout(Math.max(this.timeout(), 20000));
+
+    const serverArrayNodeId = makeNodeId(VariableIds.Server_ServerArray);
+
+    async function readServerArray(server: OPCUAServer): Promise<string[]> {
+        const client = OPCUAClient.create({ endpointMustExist: false });
+        return await client.withSessionAsync(server.getEndpointUrl(), async (session) => {
+            const dataValue = await session.read({ nodeId: serverArrayNodeId, attributeId: AttributeIds.Value });
+            dataValue.statusCode.isGood().should.eql(true);
+            dataValue.value.dataType.should.eql(DataType.String);
+            return dataValue.value.value as string[];
+        });
+    }
+
+    it("SAP-1 should expose provider entries at indices 1..n, keeping the server's own URI at index 0, and keep indices stable when an entry is withdrawn", async () => {
+        const server = new OPCUAServer({ port });
+        try {
+            await server.initialize();
+
+            const additionalEntries = ["urn:aggregated-server-A", "urn:aggregated-server-B"];
+            server.engine.setServerArrayProvider(() => additionalEntries);
+
+            await server.start();
+            const ownUri = server.engine.serverNameUrn;
+
+            const serverArray1 = await readServerArray(server);
+            serverArray1.should.eql([ownUri, "urn:aggregated-server-A", "urn:aggregated-server-B"]);
+
+            // withdrawing an entry leaves an empty-string hole: the index of every
+            // remaining entry must not shift
+            additionalEntries[0] = "";
+            const serverArray2 = await readServerArray(server);
+            serverArray2.should.eql([ownUri, "", "urn:aggregated-server-B"]);
+            serverArray2[2].should.eql(serverArray1[2]);
+        } finally {
+            await server.shutdown();
+        }
+    });
+
+    it("SAP-2 should serve only the server's own URI when no provider is installed or after the provider is removed", async () => {
+        const server = new OPCUAServer({ port });
+        try {
+            await server.start();
+            const ownUri = server.engine.serverNameUrn;
+
+            (await readServerArray(server)).should.eql([ownUri]);
+
+            server.engine.setServerArrayProvider(() => ["urn:aggregated-server-A"]);
+            (await readServerArray(server)).should.eql([ownUri, "urn:aggregated-server-A"]);
+
+            server.engine.setServerArrayProvider(null);
+            (await readServerArray(server)).should.eql([ownUri]);
+        } finally {
+            await server.shutdown();
+        }
+    });
+});

--- a/packages/node-opcua-server/source/server_engine.ts
+++ b/packages/node-opcua-server/source/server_engine.ts
@@ -403,6 +403,7 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
     private _expectedShutdownTime!: Date;
     private _serverStatus: ServerStatusDataType;
     private _globalCounter: { totalMonitoredItemCount: number } = { totalMonitoredItemCount: 0 };
+    private _serverArrayProvider?: () => string[];
 
     constructor(options?: ServerEngineOptions) {
         super();
@@ -758,6 +759,33 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
     }
 
     /**
+     * Install a provider that contributes additional entries to the `Server_ServerArray`
+     * variable (ns=0;i=2254).
+     *
+     * OPC 10000-17 (GDS) Annex C.2 requires an aggregating server to expose the ServerUri
+     * of every aggregated server in its ServerArray, so that `ExpandedNodeId.serverIndex`
+     * values returned by services such as `FindAlias` can be resolved by clients.
+     *
+     * The ServerArray value served to clients is `[serverNameUrn, ...provider()]`:
+     * index 0 always remains this server's own URI, and the provider supplies the
+     * entries for indices 1..n.
+     *
+     * Index-stability contract: a `serverIndex` handed out to clients must keep
+     * designating the same server for the lifetime of this server. The provider must
+     * therefore never reorder or compact its array when a server is withdrawn; instead
+     * it must leave an empty-string hole at the withdrawn position so that subsequent
+     * indices do not shift.
+     *
+     * The provider is consulted on every read of the variable, so its result should be
+     * cheap to compute (e.g. a cached array). Pass `null` to remove a previously
+     * installed provider. The provider may be installed before or after the server is
+     * started.
+     */
+    public setServerArrayProvider(provider: (() => string[]) | null): void {
+        this._serverArrayProvider = provider || undefined;
+    }
+
+    /**
      * the urn of the server namespace
      */
     public get serverNamespaceUrn(): string {
@@ -924,18 +952,18 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
                     set: null // read only
                 });
 
-                const server_NameUrn_var = new Variant({
-                    arrayType: VariantArrayType.Array,
-                    dataType: DataType.String,
-                    value: [
-                        this.serverNameUrn // this is us !
-                    ]
-                });
                 const server_ServerArray_Id = makeNodeId(VariableIds.Server_ServerArray); // ns=0;i=2254
 
                 bindVariableIfPresent(server_ServerArray_Id, {
-                    get() {
-                        return server_NameUrn_var;
+                    get: () => {
+                        // index 0 is always this server's own URI; an installed provider
+                        // (see setServerArrayProvider) contributes indices 1..n
+                        const additionalEntries = this._serverArrayProvider ? this._serverArrayProvider() : [];
+                        return new Variant({
+                            arrayType: VariantArrayType.Array,
+                            dataType: DataType.String,
+                            value: [this.serverNameUrn, ...additionalEntries]
+                        });
                     },
                     set: null // read only
                 });


### PR DESCRIPTION
## Motivation

OPC 10000-17 (GDS) Annex C.2 requires an aggregating server to add the ServerUri of every aggregated server into its `ServerArray`, so that `ExpandedNodeId.serverIndex` values returned by services such as `FindAlias` can be resolved by clients.

Today `ServerEngine` binds `Server_ServerArray` (ns=0;i=2254) internally during `initialize()` with a fixed one-entry array, and any value a host writes with `setValueFromSource` does not stick. Aggregating hosts are forced to re-bind the variable with `bindVariable(..., /*overwrite*/ true)` behind the engine's back, which is fragile against future changes to the internal binding.

## Change

A small supported API on the engine:

```ts
server.engine.setServerArrayProvider(() => string[] | null)
```

The internal binding now serves `[serverNameUrn, ...provider()]`:

- index 0 always remains this server's own URI;
- the provider supplies indices 1..n;
- **index-stability contract**: when an aggregated server is withdrawn, the provider must leave an empty-string hole at its position instead of compacting the array, so previously handed-out `serverIndex` values keep designating the same server;
- the provider is consulted on every read, so entries can change while the server is running; `null` removes it.

## Test

`test_e2e_server_array_provider.ts` starts a real `OPCUAServer`, reads `i=2254` through a live client session, and checks that:

- contributed entries appear at indices 1..n with the server's own URI at index 0;
- withdrawing an entry (empty-string hole) does not shift the indices of the remaining entries;
- with no provider (or after removing it) the array contains only the server's own URI.

Both new tests pass, plus the 113 existing `test_server_engine.ts` tests.

No unrelated refactors; the only behavioral change for servers that never call the new API is that the ServerArray variant is now built per read instead of cached (matching the existing `NamespaceArray` binding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)