### PR TITLE
feat(alias-name-client): recover the per-target ReferenceType of an AliasName

### DIFF
--- a/packages/node-opcua-alias-name-client/README.md
+++ b/packages/node-opcua-alias-name-client/README.md
@@ -101,6 +101,43 @@ for one, so a later `findAliasVerbose` after a `findAlias` makes no further roun
 Construct one `ClientAliasSet` per session; call `invalidate()` if the Server's address
 space changes underneath it.
 
+## Recovering the ReferenceType of each target
+
+`AliasNameDataType` and `AliasNameVerboseDataType` (clauses 7.2 and 7.3) carry the
+referenced Nodes but **not** the ReferenceType of each Reference: a target linked with a
+vendor subtype of `AliasFor` (clause 8.2) comes back indistinguishable from one linked
+with `AliasFor` itself. That is a limitation of the DataTypes, not of any Server.
+
+Most Clients never care — they want the NodeId. An **aggregator** re-publishing pulled
+aliases does: recorded as plain `AliasFor`, a downstream `FindAlias` whose
+`ReferenceTypeFilter` names the subtype can no longer be answered faithfully across the
+aggregation hop. `readAliasReferenceTypes` recovers the actual ReferenceType per
+(alias, target) by browsing the `AliasNameType` instance Nodes:
+
+```ts
+import { readAliasReferenceTypes } from "node-opcua-alias-name-client";
+
+const entries = await aliases.findAliasVerbose("%", { categoryNodeId });
+const referenceTypes = await readAliasReferenceTypes(session, entries);
+for (const entry of entries) {
+    for (const { targetNodeId, referenceTypeId } of referenceTypes.get(entry) ?? []) {
+        republish(entry.aliasName, targetNodeId, referenceTypeId);
+    }
+}
+```
+
+The map is keyed by the very elements passed in; an entry the Server could not resolve
+(deleted since the find, for instance) is absent rather than guessed at. Callers that
+already know the `AliasNameType` instance NodeIds can pass those instead of verbose
+entries and skip the lookup step.
+
+**Cost.** One `TranslateBrowsePaths` request per 1000 aliases to locate the instance
+Nodes (skipped when NodeIds are passed), one `Browse` request per 1000, plus a
+`BrowseNext` round trip per continuation the Server imposes — batched precisely so a
+large category is a handful of round trips, never one per alias. Lower `maxNodesPerCall`
+when a Server advertises tighter `OperationLimits` (OPC 10000-5 clause 6.3.11). If you
+only resolve names to NodeIds, skip all of it.
+
 ## Nodes on another Server (Annex A)
 
 A returned `ExpandedNodeId` may carry a non-zero `ServerIndex`, which says only "this Node

--- a/packages/node-opcua-alias-name-client/source/index.ts
+++ b/packages/node-opcua-alias-name-client/source/index.ts
@@ -20,4 +20,9 @@ export {
     TOPICS
 } from "./client_alias_set.js";
 export { AliasNameCallError, AliasNameMethodNotSupportedError } from "./errors.js";
+export {
+    type AliasReferenceTypeEntry,
+    type ReadAliasReferenceTypesOptions,
+    readAliasReferenceTypes
+} from "./read_alias_reference_types.js";
 export { LOCAL_SERVER_INDEX, ServerIndexResolver } from "./server_index_resolver.js";

