### PR TITLE
feat(role-set): option to install a RoleSet without UserManagement

### DIFF
--- a/packages/node-opcua-role-set-server/source/install_role_based_security.ts
+++ b/packages/node-opcua-role-set-server/source/install_role_based_security.ts
@@ -89,6 +89,24 @@ export interface InstallRoleBasedSecurityOptions {
     persistencePath?: string;
     /** Encrypt that archive at rest (AES-256-GCM, key derived from this secret). */
     persistenceSecret?: string;
+    /**
+     * Install the `UserManagement` Object (OPC 10000-18 §5). Default `true`.
+     *
+     * Set `false` to model a server that implements the RoleSet — roles and
+     * their identity mappings — **without** the optional `UserManagement`
+     * companion Object. That shape is common in the field, and it behaves
+     * differently in a client in a way worth being able to test: `readUsers()`
+     * answers with an *empty list* rather than failing, because there is no API
+     * to enumerate accounts at all. A client cannot tell that apart from "this
+     * server has no users" unless it looks for the Object.
+     *
+     * **Authentication is unaffected.** The `userManager` bridge still validates
+     * credentials against the seeded user store and still resolves Roles; only
+     * the Object exposing user *administration* is left out. That is exactly the
+     * real-world case: the server knows its users, but offers no way to list or
+     * manage them over OPC UA.
+     */
+    userManagement?: boolean;
 }
 
 /** The shared stores + bridge produced by {@link createRoleBasedSecurity}. */
@@ -106,7 +124,11 @@ export interface RoleBasedSecurity {
     install(
         server: IServerForRoleSet & IServerForUserManagement,
         options?: InstallRoleBasedSecurityOptions
-    ): Promise<{ roleSet: InstallRoleSetResult; userManagement: InstallUserManagementResult }>;
+    ): Promise<{
+        roleSet: InstallRoleSetResult;
+        /** Absent when `userManagement: false` — there is nothing to return. */
+        userManagement?: InstallUserManagementResult;
+    }>;
 }
 
 const userNameRule = (userName: string): IdentityMappingRuleType =>
@@ -200,6 +222,11 @@ export async function createRoleBasedSecurity(options?: CreateRoleBasedSecurityO
             }
 
             const roleSet = await installRoleSet(server, { store: identityStore, persistence });
+            if (installOptions?.userManagement === false) {
+                // Deliberately no UserManagement Object. Credentials still work:
+                // the userManager bridge authenticates from userStore either way.
+                return { roleSet };
+            }
             const userManagement = await installUserManagement(server, { store: userStore, persistence });
             return { roleSet, userManagement };
         }

--- a/packages/node-opcua-role-set-server/test/test_install_role_based_security.ts
+++ b/packages/node-opcua-role-set-server/test/test_install_role_based_security.ts
@@ -1,10 +1,15 @@
 import "mocha";
+import { AddressSpace } from "node-opcua-address-space";
+import { generateAddressSpace } from "node-opcua-address-space/nodeJS";
 import { sameNodeId } from "node-opcua-nodeid";
+import { nodesets } from "node-opcua-nodesets";
 import { serializeUser, WellKnownRoleIds } from "node-opcua-role-set-common";
 import { StatusCodes } from "node-opcua-status-code";
 import { UserConfigurationMask } from "node-opcua-types";
 import should from "should";
 import { createRoleBasedSecurity } from "../source/install_role_based_security.js";
