### PR TITLE
docs(alias-name): bless lastChange.touch() for out-of-band store mutations

### DIFF
--- a/packages/node-opcua-alias-name-server/README.md
+++ b/packages/node-opcua-alias-name-server/README.md
@@ -312,6 +312,36 @@ Two things worth designing around:
   (`ns=1;s=Aliases/TagVariables/Unit200`) rather than taking the next free numeric id,
   which would shift whenever an unrelated Node happened to be created first.
 
+### Out-of-band store mutations
+
+The binding advances `LastChange` by itself for every change that flows through it:
+`addAlias`, `removeAlias`, `addAliasCategory`, and the `AddAliasesToCategory` /
+`DeleteAliasesFromCategory` Methods. A host that mutates an **injected store**
+directly — replacing entries during a reconcile, re-reading a database, swapping a
+whole subtree — is the one case the binding cannot observe, so such a host reports
+the change itself through the tracker returned by installation:
+
+```ts
+import { installAliasNames, WellKnownCategories } from "node-opcua-alias-name-server";
+
+const { lastChange } = await installAliasNames(server, { store: myStore });
+
+// ... after each out-of-band mutation of myStore:
+await lastChange?.touch(WellKnownCategories.Aliases);
+```
+
+`touch(categoryNodeId, versionTime?)` records the change on that category and rolls
+it up to every ancestor including the `Aliases` root, exactly as an internal change
+would — clause 6.3.1's nested rule, "the latest VersionTime of all Organized
+AliasNames and AliasNameCategories". Touch the most specific category that changed,
+not the root: the rollup moves ancestors for you, and a Client watching one branch
+only re-browses when *that* branch moved. `versionTime` defaults to "now"; pass one
+to backdate a change that was discovered late. Values never move backwards.
+
+This is the supported API for a store whose content changes behind the Server's
+back; there is no store-side change-notification hook, deliberately, so a store
+stays a plain data source.
+
 ## The configuration Methods (clauses 6.3.4, 6.3.5)
 
 Off by default. Turning them on exposes `AddAliasesToCategory` and

--- a/packages/node-opcua-alias-name-server/source/install_alias_names.ts
+++ b/packages/node-opcua-alias-name-server/source/install_alias_names.ts
@@ -182,6 +182,26 @@ export interface InstallAliasNamesResult {
     /**
      * Keeps `LastChange` correct across the hierarchy, and persists it
      * (clause 6.3.1).
+     *
+     * The binding advances it by itself for every change that flows through this
+     * package — `addAlias`, `removeAlias`, `addAliasCategory`, and the
+     * `AddAliasesToCategory` / `DeleteAliasesFromCategory` Methods. A host that
+     * mutates an **injected store out-of-band** — replacing entries during a
+     * reconcile, pulling a fresh snapshot from a database — is the one case the
+     * binding cannot see, so such a host reports the change itself:
+     *
+     * ```ts
+     * const { lastChange } = await installAliasNames(server, { store: myStore });
+     * // ... after each out-of-band mutation of myStore:
+     * await lastChange?.touch(categoryNodeId);
+     * ```
+     *
+     * `touch(categoryNodeId, versionTime?)` records the change on that category
+     * and rolls it up to every ancestor including the `Aliases` root, exactly as
+     * an internal change would (clause 6.3.1's nested-category rule). Omit
+     * `versionTime` to use "now"; pass one to backdate a change that was
+     * discovered late. This is the supported API for out-of-band store
+     * mutations.
      */
     lastChange?: LastChangeTracker;
     /**

--- a/packages/node-opcua-alias-name-server/source/last_change.ts
+++ b/packages/node-opcua-alias-name-server/source/last_change.ts
@@ -83,10 +83,20 @@ export class LastChangeTracker {
     /**
      * Record that a category changed, and roll the change up to every ancestor.
      *
+     * This is a public entry point, not only the binding's internal hook: a host
+     * that mutates an injected `IAliasStore` out-of-band — outside
+     * `addAlias`/`removeAlias` and the configuration Methods — calls it to
+     * report the change, since the binding has no way to observe one. Reach the
+     * tracker through the `lastChange` field of the `installAliasNames` result.
+     *
      * Ancestors are walked at write time rather than computed at read time, so
      * the Property a Client subscribes to actually carries the value — a
      * rollup that existed only inside the Server would be invisible on the
      * wire, which is the whole point of the Property.
+     *
+     * @param categoryNodeId the category that changed
+     * @param versionTime the change's VersionTime; defaults to "now"
+     * @returns the VersionTime that was recorded
      */
     public async touch(categoryNodeId: NodeId, versionTime?: number): Promise<number> {
         const value = versionTime ?? this.now();

--- a/packages/node-opcua-alias-name-server/test/test_last_change.ts
+++ b/packages/node-opcua-alias-name-server/test/test_last_change.ts
@@ -3,9 +3,9 @@ import os from "node:os";
 import path from "node:path";
 import "mocha";
 import type { AddressSpace, UAObject, UAVariable } from "node-opcua-address-space";
-import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
-import { fromVersionTime, toVersionTime } from "node-opcua-alias-name-common";
+import { fromVersionTime, type IAliasStore, toVersionTime } from "node-opcua-alias-name-common";
 import { AttributeIds } from "node-opcua-data-model";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { resolveNodeId } from "node-opcua-nodeid";
 import { DataType } from "node-opcua-variant";
 import should from "should";
@@ -340,6 +340,56 @@ describe("OPC 10000-17: LastChange (clause 6.3.1)", () => {
             const tagVariables = getObject(space, WellKnownCategories.TagVariables);
             addAlias(space, tagVariables, "TI101", space.getOwnNamespace().addVariable({ browseName: "T1", dataType: "Double" }));
             readLastChange(space, WellKnownCategories.TagVariables).should.eql(4242);
+        });
+    });
+
+    describe("out-of-band mutations of an injected store", () => {
+        // A host that injects its own IAliasStore and mutates it directly -
+        // replacing entries during a reconcile, re-reading a database - changes
+        // aliases without going through addAlias or the configuration Methods,
+        // so the binding cannot see the change. `touch` on the tracker returned
+        // by installation is the supported way to report it.
+
+        it("should advance the root Aliases LastChange when the host calls touch (clause 9.2)", async () => {
+            const space = await pristine();
+            const store: IAliasStore = { find: () => [], lastChange: () => 0 };
+            const { lastChange } = await installAliasNamesOnAddressSpace(space, { store, nowVersionTime: () => 1000 });
+            readLastChange(space, WellKnownCategories.Aliases).should.eql(0);
+
+            // the host mutated `store` behind the Server's back, then reports it
+            await lastChange!.touch(WellKnownCategories.Aliases);
+
+            readLastChange(space, WellKnownCategories.Aliases).should.eql(1000);
+        });
+
+        it("should roll a touch on a nested category up to every ancestor (clause 6.3.1)", async () => {
+            const space = await pristine();
+            const store: IAliasStore = { find: () => [], lastChange: () => 0 };
+            let now = 1000;
+            const { lastChange } = await installAliasNamesOnAddressSpace(space, { store, nowVersionTime: () => now });
+            const unit200 = addAliasCategory(space, WellKnownCategories.TagVariables, "Unit200");
+            const wells = addAliasCategory(space, unit200, "Wells");
+            const sibling = addAliasCategory(space, WellKnownCategories.TagVariables, "Sibling");
+
+            now = 7000;
+            await lastChange!.touch(wells.nodeId);
+
+            readLastChange(space, wells.nodeId).should.eql(7000, "the category that changed");
+            readLastChange(space, unit200.nodeId).should.eql(7000, "its parent");
+            readLastChange(space, WellKnownCategories.TagVariables).should.eql(7000, "its grandparent");
+            readLastChange(space, WellKnownCategories.Aliases).should.eql(7000, "the root");
+            readLastChange(space, sibling.nodeId).should.eql(0, "a sibling branch is unaffected");
+        });
+
+        it("should honour an explicit VersionTime, for a change discovered late", async () => {
+            const space = await pristine();
+            const store: IAliasStore = { find: () => [], lastChange: () => 0 };
+            const { lastChange } = await installAliasNamesOnAddressSpace(space, { store, nowVersionTime: () => 9999 });
+
+            const recorded = await lastChange!.touch(WellKnownCategories.Aliases, 4321);
+
+            recorded.should.eql(4321);
+            readLastChange(space, WellKnownCategories.Aliases).should.eql(4321);
         });
     });
 


