### PR TITLE
fix(role-set): X509Subject matching silently dropped the OU

### DIFF
--- a/packages/node-opcua-role-set-common/source/x509_subject.ts
+++ b/packages/node-opcua-role-set-common/source/x509_subject.ts
@@ -13,10 +13,40 @@
 export interface X509SubjectName {
     commonName?: string;
     organizationName?: string;
+    /**
+     * OU (2.5.4.11), as `node-opcua-crypto` actually reports it.
+     *
+     * Note the spelling. The OID table resolves this attribute to
+     * `organizational`**Unit**`Name`, and the certificate parser keys its result
+     * by that resolved name — so this is the property a parsed certificate
+     * carries. Verified against a real certificate with `/OU=Plant`:
+     *
+     * ```
+     * {"commonName":"operator-1","organizationName":"Sterfive",
+     *  "organizationalUnitName":"Plant","countryName":"FR"}
+     * ```
+     */
+    organizationalUnitName?: string;
+    /**
+     * @deprecated Misspelling of {@link X509SubjectName.organizationalUnitName}.
+     *
+     * A parsed certificate never carries this property, so reading it always
+     * yielded `undefined` and the OU was silently dropped. Still accepted on
+     * input for callers that build a subject by hand.
+     */
     organizationUnitName?: string;
     localityName?: string;
     stateOrProvinceName?: string;
     countryName?: string;
+    /**
+     * These three are produced by the certificate parser — their OIDs resolve to
+     * these names — but were absent from this interface, so they never reached
+     * the criteria. Part 18 lists all three in Table 10.
+     */
+    domainComponent?: string;
+    dnQualifier?: string;
+    /** The DN's own `serialNumber` attribute (2.5.4.5), not the certificate's. */
+    serialNumber?: string;
 }
 
 /**
@@ -51,15 +81,27 @@ export function parseX509SubjectCriteria(criteria: string): Array<[string, strin
     return pairs;
 }
 
-/** Build ordered name/value pairs from a certificate subject. */
+/**
+ * Build ordered name/value pairs from a certificate subject.
+ *
+ * Every attribute the subject carries must appear: Part 18 has no wildcards, so
+ * a pair silently left out here does not make matching *looser* — it makes the
+ * two sides disagree, and a correctly written rule then matches nobody.
+ */
 export function certificateSubjectPairs(subject: X509SubjectName): Array<[string, string]> {
     const pairs: Array<[string, string]> = [];
     if (subject.commonName) pairs.push(["CN", subject.commonName]);
     if (subject.organizationName) pairs.push(["O", subject.organizationName]);
-    if (subject.organizationUnitName) pairs.push(["OU", subject.organizationUnitName]);
+    // Both spellings: a parsed certificate carries `organizationalUnitName`,
+    // while hand-built subjects in existing code may use the older misspelling.
+    const organizationalUnit = subject.organizationalUnitName ?? subject.organizationUnitName;
+    if (organizationalUnit) pairs.push(["OU", organizationalUnit]);
+    if (subject.domainComponent) pairs.push(["DC", subject.domainComponent]);
     if (subject.localityName) pairs.push(["L", subject.localityName]);
     if (subject.stateOrProvinceName) pairs.push(["S", subject.stateOrProvinceName]);
     if (subject.countryName) pairs.push(["C", subject.countryName]);
+    if (subject.dnQualifier) pairs.push(["dnQualifier", subject.dnQualifier]);
+    if (subject.serialNumber) pairs.push(["serialNumber", subject.serialNumber]);
     return pairs;
 }
 

--- a/packages/node-opcua-role-set-common/test/test_x509_subject.ts
+++ b/packages/node-opcua-role-set-common/test/test_x509_subject.ts
@@ -1,4 +1,5 @@
 import "should";
