### PR TITLE
fix(server): a session's SessionContext now sees the whole IServerBase

### DIFF
--- a/packages/node-opcua-server/source/server_engine.ts
+++ b/packages/node-opcua-server/source/server_engine.ts
@@ -1651,7 +1651,11 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
         const sessionTimeout = options.sessionTimeout || 1000;
         assert(typeof sessionTimeout === "number");
 
-        const session = new ServerSession(this, options.server.userManager || {}, sessionTimeout);
+        // Hand the session the IServerBase itself. Reducing it to
+        // `options.server.userManager` severed roleResolvers,
+        // rolePolicyOverride and unresolvedPermissionPolicy from every real
+        // session's SessionContext (see ServerSession's constructor).
+        const session = new ServerSession(this, options.server, sessionTimeout);
 
         debugLog("createSession :sessionTimeout = ", session.sessionTimeout);
 

--- a/packages/node-opcua-server/source/server_session.ts
+++ b/packages/node-opcua-server/source/server_session.ts
@@ -13,7 +13,7 @@ import {
     type DTSessionSecurityDiagnostics,
     ensureObjectIsSecure,
     type ISessionBase,
-    type IUserManager,
+    type IServerBase,
     removeElement,
     SessionContext,
     type UADynamicVariableArray,
@@ -138,16 +138,23 @@ export class ServerSession extends EventEmitter implements ISubscriber, ISession
 
     private channel_abort_event_handler: any;
 
-    constructor(parent: ServerEngine, userManager: IUserManager, sessionTimeout: number) {
+    constructor(parent: ServerEngine, server: IServerBase, sessionTimeout: number) {
         super();
 
         this.parent = parent; // SessionEngine
 
         ServerSession.registry.register(this);
 
+        // The whole IServerBase, not a `{ userManager }` wrapper around one of
+        // its fields: SessionContext.getCurrentUserRoles also consults
+        // server.roleResolvers (OPC 10000-18 §4.4 identity mapping),
+        // server.rolePolicyOverride and server.unresolvedPermissionPolicy.
+        // Wrapping the manager alone made all three invisible to every real
+        // session, so e.g. a Thumbprint rule accepted by AddIdentity was never
+        // applied when the matching X509 session actually connected.
         this.sessionContext = new SessionContext({
             session: this,
-            server: { userManager }
+            server
         });
 
         assert(isFinite(sessionTimeout));

--- a/packages/node-opcua-server/test/test_session_context_server_wiring.ts
+++ b/packages/node-opcua-server/test/test_session_context_server_wiring.ts
@@ -1,0 +1,89 @@
+// ---------------------------------------------------------------------------
+// A ServerSession's SessionContext must see the whole IServerBase.
+//
+// It used to be built with `server: { userManager }` — a fresh literal
+// carrying one field — so everything else `getCurrentUserRoles` reads off
+// `this.server` was invisible to every real session:
+//
+//   - `roleResolvers` (OPC 10000-18 §4.4 identity mapping): a Thumbprint rule
+//     accepted by AddIdentity was never applied when the matching session
+//     actually connected;
+//   - `rolePolicyOverride` (setRolePolicyOverride wrote to the OPCUAServer,
+//     sessions read the wrapper);
+//   - `unresolvedPermissionPolicy`.
+//
+// Found on 2026-08-15 driving a real X509 session against installRoleSet from
+// node-opcua-role-set-server: AddIdentity returned Good, the store held the
+// rule, and the session resolved to Anonymous + AuthenticatedUser anyway.
+// ---------------------------------------------------------------------------
+import { type IServerBase, makeRoles, WellKnownRoles } from "node-opcua-address-space";
+import { type NodeId, resolveNodeId, sameNodeId } from "node-opcua-nodeid";
+import { UserNameIdentityToken } from "node-opcua-types";
+import "should";
+import { ServerEngine } from "../source";
+
+const securityAdmin = resolveNodeId(WellKnownRoles.SecurityAdmin);
+const hasRole = (roles: NodeId[], role: NodeId) => roles.some((r) => sameNodeId(r, role));
+const show = (roles: NodeId[]) => roles.map(String).join(", ");
+
+describe("SessionContext receives the whole IServerBase", () => {
+    it("consults server.roleResolvers when resolving a real session's roles", async () => {
+        const engine = new ServerEngine({ applicationUri: "application:uri" });
+        const server: IServerBase = {
+            userManager: { getUserRoles: () => makeRoles("Operator") },
+            roleResolvers: [
+                {
+                    resolveRoles: (token) =>
+                        token instanceof UserNameIdentityToken && token.userName === "bob" ? [securityAdmin] : []
+                }
+            ]
+        };
+
+        const session = engine.createSession({ server });
+        session.userIdentityToken = new UserNameIdentityToken({ userName: "bob" });
+        const roles = session.sessionContext.getCurrentUserRoles();
+
+        // the regression: this role came from the resolver, which the
+        // `{ userManager }` wrapper made unreachable
+        hasRole(roles, securityAdmin).should.eql(true, `resolver-granted role missing, got [${show(roles)}]`);
+        // and the userManager path is still consulted alongside it
+        hasRole(roles, resolveNodeId(WellKnownRoles.Operator)).should.eql(true, `userManager role missing, got [${show(roles)}]`);
+
+        await engine.shutdown();
+    });
+
+    it("honours server.rolePolicyOverride ahead of the userManager", async () => {
+        const engine = new ServerEngine({ applicationUri: "application:uri" });
+        const server: IServerBase = {
+            userManager: { getUserRoles: () => makeRoles("Operator") },
+            rolePolicyOverride: {
+                getUserRoles: (userName: string) => (userName === "bob" ? makeRoles("Engineer") : null)
+            }
+        };
+
+        const session = engine.createSession({ server });
+        session.userIdentityToken = new UserNameIdentityToken({ userName: "bob" });
+        const roles = session.sessionContext.getCurrentUserRoles();
+
+        hasRole(roles, resolveNodeId(WellKnownRoles.Engineer)).should.eql(true, `override role missing, got [${show(roles)}]`);
+        hasRole(roles, resolveNodeId(WellKnownRoles.Operator)).should.eql(false, `override must win, got [${show(roles)}]`);
+
+        await engine.shutdown();
+    });
+
+    it("still resolves roles through a bare userManager (the pre-fix caller shape)", async () => {
+        const engine = new ServerEngine({ applicationUri: "application:uri" });
+        const server: IServerBase = {
+            userManager: { getUserRoles: () => makeRoles("Operator") }
+        };
+
+        const session = engine.createSession({ server });
+        session.userIdentityToken = new UserNameIdentityToken({ userName: "alice" });
+        const roles = session.sessionContext.getCurrentUserRoles();
+
+        hasRole(roles, resolveNodeId(WellKnownRoles.Operator)).should.eql(true, `userManager role missing, got [${show(roles)}]`);
+        hasRole(roles, resolveNodeId(WellKnownRoles.AuthenticatedUser)).should.eql(true);
+
+        await engine.shutdown();
+    });
+});


### PR DESCRIPTION
## Problem

`ServerSession` constructs its `SessionContext` with `server: { userManager }` — a fresh object literal carrying a single field. `SessionContext.getCurrentUserRoles` reads three other things off `this.server`, and none of them were ever visible to a real client session:

- **`roleResolvers`** (OPC 10000-18 §4.4 identity mapping): a Thumbprint rule accepted by a RoleSet `AddIdentity` was never applied when the matching X.509 session actually connected — the session resolved to `Anonymous` + `AuthenticatedUser` regardless.
- **`rolePolicyOverride`**: `OPCUAServer.setRolePolicyOverride` writes to the server object; sessions read the wrapper.
- **`unresolvedPermissionPolicy`**.

Found while driving a real X.509 session against `installRoleSet` (node-opcua-role-set-server): `AddIdentity` returned `Good`, the store held the rule, and the role-gated operation still returned `BadUserAccessDenied`.

## Fix

`ServerEngine.createSession` already receives the `OPCUAServer` as `options.server`, and `SessionContextOptions.server` is already typed `IServerBase /* OPCUAServer */` — the wrapper was the only thing between them. `ServerSession` now takes the `IServerBase` and hands it to `SessionContext` whole.

Only one construction site exists in the monorepo; `createSession({ server: {} })` callers are unaffected (verified by a test pinning the bare-userManager shape).

## Tests

- `test_session_context_server_wiring.ts`: three cases — resolver-granted role reaches a real session's roles, `rolePolicyOverride` wins over the userManager, and the pre-fix caller shape still resolves. The first two fail without the source change (verified by stashing it).
- Full `node-opcua-server` suite: 461 passing, 0 failing. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)