--- a/packages/node-opcua-alias-name-client/source/read_alias_reference_types.ts
+++ b/packages/node-opcua-alias-name-client/source/read_alias_reference_types.ts
@@ -1,0 +1,257 @@
+/**
+ * @module node-opcua-alias-name-client
+ *
+ * Recover the ReferenceType linking each AliasName to each of its targets.
+ *
+ * `AliasNameDataType` and `AliasNameVerboseDataType` (OPC 10000-17 clauses 7.2
+ * and 7.3) carry the referenced Nodes, but **not** the ReferenceType of each
+ * Reference: a target linked with a vendor subtype of `AliasFor` (clause 8.2)
+ * comes back from `FindAlias` / `FindAliasVerbose` indistinguishable from one
+ * linked with `AliasFor` itself. That is a limitation of the DataTypes, not of
+ * any particular Server.
+ *
+ * Most Clients never notice — they want the NodeId and the subtype carries no
+ * extra meaning for them. An **aggregating** Server does: re-published as plain
+ * `AliasFor`, a downstream `FindAlias` whose `ReferenceTypeFilter` names the
+ * subtype (clause 6.3.2 Table 3) cannot be answered faithfully across the
+ * aggregation hop. {@link readAliasReferenceTypes} closes that gap by going
+ * back to the address space: the `AliasNameType` instances are Nodes, and
+ * Browse reports the ReferenceType of every Reference they hold.
+ */
+
+import { ReferenceTypeIds } from "node-opcua-constants";
+import { BrowseDirection, makeResultMask } from "node-opcua-data-model";
+import { type ExpandedNodeId, type NodeId, NodeId as NodeIdClass, resolveNodeId } from "node-opcua-nodeid";
+import type { IBasicSessionAsync2 } from "node-opcua-pseudo-session";
+import { BrowsePath } from "node-opcua-service-translate-browse-path";
+import type { ReferenceDescription } from "node-opcua-types";
+import type { ClientAliasVerboseEntry } from "./client_alias_set.js";
+
+/** `AliasFor` (i=23469), the base ReferenceType of every alias link (clause 8.2). */
+const ALIAS_FOR: NodeId = resolveNodeId(ReferenceTypeIds.AliasFor);
+const HIERARCHICAL_REFERENCES: NodeId = resolveNodeId(ReferenceTypeIds.HierarchicalReferences);
+const REFERENCE_TYPE_RESULT_MASK = makeResultMask("ReferenceType");
+const DEFAULT_MAX_NODES_PER_CALL = 1000;
+
+/** One (alias, target) link, with the ReferenceType the find Methods cannot report. */
+export interface AliasReferenceTypeEntry {
+    /** The Node the alias names — matches one element of `referencedNodes`. */
+    targetNodeId: ExpandedNodeId;
+    /** `AliasFor` (i=23469) or the subtype the publisher actually used. */
+    referenceTypeId: NodeId;
+}
+
+export interface ReadAliasReferenceTypesOptions {
+    /**
+     * Upper bound on the operations packed into one `TranslateBrowsePaths` or
+     * `Browse` request. The default of 1000 fits most Servers; lower it when a
+     * Server advertises tighter `OperationLimits` (OPC 10000-5 clause 6.3.11) —
+     * `Bad_TooManyOperations` is the symptom of exceeding them.
+     */
+    maxNodesPerCall?: number;
+}
+
+/**
+ * Read the ReferenceType of every `AliasFor` Reference (and subtype) each alias
+ * holds, which is the one thing `FindAliasVerbose` cannot report.
+ *
+ * ```ts
+ * const entries = await aliases.findAliasVerbose("%", { categoryNodeId });
+ * const referenceTypes = await readAliasReferenceTypes(session, entries);
+ * for (const entry of entries) {
+ *     for (const { targetNodeId, referenceTypeId } of referenceTypes.get(entry) ?? []) {
+ *         republish(entry.aliasName, targetNodeId, referenceTypeId);
+ *     }
+ * }
+ * ```
+ *
+ * **When to use it.** Only when the ReferenceType itself matters — typically an
+ * aggregator that must re-publish pulled aliases with reference-type fidelity,
+ * so a downstream `ReferenceTypeFilter` naming an `AliasFor` subtype keeps
+ * working across the hop. A Client that only resolves names to NodeIds gets
+ * nothing from it and should not pay for it.
+ *
+ * **What it costs.** On top of the find call already made: one
+ * `TranslateBrowsePaths` request per {@link ReadAliasReferenceTypesOptions.maxNodesPerCall}
+ * aliases to locate the `AliasNameType` instance Nodes (skipped when NodeIds
+ * are passed directly), then one `Browse` request per batch, plus one
+ * `BrowseNext` round trip per continuation the Server imposes. The requests are
+ * batched precisely so a large category does **not** become one round trip per
+ * alias: 1000 aliases resolve in two or three round trips, not 1000.
+ *
+ * The result is keyed by the **very elements passed in** — look entries up with
+ * the objects from the input array, not with reconstructed equals. An input the
+ * Server could not resolve (the alias was deleted since the find, a NodeId that
+ * no longer browses) is absent from the map rather than present with a guess.
+ *
+ * @param session any `IBasicSessionAsync2` — a remote `ClientSession` or an
+ *   in-process `PseudoSession`, as everywhere in this package
+ * @param aliases either the entries of a `findAliasVerbose` call, or the
+ *   NodeIds of `AliasNameType` instance Nodes when the caller already knows
+ *   them (from browsing a category, or from its own bookkeeping)
+ */
+export async function readAliasReferenceTypes(
+    session: IBasicSessionAsync2,
+    aliases: NodeId[],
+    options?: ReadAliasReferenceTypesOptions
+): Promise<Map<NodeId, AliasReferenceTypeEntry[]>>;
+export async function readAliasReferenceTypes(
+    session: IBasicSessionAsync2,
+    aliases: ClientAliasVerboseEntry[],
+    options?: ReadAliasReferenceTypesOptions
+): Promise<Map<ClientAliasVerboseEntry, AliasReferenceTypeEntry[]>>;
+export async function readAliasReferenceTypes(
+    session: IBasicSessionAsync2,
+    aliases: NodeId[] | ClientAliasVerboseEntry[],
+    options?: ReadAliasReferenceTypesOptions
+): Promise<Map<NodeId | ClientAliasVerboseEntry, AliasReferenceTypeEntry[]>> {
+    const maxNodesPerCall = Math.max(1, options?.maxNodesPerCall ?? DEFAULT_MAX_NODES_PER_CALL);
+    const result = new Map<NodeId | ClientAliasVerboseEntry, AliasReferenceTypeEntry[]>();
+    if (aliases.length === 0) {
+        return result;
+    }
+
+    const aliasNodeIds: (NodeId | null)[] =
+        aliases[0] instanceof NodeIdClass
+            ? (aliases as NodeId[])
+            : await resolveAliasNodeIds(session, aliases as ClientAliasVerboseEntry[], maxNodesPerCall);
+
+    const targets = await browseAliasTargets(session, aliasNodeIds, maxNodesPerCall);
+    aliases.forEach((key: NodeId | ClientAliasVerboseEntry, index: number) => {
+        const entries = targets[index];
+        if (entries) {
+            result.set(key, entries);
+        }
+    });
+    return result;
+}
+
+/**
+ * Locate the `AliasNameType` instance Node behind each verbose entry.
+ *
+ * `FindAliasVerbose` names the category that held the alias
+ * (`aliasNameCategoryId`, clause 7.3) but not the alias Node itself, so the
+ * Node is found by translating one browse path below the category. The
+ * `RelativePath` is built element by element rather than parsed from a string,
+ * so an alias name containing `/`, `&` or the other OPC 10000-4 Annex A
+ * reserved characters needs no escaping. The QualifiedName match is exact —
+ * the entry's `namespaceIndex` is the one the Server reported, so this is the
+ * one place the namespace of an AliasName is **not** ignored.
+ *
+ * Unresolvable entries yield `null`, keeping positions aligned with the input.
+ */
+async function resolveAliasNodeIds(
+    session: IBasicSessionAsync2,
+    entries: ClientAliasVerboseEntry[],
+    maxNodesPerCall: number
+): Promise<(NodeId | null)[]> {
+    const aliasNodeIds: (NodeId | null)[] = new Array(entries.length).fill(null);
+    for (let offset = 0; offset < entries.length; offset += maxNodesPerCall) {
+        const chunk = entries.slice(offset, offset + maxNodesPerCall);
+        const results = await session.translateBrowsePath(
+            chunk.map(
+                (entry) =>
+                    new BrowsePath({
+                        startingNode: entry.aliasNameCategoryId,
+                        relativePath: {
+                            elements: [
+                                {
+                                    referenceTypeId: HIERARCHICAL_REFERENCES,
+                                    isInverse: false,
+                                    includeSubtypes: true,
+                                    targetName: { namespaceIndex: entry.namespaceIndex, name: entry.aliasName }
+                                }
+                            ]
+                        }
+                    })
+            )
+        );
+        results.forEach((browsePathResult, index) => {
+            if (browsePathResult.statusCode.isGood() && browsePathResult.targets?.length) {
+                // the targetId of a local Node is an ExpandedNodeId with
+                // serverIndex 0, usable as a NodeId as-is
+                aliasNodeIds[offset + index] = browsePathResult.targets[0].targetId;
+            }
+        });
+    }
+    return aliasNodeIds;
+}
+
+/**
+ * Browse the forward `AliasFor` References (subtypes included) of many alias
+ * Nodes in as few requests as possible, following every continuation point.
+ *
+ * Positions align with the input; `null` marks a Node that could not be
+ * resolved upstream or whose Browse did not complete — for the fidelity use
+ * case, an absent answer beats a truncated one presented as complete.
+ */
+async function browseAliasTargets(
+    session: IBasicSessionAsync2,
+    aliasNodeIds: (NodeId | null)[],
+    maxNodesPerCall: number
+): Promise<(AliasReferenceTypeEntry[] | null)[]> {
+    const targets: (AliasReferenceTypeEntry[] | null)[] = new Array(aliasNodeIds.length).fill(null);
+
+    const toBrowse: { index: number; nodeId: NodeId }[] = [];
+    aliasNodeIds.forEach((nodeId, index) => {
+        if (nodeId) {
+            toBrowse.push({ index, nodeId });
+        }
+    });
+
+    const toEntry = (reference: ReferenceDescription): AliasReferenceTypeEntry => ({
+        targetNodeId: reference.nodeId,
+        referenceTypeId: reference.referenceTypeId
+    });
+
+    for (let offset = 0; offset < toBrowse.length; offset += maxNodesPerCall) {
+        const chunk = toBrowse.slice(offset, offset + maxNodesPerCall);
+        const browseResults = await session.browse(
+            chunk.map(({ nodeId }) => ({
+                nodeId,
+                browseDirection: BrowseDirection.Forward,
+                referenceTypeId: ALIAS_FOR,
+                includeSubtypes: true,
+                nodeClassMask: 0,
+                resultMask: REFERENCE_TYPE_RESULT_MASK
+            }))
+        );
+
+        // continuations, batched too: one BrowseNext round trip serves every
+        // Node of the chunk that was truncated, however many there are
+        let pending: { index: number; continuationPoint: Buffer }[] = [];
+        browseResults.forEach((browseResult, chunkIndex) => {
+            const { index } = chunk[chunkIndex];
+            if (!browseResult.statusCode.isGood()) {
+                return;
+            }
+            targets[index] = (browseResult.references ?? []).map(toEntry);
+            if (browseResult.continuationPoint?.length) {
+                pending.push({ index, continuationPoint: browseResult.continuationPoint });
+            }
+        });
+
+        while (pending.length > 0) {
+            const nextResults = await session.browseNext(
+                pending.map(({ continuationPoint }) => continuationPoint),
+                false
+            );
+            const stillPending: typeof pending = [];
+            nextResults.forEach((browseResult, pendingIndex) => {
+                const { index } = pending[pendingIndex];
+                if (!browseResult.statusCode.isGood()) {
+                    // incomplete: withdraw the partial answer rather than let it
+                    // pass for the whole truth
+                    targets[index] = null;
+                    return;
+                }
+                targets[index]?.push(...(browseResult.references ?? []).map(toEntry));
+                if (browseResult.continuationPoint?.length) {
+                    stillPending.push({ index, continuationPoint: browseResult.continuationPoint });
+                }
+            });
+            pending = stillPending;
+        }
+    }
+    return targets;
+}