+import { convertPEMtoDER, exploreCertificate } from "node-opcua-crypto";
 import {
     canonicalizeX509Subject,
     certificateSubjectPairs,
@@ -100,6 +101,96 @@ describe("x509_subject — OPC 10000-18 §4.4.3 subject criteria (Table 10)", ()
 
         it("should NOT match a different Common Name", () => {
             matchX509Subject("Someone Else", { commonName: "Jane Doe" }).should.be.false();
+        });
+    });
+    describe("certificateSubjectPairs — driven by a REAL certificate", () => {
+        /**
+         * The suite above builds X509SubjectName objects by hand, which is why a
+         * long-standing bug survived it: a parsed certificate reports its OU as
+         * `organizationalUnitName`, while this module read `organizationUnitName`
+         * (no "al"). That property is never present on a parsed certificate, so
+         * the OU was silently dropped from the pairs.
+         *
+         * The consequence was not looser matching — Part 18 has no wildcards, so
+         * a correctly written criteria containing OU could never match, and the
+         * rule authorised nobody.
+         *
+         * These cases therefore go through `exploreCertificate` rather than an
+         * object literal, so the shape under test is the one production sees.
+         */
+        // A fixed self-signed certificate whose subject is
+        // /CN=operator-1/O=Sterfive/OU=Plant/C=FR. Inlined rather than generated
+        // so the test is deterministic and needs no key generation.
+        const PEM = [
+            "-----BEGIN CERTIFICATE-----",
+            "MIIDRDCCAiygAwIBAgIUF9AndaE4GKwYRokHZ7MhwzfCNAUwDQYJKoZIhvcNAQEL",
+            "BQAwRTETMBEGA1UEAwwKb3BlcmF0b3ItMTERMA8GA1UECgwIU3RlcmZpdmUxDjAM",
+            "BgNVBAsMBVBsYW50MQswCQYDVQQGEwJGUjAeFw0yNjA4MTUyMDAxMDhaFw0yNjA4",
+            "MTYyMDAxMDhaMEUxEzARBgNVBAMMCm9wZXJhdG9yLTExETAPBgNVBAoMCFN0ZXJm",
+            "aXZlMQ4wDAYDVQQLDAVQbGFudDELMAkGA1UEBhMCRlIwggEiMA0GCSqGSIb3DQEB",
+            "AQUAA4IBDwAwggEKAoIBAQCQy5eybpCDHdKryiQdHaWp9M6BgzTMcvfX1HY8eX44",
+            "l520fcp8OXAAQu55bmefVHWyW3TW89bl14VCK1AJ/Gt1joqMXNi9C13y9pMM7GXt",
+            "4KjZSymq+eC/yPQrvf82Ll8kJIrf5+pXDlZcf2MucusteezeqQ9L9Di3vDMTfjs5",
+            "xDaBFzblr07nD7+XPgrVqEZHBFts7kkILbeUutEc8G02Ir/5s18PAOsl71Makj57",
+            "JlC+QL5csRiG9ye9wuXPP61OxaDL9/wo8fA5GZ4/VV6t3ADr2gppOjzTikN1KUfe",
+            "y3oOQhAUbv1dQL9/Q01qvVD6oMkmYSNSbcLIl4dikvuZAgMBAAGjLDAqMAkGA1Ud",
+            "EwQCMAAwHQYDVR0OBBYEFByiReafT/c7uavYII2AQ69Z3PzzMA0GCSqGSIb3DQEB",
+            "CwUAA4IBAQAf5Geh8mOX1oJzgfb7D9w0nx3g77z7HS5zGJTwKZDNhT8tABDslGr5",
+            "wrQTWq2FvNvpDOhqqY9a3QrF4QMVZuAy5HCjCRLAi9pX1FAD7nnwhhrTM22lcYQK",
+            "W+KV+3z45CiUVI9VXsUvDP6E1ESNf1ys1DXr+lFUdoZ07jtyjzeF9vS4iQwbWSQ8",
+            "QNzIrwS5tLsbvUrlSSw+upuDcXf97aXhQwL8u1Ocqf0l4Ht0z9cwz9cCal73UPNq",
+            "PSGB3y/HAzjBOmNY2yIp5uB7OXkFfqUdzJpvH8ADqXkw0odeRMaLGq8qiACyzyGq",
+            "TrDJWM0YHECjk8OhC3UVUZBxq8TslTFy",
+            "-----END CERTIFICATE-----"
+        ].join(String.fromCharCode(10));
+
+        const subject = exploreCertificate(convertPEMtoDER(PEM)).tbsCertificate.subject as X509SubjectName;
+
+        it("should include the OU of a real certificate", () => {
+            certificateSubjectPairs(subject).should.eql([
+                ["CN", "operator-1"],
+                ["O", "Sterfive"],
+                ["OU", "Plant"],
+                ["C", "FR"]
+            ]);
+        });
+
+        it("should match a criteria that names the OU", () => {
+            matchX509Subject('CN="operator-1"/O="Sterfive"/OU="Plant"/C="FR"', subject).should.be.true();
+        });
+
+        it("should NOT match a criteria that omits the OU", () => {
+            // Before the fix this passed for the wrong reason: neither side had OU.
+            matchX509Subject('CN="operator-1"/O="Sterfive"/C="FR"', subject).should.be.false();
+        });
+    });
+
+    describe("certificateSubjectPairs — attributes Table 10 lists", () => {
+        it("should place DC, dnQualifier and serialNumber in Table 10 order", () => {
+            certificateSubjectPairs({
+                commonName: "a",
+                domainComponent: "example",
+                countryName: "FR",
+                dnQualifier: "q",
+                serialNumber: "7"
+            }).should.eql([
+                ["CN", "a"],
+                ["DC", "example"],
+                ["C", "FR"],
+                ["dnQualifier", "q"],
+                ["serialNumber", "7"]
+            ]);
+        });
+
+        it("should still accept the deprecated organizationUnitName spelling", () => {
+            certificateSubjectPairs({ organizationUnitName: "R&D" }).should.eql([["OU", "R&D"]]);
+        });
+
+        it("should prefer the spelling a parsed certificate uses", () => {
+            certificateSubjectPairs({
+                organizationalUnitName: "FromCertificate",
+                organizationUnitName: "HandWritten"
+            }).should.eql([["OU", "FromCertificate"]]);
         });
     });
 });