### PR DESCRIPTION
## What

Documents `lastChange.touch(categoryNodeId, versionTime?)` on the `installAliasNames` result as the **supported host API** for advancing `LastChange` (OPC 10000-17 clause 6.3.1) when an injected `IAliasStore` is mutated out-of-band, and adds tests pinning that behaviour.

## Why

The `LastChangeTracker` only advances through the binding's internal `onChanged` hook, which fires on `AddAliasesToCategory` / `DeleteAliasesFromCategory` and the `addAlias` / `removeAlias` / `addAliasCategory` helpers. A host that mutates an injected store directly — e.g. an aggregation layer that replaces whole per-server subtrees during a reconcile pull, or a store re-read from a database — produces no event the binding can observe, so the served `LastChange` silently goes stale and Clients caching against it (clause 6.3.1) never re-browse.

Such hosts already work around this by reaching into the `{ lastChange }` field of the `installAliasNames` result and calling `touch()`, which does exactly the right thing (including the clause 6.3.1 nested-category rollup to the `Aliases` root) but was undocumented, semi-internal API. This PR blesses that surface instead of inventing a new seam: a store stays a plain data source, deliberately without a change-notification hook.

## Changes

- **TSDoc** on `InstallAliasNamesResult.lastChange` (`install_alias_names.ts`): when and how a host calls `touch()`, with an example.
- **TSDoc** on `LastChangeTracker.touch()` (`last_change.ts`): states it is a public entry point for hosts with an injected store, not only the binding's internal hook.
- **README**: new *Out-of-band store mutations* subsection under the `LastChange` section.
- **Tests** (`test_last_change.ts`, new `describe` block, 3 tests): an injected-store host calling `touch()` sees the root `Aliases` `LastChange` advance (clause 9.2); a touch on a nested category rolls up to every ancestor while leaving a sibling branch at its own value (clause 6.3.1); an explicit `versionTime` is honoured and returned.

No behavioural change — documentation and tests only.

## Verification

- `mocha` in `node-opcua-alias-name-server`: 206 passing (203 existing + 3 new).
- `tsc --noEmit -p test/tsconfig.json` clean, `biome check` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)