--- a/packages/node-opcua-alias-name-client/test/test_read_alias_reference_types.ts
+++ b/packages/node-opcua-alias-name-client/test/test_read_alias_reference_types.ts
@@ -1,0 +1,208 @@
+import "mocha";
+import { AddressSpace, PseudoSession, type UAObject, type UAReferenceType, type UAVariable } from "node-opcua-address-space";
+import { generateAddressSpace } from "node-opcua-address-space/nodeJS";
+import { addAlias, installAliasNamesOnAddressSpace, WellKnownCategories } from "node-opcua-alias-name-server";
+import { ReferenceTypeIds } from "node-opcua-constants";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { type NodeId, resolveNodeId, sameNodeId } from "node-opcua-nodeid";
+import { nodesets } from "node-opcua-nodesets";
+import should from "should";
+import { ClientAliasSet, type ClientAliasVerboseEntry, readAliasReferenceTypes, TAG_VARIABLES } from "../source";
+
+const ALIAS_FOR: NodeId = resolveNodeId(ReferenceTypeIds.AliasFor);
+
+/**
+ * `readAliasReferenceTypes` exists because `AliasNameVerboseDataType` (OPC
+ * 10000-17 clause 7.3) has no per-target ReferenceType: an alias published
+ * with a **subtype** of `AliasFor` (clause 8.2) is indistinguishable, in the
+ * find results, from one published with `AliasFor` itself. The publisher
+ * address space built here uses such a subtype on purpose, so every assertion
+ * below is about information the find Methods provably cannot carry.
+ */
+describe("OPC 10000-17: readAliasReferenceTypes", () => {
+    let addressSpace: AddressSpace;
+    let session: PseudoSession;
+    let aliases: ClientAliasSet;
+
+    /** A vendor subtype of `AliasFor`, the thing the find results erase. */
+    let hasSensorAlias: UAReferenceType;
+    let pressureSensor: UAVariable;
+    let temperatureIndicator: UAVariable;
+    /** The `AliasNameType` instance nodes, for the NodeId-input flavour. */
+    let pt42Alias: UAObject;
+    let dualAlias: UAObject;
+    let bulkAlias: UAObject;
+    let bulkTargets: UAVariable[];
+
+    before(async () => {
+        addressSpace = AddressSpace.create();
+        await generateAddressSpace(addressSpace, nodesets.standard);
+        const ns = addressSpace.registerNamespace("urn:test:alias-reference-types");
+
+        hasSensorAlias = ns.addReferenceType({
+            browseName: "HasSensorAlias",
+            inverseName: "SensorAliasOf",
+            isAbstract: false,
+            subtypeOf: addressSpace.findReferenceType(ALIAS_FOR)!
+        });
+
+        pressureSensor = ns.addVariable({ browseName: "PressureSensor", dataType: "Double" }) as UAVariable;
+        temperatureIndicator = ns.addVariable({ browseName: "TemperatureIndicator", dataType: "Double" }) as UAVariable;
+
+        // one alias on the subtype, one on plain AliasFor
+        pt42Alias = addAlias(addressSpace, WellKnownCategories.TagVariables, "PT-42", pressureSensor, {
+            referenceType: hasSensorAlias.nodeId
+        });
+        addAlias(addressSpace, WellKnownCategories.TagVariables, "TI101", temperatureIndicator);
+
+        // one alias mixing both on its two targets — fidelity must be per
+        // (alias, target), not per alias
+        dualAlias = addAlias(addressSpace, WellKnownCategories.TagVariables, "DUAL-1", temperatureIndicator);
+        addAlias(addressSpace, WellKnownCategories.TagVariables, "DUAL-1", pressureSensor, {
+            referenceType: hasSensorAlias.nodeId
+        });
+
+        // one alias with enough targets to overflow a truncated Browse
+        bulkTargets = [];
+        for (let i = 0; i < 12; i++) {
+            const variable = ns.addVariable({ browseName: `BulkSensor${i}`, dataType: "Double" }) as UAVariable;
+            bulkTargets.push(variable);
+            bulkAlias = addAlias(addressSpace, WellKnownCategories.TagVariables, "BULK-1", variable, {
+                referenceType: i % 2 === 0 ? undefined : hasSensorAlias.nodeId
+            });
+        }
+
+        await installAliasNamesOnAddressSpace(addressSpace);
+
+        session = new PseudoSession(addressSpace);
+        aliases = new ClientAliasSet(session);
+    });
+
+    after(() => addressSpace.dispose());
+
+    /** Count the requests a helper call makes, to pin down the batching. */
+    function countingSession(base: PseudoSession): {
+        session: PseudoSession;
+        counts: { browse: number; browseNext: number; translate: number };
+    } {
+        const counts = { browse: 0, browseNext: 0, translate: 0 };
+        const counting = Object.create(base) as PseudoSession;
+        const wrap = <K extends "browse" | "browseNext" | "translateBrowsePath">(name: K, counter: keyof typeof counts) => {
+            counting[name] = ((...args: unknown[]) => {
+                counts[counter] += 1;
+                return (base[name] as (...a: unknown[]) => unknown).apply(base, args);
+            }) as PseudoSession[K];
+        };
+        wrap("browse", "browse");
+        wrap("browseNext", "browseNext");
+        wrap("translateBrowsePath", "translate");
+        return { session: counting, counts };
+    }
+
+    it("should recover the AliasFor subtype that FindAliasVerbose cannot carry", async () => {
+        const [entry] = await aliases.findAliasVerbose("PT-42");
+        should.exist(entry);
+
+        const referenceTypes = await readAliasReferenceTypes(session, [entry]);
+        const targets = referenceTypes.get(entry)!;
+        should.exist(targets, "the entry itself keys the result");
+        targets.should.have.length(1);
+        sameNodeId(targets[0].targetNodeId, entry.referencedNodes[0]).should.eql(true);
+        sameNodeId(targets[0].referenceTypeId, hasSensorAlias.nodeId).should.eql(true, "the subtype, not plain AliasFor");
+    });
+
+    it("should report plain AliasFor for an alias published with it", async () => {
+        const [entry] = await aliases.findAliasVerbose("TI101");
+        const targets = (await readAliasReferenceTypes(session, [entry])).get(entry)!;
+        targets.should.have.length(1);
+        sameNodeId(targets[0].referenceTypeId, ALIAS_FOR).should.eql(true);
+    });
+
+    it("should keep fidelity per (alias, target) when one alias mixes reference types", async () => {
+        const [entry] = await aliases.findAliasVerbose("DUAL-1");
+        entry.referencedNodes.should.have.length(2);
+
+        const targets = (await readAliasReferenceTypes(session, [entry])).get(entry)!;
+        targets.should.have.length(2);
+        const byTarget = (nodeId: NodeId) => targets.find((t) => sameNodeId(t.targetNodeId, nodeId))!;
+        sameNodeId(byTarget(temperatureIndicator.nodeId).referenceTypeId, ALIAS_FOR).should.eql(true);
+        sameNodeId(byTarget(pressureSensor.nodeId).referenceTypeId, hasSensorAlias.nodeId).should.eql(true);
+    });
+
+    it("should accept AliasNameType instance NodeIds directly, skipping the lookup step", async () => {
+        const { session: counted, counts } = countingSession(session);
+        const referenceTypes = await readAliasReferenceTypes(counted, [pt42Alias.nodeId, dualAlias.nodeId]);
+
+        counts.translate.should.eql(0, "NodeIds given: nothing to translate");
+        counts.browse.should.eql(1, "two nodes, one Browse request");
+        referenceTypes.size.should.eql(2);
+        const pt42Targets = referenceTypes.get(pt42Alias.nodeId)!;
+        sameNodeId(pt42Targets[0].referenceTypeId, hasSensorAlias.nodeId).should.eql(true);
+        referenceTypes.get(dualAlias.nodeId)!.should.have.length(2);
+    });
+
+    it("should batch many verbose entries into one TranslateBrowsePaths and one Browse", async () => {
+        const entries = await aliases.findAliasVerbose("%");
+        entries.length.should.be.greaterThanOrEqual(4);
+
+        const { session: counted, counts } = countingSession(session);
+        const referenceTypes = await readAliasReferenceTypes(counted, entries);
+
+        counts.translate.should.eql(1, "one TranslateBrowsePaths for every entry");
+        counts.browse.should.eql(1, "one Browse for every alias node — never one per alias");
+        referenceTypes.size.should.eql(entries.length);
+    });
+
+    it("should honour maxNodesPerCall by splitting into that many requests", async () => {
+        const entries = await aliases.findAliasVerbose("%");
+        const { session: counted, counts } = countingSession(session);
+        const referenceTypes = await readAliasReferenceTypes(counted, entries, { maxNodesPerCall: 1 });
+
+        counts.translate.should.eql(entries.length);
+        counts.browse.should.eql(entries.length);
+        referenceTypes.size.should.eql(entries.length, "chunking changes the traffic shape, not the answer");
+    });
+
+    it("should follow continuation points when the Server truncates the Browse", async () => {
+        // a PseudoSession enforces requestedMaxReferencesPerNode exactly as a
+        // real Server enforces its own limit, continuation points included
+        const truncating = new PseudoSession(addressSpace);
+        truncating.requestedMaxReferencesPerNode = 3;
+        const { session: counted, counts } = countingSession(truncating);
+
+        const targets = (await readAliasReferenceTypes(counted, [bulkAlias.nodeId])).get(bulkAlias.nodeId)!;
+
+        counts.browseNext.should.be.greaterThan(0, "12 targets at 3 per answer forces BrowseNext");
+        targets.should.have.length(bulkTargets.length);
+        bulkTargets.forEach((variable, i) => {
+            const found = targets.find((t) => sameNodeId(t.targetNodeId, variable.nodeId))!;
+            should.exist(found, `target ${i} survives the continuation`);
+            const expected = i % 2 === 0 ? ALIAS_FOR : hasSensorAlias.nodeId;
+            sameNodeId(found.referenceTypeId, expected).should.eql(true, `target ${i} keeps its reference type`);
+        });
+    });
+
+    it("should omit an entry the address space no longer resolves, rather than guess", async () => {
+        const [real] = await aliases.findAliasVerbose("PT-42");
+        const stale: ClientAliasVerboseEntry = {
+            aliasName: "DELETED-SINCE-THE-FIND",
+            namespaceIndex: real.namespaceIndex,
+            referencedNodes: [],
+            serverUris: [],
+            aliasNameCategoryId: TAG_VARIABLES
+        };
+
+        const referenceTypes = await readAliasReferenceTypes(session, [real, stale]);
+        referenceTypes.size.should.eql(1);
+        should.exist(referenceTypes.get(real));
+        should.not.exist(referenceTypes.get(stale));
+    });
+
+    it("should return an empty map for an empty input, without any request", async () => {
+        const { session: counted, counts } = countingSession(session);
+        const referenceTypes = await readAliasReferenceTypes(counted, [] as NodeId[]);
+        referenceTypes.size.should.eql(0);
+        counts.browse.should.eql(0);
+        counts.translate.should.eql(0);
+    });
+});