### PR DESCRIPTION
`matchX509Subject` could never match a criteria naming an `OU`. The rule looked correct in the RoleSet and **authorised nobody**.

## The bug

`certificateSubjectPairs()` read `subject.organizationUnitName`. A parsed certificate reports OU as **`organizationalUnitName`** — the OID table resolves `2.5.4.11` to that spelling, and `readDirectoryName` keys its result by the resolved name. The property being read is simply never present.

Verified against a real certificate (`/CN=operator-1/O=Sterfive/OU=Plant/C=FR`):

```json
{"commonName":"operator-1","organizationName":"Sterfive",
 "organizationalUnitName":"Plant","countryName":"FR"}
```

OPC UA Part 18 §4.4.3 has **no wildcards**, so this was not "looser matching". `matchX509Subject` canonicalizes both sides and compares for equality; only one side could ever carry OU, so:

- a criteria written **with** `OU="..."` never matched a certificate that has one;
- the mismatch is silent — no error, no log, just a role that is never granted.

Anyone who wrote an OU-bearing `X509Subject` rule has a rule that does nothing. This reaches live evaluation through `in_memory_store.ts`.

## Why the tests missed it

The existing suite builds `X509SubjectName` literals by hand:

```ts
const subject: X509SubjectName = { commonName: "Jane Doe", organizationUnitName: "R&D", ... };
```

That object shape never occurs in production, so the tests asserted the mapping was correct for an input the server never sees. The new cases go through `exploreCertificate` on a fixed inlined certificate. Confirmed they **fail on the unfixed code** and pass after — a regression test, not decoration.

## Also fixed

`DC`, `dnQualifier` and `serialNumber` are listed in Table 10 and are **already produced** by the certificate parser, but were absent from `X509SubjectName` and so never reached a criteria either. Now mapped in Table 10 order.

## Compatibility

- `organizationUnitName` is kept and still honoured for hand-built subjects; marked `@deprecated`, and `organizationalUnitName` wins when both are present.
- The behaviour change is strictly "used to match nothing, now matches correctly". A deployment that worked around the bug with OU-less criteria will find those stop matching OU-bearing certificates — which is the specified behaviour, but worth a release note.

## Still open, not in this PR

- **Repeated attributes.** A subject with two `OU`s still collapses to one, because `DirectoryName` is a flat map. Addressed in node-opcua/node-opcua-crypto#75, which adds an ordered `entries` list; this module can use it once released.
- **The legacy CN-only fallback** in `matchX509Subject`: a bare criteria string is compared against `commonName` alone, ignoring every other attribute. Documented as a convenience, but materially more permissive than Table 10 — worth a deliberate decision rather than inheritance. Left untouched.

Full package suite: 114 passing.