### PR TITLE
Support encrypted-at-rest private keys via pki privateKeyPassphrase

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,24 @@
 
+Private key passphrase protection
+==================================
+
+  - opt-in private-key-at-rest protection, built on `node-opcua-pki` 6.20.0 / `node-opcua-crypto` 5.6.0
+    - `OPCUACertificateManagerOptions.privateKeyPassphrase` (`string | () => Promise<string>`) encrypts the
+      managed private key (PKCS#8, aes-256-cbc); an existing plaintext key is re-encrypted in place on
+      `initialize()`, an existing encrypted key requires the same passphrase or fails closed
+    - `OPCUACertificateManagerOptions.privateKeyProvider` sources the private key from elsewhere entirely
+      (HSM, KMS, ...)
+    - `OPCUACertificateManager.getPrivateKey()` resolves (and caches) the decrypted key asynchronously
+    - `OPCUAServer` / `OPCUAClient` resolve the key once, asynchronously, during initialization — every
+      later, synchronous `getPrivateKey()` call (secure channel layer, endpoints, ...) uses the resolved
+      key, so an encrypted key never needs a synchronous disk read
+    - push certificate management (`UpdateCertificate`) writes a pushed private key already encrypted when
+      the certificate manager is passphrase-protected — it is never written back to disk in clear, not even
+      transiently
+    - default behavior (no passphrase configured) is unchanged: the key is read and written as plaintext,
+      exactly as before
+    - see documentation/creating_a_server.md
+
 Reverse Connect
 ===============
 

--- a/documentation/creating_a_server.md
+++ b/documentation/creating_a_server.md
@@ -94,6 +94,35 @@ buildInfo : {
 }
 ```
 
+### protecting the private key with a passphrase
+
+By default, the server's private key is stored in clear on disk, under the certificate manager's PKI
+folder (`own/private/private_key.pem`). To encrypt it at rest, construct an `OPCUACertificateManager`
+explicitly and pass it as `serverCertificateManager`, with `privateKeyPassphrase` set:
+
+```javascript
+const { OPCUACertificateManager } = require("node-opcua-certificate-manager");
+
+const serverCertificateManager = new OPCUACertificateManager({
+    rootFolder: "./certificates",
+    privateKeyPassphrase: "a-strong-passphrase" // or: () => Promise<string>
+});
+
+const server = new OPCUAServer({
+    port: 4334,
+    serverCertificateManager
+});
+```
+
+An existing plaintext key is re-encrypted in place the first time `serverCertificateManager` initializes
+with a passphrase configured; an existing encrypted key requires the same passphrase, or `server.start()`
+fails closed with an explicit error. The default (no `privateKeyPassphrase`) behavior — a plaintext key —
+is unchanged.
+
+Note: the process-wide default certificate manager (used when `serverCertificateManager` is omitted) is
+always passphrase-less — passphrase protection requires constructing your own `OPCUACertificateManager` as
+shown above. The same option is available on `clientCertificateManager` for `OPCUAClient`.
+
 ### server initialization
 
 Once created the server shall be initialized.

--- a/packages/node-opcua-certificate-manager/source/certificate_manager.ts
+++ b/packages/node-opcua-certificate-manager/source/certificate_manager.ts
@@ -5,11 +5,17 @@ import fs from "node:fs";
 import path from "node:path";
 import envPaths from "env-paths";
 import { assert } from "node-opcua-assert";
+import type { ICertificateStore } from "node-opcua-common";
 import { type Certificate, makeSHA1Thumbprint } from "node-opcua-crypto/web";
 import { checkDebugFlag, make_debugLog, make_errorLog } from "node-opcua-debug";
-import type { ICertificateStore } from "node-opcua-common";
 import { ObjectRegistry } from "node-opcua-object-registry";
-import { CertificateManager, type CertificateManagerOptions } from "node-opcua-pki";
+import {
+    CertificateManager,
+    type CertificateManagerOptions,
+    type PrivateKeyPassphrase,
+    type PrivateKeyProvider,
+    resolvePrivateKeyPassphrase
+} from "node-opcua-pki";
 import { type StatusCode, type StatusCodeCallback, StatusCodes } from "node-opcua-status-code";
 
 const paths = envPaths("node-opcua-default");
@@ -73,6 +79,43 @@ export interface OPCUACertificateManagerOptions {
      * @defaultValue false
      */
     disableFileWatchers?: boolean;
+
+    /**
+     * Encrypt the private key at rest with this passphrase (opt-in,
+     * default off — a plaintext key is written, exactly as before). When set:
+     * - a freshly generated key is written already encrypted (PKCS#8);
+     * - an existing *plaintext* key is re-encrypted in place by
+     *   {@link OPCUACertificateManager.initialize}, so turning the option on
+     *   for an existing install never leaves the key in cleartext;
+     * - an existing encrypted key requires the same passphrase — a mismatch,
+     *   or an encrypted key with no passphrase configured, fails
+     *   `initialize()` closed with `PrivateKeyPassphraseRequiredError`.
+     *
+     * A function is called at most once per `OPCUACertificateManager`
+     * instance (the decrypted key is cached in memory for the instance's
+     * lifetime, see {@link OPCUACertificateManager.getPrivateKey}). Never
+     * logged.
+     *
+     * The in-process default managers returned by
+     * {@link getDefaultCertificateManager} (memoized by name, e.g. `"PKI"` /
+     * `"UserPKI"`) are always passphrase-less — construct your own
+     * `OPCUACertificateManager` and pass it as `serverCertificateManager` /
+     * `clientCertificateManager` to use passphrase protection.
+     *
+     * @defaultValue undefined (plaintext key)
+     */
+    privateKeyPassphrase?: PrivateKeyPassphrase;
+
+    /**
+     * Source the private key from somewhere other than
+     * `own/private/private_key.pem` (an HSM, a KMS, ...). When set, it
+     * overrides disk entirely for every operation that needs the private
+     * key — the on-disk file is not read, and `privateKeyPassphrase` is
+     * ignored.
+     *
+     * @defaultValue undefined
+     */
+    privateKeyProvider?: PrivateKeyProvider;
 }
 
 export class OPCUACertificateManager extends CertificateManager implements ICertificateManager, ICertificateStore {
@@ -81,6 +124,8 @@ export class OPCUACertificateManager extends CertificateManager implements ICert
     public static registry = new ObjectRegistry();
     public referenceCounter: number;
     public automaticallyAcceptUnknownCertificate: boolean;
+    readonly #privateKeyPassphrase?: PrivateKeyPassphrase;
+    readonly #privateKeyManaged: boolean;
     /* */
     constructor(options: OPCUACertificateManagerOptions) {
         options = options || {};
@@ -97,9 +142,14 @@ export class OPCUACertificateManager extends CertificateManager implements ICert
         const _options: CertificateManagerOptions = {
             keySize: options.keySize || 2048,
             location,
-            disableFileWatchers: options.disableFileWatchers
+            disableFileWatchers: options.disableFileWatchers,
+            privateKeyPassphrase: options.privateKeyPassphrase,
+            privateKeyProvider: options.privateKeyProvider
         };
         super(_options);
+
+        this.#privateKeyPassphrase = options.privateKeyPassphrase;
+        this.#privateKeyManaged = !!options.privateKeyPassphrase || !!options.privateKeyProvider;
 
         this.referenceCounter = 0;
 
@@ -115,6 +165,40 @@ export class OPCUACertificateManager extends CertificateManager implements ICert
             .initialize()
             .then(() => callback())
             .catch((err) => callback(err as Error));
+    }
+
+    /**
+     * Resolve this manager's configured `privateKeyPassphrase` (calling it,
+     * if it is a function, at most once — see
+     * {@link resolvePrivateKeyPassphrase}). Returns `undefined` when no
+     * passphrase is configured (plaintext key).
+     *
+     * Intended for callers that need to write a *new* private key to disk
+     * with the same protection as this manager (push certificate
+     * management), rather than for reading the current key — prefer
+     * {@link CertificateManager.getPrivateKey} for that.
+     */
+    public async getPrivateKeyPassphrase(): Promise<string | undefined> {
+        return resolvePrivateKeyPassphrase(this.#privateKeyPassphrase);
+    }
+
+    /**
+     * `true` when this manager was constructed with `privateKeyPassphrase`
+     * and/or `privateKeyProvider` — i.e. `getPrivateKey()` may need to do
+     * asynchronous work (decrypt, or fetch from an external source) rather
+     * than a plain synchronous disk read.
+     *
+     * Consumers (e.g. `OPCUAServer`/`OPCUAClient`'s private-key resolution)
+     * use this to decide whether installing an async-resolved, permanently
+     * cached provider is necessary at all: for a manager with neither option
+     * set, the on-disk key is always plaintext, so a plain
+     * `DiskCertificateKeyPairProvider` keeps working exactly as before —
+     * including re-reading a manually replaced key after `invalidate()`,
+     * which a resolved provider deliberately does not do (see
+     * {@link ResolvedCertificateKeyPairProvider} in `node-opcua-common`).
+     */
+    public isPrivateKeyManaged(): boolean {
+        return this.#privateKeyManaged;
     }
 
     public async dispose(): Promise<void> {

--- a/packages/node-opcua-certificate-manager/source/index.browser.ts
+++ b/packages/node-opcua-certificate-manager/source/index.browser.ts
@@ -36,12 +36,29 @@ export interface ICertificateManager {
     rejectCertificate(certificate: Certificate): Promise<void>;
 }
 
+/**
+ * A passphrase, or a function resolving one — mirrors `PrivateKeyProvider`
+ * from `node-opcua-pki`. Kept local (rather than imported) so this stub does
+ * not pull in `node-opcua-pki` — it is accepted for type compatibility with
+ * the Node entry point but ignored, since this stub always throws on
+ * construction.
+ */
+export type PrivateKeyPassphrase = string | (() => Promise<string>);
+
+export interface PrivateKeyProvider {
+    getPrivateKey(): Promise<unknown>;
+}
+
 export interface OPCUACertificateManagerOptions {
     rootFolder?: null | string;
     automaticallyAcceptUnknownCertificate?: boolean;
     name?: string;
     keySize?: 2048 | 3072 | 4096;
     disableFileWatchers?: boolean;
+    /** Accepted for type compatibility with the Node entry point; ignored — this stub always throws on construction. */
+    privateKeyPassphrase?: PrivateKeyPassphrase;
+    /** Accepted for type compatibility with the Node entry point; ignored — this stub always throws on construction. */
+    privateKeyProvider?: PrivateKeyProvider;
 }
 
 /**

--- a/packages/node-opcua-certificate-manager/source/index.ts
+++ b/packages/node-opcua-certificate-manager/source/index.ts
@@ -1,6 +1,8 @@
 /**
  * @module node-opcua-certificate-manager
  */
+
+export { PrivateKeyPassphraseRequiredError } from "node-opcua-crypto";
+export { CertificateManager, type PrivateKeyPassphrase, type PrivateKeyProvider } from "node-opcua-pki";
 export * from "./certificate_manager";
 export * from "./make_subject";
-export { CertificateManager } from "node-opcua-pki";

--- a/packages/node-opcua-certificate-manager/test/test_certificate_manager.ts
+++ b/packages/node-opcua-certificate-manager/test/test_certificate_manager.ts
@@ -3,14 +3,20 @@
 import fs from "node:fs";
 import path from "node:path";
 import "mocha";
-import "should";
 
-import { type Certificate, makeSHA1Thumbprint, readCertificateChainAsync, readCertificateRevocationList } from "node-opcua-crypto";
+import {
+    type Certificate,
+    makeSHA1Thumbprint,
+    PrivateKeyPassphraseRequiredError,
+    readCertificateChainAsync,
+    readCertificateRevocationList,
+    readPrivateKey
+} from "node-opcua-crypto";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { CertificateAuthority } from "node-opcua-pki";
 import { StatusCodes } from "node-opcua-status-code";
+import should from "should";
 import { CertificateManager, OPCUACertificateManager, type OPCUACertificateManagerOptions } from "../source";
-
 
 // const _tmpFolder = os.tmpdir();
 const _tmpFolder = path.join(__dirname, "../temp");
@@ -288,6 +294,7 @@ describe("Testing OPCUA Certificate Manager with automatically acceptance of unk
         //        const temporaryFolder1 = path.join(_tmpFolder, "testing_certificates1");
         acceptingCertificateMgr = await createFreshCertificateManager({
             automaticallyAcceptUnknownCertificate: true,
+            disableFileWatchers: true,
             rootFolder: temporaryFolder1
         });
         await acceptingCertificateMgr.addIssuer(issuerCertificate);
@@ -336,5 +343,123 @@ describe("Testing OPCUA Certificate Manager with automatically acceptance of unk
         const rejected = path.join(rejectingCertificateMgr.rootDir, `rejected/${certificateSelfSignedThumbprint}.pem`);
         const existsInRejectedFolder = fs.existsSync(rejected);
         existsInRejectedFolder.should.eql(true, rejected);
+    });
+});
+
+describe("OPCUACertificateManager with privateKeyPassphrase", function (this: Mocha.Suite) {
+    this.timeout(Math.max(40000, this.timeout()));
+
+    const passphrase = "unit-test-passphrase";
+
+    afterEach(async () => {
+        // best effort cleanup between tests
+    });
+
+    it("PP01- forwards privateKeyPassphrase to the underlying pki CertificateManager: a freshly generated key is written already encrypted", async () => {
+        const rootFolder = path.join(_tmpFolder, "testing_passphrase_fresh");
+        if (fs.existsSync(rootFolder)) {
+            fs.rmSync(rootFolder, { recursive: true, force: true });
+        }
+        const cm = new OPCUACertificateManager({ rootFolder, privateKeyPassphrase: passphrase });
+        try {
+            await cm.initialize();
+
+            const raw = fs.readFileSync(cm.privateKey, "utf-8");
+            raw.should.containEql("ENCRYPTED PRIVATE KEY");
+
+            // reading without a passphrase must fail closed
+            (() => readPrivateKey(cm.privateKey)).should.throw(PrivateKeyPassphraseRequiredError);
+
+            // getPrivateKey() decrypts using the configured passphrase and returns a usable key
+            const key = await cm.getPrivateKey();
+            should(key).be.ok();
+        } finally {
+            await cm.dispose();
+        }
+    });
+
+    it("PP02- getPrivateKeyPassphrase() resolves the configured passphrase", async () => {
+        const rootFolder = path.join(_tmpFolder, "testing_passphrase_accessor");
+        if (fs.existsSync(rootFolder)) {
+            fs.rmSync(rootFolder, { recursive: true, force: true });
+        }
+        const cm = new OPCUACertificateManager({ rootFolder, privateKeyPassphrase: passphrase });
+        try {
+            await cm.initialize();
+            const resolved = await cm.getPrivateKeyPassphrase();
+            should(resolved).eql(passphrase);
+        } finally {
+            await cm.dispose();
+        }
+    });
+
+    it("PP03- getPrivateKeyPassphrase() resolves to undefined when no passphrase is configured", async () => {
+        const rootFolder = path.join(_tmpFolder, "testing_passphrase_none");
+        if (fs.existsSync(rootFolder)) {
+            fs.rmSync(rootFolder, { recursive: true, force: true });
+        }
+        const cm = new OPCUACertificateManager({ rootFolder });
+        try {
+            await cm.initialize();
+            const resolved = await cm.getPrivateKeyPassphrase();
+            should(resolved).be.undefined();
+
+            // the default (no passphrase) path stays byte-for-byte plaintext
+            const raw = fs.readFileSync(cm.privateKey, "utf-8");
+            raw.should.not.containEql("ENCRYPTED");
+        } finally {
+            await cm.dispose();
+        }
+    });
+
+    it("PP04- initialize() fails closed with PrivateKeyPassphraseRequiredError when an existing encrypted key has no configured passphrase", async () => {
+        const rootFolder = path.join(_tmpFolder, "testing_passphrase_missing");
+        if (fs.existsSync(rootFolder)) {
+            fs.rmSync(rootFolder, { recursive: true, force: true });
+        }
+        // create it once, encrypted
+        const cm1 = new OPCUACertificateManager({ rootFolder, privateKeyPassphrase: passphrase });
+        await cm1.initialize();
+        await cm1.dispose();
+
+        // reopen without the passphrase
+        const cm2 = new OPCUACertificateManager({ rootFolder });
+        try {
+            let caught: unknown;
+            try {
+                await cm2.initialize();
+            } catch (err) {
+                caught = err;
+            }
+            should(caught).be.instanceOf(PrivateKeyPassphraseRequiredError);
+        } finally {
+            await cm2.dispose();
+        }
+    });
+
+    it("PP05- an existing plaintext key is re-encrypted in place once privateKeyPassphrase is turned on", async () => {
+        const rootFolder = path.join(_tmpFolder, "testing_passphrase_upgrade");
+        if (fs.existsSync(rootFolder)) {
+            fs.rmSync(rootFolder, { recursive: true, force: true });
+        }
+        // create it once, plaintext
+        const cm1 = new OPCUACertificateManager({ rootFolder });
+        await cm1.initialize();
+        const rawBefore = fs.readFileSync(cm1.privateKey, "utf-8");
+        rawBefore.should.not.containEql("ENCRYPTED");
+        await cm1.dispose();
+
+        // reopen with a passphrase configured
+        const cm2 = new OPCUACertificateManager({ rootFolder, privateKeyPassphrase: passphrase });
+        try {
+            await cm2.initialize();
+            const rawAfter = fs.readFileSync(cm2.privateKey, "utf-8");
+            rawAfter.should.containEql("ENCRYPTED PRIVATE KEY");
+
+            const key = await cm2.getPrivateKey();
+            should(key).be.ok();
+        } finally {
+            await cm2.dispose();
+        }
     });
 });

--- a/packages/node-opcua-client/source/client_base.ts
+++ b/packages/node-opcua-client/source/client_base.ts
@@ -166,6 +166,11 @@ export interface OPCUAClientBaseOptions {
      *     provided by NodeOPCUA as it may interfere.
      *   - ensure that the provided client certificate matches the private pey.
      *
+     * If the key is encrypted, `clientCertificateManager` must be an
+     * `OPCUACertificateManager` constructed with a matching
+     * `privateKeyPassphrase` (or `privateKeyProvider`) — otherwise
+     * `connect()` fails closed.
+     *
      * @default `${clientCertificateManager/rootFolder}/own/private/private_key.pem"
      */
     privateKeyFile?: string;

--- a/packages/node-opcua-client/source/private/client_base_impl.ts
+++ b/packages/node-opcua-client/source/private/client_base_impl.ts
@@ -10,7 +10,16 @@ import { withLock } from "@ster5/global-mutex";
 import chalk from "chalk";
 import { assert } from "node-opcua-assert";
 import { getDefaultCertificateManager, type OPCUACertificateManager } from "node-opcua-certificate-manager";
-import { type ICertificateStore, InMemoryCertificateStore, type IOPCUASecureObjectOptions, makeApplicationUrn, makeSubject, OPCUASecureObject } from "node-opcua-common";
+import {
+    type ICertificateStore,
+    InMemoryCertificateStore,
+    type IOPCUASecureObjectOptions,
+    makeApplicationUrn,
+    makeSubject,
+    OPCUASecureObject,
+    resolvePrivateKeyProviderIfNeeded
+} from "node-opcua-common";
+import { PrivateKeyPassphraseRequiredError } from "node-opcua-crypto";
 import { type Certificate, makeSHA1Thumbprint, split_der } from "node-opcua-crypto/web";
 import { installPeriodicClockAdjustment, periodicClockAdjustment, uninstallPeriodicClockAdjustment } from "node-opcua-date-time";
 import { checkDebugFlag, make_debugLog, make_errorLog, make_warningLog } from "node-opcua-debug";
@@ -27,7 +36,6 @@ import {
     type Response as Response1,
     type SecurityPolicy
 } from "node-opcua-secure-channel";
-import { type IAcceptedReverseConnection, type IClientTransportFactory, makeReverseClientTransportFactory } from "node-opcua-transport";
 import {
     FindServersOnNetworkRequest,
     type FindServersOnNetworkRequestOptions,
@@ -45,6 +53,7 @@ import {
 import { type ChannelSecurityToken, coerceMessageSecurityMode, MessageSecurityMode } from "node-opcua-service-secure-channel";
 import { CloseSessionRequest, type CloseSessionResponse } from "node-opcua-service-session";
 import { type ErrorCallback, StatusCodes } from "node-opcua-status-code";
+import { type IAcceptedReverseConnection, type IClientTransportFactory, makeReverseClientTransportFactory } from "node-opcua-transport";
 import { checkFileExistsAndIsNotEmpty, matchUri } from "node-opcua-utils";
 import {
     type CreateSecureChannelCallbackFunc,
@@ -116,7 +125,15 @@ function __findEndpoint(this: ClientBaseImpl, endpointUrl: string, params: FindE
         //     maxRetry: 0 /* no- retry */,
         //     maxDelay: 2000
         // },
-        privateKeyFile: params.privateKeyFile
+        privateKeyFile: params.privateKeyFile,
+
+        // TmpClient.connect() (below) calls _connectStep2() directly and never
+        // runs initializeCM() — so it never resolves a passphrase-encrypted
+        // private key on its own. Hand it the master client's own provider
+        // (already resolved, if needed) instead of letting it build a fresh
+        // disk provider from certificateFile/privateKeyFile, which would
+        // re-read the file and fail synchronously on an encrypted key.
+        certificateKeyPairProvider: masterClient.getProvider()
     };
 
     const client = new TmpClient(options);
@@ -396,6 +413,8 @@ export class ClientBaseImpl<Events extends OPCUAClientBaseEvents = OPCUAClientBa
     private _reverseConnectRegistration?: ICancelableRegistration;
 
     public clientCertificateManager: ICertificateStore;
+    /** true when the caller supplied a certificateKeyPairProvider — the private-key resolution escape hatch. */
+    #hasUserProvidedProvider = false;
 
     public isUnusable() {
         return (
@@ -438,6 +457,8 @@ export class ClientBaseImpl<Events extends OPCUAClientBaseEvents = OPCUAClientBa
     constructor(options?: OPCUAClientBaseOptions) {
         options = options || {};
 
+        const hasUserProvidedProvider = !!options.certificateKeyPairProvider;
+
         if (options.certificateKeyPairProvider) {
             // In-memory path — use a lightweight in-memory store
             // when no cert manager was explicitly provided.
@@ -456,6 +477,8 @@ export class ClientBaseImpl<Events extends OPCUAClientBaseEvents = OPCUAClientBa
                 options.certificateFile || path.join(cm.rootDir, "own/certs/client_certificate.pem");
             super(options as IOPCUASecureObjectOptions);
         }
+
+        this.#hasUserProvidedProvider = hasUserProvidedProvider;
 
         this._setInternalState("uninitialized");
 
@@ -853,7 +876,12 @@ export class ClientBaseImpl<Events extends OPCUAClientBaseEvents = OPCUAClientBa
                 }
                 debugLog("certificateFile = ", this.certificateFile);
                 const _certificate = this.getCertificate();
-                const _privateKey = this.getPrivateKey();
+                // Note: do NOT eagerly call this.getPrivateKey() here. A freshly
+                // generated key may already be passphrase-encrypted on disk (when
+                // clientCertificateManager is configured with privateKeyPassphrase),
+                // and the disk provider's getPrivateKey() is synchronous — it cannot
+                // decrypt. initializeCM() resolves the private key asynchronously
+                // (once) right after this method returns.
             });
         }
         (this as unknown as { _inCreateDefaultCertificate: boolean })._inCreateDefaultCertificate = false;
@@ -877,17 +905,43 @@ export class ClientBaseImpl<Events extends OPCUAClientBaseEvents = OPCUAClientBa
             );
             return;
         }
-        await this.clientCertificateManager.initialize();
+        // The pki-level initialize() itself already decrypts (or re-encrypts)
+        // the on-disk key when clientCertificateManager is configured with a
+        // privateKeyPassphrase, and fails closed with
+        // PrivateKeyPassphraseRequiredError on a mismatch — so this whole
+        // sequence, not just the resolve step below, needs the friendlier
+        // error message.
+        try {
+            await this.clientCertificateManager.initialize();
 
-        if (this.certificateFile === "<in-memory>" || this.certificateFile === "<unknown>") {
-            // In-memory provider — cert already available, skip disk operations
-        } else {
-            // Disk path — create default cert if missing
-            await this.createDefaultCertificate();
-            // c8 ignore next
-            if (!fs.existsSync(this.privateKeyFile)) {
-                throw new Error(` cannot locate private key file ${this.privateKeyFile}`);
+            if (this.certificateFile === "<in-memory>" || this.certificateFile === "<unknown>") {
+                // In-memory provider — cert already available, skip disk operations
+            } else {
+                // Disk path — create default cert if missing
+                await this.createDefaultCertificate();
+                // c8 ignore next
+                if (!fs.existsSync(this.privateKeyFile)) {
+                    throw new Error(` cannot locate private key file ${this.privateKeyFile}`);
+                }
+
+                // Resolve the (possibly passphrase-encrypted) private key once,
+                // asynchronously, and install it as this client's provider — so
+                // that every later, synchronous getPrivateKey() call (secure
+                // channel layer, ...) succeeds without touching disk again.
+                // No-ops when the caller supplied its own
+                // certificateKeyPairProvider, or when clientCertificateManager
+                // doesn't expose an async getPrivateKey() (e.g. a bare
+                // ICertificateStore).
+                await resolvePrivateKeyProviderIfNeeded(this, this.clientCertificateManager, this.#hasUserProvidedProvider);
             }
+        } catch (err) {
+            if (err instanceof PrivateKeyPassphraseRequiredError) {
+                throw new Error(
+                    `[NODE-OPCUA-E31] private key ${this.privateKeyFile} is encrypted; ` +
+                    "set privateKeyPassphrase on the OPCUACertificateManager passed as clientCertificateManager"
+                );
+            }
+            throw err;
         }
         if (this.isUnusable()) return;
 

--- a/packages/node-opcua-client/source/private/opcua_client_impl.ts
+++ b/packages/node-opcua-client/source/private/opcua_client_impl.ts
@@ -11,6 +11,7 @@ import { createFastUninitializedBuffer } from "node-opcua-buffer-utils";
 import { DataTypeExtractStrategy } from "node-opcua-client-dynamic-extension-object";
 import {
     type Certificate,
+    combine_der,
     exploreCertificate,
     extractPublicKeyFromCertificateSync,
     makePrivateKeyFromPem,
@@ -928,6 +929,21 @@ export class OPCUAClientImpl extends ClientBaseImpl<OPCUAClientBaseEvents> {
             return;
         }
 
+        // `session.serverCertificate` is captured once, at CreateSession. If the
+        // server has rotated its certificate since (push certificate management,
+        // OPC UA Part 12), the client has already re-learned the current one in
+        // fetchServerCertificate() while reconnecting — but the session still
+        // holds the old one. Both the clientSignature below and the encryption
+        // of a password-bearing user identity token are computed against it,
+        // so re-activating the existing session on the new channel would fail
+        // (BadApplicationSignatureInvalid on the server) and force a needless
+        // CreateSession. Refresh it from the client's current knowledge first.
+        // Only overwrite when the client actually knows a certificate: over a
+        // SecurityMode.None channel this.serverCertificate may be unset while
+        // the session's copy (from CreateSessionResponse) is still needed to
+        // encrypt the user token.
+        this.#refreshSessionServerCertificate(session);
+
         const serverCertificate = session.serverCertificate;
         // If the securityPolicyUri is None and none of the UserTokenPolicies requires encryption,
         // the Client shall ignore the ApplicationInstanceCertificate (serverCertificate)
@@ -1045,6 +1061,29 @@ export class OPCUAClientImpl extends ClientBaseImpl<OPCUAClientBaseEvents> {
             });
         });
     }
+    /**
+     * Bring `session.serverCertificate` in line with the server certificate the
+     * client currently knows (see the comment in {@link _activateSession}).
+     * No-op when the client has no certificate of its own to offer.
+     * @private
+     */
+    #refreshSessionServerCertificate(session: ClientSessionImpl): void {
+        const current = this.serverCertificate;
+        if (!current || current.length === 0) {
+            return;
+        }
+        const currentDer = Array.isArray(current) ? combine_der(current) : current;
+        if (session.serverCertificate && session.serverCertificate.equals(currentDer)) {
+            return;
+        }
+        doDebug &&
+            debugLog(
+                "refreshing session.serverCertificate before ActivateSession (server certificate changed since CreateSession)",
+                session.sessionId.toString()
+            );
+        session.serverCertificate = currentDer;
+    }
+
     /**
      *
      * @private

--- a/packages/node-opcua-client/test/test_client_with_encrypted_private_key.ts
+++ b/packages/node-opcua-client/test/test_client_with_encrypted_private_key.ts
@@ -1,0 +1,176 @@
+/**
+ * Client-side private-key-passphrase tests.
+ *
+ * `ClientBaseImpl#initializeCM()` (invoked at the start of `connect()`, before
+ * any network I/O) creates/loads the client certificate and private key
+ * through `clientCertificateManager`. These tests exercise that stage in
+ * isolation, against an unreachable endpoint, so they don't need a live
+ * OPCUAServer (node-opcua-client does not depend on node-opcua-server) — the
+ * subsequent network failure is the *expected* outcome once certificate
+ * setup has already succeeded (or failed) as asserted.
+ *
+ * A full round-trip session with both an encrypted server key and an
+ * encrypted client key is covered separately in node-opcua-end2end-test.
+ */
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { OPCUACertificateManager } from "node-opcua-certificate-manager";
+import should from "should";
+import { OPCUAClient } from "../source";
+
+const passphrase = "client-side-passphrase";
+
+/**
+ * A genuinely closed local port: bind an ephemeral port, then close it
+ * immediately so nothing listens there. connect() must then fail fast with
+ * ECONNREFUSED at the network stage (never a passphrase error), once cert/key
+ * setup (initializeCM) has already succeeded. A well-known low port (e.g.
+ * ":1") is not used here — on some systems it is firewall-filtered rather
+ * than refused, which can hang the connect attempt instead of failing fast.
+ */
+async function getUnreachableEndpoint(): Promise<string> {
+    const server = net.createServer();
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as net.AddressInfo).port;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    return `opc.tcp://127.0.0.1:${port}`;
+}
+
+async function makeTmpDir(name: string): Promise<string> {
+    const tmpDir = path.join(os.tmpdir(), `test-client-encrypted-key-${name}-${process.pid}-${Date.now()}`);
+    await fs.promises.mkdir(tmpDir, { recursive: true });
+    return tmpDir;
+}
+
+describe("OPCUAClient with a passphrase-protected private key", function (this: Mocha.Suite) {
+    this.timeout(Math.max(30000, this.timeout()));
+
+    it("CE1: resolves an encrypted key during connect() setup — network failure surfaces, not a passphrase error", async () => {
+        const tmpDir = await makeTmpDir("ce1");
+        const cm = new OPCUACertificateManager({
+            rootFolder: path.join(tmpDir, "pki"),
+            automaticallyAcceptUnknownCertificate: true,
+            disableFileWatchers: true,
+            privateKeyPassphrase: passphrase
+        });
+        await cm.initialize();
+
+        const rawBefore = fs.readFileSync(cm.privateKey, "utf-8");
+        rawBefore.should.containEql("ENCRYPTED PRIVATE KEY");
+
+        const client = OPCUAClient.create({
+            clientCertificateManager: cm,
+            connectionStrategy: { maxRetry: 0 },
+            endpointMustExist: false
+        });
+        try {
+            let caught: unknown;
+            try {
+                const unreachableEndpoint = await getUnreachableEndpoint();
+                await client.connect(unreachableEndpoint);
+            } catch (err) {
+                caught = err;
+            }
+            should.exist(caught, "expecting connect() to fail (unreachable endpoint)");
+            const message = (caught as Error).message;
+            message.should.not.match(/encrypted/i);
+            message.should.not.match(/privateKeyPassphrase/);
+        } finally {
+            await client.disconnect().catch(() => {
+                /* already disconnected/failed */
+            });
+            await cm.dispose();
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it("CE2: connect() fails closed with a clear message when the key is encrypted and no passphrase is configured", async () => {
+        const tmpDir = await makeTmpDir("ce2");
+        const pkiFolder = path.join(tmpDir, "pki");
+
+        const cmSetup = new OPCUACertificateManager({
+            rootFolder: pkiFolder,
+            automaticallyAcceptUnknownCertificate: true,
+            disableFileWatchers: true,
+            privateKeyPassphrase: passphrase
+        });
+        await cmSetup.initialize();
+        await cmSetup.dispose();
+
+        const cmNoPassphrase = new OPCUACertificateManager({
+            rootFolder: pkiFolder,
+            automaticallyAcceptUnknownCertificate: true,
+            disableFileWatchers: true
+        });
+
+        const client = OPCUAClient.create({
+            clientCertificateManager: cmNoPassphrase,
+            connectionStrategy: { maxRetry: 0 },
+            endpointMustExist: false
+        });
+        try {
+            let caught: unknown;
+            try {
+                const unreachableEndpoint = await getUnreachableEndpoint();
+                await client.connect(unreachableEndpoint);
+            } catch (err) {
+                caught = err;
+            }
+            should.exist(caught, "expecting connect() to fail");
+            const message = (caught as Error).message;
+            message.should.match(/encrypted/);
+            message.should.match(/privateKeyPassphrase/);
+        } finally {
+            await client.disconnect().catch(() => {
+                /* already disconnected/failed */
+            });
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it("CE3: a plaintext client key is encrypted in place once privateKeyPassphrase is configured", async () => {
+        const tmpDir = await makeTmpDir("ce3");
+        const pkiFolder = path.join(tmpDir, "pki");
+
+        const cmSetup = new OPCUACertificateManager({
+            rootFolder: pkiFolder,
+            automaticallyAcceptUnknownCertificate: true,
+            disableFileWatchers: true
+        });
+        await cmSetup.initialize();
+        const rawBefore = fs.readFileSync(cmSetup.privateKey, "utf-8");
+        rawBefore.should.not.containEql("ENCRYPTED");
+        await cmSetup.dispose();
+
+        const cm = new OPCUACertificateManager({
+            rootFolder: pkiFolder,
+            automaticallyAcceptUnknownCertificate: true,
+            disableFileWatchers: true,
+            privateKeyPassphrase: passphrase
+        });
+
+        const client = OPCUAClient.create({
+            clientCertificateManager: cm,
+            connectionStrategy: { maxRetry: 0 },
+            endpointMustExist: false
+        });
+        try {
+            try {
+                const unreachableEndpoint = await getUnreachableEndpoint();
+                await client.connect(unreachableEndpoint);
+            } catch {
+                // expected: network failure once cert/key setup has completed
+            }
+            const rawAfter = fs.readFileSync(cm.privateKey, "utf-8");
+            rawAfter.should.containEql("ENCRYPTED PRIVATE KEY");
+        } finally {
+            await client.disconnect().catch(() => {
+                /* already disconnected/failed */
+            });
+            await cm.dispose();
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/packages/node-opcua-common/source/disk_certificate_key_pair_provider.ts
+++ b/packages/node-opcua-common/source/disk_certificate_key_pair_provider.ts
@@ -19,10 +19,20 @@ export class DiskCertificateKeyPairProvider implements ICertificateChainProvider
     #privateKey: PrivateKey | null = null;
     readonly #certificateFile: string;
     readonly #privateKeyFile: string;
+    readonly #passphrase?: string | Buffer;
 
-    constructor(certificateFile: string, privateKeyFile: string) {
+    /**
+     * @param certificateFile - path to the certificate (chain) PEM file
+     * @param privateKeyFile - path to the private key PEM file
+     * @param passphrase - optional passphrase to decrypt `privateKeyFile` if it is
+     * an encrypted PKCS#8 key. Omit for a plaintext key. If the key is encrypted
+     * and no (or the wrong) passphrase is given, `getPrivateKey()` throws
+     * `PrivateKeyPassphraseRequiredError` (fails closed).
+     */
+    constructor(certificateFile: string, privateKeyFile: string, passphrase?: string | Buffer) {
         this.#certificateFile = certificateFile;
         this.#privateKeyFile = privateKeyFile;
+        this.#passphrase = passphrase;
     }
 
     public get certificateFile(): string {
@@ -56,7 +66,9 @@ export class DiskCertificateKeyPairProvider implements ICertificateChainProvider
             if (!fs.existsSync(this.#privateKeyFile)) {
                 throw new Error(`Private key file not found: ${this.#privateKeyFile}`);
             }
-            const key = readPrivateKey(this.#privateKeyFile);
+            // Fails closed with PrivateKeyPassphraseRequiredError when the key
+            // is encrypted and #passphrase is missing or wrong.
+            const key = readPrivateKey(this.#privateKeyFile, this.#passphrase);
             if (key instanceof Buffer) {
                 throw new Error(`Invalid private key ${this.#privateKeyFile}. Should not be a buffer`);
             }

--- a/packages/node-opcua-common/source/index.ts
+++ b/packages/node-opcua-common/source/index.ts
@@ -49,3 +49,5 @@ export * from "./in_memory_certificate_key_pair_provider";
 export * from "./in_memory_certificate_store";
 export * from "./make_subject";
 export * from "./opcua_secure_object";
+export * from "./resolve_private_key_provider";
+export * from "./resolved_certificate_key_pair_provider";

--- a/packages/node-opcua-common/source/opcua_secure_object.ts
+++ b/packages/node-opcua-common/source/opcua_secure_object.ts
@@ -5,6 +5,7 @@ import { EventEmitter } from "node:events";
 import { assert } from "node-opcua-assert";
 import { type Certificate, type PrivateKey, split_der } from "node-opcua-crypto/web";
 
+import type { ICertificateChainProvider } from "./certificate_chain_provider";
 import { DiskCertificateKeyPairProvider } from "./disk_certificate_key_pair_provider";
 
 export interface ICertificateKeyPairProvider {
@@ -181,6 +182,38 @@ export class OPCUASecureObject<T extends Record<string | symbol, any> = any>
      */
     public setProvider(provider: ICertificateKeyPairProvider): void {
         this.#provider = ensureProviderHasLocation(provider);
+    }
+
+    /**
+     * Return the current provider, e.g. so a caller can install the exact
+     * same provider instance elsewhere (endpoints reusing the server's
+     * resolved private-key provider rather than each re-resolving it).
+     */
+    public getProvider(): ICertificateKeyPairProviderWithLocation {
+        return this.#provider;
+    }
+
+    /**
+     * Same as {@link getProvider}, but guarantees `invalidate()` is present
+     * — wrapping with a no-op if the current provider doesn't implement it
+     * — for callers, such as `OPCUAServerEndPoint.setCertificateProvider()`,
+     * that require the stricter {@link ICertificateChainProvider} shape.
+     * Every call delegates live to whatever provider is current *at call
+     * time*; it does not track later `setProvider()` swaps.
+     */
+    public getCertificateChainProvider(): ICertificateChainProvider {
+        const provider = this.#provider;
+        if (typeof provider.invalidate === "function") {
+            return provider as ICertificateChainProvider;
+        }
+        return {
+            getCertificate: () => provider.getCertificate(),
+            getCertificateChain: () => provider.getCertificateChain(),
+            getPrivateKey: () => provider.getPrivateKey(),
+            invalidate: () => {
+                /* no-op: underlying provider does not implement invalidate() */
+            }
+        };
     }
 
     /**

--- a/packages/node-opcua-common/source/resolve_private_key_provider.ts
+++ b/packages/node-opcua-common/source/resolve_private_key_provider.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared helper used by `OPCUAServer` and `OPCUAClient` (and by push
+ * certificate management, after a key rotation) to resolve a possibly
+ * passphrase-encrypted private key once, asynchronously, and install it as
+ * a {@link ResolvedCertificateKeyPairProvider} — so that every later,
+ * synchronous `getPrivateKey()` call on the secure object succeeds without
+ * touching disk (or a passphrase prompt) again.
+ *
+ * @module node-opcua-common
+ */
+import type { PrivateKey } from "node-opcua-crypto/web";
+
+import type { ICertificateKeyPairProvider } from "./opcua_secure_object";
+import { ResolvedCertificateKeyPairProvider } from "./resolved_certificate_key_pair_provider";
+
+/** Minimal shape of an `OPCUACertificateManager` needed to resolve the private key. */
+export interface ICertificateManagerWithAsyncPrivateKey {
+    getPrivateKey(): Promise<PrivateKey>;
+}
+
+/**
+ * Minimal structural shape needed from an `OPCUASecureObject` (an
+ * `OPCUAServer`, an `OPCUAClient`, or — via `install_push_certificate_management`
+ * — a plain object exposing the same public surface) to install a resolved
+ * provider. Kept structural (rather than importing the `OPCUASecureObject`
+ * class type) so callers that only have a duck-typed view — e.g. push
+ * certificate management's `OPCUAServerPartial` — can use it too.
+ */
+export interface ISecureObjectProviderTarget {
+    readonly certificateFile: string;
+    readonly privateKeyFile: string;
+    setProvider(provider: ICertificateKeyPairProvider): void;
+}
+
+function hasAsyncGetPrivateKey(manager: unknown): manager is ICertificateManagerWithAsyncPrivateKey {
+    return !!manager && typeof (manager as ICertificateManagerWithAsyncPrivateKey).getPrivateKey === "function";
+}
+
+/** Shape exposing the certificate manager's own managed private-key path (`own/private/private_key.pem`). */
+interface IHasOwnPrivateKeyPath {
+    privateKey: string;
+}
+
+function hasOwnPrivateKeyPath(manager: unknown): manager is IHasOwnPrivateKeyPath {
+    return !!manager && typeof (manager as IHasOwnPrivateKeyPath).privateKey === "string";
+}
+
+/** Shape exposing `OPCUACertificateManager.isPrivateKeyManaged()`. */
+interface IHasIsPrivateKeyManaged {
+    isPrivateKeyManaged(): boolean;
+}
+
+function hasIsPrivateKeyManaged(manager: unknown): manager is IHasIsPrivateKeyManaged {
+    return !!manager && typeof (manager as IHasIsPrivateKeyManaged).isPrivateKeyManaged === "function";
+}
+
+/**
+ * Resolve the private key via `certificateManager.getPrivateKey()`
+ * (decrypting with the manager's configured `privateKeyPassphrase` /
+ * `privateKeyProvider` if needed) and install it as `secureObject`'s
+ * provider.
+ *
+ * No-ops — leaves the current provider untouched — when:
+ * - `hasUserProvidedProvider` is `true` (the secure object was constructed
+ *   with a user-supplied `certificateKeyPairProvider` — the existing
+ *   escape hatch; the caller owns key resolution entirely), or
+ * - the secure object is in-memory (`certificateFile` is `"<in-memory>"` /
+ *   `"<unknown>"`), or
+ * - `certificateManager` does not expose an async `getPrivateKey()` (e.g. a
+ *   bare `ICertificateStore` rather than a full `OPCUACertificateManager`), or
+ * - `certificateManager` exposes `isPrivateKeyManaged()` and it returns
+ *   `false` — no `privateKeyPassphrase` / `privateKeyProvider` configured,
+ *   so the on-disk key is always plaintext and a plain
+ *   `DiskCertificateKeyPairProvider` already handles it correctly (crucially,
+ *   including re-reading a manually replaced key after `invalidate()` — a
+ *   {@link ResolvedCertificateKeyPairProvider} deliberately does not do
+ *   that, see its doc — so swapping to one when there is nothing to decrypt
+ *   would be a regression, not just unnecessary work), or
+ * - `secureObject.privateKeyFile` is not the certificate manager's own
+ *   managed key path (`certificateManager.privateKey`, i.e.
+ *   `own/private/private_key.pem`). `getPrivateKey()` only ever resolves
+ *   *that* file — a caller that overrode `privateKeyFile` to point elsewhere
+ *   (a key entirely outside the PKI folder) is opting out of
+ *   certificate-manager-managed key handling, and that external file is
+ *   read as plaintext exactly as before.
+ *
+ * Propagates `PrivateKeyPassphraseRequiredError` (from `node-opcua-crypto`)
+ * unchanged when the on-disk key is encrypted and no, or the wrong,
+ * passphrase is configured on the certificate manager. Callers typically
+ * catch this to raise a more actionable, product-specific error message.
+ *
+ * @returns `true` if a resolved provider was installed, `false` if this
+ * call no-op'd for any of the reasons above — callers that need *some* form
+ * of refresh either way (e.g. after a certificate rotation) can fall back to
+ * a plain `invalidate()` when this returns `false`.
+ */
+export async function resolvePrivateKeyProviderIfNeeded(
+    secureObject: ISecureObjectProviderTarget,
+    certificateManager: unknown,
+    hasUserProvidedProvider: boolean
+): Promise<boolean> {
+    if (hasUserProvidedProvider) {
+        return false;
+    }
+    const certificateFile = secureObject.certificateFile;
+    if (certificateFile === "<in-memory>" || certificateFile === "<unknown>") {
+        return false;
+    }
+    if (!hasAsyncGetPrivateKey(certificateManager)) {
+        return false;
+    }
+    if (hasIsPrivateKeyManaged(certificateManager) && !certificateManager.isPrivateKeyManaged()) {
+        return false;
+    }
+    if (hasOwnPrivateKeyPath(certificateManager) && certificateManager.privateKey !== secureObject.privateKeyFile) {
+        return false;
+    }
+    const privateKey = await certificateManager.getPrivateKey();
+    secureObject.setProvider(new ResolvedCertificateKeyPairProvider(certificateFile, secureObject.privateKeyFile, privateKey));
+    return true;
+}

--- a/packages/node-opcua-common/source/resolved_certificate_key_pair_provider.ts
+++ b/packages/node-opcua-common/source/resolved_certificate_key_pair_provider.ts
@@ -1,0 +1,90 @@
+/**
+ * Certificate/key provider for a private key that has already been
+ * resolved asynchronously (e.g. decrypted from an encrypted PKCS#8 file
+ * via `OPCUACertificateManager.getPrivateKey()`).
+ *
+ * The certificate chain is still read lazily from disk (same behavior as
+ * {@link DiskCertificateKeyPairProvider}, including re-read on
+ * `invalidate()`) so that certificate rotation keeps working. The private
+ * key, however, is held in memory as-provided: it is never re-read from
+ * disk by this provider, since doing so would require an async decrypt
+ * that the synchronous `getPrivateKey()` contract cannot perform. Callers
+ * that rotate the private key must construct a new instance (with the
+ * newly resolved key) and install it via `setProvider()` /
+ * `setCertificateProvider()`.
+ *
+ * @module node-opcua-common
+ */
+import fs from "node:fs";
+import { readCertificateChain } from "node-opcua-crypto";
+import type { Certificate, PrivateKey } from "node-opcua-crypto/web";
+
+import type { ICertificateChainProvider } from "./certificate_chain_provider";
+import type { ICertificateKeyPairProviderWithLocation } from "./opcua_secure_object";
+
+export class ResolvedCertificateKeyPairProvider implements ICertificateChainProvider, ICertificateKeyPairProviderWithLocation {
+    #certificateChain: Certificate[] | null = null;
+    readonly #certificateFile: string;
+    readonly #privateKeyFile: string;
+    readonly #privateKey: PrivateKey;
+
+    constructor(certificateFile: string, privateKeyFile: string, privateKey: PrivateKey) {
+        this.#certificateFile = certificateFile;
+        this.#privateKeyFile = privateKeyFile;
+        this.#privateKey = privateKey;
+    }
+
+    public get certificateFile(): string {
+        return this.#certificateFile;
+    }
+
+    /** Real path of the private key file (needed by push-management, even though the key itself is held in memory). */
+    public get privateKeyFile(): string {
+        return this.#privateKeyFile;
+    }
+
+    public getCertificate(): Certificate {
+        return this.getCertificateChain()[0];
+    }
+
+    public getCertificateChain(): Certificate[] {
+        if (!this.#certificateChain) {
+            if (!fs.existsSync(this.#certificateFile)) {
+                throw new Error(`Certificate file not found: ${this.#certificateFile}`);
+            }
+            const chain = readCertificateChain(this.#certificateFile);
+            if (!chain || chain.length === 0) {
+                throw new Error(`Invalid certificate chain (length=0) ${this.#certificateFile}`);
+            }
+            this.#certificateChain = chain;
+        }
+        return this.#certificateChain;
+    }
+
+    public getPrivateKey(): PrivateKey {
+        return this.#privateKey;
+    }
+
+    /**
+     * Re-reads the certificate chain from disk on next access. The
+     * in-memory private key is untouched — construct a new provider to
+     * rotate the key (see class doc).
+     */
+    public invalidate(): void {
+        this.#certificateChain = null;
+    }
+
+    // Prevent secrets from leaking through JSON serialization
+    public toJSON(): Record<string, string> {
+        return {
+            provider: "ResolvedCertificateKeyPairProvider",
+            certificateFile: this.#certificateFile,
+            privateKeyFile: this.#privateKeyFile
+        };
+    }
+
+    // Prevent secrets from leaking through console.log / util.inspect
+    public [Symbol.for("nodejs.util.inspect.custom")](): string {
+        return `ResolvedCertificateKeyPairProvider { certificateFile: "${this.#certificateFile}", privateKeyFile: "${this.#privateKeyFile}" }`;
+    }
+}

--- a/packages/node-opcua-common/test/test_disk_certificate_key_pair_provider.ts
+++ b/packages/node-opcua-common/test/test_disk_certificate_key_pair_provider.ts
@@ -1,0 +1,158 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import util from "node:util";
+import "mocha";
+
+import { PrivateKeyPassphraseRequiredError, writePrivateKeyFile } from "node-opcua-crypto";
+import {
+    CertificatePurpose,
+    convertPEMtoDER,
+    createSelfSignedCertificate,
+    generatePrivateKey,
+    makePrivateKeyFromPem,
+    privateKeyToPEM
+} from "node-opcua-crypto/web";
+import should from "should";
+
+import { DiskCertificateKeyPairProvider } from "../source/disk_certificate_key_pair_provider";
+import { ResolvedCertificateKeyPairProvider } from "../source/resolved_certificate_key_pair_provider";
+
+describe("DiskCertificateKeyPairProvider & ResolvedCertificateKeyPairProvider", function (this: Mocha.Suite) {
+    this.timeout(Math.max(30000, this.timeout()));
+
+    let tmpDir: string;
+    let certificateFile: string;
+    let plainKeyFile: string;
+    let encryptedKeyFile: string;
+    const passphrase = "s3cr3t-passphrase";
+
+    before(async () => {
+        tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "node-opcua-common-test-"));
+        certificateFile = path.join(tmpDir, "certificate.pem");
+        plainKeyFile = path.join(tmpDir, "private_key_plain.pem");
+        encryptedKeyFile = path.join(tmpDir, "private_key_encrypted.pem");
+
+        const cryptoKey = await generatePrivateKey(2048);
+        const { privPem } = await privateKeyToPEM(cryptoKey);
+        const privateKeyObj = makePrivateKeyFromPem(privPem);
+
+        fs.writeFileSync(plainKeyFile, privPem);
+        await writePrivateKeyFile(encryptedKeyFile, privateKeyObj, { passphrase });
+
+        const { cert } = await createSelfSignedCertificate({
+            privateKey: cryptoKey,
+            subject: "/CN=DiskCertificateKeyPairProviderTest",
+            applicationUri: "urn:test:disk-provider",
+            dns: ["localhost"],
+            validity: 365,
+            notBefore: new Date(),
+            purpose: CertificatePurpose.ForApplication
+        });
+        fs.writeFileSync(certificateFile, cert);
+        // sanity check — convertPEMtoDER should not throw
+        convertPEMtoDER(cert);
+    });
+
+    after(async () => {
+        await fs.promises.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    describe("DiskCertificateKeyPairProvider", () => {
+        it("reads a plaintext private key when no passphrase is given", () => {
+            const p = new DiskCertificateKeyPairProvider(certificateFile, plainKeyFile);
+            const key = p.getPrivateKey();
+            should(key).be.ok();
+        });
+
+        it("reads an encrypted private key when the correct passphrase is given", () => {
+            const p = new DiskCertificateKeyPairProvider(certificateFile, encryptedKeyFile, passphrase);
+            const key = p.getPrivateKey();
+            should(key).be.ok();
+        });
+
+        it("throws PrivateKeyPassphraseRequiredError for an encrypted key with no passphrase", () => {
+            const p = new DiskCertificateKeyPairProvider(certificateFile, encryptedKeyFile);
+            (() => p.getPrivateKey()).should.throw(PrivateKeyPassphraseRequiredError);
+        });
+
+        it("fails closed for an encrypted key with the wrong passphrase (does not silently decrypt)", () => {
+            const p = new DiskCertificateKeyPairProvider(certificateFile, encryptedKeyFile, "wrong-passphrase");
+            (() => p.getPrivateKey()).should.throw();
+        });
+
+        it("still reads the certificate chain regardless of key encryption", () => {
+            const p = new DiskCertificateKeyPairProvider(certificateFile, encryptedKeyFile, passphrase);
+            const chain = p.getCertificateChain();
+            chain.should.have.length(1);
+        });
+
+        it("caches the private key across calls", () => {
+            const p = new DiskCertificateKeyPairProvider(certificateFile, plainKeyFile);
+            const key1 = p.getPrivateKey();
+            const key2 = p.getPrivateKey();
+            key1.should.equal(key2);
+        });
+
+        it("re-reads from disk after invalidate()", () => {
+            const p = new DiskCertificateKeyPairProvider(certificateFile, plainKeyFile);
+            const key1 = p.getPrivateKey();
+            p.invalidate();
+            const key2 = p.getPrivateKey();
+            should(key2).be.ok();
+            // Different object instances after invalidate + re-read
+            key1.should.not.equal(key2);
+        });
+    });
+
+    describe("ResolvedCertificateKeyPairProvider", () => {
+        it("returns the in-memory private key it was constructed with, without touching disk", () => {
+            const p = new DiskCertificateKeyPairProvider(certificateFile, encryptedKeyFile, passphrase);
+            const resolvedKey = p.getPrivateKey();
+
+            // Point privateKeyFile at a path that does not exist — proves getPrivateKey()
+            // never tries to read it.
+            const bogusKeyFile = path.join(tmpDir, "does-not-exist.pem");
+            const resolved = new ResolvedCertificateKeyPairProvider(certificateFile, bogusKeyFile, resolvedKey);
+
+            resolved.getPrivateKey().should.equal(resolvedKey);
+            resolved.privateKeyFile.should.equal(bogusKeyFile);
+        });
+
+        it("reads the certificate chain from disk lazily, same as DiskCertificateKeyPairProvider", () => {
+            const p = new DiskCertificateKeyPairProvider(certificateFile, encryptedKeyFile, passphrase);
+            const resolvedKey = p.getPrivateKey();
+            const resolved = new ResolvedCertificateKeyPairProvider(certificateFile, encryptedKeyFile, resolvedKey);
+
+            const chain = resolved.getCertificateChain();
+            chain.should.have.length(1);
+            resolved.getCertificate().should.equal(chain[0]);
+        });
+
+        it("invalidate() re-reads the certificate chain but keeps the in-memory private key", () => {
+            const p = new DiskCertificateKeyPairProvider(certificateFile, encryptedKeyFile, passphrase);
+            const resolvedKey = p.getPrivateKey();
+            const resolved = new ResolvedCertificateKeyPairProvider(certificateFile, encryptedKeyFile, resolvedKey);
+
+            const chain1 = resolved.getCertificateChain();
+            resolved.invalidate();
+            const chain2 = resolved.getCertificateChain();
+            chain1.should.not.equal(chain2); // different array instance after invalidate
+            chain1[0].should.deepEqual(chain2[0]); // same certificate content
+
+            resolved.getPrivateKey().should.equal(resolvedKey);
+        });
+
+        it("does not leak the private key via toJSON or console.log formatting", () => {
+            const p = new DiskCertificateKeyPairProvider(certificateFile, encryptedKeyFile, passphrase);
+            const resolvedKey = p.getPrivateKey();
+            const resolved = new ResolvedCertificateKeyPairProvider(certificateFile, encryptedKeyFile, resolvedKey);
+
+            const json = JSON.stringify(resolved);
+            json.should.not.containEql("PRIVATE KEY");
+            const inspected = util.inspect(resolved);
+            inspected.should.not.containEql("PRIVATE KEY");
+            inspected.should.containEql("ResolvedCertificateKeyPairProvider");
+        });
+    });
+});

--- a/packages/node-opcua-end2end-test/test/secure_connection/test_e2e_encrypted_private_key.ts
+++ b/packages/node-opcua-end2end-test/test/secure_connection/test_e2e_encrypted_private_key.ts
@@ -1,0 +1,86 @@
+/**
+ * End-to-end: a server AND a client, each with a passphrase-protected
+ * (encrypted-at-rest) private key, establish a SignAndEncrypt secure session.
+ *
+ * Proves the whole chain works together: OPCUACertificateManager encrypts
+ * the key, OPCUAServer/OPCUAClient resolve it asynchronously once during
+ * initialization, and the secure channel layer (which only ever calls the
+ * synchronous ICertificateKeyPairProvider.getPrivateKey()) uses the already
+ * resolved key without touching disk again.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { MessageSecurityMode, OPCUACertificateManager, OPCUAClient, OPCUAServer, SecurityPolicy } from "node-opcua";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import should from "should";
+import "mocha";
+
+describe("End-to-End: encrypted-at-rest private key on both server and client", function (this: Mocha.Suite) {
+    this.timeout(60000);
+
+    const tmpFolder = path.join(__dirname, "../../tmp_encrypted_private_key_test");
+
+    before(() => {
+        if (fs.existsSync(tmpFolder)) {
+            fs.rmSync(tmpFolder, { recursive: true, force: true });
+        }
+        fs.mkdirSync(tmpFolder, { recursive: true });
+    });
+
+    after(() => {
+        fs.rmSync(tmpFolder, { recursive: true, force: true });
+    });
+
+    it("EE1 - a SignAndEncrypt session succeeds when both the server's and the client's private keys are passphrase-encrypted", async () => {
+        const serverCertificateManager = new OPCUACertificateManager({
+            rootFolder: path.join(tmpFolder, "server_pki"),
+            automaticallyAcceptUnknownCertificate: true,
+            privateKeyPassphrase: "server-side-passphrase",
+            // Avoid a chokidar watcher on a folder this test deletes in
+            // after() — a live watcher racing the deletion throws an async
+            // EPERM on Windows well after the test itself has finished.
+            disableFileWatchers: true
+        });
+        await serverCertificateManager.initialize();
+
+        const clientCertificateManager = new OPCUACertificateManager({
+            rootFolder: path.join(tmpFolder, "client_pki"),
+            automaticallyAcceptUnknownCertificate: true,
+            privateKeyPassphrase: "client-side-passphrase",
+            disableFileWatchers: true
+        });
+        await clientCertificateManager.initialize();
+
+        // Both keys must already be encrypted on disk before any connection is made.
+        fs.readFileSync(serverCertificateManager.privateKey, "utf-8").should.containEql("ENCRYPTED PRIVATE KEY");
+        fs.readFileSync(clientCertificateManager.privateKey, "utf-8").should.containEql("ENCRYPTED PRIVATE KEY");
+
+        const server = new OPCUAServer({
+            port: 20913,
+            serverCertificateManager,
+            securityPolicies: [SecurityPolicy.Basic256Sha256],
+            securityModes: [MessageSecurityMode.SignAndEncrypt]
+        });
+        await server.start();
+
+        try {
+            const endpointUrl = server.getEndpointUrl();
+
+            const client = OPCUAClient.create({
+                clientCertificateManager,
+                securityMode: MessageSecurityMode.SignAndEncrypt,
+                securityPolicy: SecurityPolicy.Basic256Sha256
+            });
+
+            await client.withSessionAsync(endpointUrl, async (session) => {
+                should(session.sessionId).be.ok();
+            });
+        } finally {
+            await server.shutdown();
+        }
+
+        // Neither key was ever written back to disk in clear.
+        fs.readFileSync(serverCertificateManager.privateKey, "utf-8").should.containEql("ENCRYPTED PRIVATE KEY");
+        fs.readFileSync(clientCertificateManager.privateKey, "utf-8").should.containEql("ENCRYPTED PRIVATE KEY");
+    });
+});

--- a/packages/node-opcua-secure-channel/source/server/server_secure_channel_layer.ts
+++ b/packages/node-opcua-secure-channel/source/server/server_secure_channel_layer.ts
@@ -114,10 +114,7 @@ export interface ServerSecureChannelParent extends ICertificateKeyPairProvider {
      * If not implemented, the original status code is returned
      * unchanged.
      */
-    adjustCertificateStatus?(
-        statusCode: StatusCode,
-        certificate: Certificate
-    ): StatusCode | Promise<StatusCode>;
+    adjustCertificateStatus?(statusCode: StatusCode, certificate: Certificate): StatusCode | Promise<StatusCode>;
 }
 
 export interface ServerSecureChannelLayerOptions {
@@ -190,7 +187,7 @@ export class ServerSecureChannelLayer extends EventEmitter {
     #counter: number = ServerSecureChannelLayer.g_counter++;
     #status: "new" | "connecting" | "open" | "closing" | "closed" = "new";
 
-    public beforeHandleOpenSecureChannelRequest = async (): Promise<void> => { };
+    public beforeHandleOpenSecureChannelRequest = async (): Promise<void> => {};
     public get securityTokenCount(): number {
         assert(typeof this.#lastTokenId === "number");
         return this.#lastTokenId;
@@ -289,6 +286,28 @@ export class ServerSecureChannelLayer extends EventEmitter {
     public securityPolicy: SecurityPolicy = SecurityPolicy.Invalid;
 
     #parent: ServerSecureChannelParent | null;
+    /**
+     * The certificate chain and private key this channel operates with,
+     * captured from the parent on first access and kept for the channel's
+     * whole lifetime.
+     *
+     * OPC UA Part 6 defines the asymmetric handshake per *SecureChannel*,
+     * not per current-server-state: §6.7.2 — "The receiver shall reject the
+     * MessageChunk if the Certificate identified does not match the
+     * Certificate **it is using for the SecureChannel**" — and §6.7.4
+     * requires the client to close the channel if the certificate used to
+     * sign an OpenSecureChannel response differs from the one it encrypted
+     * the request to. So when the server's certificate/key pair is rotated
+     * (push certificate management) while this channel is alive, this
+     * channel must keep honoring — and answering under — the pair it was
+     * created with: thumbprint check, response signing, and the
+     * senderCertificate chain all use the bound pair. New channels bind the
+     * new pair. (The MessageBuilder already captures the decryption key at
+     * channel setup; these fields make the remaining asymmetric operations
+     * consistent with it.)
+     */
+    #boundCertificateChain: Certificate[] | null = null;
+    #boundPrivateKey: PrivateKey | null = null;
     readonly #protocolVersion: number;
     #lastTokenId: number;
     readonly #defaultSecureTokenLifetime: number;
@@ -426,6 +445,10 @@ export class ServerSecureChannelLayer extends EventEmitter {
 
         this.#parent = null;
         this.#objectFactory = undefined;
+        // release the bound certificate/key material (may be a pair the
+        // server has already rotated away from)
+        this.#boundCertificateChain = null;
+        this.#boundPrivateKey = null;
 
         if (this.#messageBuilder) {
             this.#messageBuilder.dispose();
@@ -437,7 +460,7 @@ export class ServerSecureChannelLayer extends EventEmitter {
         }
         if (this.#transport) {
             this.#transport.dispose();
-            (this as unknown as {transport: undefined | ServerTCP_transport}).transport = undefined;
+            (this as unknown as { transport: undefined | ServerTCP_transport }).transport = undefined;
         }
         this.channelId = 0xdeadbeef;
         this.#timeoutId = null;
@@ -478,25 +501,25 @@ export class ServerSecureChannelLayer extends EventEmitter {
     }
 
     /**
-
-     * @return the X509 DER form certificate
+     * The X509 DER form certificate chain this channel is bound to
+     * (captured from the parent on first access — see the note on
+     * `#boundCertificateChain`).
      */
     public getCertificateChain(): Certificate[] {
-        if (!this.#parent) {
-            throw new Error("expecting a valid parent");
+        if (!this.#boundCertificateChain) {
+            if (!this.#parent) {
+                throw new Error("expecting a valid parent");
+            }
+            this.#boundCertificateChain = this.#parent.getCertificateChain();
         }
-        return this.#parent.getCertificateChain();
+        return this.#boundCertificateChain;
     }
 
     /**
-
-     * @return  the X509 DER form certificate
+     * The X509 DER form (leaf) certificate this channel is bound to.
      */
     public getCertificate(): Certificate {
-        if (!this.#parent) {
-            throw new Error("expecting a valid parent");
-        }
-        return this.#parent.getCertificate();
+        return this.getCertificateChain()[0];
     }
 
     public getSignatureLength(): PublicKeyLength {
@@ -506,14 +529,17 @@ export class ServerSecureChannelLayer extends EventEmitter {
     }
 
     /**
-
-     * @return the privateKey
+     * The private key this channel is bound to (captured from the parent on
+     * first access — see the note on `#boundCertificateChain`).
      */
     public getPrivateKey(): PrivateKey {
-        if (!this.#parent) {
-            return invalidPrivateKey;
+        if (!this.#boundPrivateKey) {
+            if (!this.#parent) {
+                return invalidPrivateKey;
+            }
+            this.#boundPrivateKey = this.#parent.getPrivateKey();
         }
-        return this.#parent.getPrivateKey();
+        return this.#boundPrivateKey;
     }
 
     /**
@@ -745,7 +771,7 @@ export class ServerSecureChannelLayer extends EventEmitter {
      *
      */
     public close(callback?: ErrorCallback): void {
-        callback = callback || (() => { });
+        callback = callback || (() => {});
         if (!this.#transport) {
             if (typeof callback === "function") {
                 callback();
@@ -1199,8 +1225,8 @@ export class ServerSecureChannelLayer extends EventEmitter {
             if (fallbackToken) {
                 warningLog(
                     `tokenId ${tokenId} expired — falling back to` +
-                    ` latest valid token ${fallbackToken.tokenId}` +
-                    ` (securityMode=${MessageSecurityMode[this.securityMode]})`
+                        ` latest valid token ${fallbackToken.tokenId}` +
+                        ` (securityMode=${MessageSecurityMode[this.securityMode]})`
                 );
                 derivedKeys = fallbackToken.derivedKeys;
             } else {
@@ -1284,10 +1310,10 @@ export class ServerSecureChannelLayer extends EventEmitter {
         //   This field shall be null if the message is not encrypted.
         const evaluateReceiverThumbprint = () => {
             if (this.securityMode === MessageSecurityMode.None) return null;
-            
+
             // c8 ignore next: this should never happen
             if (!this.#clientCertificate) return null;
-            
+
             const part1 = split_der(this.#clientCertificate)[0];
             const receiverCertificateThumbprint = getThumbprint(part1);
             return receiverCertificateThumbprint;
@@ -1355,9 +1381,7 @@ export class ServerSecureChannelLayer extends EventEmitter {
                 break;
             }
             default:
-                throw new Error(
-                    `BadSecurityModeRejected: unexpected securityMode ${request.securityMode}`
-                );
+                throw new Error(`BadSecurityModeRejected: unexpected securityMode ${request.securityMode}`);
         }
         return securityHeader;
     }
@@ -1601,7 +1625,7 @@ export class ServerSecureChannelLayer extends EventEmitter {
                 if (!securityToken) {
                     const _tokenStack = this.#tokenStack;
                     const description = `cannot find security token ${tokenId}  ${msgType}`;
-                    return this.#_sendFatalErrorAndAbort(StatusCodes.BadCommunicationError, description, message, () => { });
+                    return this.#_sendFatalErrorAndAbort(StatusCodes.BadCommunicationError, description, message, () => {});
                 }
                 if (securityToken && channelId !== securityToken.channelId) {
                     // response = new ServiceFault({responseHeader: {serviceResult: certificate_status}});

--- a/packages/node-opcua-server-configuration/source/server/install_push_certificate_management.ts
+++ b/packages/node-opcua-server-configuration/source/server/install_push_certificate_management.ts
@@ -8,10 +8,15 @@ import chalk from "chalk";
 import type { AddressSpace, UAServerConfiguration } from "node-opcua-address-space";
 import { assert } from "node-opcua-assert";
 import { OPCUACertificateManager } from "node-opcua-certificate-manager";
-import { DiskCertificateKeyPairProvider, type ICertificateKeyPairProvider } from "node-opcua-common";
-import { type Certificate, split_der, exploreCertificateInfo } from "node-opcua-crypto/web";
+import {
+    DiskCertificateKeyPairProvider,
+    type ICertificateChainProvider,
+    type ICertificateKeyPairProvider,
+    resolvePrivateKeyProviderIfNeeded
+} from "node-opcua-common";
+import { type Certificate, exploreCertificateInfo, split_der } from "node-opcua-crypto/web";
 import { checkDebugFlag, make_debugLog, make_errorLog, make_warningLog } from "node-opcua-debug";
-import { invalidateServerCertificateCache, type OPCUAServer, type OPCUAServerEndPoint } from "node-opcua-server";
+import type { OPCUAServer, OPCUAServerEndPoint } from "node-opcua-server";
 import { type StatusCode, StatusCodes } from "node-opcua-status-code";
 import { type ApplicationDescriptionOptions, ServerState } from "node-opcua-types";
 
@@ -35,6 +40,7 @@ export interface OPCUAServerPartial extends ICertificateKeyPairProvider {
     createDefaultCertificate(): Promise<void>;
     setProvider(provider: ICertificateKeyPairProvider): void;
     invalidateCachedCertificates(): void;
+    getCertificateChainProvider(): ICertificateChainProvider;
 }
 
 async function onCertificateAboutToChange(server: OPCUAServer) {
@@ -56,7 +62,39 @@ async function onCertificateAboutToChange(server: OPCUAServer) {
  */
 async function onCertificateChange(server: OPCUAServer) {
     doDebug && debugLog("on CertificateChanged");
-    invalidateServerCertificateCache(server);
+    await reresolveServerCertificateProvider(server);
+}
+
+/**
+ * Refresh the server's certificate/private-key provider after a rotation,
+ * and push the result to every endpoint.
+ *
+ * When the certificate manager is passphrase-/provider-managed, a
+ * synchronous "invalidate, let it lazily re-read the file" (the old
+ * behavior) cannot decrypt the key — so the key is instead resolved here,
+ * eagerly and asynchronously, via `resolvePrivateKeyProviderIfNeeded()`, and
+ * the resulting provider handed out explicitly to the server and every
+ * endpoint.
+ *
+ * For a plain (unmanaged) certificate manager, `resolvePrivateKeyProviderIfNeeded`
+ * is a deliberate no-op (see its doc), so this falls back to exactly the
+ * previous behavior: invalidate the server's and every endpoint's cached
+ * certificate/key so the next access re-reads the (plaintext) files from
+ * disk.
+ */
+async function reresolveServerCertificateProvider(server: OPCUAServer): Promise<void> {
+    const resolved = await resolvePrivateKeyProviderIfNeeded(server, server.serverCertificateManager, false);
+    if (resolved) {
+        const provider = server.getCertificateChainProvider();
+        for (const endpoint of server.endpoints) {
+            endpoint.setCertificateProvider(provider);
+        }
+    } else {
+        server.invalidateCachedCertificates();
+        for (const endpoint of server.endpoints) {
+            endpoint.invalidateCertificates();
+        }
+    }
 }
 
 /**
@@ -88,9 +126,11 @@ async function install(this: OPCUAServerPartial): Promise<void> {
     const certFile = path.join(this.serverCertificateManager.rootDir, CERT_PEM_RELATIVE_PATH);
     const keyFile = this.serverCertificateManager.privateKey;
 
-    // Inject a new disk provider pointing at the cert manager's
-    // paths. The server's certificateFile/privateKeyFile getters
-    // now automatically return the new paths.
+    // Inject a new disk provider pointing at the cert manager's paths. The
+    // server's certificateFile/privateKeyFile getters now automatically
+    // return the new paths. If the key turns out to be passphrase-encrypted,
+    // resolvePrivateKeyProviderIfNeeded() below immediately replaces this
+    // with a resolved, in-memory provider.
     this.setProvider(new DiskCertificateKeyPairProvider(certFile, keyFile));
 
     // Delegate to the base server's createDefaultCertificate() which
@@ -98,9 +138,12 @@ async function install(this: OPCUAServerPartial): Promise<void> {
     // proper subject via makeSubject(), mutex locking, and file checks.
     await this.createDefaultCertificate();
 
-    // Invalidate any previously cached secrets so that
-    // getCertificateChain() / getPrivateKey() will re-read from disk.
-    this.invalidateCachedCertificates();
+    // Resolve the (possibly passphrase-encrypted) private key once,
+    // asynchronously, and install the resolved provider — a synchronous
+    // disk re-read (the old invalidateCachedCertificates() behavior) cannot
+    // decrypt an encrypted key. For a plaintext key this just replaces the
+    // disk provider above with an equivalent resolved one.
+    await resolvePrivateKeyProviderIfNeeded(this, this.serverCertificateManager, false);
 }
 
 interface UAServerConfigurationEx extends UAServerConfiguration {
@@ -108,7 +151,7 @@ interface UAServerConfigurationEx extends UAServerConfiguration {
 }
 
 export async function installPushCertificateManagementOnServer(server: OPCUAServer): Promise<void> {
-    if (!server.engine || !server.engine.addressSpace) {
+    if (!server.engine?.addressSpace) {
         throw new Error(
             "Server must have a valid address space. " +
             "You need to call installPushCertificateManagementOnServer after server has been initialized"
@@ -129,10 +172,14 @@ export async function installPushCertificateManagementOnServer(server: OPCUAServ
         );
     }
     const cm = server.serverCertificateManager;
-    const certFile = path.join(cm.rootDir, CERT_PEM_RELATIVE_PATH);
-    const keyFile = cm.privateKey;
+    // Reuse the server's own provider (installed by install() above, and
+    // already resolved if the key is passphrase-encrypted) rather than
+    // constructing a fresh DiskCertificateKeyPairProvider from the file
+    // paths — a plain disk provider would re-read the file and fail
+    // synchronously on an encrypted key.
+    const provider = server.getCertificateChainProvider();
     for (const endpoint of server.endpoints) {
-        endpoint.setCertificateProvider(new DiskCertificateKeyPairProvider(certFile, keyFile));
+        endpoint.setCertificateProvider(provider);
     }
 
     await installPushCertificateManagement(server.engine.addressSpace, {

--- a/packages/node-opcua-server-configuration/source/server/install_push_certificate_management.ts
+++ b/packages/node-opcua-server-configuration/source/server/install_push_certificate_management.ts
@@ -137,10 +137,9 @@ async function reresolveServerCertificateProvider(server: OPCUAServer): Promise<
  * With `closeChannelsOnApplyChanges` (the default) every existing secure
  * channel is shut down immediately, forcing all connected clients to
  * reconnect with the new certificate right away. Without it, existing
- * channels are left alone: each keeps running on the symmetric keys it
- * already derived until its next OpenSecureChannel *Renew*, which the
- * server then rejects (the client still addresses the old certificate)
- * and closes the channel — at which point that client reconnects. See
+ * channels are left alone and continue — including OpenSecureChannel
+ * *Renews* — under the certificate/key pair each channel is bound to,
+ * while new connections use the new pair. See
  * {@link InstallPushCertificateManagementOnServerOptions.closeChannelsOnApplyChanges}
  * for when each is appropriate.
  *
@@ -153,7 +152,8 @@ async function onApplyChangesCompleted(server: OPCUAServer, closeChannels: boole
         await server.shutdownChannels();
         doDebug && debugLog(chalk.yellow(" onApplyChangesCompleted => channels shut down"));
     } else {
-        doDebug && debugLog(chalk.yellow(" onApplyChangesCompleted => leaving existing channels open until their next renew"));
+        doDebug &&
+            debugLog(chalk.yellow(" onApplyChangesCompleted => leaving existing channels open (bound to their original pair)"));
     }
 
     doDebug && debugLog(chalk.yellow(" onApplyChangesCompleted => resuming end points"));
@@ -212,15 +212,20 @@ export interface InstallPushCertificateManagementOnServerOptions {
      *   choice when the rotation is a response to a **compromised or
      *   revoked** key: nothing keeps running under the old one.
      *
-     * - `false`: existing channels are left open. Each keeps running on the
-     *   symmetric keys it already derived until its next OpenSecureChannel
-     *   *Renew* (at ~75% of its token lifetime); the server rejects that
-     *   Renew — the client still addresses the old certificate — and closes
-     *   the channel, and only then does that client reconnect. Choose this
-     *   for a **planned** rotation: in-flight transactions complete, and N
-     *   clients reconnect spread over a token lifetime instead of all at
-     *   once. Note the reconnection still happens — this defers it, it does
-     *   not make the rotation seamless.
+     * - `false`: existing channels are left open and the rotation is
+     *   **seamless** for them. Each server channel is bound to the
+     *   certificate/key pair it was created with (OPC UA Part 6 §6.7.2
+     *   defines the thumbprint check against "the Certificate it is using
+     *   for the SecureChannel", and §6.7.4 requires the client to close the
+     *   channel if a response is signed with a different certificate than
+     *   the request was encrypted to — so the old pair is the only one a
+     *   Renew on an old channel can conformantly use). Connected clients
+     *   keep renewing their security token under the old pair, unmodified
+     *   third-party clients included; new connections use the new pair.
+     *   Choose this for a **planned** rotation. The old pair remains in use
+     *   by those channels until they close naturally — which is exactly why
+     *   `true` stays the default: when the rotation answers a **compromised
+     *   or revoked** key, nothing must keep running under it.
      *
      * @defaultValue true
      */

--- a/packages/node-opcua-server-configuration/source/server/install_push_certificate_management.ts
+++ b/packages/node-opcua-server-configuration/source/server/install_push_certificate_management.ts
@@ -130,21 +130,39 @@ async function reresolveServerCertificateProvider(server: OPCUAServer): Promise<
 }
 
 /**
- * Deferred channel restart: called after the ApplyChanges method
- * response has been sent.  Shuts down all existing secure channels
- * (which forces clients to reconnect with the new cert) and resumes
- * the endpoints.
+ * Deferred step, called after the ApplyChanges method response has been
+ * sent (so the admin client gets its answer before its own channel is
+ * affected).
+ *
+ * With `closeChannelsOnApplyChanges` (the default) every existing secure
+ * channel is shut down immediately, forcing all connected clients to
+ * reconnect with the new certificate right away. Without it, existing
+ * channels are left alone: each keeps running on the symmetric keys it
+ * already derived until its next OpenSecureChannel *Renew*, which the
+ * server then rejects (the client still addresses the old certificate)
+ * and closes the channel — at which point that client reconnects. See
+ * {@link InstallPushCertificateManagementOnServerOptions.closeChannelsOnApplyChanges}
+ * for when each is appropriate.
+ *
+ * Either way the endpoints, suspended in `onCertificateAboutToChange`,
+ * are resumed here.
  */
-async function onApplyChangesCompleted(server: OPCUAServer) {
-    doDebug && debugLog(chalk.yellow(" onApplyChangesCompleted => shutting down channels"));
-    await server.shutdownChannels();
-    doDebug && debugLog(chalk.yellow(" onApplyChangesCompleted => channels shut down"));
+async function onApplyChangesCompleted(server: OPCUAServer, closeChannels: boolean) {
+    if (closeChannels) {
+        doDebug && debugLog(chalk.yellow(" onApplyChangesCompleted => shutting down channels"));
+        await server.shutdownChannels();
+        doDebug && debugLog(chalk.yellow(" onApplyChangesCompleted => channels shut down"));
+    } else {
+        doDebug && debugLog(chalk.yellow(" onApplyChangesCompleted => leaving existing channels open until their next renew"));
+    }
 
     doDebug && debugLog(chalk.yellow(" onApplyChangesCompleted => resuming end points"));
     await server.resumeEndPoints();
     doDebug && debugLog(chalk.yellow(" onApplyChangesCompleted => end points resumed"));
 
-    debugLog(chalk.yellow("channels have been closed -> client should reconnect "));
+    if (closeChannels) {
+        debugLog(chalk.yellow("channels have been closed -> client should reconnect "));
+    }
 }
 
 /**
@@ -182,7 +200,38 @@ interface UAServerConfigurationEx extends UAServerConfiguration {
     $pushCertificateManager: PushCertificateManagerServerImpl;
 }
 
-export async function installPushCertificateManagementOnServer(server: OPCUAServer): Promise<void> {
+export interface InstallPushCertificateManagementOnServerOptions {
+    /**
+     * What happens to secure channels that are already open when
+     * `ApplyChanges` installs a new server certificate (and possibly a new
+     * private key).
+     *
+     * - `true` (default): every existing channel is shut down as soon as
+     *   the ApplyChanges response has been sent. All connected clients
+     *   reconnect immediately with the new certificate. This is the safe
+     *   choice when the rotation is a response to a **compromised or
+     *   revoked** key: nothing keeps running under the old one.
+     *
+     * - `false`: existing channels are left open. Each keeps running on the
+     *   symmetric keys it already derived until its next OpenSecureChannel
+     *   *Renew* (at ~75% of its token lifetime); the server rejects that
+     *   Renew — the client still addresses the old certificate — and closes
+     *   the channel, and only then does that client reconnect. Choose this
+     *   for a **planned** rotation: in-flight transactions complete, and N
+     *   clients reconnect spread over a token lifetime instead of all at
+     *   once. Note the reconnection still happens — this defers it, it does
+     *   not make the rotation seamless.
+     *
+     * @defaultValue true
+     */
+    closeChannelsOnApplyChanges?: boolean;
+}
+
+export async function installPushCertificateManagementOnServer(
+    server: OPCUAServer,
+    options?: InstallPushCertificateManagementOnServerOptions
+): Promise<void> {
+    const closeChannelsOnApplyChanges = options?.closeChannelsOnApplyChanges ?? true;
     if (!server.engine?.addressSpace) {
         throw new Error(
             "Server must have a valid address space. " +
@@ -241,11 +290,11 @@ export async function installPushCertificateManagementOnServer(server: OPCUAServ
     });
 
     serverConfigurationPriv.$pushCertificateManager.on("applyChangesCompleted", () => {
-        // Fire-and-forget: schedule channel teardown + endpoint
+        // Fire-and-forget: schedule (optional) channel teardown + endpoint
         // resumption AFTER the method response is sent.
         setImmediate(async () => {
             try {
-                await onApplyChangesCompleted(server);
+                await onApplyChangesCompleted(server, closeChannelsOnApplyChanges);
             } catch (err) {
                 errorLog("onApplyChangesCompleted error:", (err as Error).message);
             }

--- a/packages/node-opcua-server-configuration/source/server/install_push_certificate_management.ts
+++ b/packages/node-opcua-server-configuration/source/server/install_push_certificate_management.ts
@@ -12,8 +12,10 @@ import {
     DiskCertificateKeyPairProvider,
     type ICertificateChainProvider,
     type ICertificateKeyPairProvider,
+    ResolvedCertificateKeyPairProvider,
     resolvePrivateKeyProviderIfNeeded
 } from "node-opcua-common";
+import { readPrivateKey } from "node-opcua-crypto";
 import { type Certificate, exploreCertificateInfo, split_der } from "node-opcua-crypto/web";
 import { checkDebugFlag, make_debugLog, make_errorLog, make_warningLog } from "node-opcua-debug";
 import type { OPCUAServer, OPCUAServerEndPoint } from "node-opcua-server";
@@ -66,25 +68,55 @@ async function onCertificateChange(server: OPCUAServer) {
 }
 
 /**
+ * Resolve the private key immediately after a rotation, bypassing
+ * `OPCUACertificateManager.getPrivateKey()`'s cache.
+ *
+ * `getPrivateKey()` decrypts the on-disk key *once* and caches it for the
+ * manager instance's whole lifetime (pki's documented behavior — see
+ * `CertificateManager.getPrivateKey`). That's exactly right for a normal
+ * startup resolve (`resolvePrivateKeyProviderIfNeeded`, used by
+ * `initializeCM()`), but wrong here: `UpdateCertificate`/`ApplyChanges` just
+ * replaced the on-disk key file underneath this *same, long-lived*
+ * `certificateManager` instance, so a cached call would silently keep
+ * returning the pre-rotation key — certificate and key would then belong to
+ * different key pairs, and every subsequent handshake fails signature
+ * verification.
+ *
+ * `privateKeyProvider` mode has no such cache — pki consults the injected
+ * provider on every call — so this only special-cases `privateKeyPassphrase`
+ * (reading the file directly, with the manager's own configured passphrase,
+ * instead of going through the memoized `getPrivateKey()`).
+ */
+async function resolvePrivateKeyAfterRotation(certificateManager: OPCUACertificateManager, privateKeyFile: string) {
+    const passphrase = await certificateManager.getPrivateKeyPassphrase();
+    if (passphrase !== undefined) {
+        return readPrivateKey(privateKeyFile, passphrase);
+    }
+    return certificateManager.getPrivateKey();
+}
+
+/**
  * Refresh the server's certificate/private-key provider after a rotation,
  * and push the result to every endpoint.
  *
  * When the certificate manager is passphrase-/provider-managed, a
  * synchronous "invalidate, let it lazily re-read the file" (the old
  * behavior) cannot decrypt the key — so the key is instead resolved here,
- * eagerly and asynchronously, via `resolvePrivateKeyProviderIfNeeded()`, and
- * the resulting provider handed out explicitly to the server and every
+ * eagerly and asynchronously (see `resolvePrivateKeyAfterRotation`), and the
+ * resulting provider handed out explicitly to the server and every
  * endpoint.
  *
- * For a plain (unmanaged) certificate manager, `resolvePrivateKeyProviderIfNeeded`
- * is a deliberate no-op (see its doc), so this falls back to exactly the
- * previous behavior: invalidate the server's and every endpoint's cached
- * certificate/key so the next access re-reads the (plaintext) files from
- * disk.
+ * For a plain (unmanaged) certificate manager, this falls back to exactly
+ * the previous behavior: invalidate the server's and every endpoint's
+ * cached certificate/key so the next access re-reads the (plaintext) files
+ * from disk.
  */
 async function reresolveServerCertificateProvider(server: OPCUAServer): Promise<void> {
-    const resolved = await resolvePrivateKeyProviderIfNeeded(server, server.serverCertificateManager, false);
-    if (resolved) {
+    const certificateManager = server.serverCertificateManager;
+    const isManaged = certificateManager instanceof OPCUACertificateManager && certificateManager.isPrivateKeyManaged();
+    if (isManaged) {
+        const privateKey = await resolvePrivateKeyAfterRotation(certificateManager, server.privateKeyFile);
+        server.setProvider(new ResolvedCertificateKeyPairProvider(server.certificateFile, server.privateKeyFile, privateKey));
         const provider = server.getCertificateChainProvider();
         for (const endpoint of server.endpoints) {
             endpoint.setCertificateProvider(provider);
@@ -154,7 +186,7 @@ export async function installPushCertificateManagementOnServer(server: OPCUAServ
     if (!server.engine?.addressSpace) {
         throw new Error(
             "Server must have a valid address space. " +
-            "You need to call installPushCertificateManagementOnServer after server has been initialized"
+                "You need to call installPushCertificateManagementOnServer after server has been initialized"
         );
     }
     await install.call(server as unknown as OPCUAServerPartial);
@@ -167,8 +199,8 @@ export async function installPushCertificateManagementOnServer(server: OPCUAServ
     if (!(server.serverCertificateManager instanceof OPCUACertificateManager)) {
         throw new Error(
             "installPushCertificateManagementOnServer requires a" +
-            " disk-based OPCUACertificateManager as" +
-            " serverCertificateManager"
+                " disk-based OPCUACertificateManager as" +
+                " serverCertificateManager"
         );
     }
     const cm = server.serverCertificateManager;
@@ -285,18 +317,12 @@ function isRelaxableCertificateError(statusCode: StatusCode): boolean {
  * connection from unintentionally granting trust to every
  * certificate signed by the same CA.
  */
-async function autoTrustCertificateChain(
-    server: OPCUAServer,
-    certificate: Certificate
-): Promise<void> {
+async function autoTrustCertificateChain(server: OPCUAServer, certificate: Certificate): Promise<void> {
     let chain: Certificate[];
     try {
         chain = split_der(certificate);
     } catch (err) {
-        warningLog(
-            "[NoConfiguration] Cannot parse certificate chain for auto-trust:",
-            (err as Error).message
-        );
+        warningLog("[NoConfiguration] Cannot parse certificate chain for auto-trust:", (err as Error).message);
         return;
     }
 
@@ -310,10 +336,7 @@ async function autoTrustCertificateChain(
         try {
             exploreCertificateInfo(cert);
         } catch (err) {
-            warningLog(
-                "[NoConfiguration] Skipping invalid certificate in chain for auto-trust:",
-                (err as Error).message
-            );
+            warningLog("[NoConfiguration] Skipping invalid certificate in chain for auto-trust:", (err as Error).message);
             continue;
         }
 
@@ -325,10 +348,7 @@ async function autoTrustCertificateChain(
                 // ENOENT can happen if another concurrent call already
                 // moved the cert from rejected to trusted.
                 if ((err as Error & { code?: string }).code !== "ENOENT") {
-                    warningLog(
-                        "[NoConfiguration] Failed to auto-trust leaf certificate:",
-                        (err as Error).message
-                    );
+                    warningLog("[NoConfiguration] Failed to auto-trust leaf certificate:", (err as Error).message);
                 }
             }
         } else {
@@ -337,10 +357,7 @@ async function autoTrustCertificateChain(
             try {
                 await cm.addIssuer(cert);
             } catch (err) {
-                warningLog(
-                    "[NoConfiguration] Failed to add issuer certificate:",
-                    (err as Error).message
-                );
+                warningLog("[NoConfiguration] Failed to add issuer certificate:", (err as Error).message);
             }
         }
     }
@@ -359,10 +376,7 @@ async function autoTrustCertificateChain(
  * building but do not become trust anchors.
  */
 function installCertificateRelaxationHook(server: OPCUAServer): void {
-    const adjustCertificateStatus = async (
-        statusCode: StatusCode,
-        certificate: Certificate
-    ): Promise<StatusCode> => {
+    const adjustCertificateStatus = async (statusCode: StatusCode, certificate: Certificate): Promise<StatusCode> => {
         // Only relax in NoConfiguration state
         if (server.engine.getServerState() !== ServerState.NoConfiguration) {
             return statusCode;
@@ -373,11 +387,12 @@ function installCertificateRelaxationHook(server: OPCUAServer): void {
             return statusCode;
         }
 
-        doDebug && warningLog(
-            `[NoConfiguration] Relaxing certificate check:`,
-            `${statusCode.toString()} → Good`,
-            "(server is awaiting GDS provisioning)"
-        );
+        doDebug &&
+            warningLog(
+                `[NoConfiguration] Relaxing certificate check:`,
+                `${statusCode.toString()} → Good`,
+                "(server is awaiting GDS provisioning)"
+            );
 
         // Auto-trust the leaf certificate; issuer CAs go to issuers/
         await autoTrustCertificateChain(server, certificate);

--- a/packages/node-opcua-server-configuration/source/server/push_certificate_manager/update_certificate.ts
+++ b/packages/node-opcua-server-configuration/source/server/push_certificate_manager/update_certificate.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { assert } from "node-opcua-assert";
 import type { ByteString } from "node-opcua-basic-types";
 import type { CertificateManager, OPCUACertificateManager } from "node-opcua-certificate-manager";
-import { exploreCertificate } from "node-opcua-crypto";
+import { _toExportableKeyObject, exploreCertificate } from "node-opcua-crypto";
 import {
     type Certificate,
     certificateMatchesPrivateKey,
@@ -83,6 +83,22 @@ async function preInstallCertificate(
     }
 }
 
+/**
+ * Encode `privateKeyObj` as a PKCS#8 PEM string, encrypted with `passphrase`
+ * (aes-256-cbc — same cipher `writePrivateKeyFile` uses) when given, plaintext
+ * otherwise. Never touches disk — the caller stages the resulting string via
+ * `FileTransactionManager.stageFile()`, so an encrypted key is the only form
+ * that is ever written, whether to the staging temp file or the final
+ * destination.
+ */
+function encodePrivateKeyPem(privateKeyObj: PrivateKey, passphrase: string | undefined): string {
+    if (!passphrase) {
+        return coercePrivateKeyPem(privateKeyObj);
+    }
+    const keyObject = _toExportableKeyObject(privateKeyObj);
+    return keyObject.export({ type: "pkcs8", format: "pem", cipher: "aes-256-cbc", passphrase }) as string;
+}
+
 // Helper: Stage private key to temporary file
 async function preInstallPrivateKey(
     serverImpl: PushCertificateManagerInternalContext,
@@ -94,7 +110,11 @@ async function preInstallPrivateKey(
 
     if (privateKey) {
         const privateKeyObj = coercePEMorDerToPrivateKey(privateKey as string | Buffer);
-        const privateKeyPEM = coercePrivateKeyPem(privateKeyObj);
+        // If the certificate manager is configured with a privateKeyPassphrase,
+        // the staged (and later applied) key must be encrypted with it — never
+        // written back to disk in clear.
+        const passphrase = await (certificateManager as OPCUACertificateManager).getPrivateKeyPassphrase?.();
+        const privateKeyPEM = encodePrivateKeyPem(privateKeyObj, passphrase);
         await serverImpl.fileTransactionManager.stageFile(certificateManager.privateKey, privateKeyPEM, "utf-8");
     }
 }
@@ -170,14 +190,17 @@ export async function executeUpdateCertificate(
         }
 
         if (!hasPrivateKeyFormat && !hasPrivateKey) {
-            // CertificateManager.getPrivateKey() caches the decoded key for the lifetime of the
-            // instance (see node-opcua-pki). createCertificateRequest()/createSelfSignedCertificate()
-            // both go through that cache, so the CSR that produced `certificate` was necessarily
-            // signed with the *cached* key. Comparing against a fresh disk read here (readPrivateKey
-            // on the file path) would compare against whatever is currently on disk instead — which
-            // can differ right after a previous updateCertificate() call replaced the private key
-            // file directly (bypassing the cache), causing a spurious BadSecurityChecksFailed.
-            const privateKeyObj = await (serverImpl.tmpCertificateManager || certificateManager).getPrivateKey();
+            // Resolve via getPrivateKey(), for two independent reasons:
+            // - CertificateManager.getPrivateKey() caches the decoded key for the lifetime of the
+            //   instance (see node-opcua-pki). createCertificateRequest()/createSelfSignedCertificate()
+            //   both go through that cache, so the CSR that produced `certificate` was necessarily
+            //   signed with the *cached* key. Comparing against a fresh disk read (readPrivateKey
+            //   on the file path) would compare against whatever is currently on disk instead — which
+            //   can differ right after a previous updateCertificate() call replaced the private key
+            //   file directly (bypassing the cache), causing a spurious BadSecurityChecksFailed.
+            // - the on-disk file may be an encrypted PKCS#8 key (privateKeyPassphrase); a raw
+            //   readPrivateKey without the manager's passphrase would fail on it.
+            const privateKeyObj = await (serverImpl.tmpCertificateManager ?? certificateManager).getPrivateKey();
 
             if (!certificateMatchesPrivateKey(certificate, privateKeyObj)) {
                 warningLog("certificate doesn't match privateKey");

--- a/packages/node-opcua-server-configuration/test/server/test_certificate_rotation_with_connected_client.ts
+++ b/packages/node-opcua-server-configuration/test/server/test_certificate_rotation_with_connected_client.ts
@@ -1,0 +1,272 @@
+/**
+ * Certificate rotation via push certificate management while a client is
+ * connected, using a CA-issued certificate chain on both the server's
+ * initial and rotated certificates.
+ *
+ * Because the client trusts the CA + CRL once (rather than each individual
+ * certificate, or blanket-accepting anything unknown), it accepts the
+ * server's rotated certificate automatically — no per-certificate trust
+ * step is needed for the new pair. This is the realistic shape of a
+ * production push-certificate-management deployment.
+ *
+ * Proves that:
+ *  - the client's session survives the rotation from the *caller's*
+ *    perspective: push certificate management forces the old channel
+ *    closed (`ApplyChanges`), and the client's own reconnection logic
+ *    re-establishes a new channel and gets the same `ClientSession` object
+ *    working again — without the test ever calling `createSession()` a
+ *    second time. (The underlying OPC UA session is not guaranteed to keep
+ *    the same NodeId across this repair — reactivating it under the new
+ *    channel can itself fail and fall back to transparently recreating one
+ *    — but the caller's `session` reference and its subscriptions are
+ *    unaffected either way.)
+ *  - once reconnected, the new channel's OpenSecureChannel *Renew* (not
+ *    just the initial handshake) succeeds using the rotated pair — i.e.
+ *    the new certificate and private key are fully consistent, not merely
+ *    good enough for a single exchange.
+ */
+import fs from "node:fs";
+import os, { hostname } from "node:os";
+import path from "node:path";
+
+import "should";
+import { makeRoles } from "node-opcua-address-space";
+import { CertificateManager, OPCUACertificateManager } from "node-opcua-certificate-manager";
+import {
+    type ClientSession,
+    MessageSecurityMode,
+    makeApplicationUrn,
+    OPCUAClient,
+    SecurityPolicy,
+    type UserIdentityInfoUserName
+} from "node-opcua-client";
+import { makeSHA1Thumbprint, readCertificateChain } from "node-opcua-crypto";
+import { AttributeIds } from "node-opcua-data-model";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { NodeId } from "node-opcua-nodeid";
+import type { CertificateAuthority } from "node-opcua-pki";
+import { OPCUAServer } from "node-opcua-server";
+import { UserTokenType } from "node-opcua-types";
+import { randomBytes } from "node-opcua-utils";
+import { ClientPushCertificateManagement, installPushCertificateManagementOnServer } from "../../dist/index.js";
+import {
+    _getFakeAuthorityCertificate,
+    getSharedCertificateAuthority,
+    initializeHelpers,
+    produceCertificate
+} from "../helpers/fake_certificate_authority.js";
+
+const port = 20117;
+
+/** Issue a CA-signed leaf certificate directly into `mgr`'s own cert folder, before `initialize()`/`server.initialize()` ever runs — so the manager never has a self-signed certificate to begin with. */
+async function issueCASignedCertificate(
+    ca: CertificateAuthority,
+    mgr: OPCUACertificateManager,
+    name: string,
+    outputFile: string
+): Promise<void> {
+    const csrFile = await mgr.createCertificateRequest({
+        applicationUri: makeApplicationUrn(hostname(), name),
+        dns: [os.hostname()],
+        subject: `/CN=${name}`,
+        validity: 365
+    });
+    await ca.signCertificateRequest(outputFile, csrFile, {
+        applicationUri: makeApplicationUrn(hostname(), name),
+        dns: [os.hostname()]
+    });
+}
+
+describe("Certificate rotation with a connected client (CA-chain trust)", function (this: Mocha.Suite) {
+    this.timeout(Math.max(this.timeout(), 60_000));
+
+    it("RCC1: the client's session survives a push-cert-management rotation, and the reconnected channel renews correctly with the new CA-signed pair", async () => {
+        await CertificateManager.disposeAll();
+        const folder = await initializeHelpers("RCC", 1);
+        const ca = await getSharedCertificateAuthority();
+        const { certificate: caCertificate, crl } = await _getFakeAuthorityCertificate(folder);
+
+        // --- client: self-signed is fine here, the point under test is the
+        //     server's certificate; the client just needs to trust the CA + CRL.
+        const clientPki = path.join(folder, "ClientPKI");
+        fs.mkdirSync(clientPki, { recursive: true });
+        const clientCertificateManager = new OPCUACertificateManager({
+            rootFolder: clientPki,
+            disableFileWatchers: true
+        });
+        await clientCertificateManager.initialize();
+        const clientCertificateFile = path.join(clientCertificateManager.rootDir, "own/certs/certificate.pem");
+        await clientCertificateManager.createSelfSignedCertificate({
+            applicationUri: makeApplicationUrn(hostname(), "NodeOPCUA-Client"),
+            subject: "/CN=RCC-Client",
+            dns: [os.hostname()],
+            ip: [],
+            startDate: new Date(),
+            validity: 365,
+            outputFile: clientCertificateFile
+        });
+        await clientCertificateManager.addIssuer(caCertificate, false, true);
+        await clientCertificateManager.addRevocationList(crl);
+        await clientCertificateManager.trustCertificate(caCertificate);
+
+        // --- server: certificate is CA-signed from the very first start —
+        //     never self-signed, so the client only ever needs CA + CRL trust.
+        const serverPki = path.join(folder, "ServerPKI");
+        fs.mkdirSync(serverPki, { recursive: true });
+        const serverCertificateManager = new OPCUACertificateManager({
+            rootFolder: serverPki,
+            disableFileWatchers: true
+        });
+        await serverCertificateManager.initialize();
+        await serverCertificateManager.addIssuer(caCertificate, false, true);
+        await serverCertificateManager.addRevocationList(crl);
+        await serverCertificateManager.trustCertificate(caCertificate);
+
+        const serverCertificateFile = path.join(serverCertificateManager.rootDir, "own/certs/certificate.pem");
+        await issueCASignedCertificate(ca, serverCertificateManager, "RCC-Server", serverCertificateFile);
+
+        // trust the client's certificate explicitly (no auto-accept on either side)
+        const clientCertificatePEM = await fs.promises.readFile(clientCertificateFile, "utf8");
+        const { convertPEMtoDER } = await import("node-opcua-crypto");
+        await serverCertificateManager.trustCertificate(convertPEMtoDER(clientCertificatePEM));
+
+        const applicationUri = makeApplicationUrn(hostname(), "RCC-Server");
+        const mockUserManager = {
+            isValidUser: (userName: string, password: string) => userName === "admin" && password === "secret",
+            getUserRoles(username: string): NodeId[] {
+                if (username === "admin") {
+                    return makeRoles("AuthenticatedUser;SecurityAdmin");
+                }
+                return makeRoles("Anonymous");
+            }
+        };
+
+        const server = new OPCUAServer({
+            port,
+            serverInfo: { applicationUri },
+            userManager: mockUserManager,
+            serverCertificateManager,
+            securityModes: [MessageSecurityMode.SignAndEncrypt],
+            securityPolicies: [SecurityPolicy.Basic256Sha256]
+        });
+        await server.initialize();
+        await installPushCertificateManagementOnServer(server);
+
+        const certificateBeforeThumb = makeSHA1Thumbprint(server.getCertificate()).toString("hex");
+
+        await server.start();
+        let client: OPCUAClient | undefined;
+        let session: ClientSession | undefined;
+        try {
+            const endpointUrl = server.getEndpointUrl();
+
+            client = OPCUAClient.create({
+                clientCertificateManager,
+                certificateFile: clientCertificateFile,
+                securityMode: MessageSecurityMode.SignAndEncrypt,
+                securityPolicy: SecurityPolicy.Basic256Sha256,
+                clientName: "RCC-client",
+                // force a channel renewal shortly after (re)connection, instead
+                // of waiting out the default token lifetime, so the test can
+                // observe a post-rotation Renew without an artificially long run.
+                tokenRenewalInterval: 1500
+            });
+
+            let renewedCount = 0;
+            client.on("security_token_renewed", () => {
+                renewedCount++;
+            });
+            let reconnected = false;
+            client.on("connection_reestablished", () => {
+                reconnected = true;
+            });
+
+            await client.connect(endpointUrl);
+            const userIdentityToken: UserIdentityInfoUserName = {
+                type: UserTokenType.UserName,
+                userName: "admin",
+                password: "secret"
+            };
+            session = await client.createSession(userIdentityToken);
+            const sessionIdBefore = session.sessionId;
+
+            const before = await session.read({ nodeId: "ns=0;i=2258", attributeId: AttributeIds.Value });
+            before.statusCode.isGood().should.eql(true, "expecting a Good read before rotation");
+
+            // --- rotate: request a new keypair + CSR from the server's own
+            //     certificate manager, CA-sign it, and push it back.
+            const pm = new ClientPushCertificateManagement(session);
+            const csrResponse = await pm.createSigningRequest(
+                "DefaultApplicationGroup",
+                NodeId.nullNodeId,
+                null,
+                true,
+                randomBytes(32)
+            );
+            if (csrResponse.statusCode.isNotGood() || !csrResponse.certificateSigningRequest) {
+                throw new Error(`createSigningRequest failed: ${csrResponse.statusCode.toString()}`);
+            }
+            const newChain = await produceCertificate(folder, csrResponse.certificateSigningRequest);
+            const newCertificate = newChain[0];
+            const issuerCertificates = newChain.slice(1);
+
+            const updateResponse = await pm.updateCertificate(
+                "DefaultApplicationGroup",
+                NodeId.nullNodeId,
+                newCertificate,
+                issuerCertificates
+            );
+            if (updateResponse.statusCode.isNotGood()) {
+                throw new Error(`updateCertificate failed: ${updateResponse.statusCode.toString()}`);
+            }
+            await pm.applyChanges();
+
+            // The rotation forces the current channel closed; give the client's
+            // own auto-reconnect logic time to re-establish a new one, transfer
+            // the session onto it, and — thanks to the short tokenRenewalInterval
+            // — go through at least one Renew on that new channel.
+            const deadline = Date.now() + 20_000;
+            while ((!reconnected || renewedCount < 1) && Date.now() < deadline) {
+                await new Promise((resolve) => setTimeout(resolve, 250));
+            }
+            reconnected.should.eql(true, "expecting the client to have reconnected automatically after the rotation");
+            renewedCount.should.be.aboveOrEqual(
+                1,
+                "expecting at least one successful channel renewal on the reconnected channel, using the new pair"
+            );
+
+            // The caller's own `session` object — the same JS reference used
+            // before the rotation, never replaced by any reconnection code in
+            // this test — must still work: whether the client library
+            // reactivated the pre-existing OPC UA session or transparently
+            // recreated one and re-subscribed underneath it, the application
+            // never lost its logical connection and never had to intervene.
+            if (session.sessionId.toString() !== sessionIdBefore.toString()) {
+                console.log(
+                    "note: the underlying OPC UA session was recreated during reconnection",
+                    `(${sessionIdBefore.toString()} -> ${session.sessionId.toString()})`,
+                    "— the client-side session object is unaffected."
+                );
+            }
+
+            const after = await session.read({ nodeId: "ns=0;i=2258", attributeId: AttributeIds.Value });
+            after.statusCode.isGood().should.eql(true, "expecting a Good read after rotation + renewal");
+
+            const certificateAfterThumb = makeSHA1Thumbprint(server.getCertificate()).toString("hex");
+            certificateAfterThumb.should.not.eql(certificateBeforeThumb, "server certificate should have changed");
+
+            const chainOnDisk = readCertificateChain(serverCertificateFile);
+            chainOnDisk.length.should.be.aboveOrEqual(2, "certificate.pem should contain the leaf and the CA");
+        } finally {
+            if (session) {
+                await session.close().catch(() => {
+                    /* channel may already be gone */
+                });
+            }
+            if (client) {
+                await client.disconnect();
+            }
+            await server.shutdown();
+        }
+    });
+});

--- a/packages/node-opcua-server-configuration/test/server/test_certificate_rotation_with_connected_client.ts
+++ b/packages/node-opcua-server-configuration/test/server/test_certificate_rotation_with_connected_client.ts
@@ -1,7 +1,7 @@
 /**
- * Certificate rotation via push certificate management while a client is
- * connected, using a CA-issued certificate chain on both the server's
- * initial and rotated certificates.
+ * Certificate + private key rotation via push certificate management while
+ * a client is connected, using a CA-issued certificate chain on both the
+ * server's initial and rotated certificates.
  *
  * Because the client trusts the CA + CRL once (rather than each individual
  * certificate, or blanket-accepting anything unknown), it accepts the
@@ -9,23 +9,27 @@
  * step is needed for the new pair. This is the realistic shape of a
  * production push-certificate-management deployment.
  *
- * Proves that:
- *  - the client's session survives the rotation: push certificate
- *    management forces the old channel closed (`ApplyChanges` →
- *    `shutdownChannels()`), the client's own reconnection logic
- *    re-establishes a new channel (first attempt is rejected because the
- *    client still addresses the server's old certificate; it then
- *    re-fetches the current one and succeeds), and the *existing* OPC UA
- *    session is reactivated on that new channel — same sessionId, no
- *    CreateSession — so the caller never loses its logical connection;
- *  - once reconnected, the new channel's OpenSecureChannel *Renew* (not
- *    just the initial handshake) succeeds using the rotated pair — i.e.
- *    the new certificate and private key are fully consistent, not merely
- *    good enough for a single exchange.
+ * Two cases, differing only in `closeChannelsOnApplyChanges`:
  *
- * Note: the client never Renews on the *original* channel across the
- * rotation — push certificate management shuts it down first. Renewing
- * a live channel across a key rotation is a separate scenario.
+ *  RCC1 — default (`true`): `ApplyChanges` shuts every existing channel
+ *    down at once. The client reconnects immediately (first attempt is
+ *    rejected because it still addresses the server's old certificate; it
+ *    re-fetches the current one and succeeds), the *existing* OPC UA
+ *    session is reactivated on the new channel — same sessionId, no
+ *    CreateSession — and Renews on that new channel succeed with the
+ *    rotated pair.
+ *
+ *  RCC2 — `false`: `ApplyChanges` leaves existing channels alone. The
+ *    client keeps working on its old channel (old symmetric keys) after
+ *    the rotation; its next OpenSecureChannel *Renew* is rejected by the
+ *    server (old certificate addressed) and the channel closed, and only
+ *    then does it reconnect — again reactivating the same session. The
+ *    rotation is deferred, not seamless.
+ *
+ * In neither case does a Renew *succeed* on the original channel across
+ * the rotation: that would need the server to accept its previous
+ * certificate/key for a grace period and the client to adopt the new
+ * certificate from the Renew response — a separate scenario.
  */
 import fs from "node:fs";
 import os, { hostname } from "node:os";
@@ -42,7 +46,7 @@ import {
     SecurityPolicy,
     type UserIdentityInfoUserName
 } from "node-opcua-client";
-import { makeSHA1Thumbprint, readCertificateChain } from "node-opcua-crypto";
+import { convertPEMtoDER, makeSHA1Thumbprint, readCertificateChain } from "node-opcua-crypto";
 import { AttributeIds } from "node-opcua-data-model";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { NodeId } from "node-opcua-nodeid";
@@ -50,7 +54,11 @@ import type { CertificateAuthority } from "node-opcua-pki";
 import { OPCUAServer } from "node-opcua-server";
 import { UserTokenType } from "node-opcua-types";
 import { randomBytes } from "node-opcua-utils";
-import { ClientPushCertificateManagement, installPushCertificateManagementOnServer } from "../../dist/index.js";
+import {
+    ClientPushCertificateManagement,
+    type InstallPushCertificateManagementOnServerOptions,
+    installPushCertificateManagementOnServer
+} from "../../dist/index.js";
 import {
     _getFakeAuthorityCertificate,
     getSharedCertificateAuthority,
@@ -58,9 +66,26 @@ import {
     produceCertificate
 } from "../helpers/fake_certificate_authority.js";
 
-const port = 20117;
+const portRCC1 = 20117;
+const portRCC2 = 20118;
 
-/** Issue a CA-signed leaf certificate directly into `mgr`'s own cert folder, before `initialize()`/`server.initialize()` ever runs — so the manager never has a self-signed certificate to begin with. */
+const adminIdentity: UserIdentityInfoUserName = {
+    type: UserTokenType.UserName,
+    userName: "admin",
+    password: "secret"
+};
+
+const mockUserManager = {
+    isValidUser: (userName: string, password: string) => userName === "admin" && password === "secret",
+    getUserRoles(username: string): NodeId[] {
+        if (username === "admin") {
+            return makeRoles("AuthenticatedUser;SecurityAdmin");
+        }
+        return makeRoles("Anonymous");
+    }
+};
+
+/** Issue a CA-signed leaf certificate directly into `mgr`'s own cert folder, before the server ever starts — so the manager never has a self-signed certificate to begin with. */
 async function issueCASignedCertificate(
     ca: CertificateAuthority,
     mgr: OPCUACertificateManager,
@@ -79,101 +104,142 @@ async function issueCASignedCertificate(
     });
 }
 
+interface Fixture {
+    folder: string;
+    clientCertificateManager: OPCUACertificateManager;
+    clientCertificateFile: string;
+    serverCertificateManager: OPCUACertificateManager;
+    serverCertificateFile: string;
+    applicationUri: string;
+}
+
+/**
+ * One CA, trusted (issuer + CRL) by both sides. Client: self-signed
+ * (its certificate is not what's under test), explicitly trusted by the
+ * server. Server: CA-signed from the very first start.
+ */
+async function setUpFixture(name: string): Promise<Fixture> {
+    await CertificateManager.disposeAll();
+    const folder = await initializeHelpers(name, 1);
+    const ca = await getSharedCertificateAuthority();
+    const { certificate: caCertificate, crl } = await _getFakeAuthorityCertificate(folder);
+
+    const clientPki = path.join(folder, "ClientPKI");
+    fs.mkdirSync(clientPki, { recursive: true });
+    const clientCertificateManager = new OPCUACertificateManager({ rootFolder: clientPki, disableFileWatchers: true });
+    await clientCertificateManager.initialize();
+    const clientCertificateFile = path.join(clientCertificateManager.rootDir, "own/certs/certificate.pem");
+    await clientCertificateManager.createSelfSignedCertificate({
+        applicationUri: makeApplicationUrn(hostname(), "NodeOPCUA-Client"),
+        subject: "/CN=RCC-Client",
+        dns: [os.hostname()],
+        ip: [],
+        startDate: new Date(),
+        validity: 365,
+        outputFile: clientCertificateFile
+    });
+    await clientCertificateManager.addIssuer(caCertificate, false, true);
+    await clientCertificateManager.addRevocationList(crl);
+    await clientCertificateManager.trustCertificate(caCertificate);
+
+    const serverPki = path.join(folder, "ServerPKI");
+    fs.mkdirSync(serverPki, { recursive: true });
+    const serverCertificateManager = new OPCUACertificateManager({ rootFolder: serverPki, disableFileWatchers: true });
+    await serverCertificateManager.initialize();
+    await serverCertificateManager.addIssuer(caCertificate, false, true);
+    await serverCertificateManager.addRevocationList(crl);
+    await serverCertificateManager.trustCertificate(caCertificate);
+
+    const serverCertificateFile = path.join(serverCertificateManager.rootDir, "own/certs/certificate.pem");
+    await issueCASignedCertificate(ca, serverCertificateManager, "RCC-Server", serverCertificateFile);
+
+    const clientCertificatePEM = await fs.promises.readFile(clientCertificateFile, "utf8");
+    await serverCertificateManager.trustCertificate(convertPEMtoDER(clientCertificatePEM));
+
+    return {
+        folder,
+        clientCertificateManager,
+        clientCertificateFile,
+        serverCertificateManager,
+        serverCertificateFile,
+        applicationUri: makeApplicationUrn(hostname(), "RCC-Server")
+    };
+}
+
+async function startServer(
+    fixture: Fixture,
+    port: number,
+    installOptions?: InstallPushCertificateManagementOnServerOptions
+): Promise<OPCUAServer> {
+    const server = new OPCUAServer({
+        port,
+        serverInfo: { applicationUri: fixture.applicationUri },
+        userManager: mockUserManager,
+        serverCertificateManager: fixture.serverCertificateManager,
+        securityModes: [MessageSecurityMode.SignAndEncrypt],
+        securityPolicies: [SecurityPolicy.Basic256Sha256]
+    });
+    await server.initialize();
+    await installPushCertificateManagementOnServer(server, installOptions);
+    await server.start();
+    return server;
+}
+
+/** Request a new key pair + CSR from the server's own certificate manager, CA-sign it, push it back, apply. */
+async function rotateServerKeyPairAndCertificate(session: ClientSession, folder: string): Promise<void> {
+    const pm = new ClientPushCertificateManagement(session);
+    const csrResponse = await pm.createSigningRequest(
+        "DefaultApplicationGroup",
+        NodeId.nullNodeId,
+        null,
+        /* regeneratePrivateKey */ true,
+        randomBytes(32)
+    );
+    if (csrResponse.statusCode.isNotGood() || !csrResponse.certificateSigningRequest) {
+        throw new Error(`createSigningRequest failed: ${csrResponse.statusCode.toString()}`);
+    }
+    const newChain = await produceCertificate(folder, csrResponse.certificateSigningRequest);
+    const updateResponse = await pm.updateCertificate("DefaultApplicationGroup", NodeId.nullNodeId, newChain[0], newChain.slice(1));
+    if (updateResponse.statusCode.isNotGood()) {
+        throw new Error(`updateCertificate failed: ${updateResponse.statusCode.toString()}`);
+    }
+    await pm.applyChanges();
+}
+
+async function readServerTime(session: ClientSession): Promise<void> {
+    const dv = await session.read({ nodeId: "ns=0;i=2258", attributeId: AttributeIds.Value });
+    dv.statusCode.isGood().should.eql(true, "expecting a Good read");
+}
+
+async function waitUntil(cond: () => boolean, timeoutMs: number): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (!cond() && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+}
+
 describe("Certificate rotation with a connected client (CA-chain trust)", function (this: Mocha.Suite) {
-    this.timeout(Math.max(this.timeout(), 60_000));
+    this.timeout(Math.max(this.timeout(), 90_000));
 
-    it("RCC1: the client's session survives a push-cert-management rotation, and the reconnected channel renews correctly with the new CA-signed pair", async () => {
-        await CertificateManager.disposeAll();
-        const folder = await initializeHelpers("RCC", 1);
-        const ca = await getSharedCertificateAuthority();
-        const { certificate: caCertificate, crl } = await _getFakeAuthorityCertificate(folder);
-
-        // --- client: self-signed is fine here, the point under test is the
-        //     server's certificate; the client just needs to trust the CA + CRL.
-        const clientPki = path.join(folder, "ClientPKI");
-        fs.mkdirSync(clientPki, { recursive: true });
-        const clientCertificateManager = new OPCUACertificateManager({
-            rootFolder: clientPki,
-            disableFileWatchers: true
-        });
-        await clientCertificateManager.initialize();
-        const clientCertificateFile = path.join(clientCertificateManager.rootDir, "own/certs/certificate.pem");
-        await clientCertificateManager.createSelfSignedCertificate({
-            applicationUri: makeApplicationUrn(hostname(), "NodeOPCUA-Client"),
-            subject: "/CN=RCC-Client",
-            dns: [os.hostname()],
-            ip: [],
-            startDate: new Date(),
-            validity: 365,
-            outputFile: clientCertificateFile
-        });
-        await clientCertificateManager.addIssuer(caCertificate, false, true);
-        await clientCertificateManager.addRevocationList(crl);
-        await clientCertificateManager.trustCertificate(caCertificate);
-
-        // --- server: certificate is CA-signed from the very first start —
-        //     never self-signed, so the client only ever needs CA + CRL trust.
-        const serverPki = path.join(folder, "ServerPKI");
-        fs.mkdirSync(serverPki, { recursive: true });
-        const serverCertificateManager = new OPCUACertificateManager({
-            rootFolder: serverPki,
-            disableFileWatchers: true
-        });
-        await serverCertificateManager.initialize();
-        await serverCertificateManager.addIssuer(caCertificate, false, true);
-        await serverCertificateManager.addRevocationList(crl);
-        await serverCertificateManager.trustCertificate(caCertificate);
-
-        const serverCertificateFile = path.join(serverCertificateManager.rootDir, "own/certs/certificate.pem");
-        await issueCASignedCertificate(ca, serverCertificateManager, "RCC-Server", serverCertificateFile);
-
-        // trust the client's certificate explicitly (no auto-accept on either side)
-        const clientCertificatePEM = await fs.promises.readFile(clientCertificateFile, "utf8");
-        const { convertPEMtoDER } = await import("node-opcua-crypto");
-        await serverCertificateManager.trustCertificate(convertPEMtoDER(clientCertificatePEM));
-
-        const applicationUri = makeApplicationUrn(hostname(), "RCC-Server");
-        const mockUserManager = {
-            isValidUser: (userName: string, password: string) => userName === "admin" && password === "secret",
-            getUserRoles(username: string): NodeId[] {
-                if (username === "admin") {
-                    return makeRoles("AuthenticatedUser;SecurityAdmin");
-                }
-                return makeRoles("Anonymous");
-            }
-        };
-
-        const server = new OPCUAServer({
-            port,
-            serverInfo: { applicationUri },
-            userManager: mockUserManager,
-            serverCertificateManager,
-            securityModes: [MessageSecurityMode.SignAndEncrypt],
-            securityPolicies: [SecurityPolicy.Basic256Sha256]
-        });
-        await server.initialize();
-        await installPushCertificateManagementOnServer(server);
-
+    it("RCC1: closeChannelsOnApplyChanges (default) — the client reconnects at once, the same session is reactivated, and the new channel renews with the new pair", async () => {
+        const fixture = await setUpFixture("RCC1");
+        const server = await startServer(fixture, portRCC1);
         const certificateBeforeThumb = makeSHA1Thumbprint(server.getCertificate()).toString("hex");
 
-        await server.start();
         let client: OPCUAClient | undefined;
         let session: ClientSession | undefined;
         try {
-            const endpointUrl = server.getEndpointUrl();
-
             client = OPCUAClient.create({
-                clientCertificateManager,
-                certificateFile: clientCertificateFile,
+                clientCertificateManager: fixture.clientCertificateManager,
+                certificateFile: fixture.clientCertificateFile,
                 securityMode: MessageSecurityMode.SignAndEncrypt,
                 securityPolicy: SecurityPolicy.Basic256Sha256,
-                clientName: "RCC-client",
-                // force a channel renewal shortly after (re)connection, instead
-                // of waiting out the default token lifetime, so the test can
-                // observe a post-rotation Renew without an artificially long run.
+                clientName: "RCC1-client",
+                // Renew shortly after (re)connection instead of waiting out the
+                // default token lifetime, so a post-rotation Renew on the new
+                // channel is observable within the test.
                 tokenRenewalInterval: 1500
             });
-
             let renewedCount = 0;
             client.on("security_token_renewed", () => {
                 renewedCount++;
@@ -183,94 +249,105 @@ describe("Certificate rotation with a connected client (CA-chain trust)", functi
                 reconnected = true;
             });
 
-            await client.connect(endpointUrl);
-            const userIdentityToken: UserIdentityInfoUserName = {
-                type: UserTokenType.UserName,
-                userName: "admin",
-                password: "secret"
-            };
-            session = await client.createSession(userIdentityToken);
+            await client.connect(server.getEndpointUrl());
+            session = await client.createSession(adminIdentity);
             const sessionIdBefore = session.sessionId;
+            await readServerTime(session);
 
-            const before = await session.read({ nodeId: "ns=0;i=2258", attributeId: AttributeIds.Value });
-            before.statusCode.isGood().should.eql(true, "expecting a Good read before rotation");
+            await rotateServerKeyPairAndCertificate(session, fixture.folder);
 
-            // --- rotate: request a new keypair + CSR from the server's own
-            //     certificate manager, CA-sign it, and push it back.
-            const pm = new ClientPushCertificateManagement(session);
-            const csrResponse = await pm.createSigningRequest(
-                "DefaultApplicationGroup",
-                NodeId.nullNodeId,
-                null,
-                true,
-                randomBytes(32)
-            );
-            if (csrResponse.statusCode.isNotGood() || !csrResponse.certificateSigningRequest) {
-                throw new Error(`createSigningRequest failed: ${csrResponse.statusCode.toString()}`);
-            }
-            const newChain = await produceCertificate(folder, csrResponse.certificateSigningRequest);
-            const newCertificate = newChain[0];
-            const issuerCertificates = newChain.slice(1);
-
-            const updateResponse = await pm.updateCertificate(
-                "DefaultApplicationGroup",
-                NodeId.nullNodeId,
-                newCertificate,
-                issuerCertificates
-            );
-            if (updateResponse.statusCode.isNotGood()) {
-                throw new Error(`updateCertificate failed: ${updateResponse.statusCode.toString()}`);
-            }
-            await pm.applyChanges();
-
-            // The rotation forces the current channel closed; give the client's
-            // own auto-reconnect logic time to re-establish a new one, transfer
-            // the session onto it, and — thanks to the short tokenRenewalInterval
-            // — go through at least one Renew on that new channel.
-            const deadline = Date.now() + 20_000;
-            while ((!reconnected || renewedCount < 1) && Date.now() < deadline) {
-                await new Promise((resolve) => setTimeout(resolve, 250));
-            }
+            await waitUntil(() => reconnected && renewedCount >= 1, 20_000);
             reconnected.should.eql(true, "expecting the client to have reconnected automatically after the rotation");
-            renewedCount.should.be.aboveOrEqual(
-                1,
-                "expecting at least one successful channel renewal on the reconnected channel, using the new pair"
-            );
+            renewedCount.should.be.aboveOrEqual(1, "expecting at least one Renew on the reconnected channel, with the new pair");
 
-            // The existing OPC UA session must have been *reactivated* on the
-            // new channel (ActivateSession with the same authenticationToken),
-            // not torn down and recreated: the sessionId must be unchanged.
-            //
-            // Regression guard: before the fix in OPCUAClientImpl._activateSession,
-            // the client signed the reactivation request (and encrypted the
-            // user token) against session.serverCertificate as captured at the
-            // original CreateSession — i.e. the server's *old* certificate —
-            // so the server rejected it with BadApplicationSignatureInvalid and
-            // the client silently fell back to creating a brand-new session.
+            // The existing session must have been *reactivated* on the new
+            // channel, not torn down and recreated. Regression guard for
+            // OPCUAClientImpl._activateSession signing against the stale
+            // session.serverCertificate (→ BadApplicationSignatureInvalid →
+            // silent CreateSession fallback).
             session.sessionId
                 .toString()
-                .should.eql(
-                    sessionIdBefore.toString(),
-                    "the existing session must be reactivated on the new channel, not recreated"
-                );
+                .should.eql(sessionIdBefore.toString(), "the existing session must be reactivated, not recreated");
 
-            const after = await session.read({ nodeId: "ns=0;i=2258", attributeId: AttributeIds.Value });
-            after.statusCode.isGood().should.eql(true, "expecting a Good read after rotation + renewal");
+            await readServerTime(session);
 
-            const certificateAfterThumb = makeSHA1Thumbprint(server.getCertificate()).toString("hex");
-            certificateAfterThumb.should.not.eql(certificateBeforeThumb, "server certificate should have changed");
-
-            const chainOnDisk = readCertificateChain(serverCertificateFile);
-            chainOnDisk.length.should.be.aboveOrEqual(2, "certificate.pem should contain the leaf and the CA");
+            makeSHA1Thumbprint(server.getCertificate())
+                .toString("hex")
+                .should.not.eql(certificateBeforeThumb, "server certificate should have changed");
+            readCertificateChain(fixture.serverCertificateFile).length.should.be.aboveOrEqual(
+                2,
+                "certificate.pem should contain the leaf and the CA"
+            );
         } finally {
-            if (session) {
-                await session.close().catch(() => {
-                    /* channel may already be gone */
-                });
-            }
-            if (client) {
-                await client.disconnect();
-            }
+            await session?.close().catch(() => {
+                /* channel may already be gone */
+            });
+            await client?.disconnect();
+            await server.shutdown();
+        }
+    });
+
+    it("RCC2: closeChannelsOnApplyChanges: false — the client keeps working on its old channel, is disconnected only at its next Renew, then reactivates the same session", async () => {
+        const fixture = await setUpFixture("RCC2");
+        const server = await startServer(fixture, portRCC2, { closeChannelsOnApplyChanges: false });
+
+        let client: OPCUAClient | undefined;
+        let session: ClientSession | undefined;
+        try {
+            // Renew interval comfortably longer than the rotation itself
+            // (~1–2 s), so the post-ApplyChanges checks land while the old
+            // channel is still alive, and the failing Renew comes after.
+            const tokenRenewalInterval = 5000;
+            client = OPCUAClient.create({
+                clientCertificateManager: fixture.clientCertificateManager,
+                certificateFile: fixture.clientCertificateFile,
+                securityMode: MessageSecurityMode.SignAndEncrypt,
+                securityPolicy: SecurityPolicy.Basic256Sha256,
+                clientName: "RCC2-client",
+                tokenRenewalInterval
+            });
+            let lostCount = 0;
+            let reestablishedCount = 0;
+            client.on("connection_lost", () => {
+                lostCount++;
+            });
+            client.on("connection_reestablished", () => {
+                reestablishedCount++;
+            });
+
+            await client.connect(server.getEndpointUrl());
+            session = await client.createSession(adminIdentity);
+            const sessionIdBefore = session.sessionId;
+            await readServerTime(session);
+            server.currentChannelCount.should.eql(1);
+
+            await rotateServerKeyPairAndCertificate(session, fixture.folder);
+            // let the fire-and-forget onApplyChangesCompleted run
+            await new Promise((resolve) => setTimeout(resolve, 200));
+
+            // --- the channel was NOT shut down: server still holds it, the
+            //     client saw no disconnection, and the session still works
+            //     over the old channel (old symmetric keys).
+            server.currentChannelCount.should.eql(1, "existing channel must survive ApplyChanges");
+            lostCount.should.eql(0, "client must not have been disconnected by ApplyChanges");
+            await readServerTime(session);
+
+            // --- the next Renew on that old channel is rejected by the server
+            //     (client still addresses the old certificate) and the channel
+            //     closed; the client then reconnects and reactivates the
+            //     same session.
+            await waitUntil(() => lostCount >= 1 && reestablishedCount >= 1, tokenRenewalInterval + 20_000);
+            lostCount.should.eql(1, "expecting exactly one disconnection, at the failed Renew");
+            reestablishedCount.should.eql(1, "expecting the client to have reconnected once");
+            session.sessionId
+                .toString()
+                .should.eql(sessionIdBefore.toString(), "the existing session must be reactivated, not recreated");
+            await readServerTime(session);
+        } finally {
+            await session?.close().catch(() => {
+                /* channel may already be gone */
+            });
+            await client?.disconnect();
             await server.shutdown();
         }
     });

--- a/packages/node-opcua-server-configuration/test/server/test_certificate_rotation_with_connected_client.ts
+++ b/packages/node-opcua-server-configuration/test/server/test_certificate_rotation_with_connected_client.ts
@@ -19,17 +19,16 @@
  *    CreateSession — and Renews on that new channel succeed with the
  *    rotated pair.
  *
- *  RCC2 — `false`: `ApplyChanges` leaves existing channels alone. The
- *    client keeps working on its old channel (old symmetric keys) after
- *    the rotation; its next OpenSecureChannel *Renew* is rejected by the
- *    server (old certificate addressed) and the channel closed, and only
- *    then does it reconnect — again reactivating the same session. The
- *    rotation is deferred, not seamless.
- *
- * In neither case does a Renew *succeed* on the original channel across
- * the rotation: that would need the server to accept its previous
- * certificate/key for a grace period and the client to adopt the new
- * certificate from the Renew response — a separate scenario.
+ *  RCC2 — `false`: `ApplyChanges` leaves existing channels alone, and the
+ *    rotation is **seamless** for them. Each server channel is bound to
+ *    the certificate/key pair it was created with (OPC UA Part 6 §6.7.2:
+ *    the thumbprint check is against "the Certificate it is using for the
+ *    SecureChannel"; §6.7.4: the client shall close the channel if a
+ *    response is signed with a different certificate than the request was
+ *    encrypted to — so the bound pair is the only conformant answer), so
+ *    OpenSecureChannel *Renews* on the original channel keep succeeding
+ *    after the rotation: the connected client is never disconnected and
+ *    never even notices. New connections are served the new certificate.
  */
 import fs from "node:fs";
 import os, { hostname } from "node:os";
@@ -46,7 +45,7 @@ import {
     SecurityPolicy,
     type UserIdentityInfoUserName
 } from "node-opcua-client";
-import { convertPEMtoDER, makeSHA1Thumbprint, readCertificateChain } from "node-opcua-crypto";
+import { convertPEMtoDER, makeSHA1Thumbprint, readCertificateChain, split_der } from "node-opcua-crypto";
 import { AttributeIds } from "node-opcua-data-model";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { NodeId } from "node-opcua-nodeid";
@@ -287,32 +286,31 @@ describe("Certificate rotation with a connected client (CA-chain trust)", functi
         }
     });
 
-    it("RCC2: closeChannelsOnApplyChanges: false — the client keeps working on its old channel, is disconnected only at its next Renew, then reactivates the same session", async () => {
+    it("RCC2: closeChannelsOnApplyChanges: false — the rotation is seamless: the connected client renews on its original channel with no disconnection, while a new client gets the new certificate", async () => {
         const fixture = await setUpFixture("RCC2");
         const server = await startServer(fixture, portRCC2, { closeChannelsOnApplyChanges: false });
+        const oldCertificateThumb = makeSHA1Thumbprint(server.getCertificate()).toString("hex");
 
         let client: OPCUAClient | undefined;
         let session: ClientSession | undefined;
         try {
-            // Renew interval comfortably longer than the rotation itself
-            // (~1–2 s), so the post-ApplyChanges checks land while the old
-            // channel is still alive, and the failing Renew comes after.
-            const tokenRenewalInterval = 5000;
             client = OPCUAClient.create({
                 clientCertificateManager: fixture.clientCertificateManager,
                 certificateFile: fixture.clientCertificateFile,
                 securityMode: MessageSecurityMode.SignAndEncrypt,
                 securityPolicy: SecurityPolicy.Basic256Sha256,
                 clientName: "RCC2-client",
-                tokenRenewalInterval
+                // renew fast so several post-rotation Renews on the ORIGINAL
+                // channel are observable within the test
+                tokenRenewalInterval: 1500
             });
             let lostCount = 0;
-            let reestablishedCount = 0;
+            let renewedCount = 0;
             client.on("connection_lost", () => {
                 lostCount++;
             });
-            client.on("connection_reestablished", () => {
-                reestablishedCount++;
+            client.on("security_token_renewed", () => {
+                renewedCount++;
             });
 
             await client.connect(server.getEndpointUrl());
@@ -326,22 +324,52 @@ describe("Certificate rotation with a connected client (CA-chain trust)", functi
             await new Promise((resolve) => setTimeout(resolve, 200));
 
             // --- the channel was NOT shut down: server still holds it, the
-            //     client saw no disconnection, and the session still works
-            //     over the old channel (old symmetric keys).
+            //     client saw no disconnection, and the session still works.
             server.currentChannelCount.should.eql(1, "existing channel must survive ApplyChanges");
             lostCount.should.eql(0, "client must not have been disconnected by ApplyChanges");
             await readServerTime(session);
 
-            // --- the next Renew on that old channel is rejected by the server
-            //     (client still addresses the old certificate) and the channel
-            //     closed; the client then reconnects and reactivates the
-            //     same session.
-            await waitUntil(() => lostCount >= 1 && reestablishedCount >= 1, tokenRenewalInterval + 20_000);
-            lostCount.should.eql(1, "expecting exactly one disconnection, at the failed Renew");
-            reestablishedCount.should.eql(1, "expecting the client to have reconnected once");
-            session.sessionId
-                .toString()
-                .should.eql(sessionIdBefore.toString(), "the existing session must be reactivated, not recreated");
+            // --- seamlessness: OpenSecureChannel *Renews* on the ORIGINAL
+            //     channel keep succeeding after the rotation. The channel is
+            //     bound to the certificate/key pair it was created with
+            //     (Part 6 §6.7.2/§6.7.4), so the unmodified client — which
+            //     still encrypts to, and verifies against, the old
+            //     certificate — renews without ever noticing the rotation.
+            const renewedAtRotation = renewedCount;
+            await waitUntil(() => renewedCount >= renewedAtRotation + 2 || lostCount > 0, 20_000);
+            lostCount.should.eql(0, "the client must never be disconnected — Renews succeed on the original channel");
+            renewedCount.should.be.aboveOrEqual(
+                renewedAtRotation + 2,
+                "expecting at least two successful Renews on the original channel after the rotation"
+            );
+            session.sessionId.toString().should.eql(sessionIdBefore.toString(), "same session throughout — nothing was recreated");
+            await readServerTime(session);
+
+            // --- meanwhile a NEW client connecting now gets the NEW
+            //     certificate (accepted via the already-trusted CA + CRL).
+            const client2 = OPCUAClient.create({
+                clientCertificateManager: fixture.clientCertificateManager,
+                certificateFile: fixture.clientCertificateFile,
+                securityMode: MessageSecurityMode.SignAndEncrypt,
+                securityPolicy: SecurityPolicy.Basic256Sha256,
+                clientName: "RCC2-client2"
+            });
+            await client2.connect(server.getEndpointUrl());
+            try {
+                const seen = client2.serverCertificate!;
+                const seenLeaf = Array.isArray(seen) ? seen[0] : split_der(seen)[0];
+                makeSHA1Thumbprint(seenLeaf)
+                    .toString("hex")
+                    .should.not.eql(oldCertificateThumb, "a new client must be served the rotated certificate");
+                const session2 = await client2.createSession(adminIdentity);
+                await readServerTime(session2);
+                await session2.close();
+            } finally {
+                await client2.disconnect();
+            }
+
+            // and the first client is STILL undisturbed
+            lostCount.should.eql(0);
             await readServerTime(session);
         } finally {
             await session?.close().catch(() => {

--- a/packages/node-opcua-server-configuration/test/server/test_certificate_rotation_with_connected_client.ts
+++ b/packages/node-opcua-server-configuration/test/server/test_certificate_rotation_with_connected_client.ts
@@ -10,20 +10,22 @@
  * production push-certificate-management deployment.
  *
  * Proves that:
- *  - the client's session survives the rotation from the *caller's*
- *    perspective: push certificate management forces the old channel
- *    closed (`ApplyChanges`), and the client's own reconnection logic
- *    re-establishes a new channel and gets the same `ClientSession` object
- *    working again — without the test ever calling `createSession()` a
- *    second time. (The underlying OPC UA session is not guaranteed to keep
- *    the same NodeId across this repair — reactivating it under the new
- *    channel can itself fail and fall back to transparently recreating one
- *    — but the caller's `session` reference and its subscriptions are
- *    unaffected either way.)
+ *  - the client's session survives the rotation: push certificate
+ *    management forces the old channel closed (`ApplyChanges` →
+ *    `shutdownChannels()`), the client's own reconnection logic
+ *    re-establishes a new channel (first attempt is rejected because the
+ *    client still addresses the server's old certificate; it then
+ *    re-fetches the current one and succeeds), and the *existing* OPC UA
+ *    session is reactivated on that new channel — same sessionId, no
+ *    CreateSession — so the caller never loses its logical connection;
  *  - once reconnected, the new channel's OpenSecureChannel *Renew* (not
  *    just the initial handshake) succeeds using the rotated pair — i.e.
  *    the new certificate and private key are fully consistent, not merely
  *    good enough for a single exchange.
+ *
+ * Note: the client never Renews on the *original* channel across the
+ * rotation — push certificate management shuts it down first. Renewing
+ * a live channel across a key rotation is a separate scenario.
  */
 import fs from "node:fs";
 import os, { hostname } from "node:os";
@@ -235,19 +237,22 @@ describe("Certificate rotation with a connected client (CA-chain trust)", functi
                 "expecting at least one successful channel renewal on the reconnected channel, using the new pair"
             );
 
-            // The caller's own `session` object — the same JS reference used
-            // before the rotation, never replaced by any reconnection code in
-            // this test — must still work: whether the client library
-            // reactivated the pre-existing OPC UA session or transparently
-            // recreated one and re-subscribed underneath it, the application
-            // never lost its logical connection and never had to intervene.
-            if (session.sessionId.toString() !== sessionIdBefore.toString()) {
-                console.log(
-                    "note: the underlying OPC UA session was recreated during reconnection",
-                    `(${sessionIdBefore.toString()} -> ${session.sessionId.toString()})`,
-                    "— the client-side session object is unaffected."
+            // The existing OPC UA session must have been *reactivated* on the
+            // new channel (ActivateSession with the same authenticationToken),
+            // not torn down and recreated: the sessionId must be unchanged.
+            //
+            // Regression guard: before the fix in OPCUAClientImpl._activateSession,
+            // the client signed the reactivation request (and encrypted the
+            // user token) against session.serverCertificate as captured at the
+            // original CreateSession — i.e. the server's *old* certificate —
+            // so the server rejected it with BadApplicationSignatureInvalid and
+            // the client silently fell back to creating a brand-new session.
+            session.sessionId
+                .toString()
+                .should.eql(
+                    sessionIdBefore.toString(),
+                    "the existing session must be reactivated on the new channel, not recreated"
                 );
-            }
 
             const after = await session.read({ nodeId: "ns=0;i=2258", attributeId: AttributeIds.Value });
             after.statusCode.isGood().should.eql(true, "expecting a Good read after rotation + renewal");

--- a/packages/node-opcua-server-configuration/test/server/test_push_certificate_management_with_passphrase.ts
+++ b/packages/node-opcua-server-configuration/test/server/test_push_certificate_management_with_passphrase.ts
@@ -1,0 +1,194 @@
+/**
+ * Push certificate management + privateKeyPassphrase.
+ *
+ * Proves that when the server's application-group certificate manager is
+ * configured with `privateKeyPassphrase`, a private key pushed via
+ * UpdateCertificate is written to disk already encrypted (never in clear,
+ * not even transiently), and that after ApplyChanges a new session still
+ * connects — server and every endpoint have re-resolved the encrypted key.
+ */
+import fs from "node:fs";
+import os, { hostname } from "node:os";
+import path from "node:path";
+
+import "should";
+import { makeRoles } from "node-opcua-address-space";
+import { CertificateManager, OPCUACertificateManager } from "node-opcua-certificate-manager";
+import { type ClientSession, makeApplicationUrn, OPCUAClient, type UserIdentityInfoUserName } from "node-opcua-client";
+import { convertPEMtoDER } from "node-opcua-crypto";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { NodeId } from "node-opcua-nodeid";
+import { nodesets } from "node-opcua-nodesets";
+import { MessageSecurityMode, SecurityPolicy } from "node-opcua-secure-channel";
+import { OPCUAServer } from "node-opcua-server";
+import { UserTokenType } from "node-opcua-types";
+import { ClientPushCertificateManagement, installPushCertificateManagementOnServer } from "../../dist/index.js";
+import {
+    _getFakeAuthorityCertificate,
+    initializeHelpers,
+    produceCertificateAndPrivateKey
+} from "../helpers/fake_certificate_authority.js";
+
+const { readFile } = fs.promises;
+
+const port = 20115;
+const passphrase = "push-cert-management-passphrase";
+
+describe("Push certificate management with a passphrase-protected server key", function (this: Mocha.Suite) {
+    this.timeout(Math.max(this.timeout(), 30_000));
+
+    let folder: string;
+    let clientCertificateFile = "";
+    let certificateManager: OPCUACertificateManager;
+    let clientCertificateManager: OPCUACertificateManager;
+    let server: OPCUAServer | undefined;
+
+    before(async () => {
+        await CertificateManager.disposeAll();
+
+        folder = await initializeHelpers("PPWD", 1);
+
+        const fakeClientPKI = path.join(folder, "FakeClientPKI");
+        fs.mkdirSync(fakeClientPKI, { recursive: true });
+        clientCertificateManager = new OPCUACertificateManager({
+            automaticallyAcceptUnknownCertificate: true,
+            disableFileWatchers: true,
+            rootFolder: fakeClientPKI
+        });
+        await clientCertificateManager.initialize();
+
+        const fakePKI = path.join(folder, "FakePKI");
+        fs.mkdirSync(fakePKI, { recursive: true });
+        certificateManager = new OPCUACertificateManager({
+            rootFolder: fakePKI,
+            automaticallyAcceptUnknownCertificate: true,
+            privateKeyPassphrase: passphrase
+        });
+        await certificateManager.initialize();
+
+        clientCertificateFile = path.join(clientCertificateManager.rootDir, "own/certs/certificate.pem");
+        await clientCertificateManager.createSelfSignedCertificate({
+            applicationUri: makeApplicationUrn(hostname(), "NodeOPCUA-Client"),
+            subject: "CN=Test",
+            dns: [os.hostname()],
+            ip: [],
+            startDate: new Date(),
+            validity: 12,
+            outputFile: clientCertificateFile
+        });
+
+        const { certificate, crl } = await _getFakeAuthorityCertificate(folder);
+        await clientCertificateManager.addIssuer(certificate);
+        await clientCertificateManager.addRevocationList(crl);
+        await clientCertificateManager.trustCertificate(certificate);
+
+        await certificateManager.addIssuer(certificate);
+        await certificateManager.addRevocationList(crl);
+        await certificateManager.trustCertificate(certificate);
+    });
+
+    after(async () => {
+        await CertificateManager.disposeAll();
+        CertificateManager.checkAllDisposed();
+    });
+
+    afterEach(async () => {
+        if (server) {
+            await server.shutdown();
+            server = undefined;
+        }
+    });
+
+    const mockUserManager = {
+        isValidUser: (userName: string, password: string) => userName === "admin" && password === "secret",
+        getUserRoles(username: string): NodeId[] {
+            if (username === "admin") {
+                return makeRoles("AuthenticatedUser;SecurityAdmin");
+            }
+            return makeRoles("Anonymous");
+        }
+    };
+
+    async function withSecureClient<T>(endpointUrl: string, func: (session: ClientSession) => Promise<T>): Promise<T> {
+        const client = OPCUAClient.create({
+            clientCertificateManager,
+            certificateFile: clientCertificateFile,
+            securityMode: MessageSecurityMode.SignAndEncrypt,
+            securityPolicy: SecurityPolicy.Basic256Sha256,
+            clientName: "test_push_certificate_management_with_passphrase"
+        });
+        try {
+            await client.connect(endpointUrl);
+            const userIdentityToken: UserIdentityInfoUserName = {
+                type: UserTokenType.UserName,
+                password: "secret",
+                userName: "admin"
+            };
+            const session = await client.createSession(userIdentityToken);
+            try {
+                return await func(session);
+            } finally {
+                await session.close();
+            }
+        } finally {
+            await client.disconnect();
+        }
+    }
+
+    it("PPW1: UpdateCertificate writes the pushed private key already encrypted, and a session still connects after ApplyChanges", async () => {
+        server = new OPCUAServer({
+            port,
+            nodeset_filename: nodesets.standard,
+            userManager: mockUserManager,
+            serverCertificateManager: certificateManager,
+            userCertificateManager: certificateManager
+        });
+        await server.initialize();
+        await installPushCertificateManagementOnServer(server);
+
+        const clientCertificatePEM = await readFile(clientCertificateFile, "utf8");
+        const clientCertificateDER = convertPEMtoDER(clientCertificatePEM);
+        await server.serverCertificateManager.trustCertificate(clientCertificateDER);
+
+        await server.start();
+        const endpointUrl = server.getEndpointUrl();
+
+        // sanity: the key installed by installPushCertificateManagementOnServer
+        // (via createDefaultCertificate/OPCUACertificateManager.initialize)
+        // is already encrypted
+        const rawInitial = fs.readFileSync(certificateManager.privateKey, "utf-8");
+        rawInitial.should.containEql("ENCRYPTED PRIVATE KEY");
+
+        // Push a brand-new certificate + matching private key (the explicit
+        // privateKeyFormat/privateKey branch of UpdateCertificate)
+        const { certificate, privateKeyPEM } = await produceCertificateAndPrivateKey(folder);
+
+        await withSecureClient(endpointUrl, async (session) => {
+            const pm = new ClientPushCertificateManagement(session);
+            const response = await pm.updateCertificate(
+                "DefaultApplicationGroup",
+                NodeId.nullNodeId,
+                certificate,
+                [],
+                "PEM",
+                privateKeyPEM
+            );
+            if (response.statusCode.isNotGood()) {
+                throw new Error(`updateCertificate failed: ${response.statusCode.toString()}`);
+            }
+            await pm.applyChanges();
+        });
+
+        // The on-disk key must still be encrypted — never written back in clear,
+        // not even transiently during the staged/applied transaction.
+        const rawAfter = fs.readFileSync(certificateManager.privateKey, "utf-8");
+        rawAfter.should.containEql("ENCRYPTED PRIVATE KEY");
+        rawAfter.should.not.containEql("-----BEGIN PRIVATE KEY-----\n");
+
+        // Server and every endpoint must have re-resolved the rotated,
+        // encrypted key — a fresh session must still succeed.
+        await withSecureClient(endpointUrl, async (session) => {
+            session.sessionId.should.be.ok();
+        });
+    });
+});

--- a/packages/node-opcua-server-configuration/test/server/test_server_with_push_certificate_management.ts
+++ b/packages/node-opcua-server-configuration/test/server/test_server_with_push_certificate_management.ts
@@ -634,6 +634,7 @@ describe("Testing server configured with push certificate management", function 
             clientName: `4 test_server_with_push_certificate_management`
         });
 
+        let reconnected = false;
         client.on("start_reconnection", () => {
             debugLog(chalk.bgWhite.red(" !!!!!!!!!!!!!!!!!!!!!!!!  Starting Reconnection !!!!!!!!!!!!!!!!!!!"));
         });
@@ -643,6 +644,7 @@ describe("Testing server configured with push certificate management", function 
         client.on("connection_reestablished", () => {
             debugLog(chalk.bgWhite.red(" !!!!!!!!!!!!!!!!!!!!!!!!  CONNECTION RE-ESTABLISHED !!!!!!!!!!!!!!!!!!!"));
             debugLog("    Server certificate is now ", short_certificate_info_toString(client.serverCertificate));
+            reconnected = true;
         });
         client.on("connection_lost", () => {
             debugLog(chalk.bgWhite.red("Client has lost connection ..."));
@@ -667,7 +669,16 @@ describe("Testing server configured with push certificate management", function 
         toPem2(privateKeyBefore, "RSA PRIVATE KEY").should.not.eql(toPem2(privateKeyAfter, "RSA PRIVATE KEY"));
 
         step("then I should see the client being reconnected");
-        await new Promise((resolve) => setTimeout(resolve, 6000));
+        // Poll for the `connection_reestablished` event (or isReconnecting
+        // dropping to false on its own, in case reconnection had already
+        // completed before the listener above could observe the event)
+        // instead of a fixed sleep: a fixed wait is either wastefully long
+        // or — under system load, where backoff/reconnect can legitimately
+        // take longer — too short, making this assertion flaky.
+        const deadline = Date.now() + 30_000;
+        while (!reconnected && client.isReconnecting && Date.now() < deadline) {
+            await new Promise((resolve) => setTimeout(resolve, 200));
+        }
 
         client.isReconnecting.should.eql(false);
 

--- a/packages/node-opcua-server/source/base_server.ts
+++ b/packages/node-opcua-server/source/base_server.ts
@@ -13,7 +13,15 @@ import chalk from "chalk";
 import { assert } from "node-opcua-assert";
 import { getDefaultCertificateManager, type OPCUACertificateManager } from "node-opcua-certificate-manager";
 import { performCertificateSanityCheck } from "node-opcua-client";
-import { type ICertificateStore, type IOPCUASecureObjectOptions, makeApplicationUrn, makeSubject, OPCUASecureObject } from "node-opcua-common";
+import {
+    type ICertificateStore,
+    type IOPCUASecureObjectOptions,
+    makeApplicationUrn,
+    makeSubject,
+    OPCUASecureObject,
+    resolvePrivateKeyProviderIfNeeded
+} from "node-opcua-common";
+import { PrivateKeyPassphraseRequiredError } from "node-opcua-crypto";
 import { exploreCertificate } from "node-opcua-crypto/web";
 import { coerceLocalizedText } from "node-opcua-data-model";
 import { installPeriodicClockAdjustment, uninstallPeriodicClockAdjustment } from "node-opcua-date-time";
@@ -278,8 +286,39 @@ export class OPCUABaseServer<T extends OPCUABaseServerEvents = any> extends OPCU
     }
 
     public async initializeCM(): Promise<void> {
-        await this.serverCertificateManager.initialize();
-        await this.createDefaultCertificate();
+        // The pki-level initialize() itself already decrypts (or re-encrypts)
+        // the on-disk key when serverCertificateManager is configured with a
+        // privateKeyPassphrase, and fails closed with
+        // PrivateKeyPassphraseRequiredError on a mismatch — so this whole
+        // sequence, not just the resolve step below, needs the friendlier
+        // error message.
+        try {
+            await this.serverCertificateManager.initialize();
+            await this.createDefaultCertificate();
+
+            // Resolve the (possibly passphrase-encrypted) private key once,
+            // asynchronously, and install it as this server's provider — so
+            // that every later, synchronous getPrivateKey() call (secure
+            // channel layer, endpoint creation, ...) succeeds without touching
+            // disk again. No-ops when the caller supplied its own
+            // certificateKeyPairProvider, when running in-memory, or when
+            // serverCertificateManager doesn't expose an async getPrivateKey()
+            // (e.g. a bare ICertificateStore).
+            await resolvePrivateKeyProviderIfNeeded(
+                this,
+                this.serverCertificateManager,
+                !!this.options.certificateKeyPairProvider
+            );
+        } catch (err) {
+            if (err instanceof PrivateKeyPassphraseRequiredError) {
+                throw new Error(
+                    `[NODE-OPCUA-E30] private key ${this.privateKeyFile} is encrypted; ` +
+                    "set privateKeyPassphrase on the OPCUACertificateManager passed as serverCertificateManager"
+                );
+            }
+            throw err;
+        }
+
         if ("privateKey" in this.serverCertificateManager) {
             debugLog("privateKey      = ", this.privateKeyFile, (this.serverCertificateManager as unknown as { privateKey: string }).privateKey);
         } else {

--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -36,7 +36,7 @@ import {
 import { assert } from "node-opcua-assert";
 import type { ByteString, UAString } from "node-opcua-basic-types";
 import { getDefaultCertificateManager, type OPCUACertificateManager } from "node-opcua-certificate-manager";
-import { DiskCertificateKeyPairProvider, ServerState } from "node-opcua-common";
+import { DiskCertificateKeyPairProvider, ResolvedCertificateKeyPairProvider, ServerState } from "node-opcua-common";
 import { type Certificate, combine_der, exploreCertificate, type Nonce } from "node-opcua-crypto/web";
 import {
     AttributeIds,
@@ -156,9 +156,9 @@ import type { IRegisterServerManager } from "./i_register_server_manager";
 import type { ISocketData } from "./i_socket_data";
 import { MonitoredItem } from "./monitored_item";
 import { RegisterServerManager } from "./register_server_manager";
-import { ReverseConnectManager, type ReverseConnectOptions } from "./reverse_connect_manager";
 import { RegisterServerManagerHidden } from "./register_server_manager_hidden";
 import { RegisterServerManagerMDNSONLY } from "./register_server_manager_mdns_only";
+import { ReverseConnectManager, type ReverseConnectOptions } from "./reverse_connect_manager";
 import type { SamplingFunc } from "./sampling_func";
 import type { ServerCapabilitiesOptions } from "./server_capabilities";
 import {
@@ -820,6 +820,10 @@ export interface OPCUAServerOptions extends OPCUABaseServerOptions, OPCUAServerE
      *
      * the private key should be in PEM format
      *
+     * If the key is encrypted, `serverCertificateManager` must be an
+     * `OPCUACertificateManager` constructed with a matching
+     * `privateKeyPassphrase` (or `privateKeyProvider`) — otherwise
+     * `initialize()` fails closed.
      */
     privateKeyFile?: string;
 
@@ -3946,11 +3950,29 @@ export class OPCUAServer extends OPCUABaseServer<OPCUAServerEvents> {
             transportSettings: serverOptions.transportSettings
         });
 
-        // DiskCertificateKeyPairProvider takes file paths directly —
-        // no reference cycle back to the server object.
-        // Push certificate management replaces this provider via
-        // server.setProvider() when installing new cert paths.
-        endPoint.setCertificateProvider(new DiskCertificateKeyPairProvider(this.certificateFile, this.privateKeyFile));
+        // Give the endpoint its own DiskCertificateKeyPairProvider — a
+        // separate instance from the server's own provider, same as before
+        // this feature existed. This matters: OPCUASecureObject#invalidateCachedCertificates()
+        // (called directly, e.g. after a manual on-disk cert/key swap) only
+        // invalidates the server's own provider, not any endpoint's — so a
+        // *shared* provider instance would still leave the endpoint's own
+        // OPCUAServerEndPoint#getCombinedCertificate() cache stale, which
+        // would be a regression, not a fix.
+        //
+        // The one case a fresh disk provider cannot handle is a
+        // passphrase-encrypted key: reading it synchronously throws. In that
+        // case (and only that case) initializeCM() has already swapped the
+        // server's own provider to a ResolvedCertificateKeyPairProvider —
+        // reuse that one instead, since there is no synchronous way to build
+        // an equivalent one from scratch here. Push certificate management
+        // replaces this provider via endpoint.setCertificateProvider() when
+        // installing new cert paths, in both cases.
+        const serverProvider = this.getProvider();
+        endPoint.setCertificateProvider(
+            serverProvider instanceof ResolvedCertificateKeyPairProvider
+                ? serverProvider
+                : new DiskCertificateKeyPairProvider(this.certificateFile, this.privateKeyFile)
+        );
 
         return endPoint;
     }

--- a/packages/node-opcua-server/test/test_server_with_encrypted_private_key.ts
+++ b/packages/node-opcua-server/test/test_server_with_encrypted_private_key.ts
@@ -1,0 +1,163 @@
+/**
+ * Server-side private-key-passphrase tests.
+ *
+ * Proves that an OPCUAServer constructed with an OPCUACertificateManager
+ * configured with `privateKeyPassphrase` starts normally, serves sessions
+ * (including SignAndEncrypt), and never writes the private key back to
+ * disk in clear — while a server given an encrypted key and no matching
+ * passphrase fails closed with a clear operator-facing message.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { OPCUACertificateManager } from "node-opcua-certificate-manager";
+import { MessageSecurityMode, OPCUAClient, SecurityPolicy } from "node-opcua-client";
+import { extractFullyQualifiedDomainName } from "node-opcua-hostname";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import should from "should";
+import { OPCUAServer } from "../source";
+
+const passphrase = "correct-horse-battery-staple";
+
+async function makeTmpDir(name: string): Promise<string> {
+    const tmpDir = path.join(os.tmpdir(), `test-encrypted-key-${name}-${process.pid}-${Date.now()}`);
+    await fs.promises.mkdir(tmpDir, { recursive: true });
+    return tmpDir;
+}
+
+describe("OPCUAServer with a passphrase-protected private key", function (this: Mocha.Suite) {
+    this.timeout(Math.max(60000, this.timeout()));
+
+    before(async () => {
+        await extractFullyQualifiedDomainName();
+    });
+
+    it("EK1: starts, serves a SignAndEncrypt session, and keeps the key encrypted on disk", async () => {
+        const tmpDir = await makeTmpDir("ek1");
+        let server: OPCUAServer | undefined;
+        let cm: OPCUACertificateManager | undefined;
+        try {
+            cm = new OPCUACertificateManager({
+                rootFolder: path.join(tmpDir, "pki"),
+                automaticallyAcceptUnknownCertificate: true,
+                disableFileWatchers: true,
+                privateKeyPassphrase: passphrase
+            });
+            await cm.initialize();
+
+            const rawBefore = fs.readFileSync(cm.privateKey, "utf-8");
+            rawBefore.should.containEql("ENCRYPTED PRIVATE KEY");
+
+            server = new OPCUAServer({
+                port: 12066,
+                serverCertificateManager: cm,
+                securityModes: [MessageSecurityMode.SignAndEncrypt],
+                securityPolicies: [SecurityPolicy.Basic256Sha256]
+            });
+            await server.start();
+            const port = server.endpoints[0].port;
+
+            const client = OPCUAClient.create({
+                securityMode: MessageSecurityMode.SignAndEncrypt,
+                securityPolicy: SecurityPolicy.Basic256Sha256,
+                endpointMustExist: false
+            });
+            await client.withSessionAsync(`opc.tcp://localhost:${port}`, async (session) => {
+                should(session).be.ok();
+            });
+
+            // The key must still be encrypted after the server ran a session
+            const rawAfter = fs.readFileSync(cm.privateKey, "utf-8");
+            rawAfter.should.containEql("ENCRYPTED PRIVATE KEY");
+        } finally {
+            await server?.shutdown();
+            await cm?.dispose();
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it("EK2: initialize() fails closed with a clear message when the key is encrypted and no passphrase is configured", async () => {
+        const tmpDir = await makeTmpDir("ek2");
+        let server: OPCUAServer | undefined;
+        let cmSetup: OPCUACertificateManager | undefined;
+        try {
+            const pkiFolder = path.join(tmpDir, "pki");
+            // create the PKI once, encrypted
+            cmSetup = new OPCUACertificateManager({
+                rootFolder: pkiFolder,
+                automaticallyAcceptUnknownCertificate: true,
+                disableFileWatchers: true,
+                privateKeyPassphrase: passphrase
+            });
+            await cmSetup.initialize();
+            await cmSetup.dispose();
+
+            // now reopen the SAME pki folder without a configured passphrase
+            const cmNoPassphrase = new OPCUACertificateManager({
+                rootFolder: pkiFolder,
+                automaticallyAcceptUnknownCertificate: true,
+                disableFileWatchers: true
+            });
+
+            server = new OPCUAServer({
+                port: 12067,
+                serverCertificateManager: cmNoPassphrase
+            });
+
+            let caught: unknown;
+            try {
+                await server.start();
+            } catch (err) {
+                caught = err;
+            }
+            should.exist(caught, "expecting server.start() to fail");
+            const message = (caught as Error).message;
+            message.should.match(/encrypted/);
+            message.should.match(/privateKeyPassphrase/);
+        } finally {
+            await server?.shutdown().catch(() => {
+                /* server may not have started */
+            });
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it("EK3: a plaintext key is encrypted in place once privateKeyPassphrase is configured, and the server still starts", async () => {
+        const tmpDir = await makeTmpDir("ek3");
+        let server: OPCUAServer | undefined;
+        let cmSetup: OPCUACertificateManager | undefined;
+        try {
+            const pkiFolder = path.join(tmpDir, "pki");
+            // create the PKI once, plaintext
+            cmSetup = new OPCUACertificateManager({
+                rootFolder: pkiFolder,
+                automaticallyAcceptUnknownCertificate: true,
+                disableFileWatchers: true
+            });
+            await cmSetup.initialize();
+            const rawBefore = fs.readFileSync(cmSetup.privateKey, "utf-8");
+            rawBefore.should.not.containEql("ENCRYPTED");
+            await cmSetup.dispose();
+
+            // reopen with a passphrase configured
+            const cm = new OPCUACertificateManager({
+                rootFolder: pkiFolder,
+                automaticallyAcceptUnknownCertificate: true,
+                disableFileWatchers: true,
+                privateKeyPassphrase: passphrase
+            });
+
+            server = new OPCUAServer({
+                port: 12068,
+                serverCertificateManager: cm
+            });
+            await server.start();
+
+            const rawAfter = fs.readFileSync(cm.privateKey, "utf-8");
+            rawAfter.should.containEql("ENCRYPTED PRIVATE KEY");
+        } finally {
+            await server?.shutdown();
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- `OPCUACertificateManager` gains `privateKeyPassphrase` / `privateKeyProvider` options (built on `node-opcua-pki` 6.20.0 / `node-opcua-crypto` 5.6.0), plus `getPrivateKey()`, `getPrivateKeyPassphrase()`, and `isPrivateKeyManaged()`.
- `OPCUAServer` / `OPCUAClient` resolve a possibly-encrypted private key once, asynchronously, in `initializeCM()`, and install a new `ResolvedCertificateKeyPairProvider` (node-opcua-common) — every later *synchronous* `getPrivateKey()` call (secure channel layer, endpoints) then succeeds without touching disk again.
- Push certificate management (`UpdateCertificate`) now encrypts a pushed private key before staging it, so it is never written back to disk in clear, not even transiently.
- Default (no `privateKeyPassphrase`) behavior is unchanged — verified by running the existing server/client/server-configuration/common test suites, not just new ones.
- Docs: `documentation/creating_a_server.md` and `RELEASE_NOTES.md` updated.

Three regressions surfaced and fixed while validating against the *existing* suites (not just new tests):
1. Swapping to a resolved provider unconditionally broke the plaintext-key "invalidate + re-read from disk" rotation path (`invalidateCachedCertificates()`) — fixed via `isPrivateKeyManaged()`, which skips the swap when no passphrase/provider is configured.
2. Endpoints sharing the server's provider by reference broke per-endpoint cache invalidation on certificate rotation — fixed so endpoints get their own disk provider unless the key is actually encrypted.
3. `TmpClient` (used internally for endpoint discovery) bypassed key resolution entirely and would throw on an encrypted key — fixed by handing it the master client's already-resolved provider.

## Push-cert-management + passphrase rotation (PPW1) — fixed

Root cause: `OPCUACertificateManager.getPrivateKey()` caches the decrypted key for the manager's whole lifetime (pki's documented behavior — correct at startup). After `UpdateCertificate`/`ApplyChanges` replaces the on-disk key underneath that same long-lived manager, the cached call kept returning the *pre-rotation* key, so certificate and key belonged to different pairs and every post-rotation handshake failed signature verification. Fixed by reading the key file directly (with the manager's own configured passphrase) right after a rotation; `privateKeyProvider` mode is unaffected since pki always calls through for it.

## Client: session is now *reactivated* across a server certificate rotation (pre-existing bug, affects all reconnects after any rotation)

`session.serverCertificate` was captured once at `CreateSession`. On reconnect after the server rotated its certificate, the client already re-learns the current certificate in `fetchServerCertificate()`, but `ActivateSession` still signed the `clientSignature` — and encrypted a password user token — against the stale one. The server verifies against its current certificate → `BadApplicationSignatureInvalid` → the client silently fell back to `CreateSession`, so the `sessionId` changed on every rotation (the existing SCT-2 test never checked it). Fixed in `OPCUAClientImpl._activateSession`: refresh `session.serverCertificate` from the client's current knowledge before building the request (only when the client actually knows one — over `SecurityMode.None` it may not, while the session's `CreateSessionResponse` copy is still needed to encrypt the user token).

## Server channels are now bound to their creation-time certificate/key pair (Part 6 conformance)

Checked OPC 10000-6 before designing this. Two normative statements decide it:
- §6.7.2 (ReceiverCertificateThumbprint): *"The receiver shall reject the MessageChunk if the Certificate identified does not match the Certificate **it is using for the SecureChannel**."* — per-channel wording, not "its current certificate".
- §6.7.4: *"The Client shall close the SecureChannel if the Certificate used to sign the response is not the same as the Certificate used to encrypt the request."* — so a server answering a Renew with its *new* certificate would force a conformant client to close the channel; the channel's original pair is the only conformant answer. (Also §6.7.4's renew-rejection rule constrains only the *client's* certificate, so continuing under the old pair is permitted.)

`ServerSecureChannelLayer` now captures its certificate chain + private key from the endpoint on first access and uses that pair for its whole lifetime (thumbprint check, OPN response signing, senderCertificate — consistent with the decryption key the MessageBuilder already captured at setup). Net effect: **key/certificate rotation no longer breaks token renewal on live channels**, with zero client-side changes — unmodified third-party conformant clients benefit too. The bound material is released on channel dispose.

## `installPushCertificateManagementOnServer(server, { closeChannelsOnApplyChanges })`

Re-assessed whether `shutdownChannels()` on `ApplyChanges` is necessary. With channel binding in place:
- **`true` (default, unchanged):** all channels shut down immediately; every client reconnects with the new pair right away. Right choice when the rotation answers a **compromised or revoked** key — nothing keeps running under it.
- **`false` (new opt-in):** rotation is **seamless** for connected clients: existing channels keep renewing their security token under their bound pair (the old one), new connections get the new pair. The old pair stays in use until those channels close naturally — which is exactly why this is opt-in.

Tests: `test_certificate_rotation_with_connected_client.ts` — RCC1 (default: immediate reconnect, same `sessionId` reactivated, Renews succeed on the new channel) and RCC2 (`false`: ≥2 successful Renews on the *original* channel post-rotation, zero disconnections, same `sessionId`, while a concurrently connecting new client is served the rotated certificate). Both over a CA-signed chain so the client accepts the rotated certificate via its already-trusted issuer + CRL.

Also: SCT-3's flaky fixed 6 s sleep replaced by polling for reconnection.

Noted, pre-existing and unrelated (not fixed here): `ClientBaseImpl` increments a caller-supplied `clientCertificateManager.referenceCounter` but never decrements it, so a manual `.dispose()` never fully releases it (chokidar watcher keeps running) — worked around in new tests with `disableFileWatchers: true`. And `node-opcua-secure-channel`'s `06-test_various_packets.ts` fails at load on `master` too (`node-opcua-transport` exports map doesn't expose `./test-fixtures/...`).

## Test plan

- [x] `node-opcua-common` full suite (incl. new `test_disk_certificate_key_pair_provider.ts`)
- [x] `node-opcua-certificate-manager` full suite (incl. new PP01-05)
- [x] `node-opcua-server` full suite, 464 passing — after channel binding
- [x] `node-opcua-client` full suite, 56 passing — after the `_activateSession` change
- [x] `node-opcua-secure-channel` suite, 243 passing (excluding `06-test_various_packets.ts`, broken at load on `master` too)
- [x] `node-opcua-server-configuration` full suite, 139 passing — SCT-1..5, PPW1, RCC1, RCC2 and everything else
- [x] `node-opcua-end2end-test`: encrypted-key (EE1), chained-certificates, connection-reconnection, X509-identity — 31 passing after channel binding
- [x] `tsc -b` clean across all touched packages plus the `node-opcua` meta package