### PR DESCRIPTION
## Why

`AliasNameDataType` and `AliasNameVerboseDataType` (OPC 10000-17 clauses 7.2 and 7.3) carry `referencedNodes`, `serverUris` and `aliasNameCategoryId`, but **no per-target ReferenceType**. A Client pulling aliases through `FindAlias` / `FindAliasVerbose` therefore cannot tell whether a target is linked with `AliasFor` (i=23469) or with one of its subtypes, which clause 8.2 explicitly allows a publisher to use.

This is a limitation of the DataTypes, not a bug in any Server.

Most Clients never notice: they want the NodeId and the subtype carries no extra meaning for them. An **aggregating** Server does notice. Once a pulled alias is recorded as plain `AliasFor`, a downstream `FindAlias` whose `ReferenceTypeFilter` names the subtype (clause 6.3.2 Table 3) can no longer be answered faithfully across the aggregation hop.

## What this adds

An optional client-side helper, `readAliasReferenceTypes(session, aliases, options?)`, that closes the gap by going back to the address space: the `AliasNameType` instances are Nodes, and Browse reports the ReferenceType of every Reference they hold.

```ts
const entries = await aliases.findAliasVerbose("%", { categoryNodeId });
const referenceTypes = await readAliasReferenceTypes(session, entries);
for (const entry of entries) {
    for (const { targetNodeId, referenceTypeId } of referenceTypes.get(entry) ?? []) {
        republish(entry.aliasName, targetNodeId, referenceTypeId);
    }
}
```