+import type { IServerForRoleSet } from "../source/install_role_set.js";
+import type { IServerForUserManagement } from "../source/install_user_management.js";
 
 describe("createRoleBasedSecurity — one store behind the userManager bridge", () => {
     it("seeds users + roles and exposes them through getUserRoles AND getIdentitiesForRole", async () => {
@@ -133,5 +138,82 @@ describe("createRoleBasedSecurity — one store behind the userManager bridge", 
                 err.message.should.match(/invalid userConfiguration/);
             }
         );
+    });
+});
+
+describe("createRoleBasedSecurity — a RoleSet without UserManagement", () => {
+    /**
+     * Many servers implement the RoleSet without the optional `UserManagement`
+     * companion Object of §5. That shape is not exotic, and it behaves
+     * differently in a client: `readUsers()` answers with an empty list rather
+     * than failing, because there is no API to enumerate accounts at all.
+     *
+     * Being able to stand one up is what makes that client behaviour testable —
+     * previously the only way to see it was to find a third-party server.
+     */
+    let addressSpace: AddressSpace;
+    let server: IServerForRoleSet & IServerForUserManagement;
+
+    beforeEach(async function () {
+        this.timeout(30000);
+        addressSpace = AddressSpace.create();
+        addressSpace.registerNamespace("http://test");
+        await generateAddressSpace(addressSpace, [nodesets.standard]);
+        server = { roleResolvers: [], engine: { addressSpace } };
+    });
+
+    afterEach(() => {
+        addressSpace.dispose();
+    });
+
+    const seeded = () =>
+        createRoleBasedSecurity({
+            users: [{ userName: "alice", password: "alicePassword123", roles: [WellKnownRoleIds.Operator] }]
+        });
+
+    it("installs the UserManagement Object by default", async () => {
+        const security = await seeded();
+        const result = await security.install(server);
+        should.exist(result.userManagement);
+    });
+
+    it("omits it, and reports nothing to return, when userManagement is false", async () => {
+        const security = await seeded();
+        const result = await security.install(server, { userManagement: false });
+        should.not.exist(result.userManagement);
+    });
+
+    it("still installs the RoleSet", async () => {
+        // The point of the option is a server that has roles but no user
+        // administration — not a server with neither.
+        const security = await seeded();
+        const result = await security.install(server, { userManagement: false });
+        should.exist(result.roleSet);
+        server.roleResolvers.should.have.length(1);
+    });
+
+    it("keeps the seeded identity mapping, so roles still resolve", async () => {
+        const security = await seeded();
+        await security.install(server, { userManagement: false });
+        const identities = security.identityStore.getIdentitiesForRole(WellKnownRoleIds.Operator);
+        identities.should.have.length(1);
+        (identities[0].criteria ?? "").should.equal("alice");
+    });
+
+    it("still authenticates: the bridge validates against the user store", async () => {
+        // Authentication is unaffected — only the Object exposing user
+        // *administration* is left out. The server knows alice; it simply offers
+        // no way to enumerate or manage her over OPC UA.
+        const security = await seeded();
+        await security.install(server, { userManagement: false });
+
+        // isValidUserAsync is callback-style, bound to the ServerSession.
+        const check = (userName: string, password: string) =>
+            new Promise<boolean>((resolve) => {
+                security.userManager.isValidUserAsync.call({}, userName, password, (_err, ok) => resolve(!!ok));
+            });
+
+        (await check("alice", "alicePassword123")).should.be.true();
+        (await check("alice", "wrong")).should.be.false();
     });
 });


### PR DESCRIPTION
`createRoleBasedSecurity().install()` always installed the `UserManagement` Object, so there was no way to stand up the shape a great many real servers have: a RoleSet with roles and identity mappings, and **no user administration at all**.

```ts
await security.install(server, { userManagement: false });
```

## Why this shape is worth being able to build

Clients behave differently against it, in a way that is easy to get wrong. `readUsers()` answers with an **empty list** rather than failing — there is no API to enumerate accounts — and a client cannot tell that apart from "this server has no users" without going looking for the Object.

Those are different facts, and conflating them matters: showing "no users, press add" on a server that has users but cannot list them invites an operator to create an account that already exists.

Until now the only way to exercise that path was to find a third-party server that happens to lack the Object. That makes it the kind of behaviour that gets implemented, shipped, and never tested.

## What is unaffected

**Authentication.** The `userManager` bridge still validates credentials against the seeded user store and still resolves Roles. Only the Object exposing user *administration* is left out — which is exactly the real-world case: the server knows its users, it simply offers no way to list or manage them over OPC UA.

**The RoleSet.** Roles, identity mappings, `AddIdentity`/`RemoveIdentity` and persistence all install as before. The option removes one Object, not half the feature.

## Breaking change

`install()` now returns `userManagement?: InstallUserManagementResult` rather than a required field, since there is nothing to return when it is skipped. Callers reading `result.userManagement.store` will need a guard under strict null checks. No runtime behaviour changes for the default path.

## Tests

Five cases: the Object installs by default; it is absent when `userManagement: false`; the RoleSet still installs and registers its resolver; the seeded identity mapping survives; and credentials still validate through the bridge (correct password accepted, wrong one rejected).

Verified the option does real work by stubbing the branch out — the "omits it" case fails, as it should. A feature test that passes with the feature removed would be worthless.

72 passing in the package. Two pre-existing `tsc` errors in `test_bind_role_methods.ts` and `test_bind_user_management.ts` are unchanged by this branch (confirmed identical on `master`).