It accepts either the entries of a `findAliasVerbose` call, or `AliasNameType` instance NodeIds when the caller already knows them, and returns a `Map` keyed by the very elements passed in.

## Batching, which is the whole point

A naive implementation is one round trip per alias, which makes it unusable on a large category. Instead:

| step | requests |
| --- | --- |
| locate the alias instance Nodes | one `TranslateBrowsePaths` per `maxNodesPerCall` (default 1000) — skipped entirely when NodeIds are passed |
| read the References | one `Browse` per `maxNodesPerCall` |
| finish truncated answers | one `BrowseNext` per continuation round, batched across every truncated Node of the chunk |

So 1000 aliases cost two or three round trips, not 1000. `maxNodesPerCall` is there for Servers advertising tighter `OperationLimits` (OPC 10000-5 clause 6.3.11).

Two deliberate choices about incomplete answers, both aimed at the fidelity use case where a wrong answer is worse than no answer:

- an alias the Server cannot resolve (deleted between the find and this call, or a NodeId that no longer browses) is **absent** from the map rather than present with a guessed `AliasFor`;
- a `BrowseNext` that fails mid-continuation withdraws the partial list rather than letting it pass for the complete set of targets.

The browse path to the alias Node is built element by element rather than parsed from a string, so an alias name containing `/`, `&` or the other OPC 10000-4 Annex A reserved characters needs no escaping.

## Tests

`packages/node-opcua-alias-name-client/test/test_read_alias_reference_types.ts`, against a publisher address space that declares `HasSensorAlias`, a vendor subtype of `AliasFor`, and uses it on some aliases and not others. Every assertion is about information the find Methods provably cannot carry:

- the subtype is recovered where `FindAliasVerbose` reports nothing;
- plain `AliasFor` still reads as `AliasFor`;
- fidelity holds **per (alias, target)** when one alias mixes both on its two targets;
- the NodeId input skips the translate step (asserted by counting requests);
- many entries collapse into exactly one `TranslateBrowsePaths` and one `Browse`, and `maxNodesPerCall` splits them as documented;
- 12 targets against a `PseudoSession` capped at 3 references per answer forces `BrowseNext`, and every target keeps its own reference type across the continuation;
- an unresolvable entry is omitted, and an empty input makes no request at all.

Full package suite: 38 passing. `tsc -b`, `tsc --noEmit -p test/tsconfig.json` and `biome check` are clean.

## Scope

Additive only. No existing behaviour changes, no refactors, no server-side changes. The helper is a free function rather than a `ClientAliasSet` method because it is a specialist tool: a Client that only resolves names to NodeIds should not pay for it, and should not have it in reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)