### PR TITLE
fix: don't abandon nodeset post-loading when one task throws

### DIFF
--- a/packages/node-opcua-address-space/source/loader/load_nodeset2.ts
+++ b/packages/node-opcua-address-space/source/loader/load_nodeset2.ts
@@ -16,7 +16,7 @@ import type {
     UAVariable,
     UAVariableType
 } from "node-opcua-address-space-base";
-import { assert, renderError } from "node-opcua-assert";
+import { assert } from "node-opcua-assert";
 import { coerceBoolean, coerceByte, coerceInt32, StatusCodes } from "node-opcua-basic-types";
 import { DataTypeIds } from "node-opcua-constants";
 import {
@@ -1160,7 +1160,19 @@ function makeNodeSetParserEngine(addressSpace: IAddressSpace, options: NodeSetLo
                     chalk.green("DONE")
             );
 
-        async function performPostLoadingTasks(tasks: Task[]): Promise<void> {
+        /**
+         * run every queued post-loading task.
+         *
+         * A task that throws (typically: a `<Value>` in a third-party nodeset that does not
+         * match the declared DataType) is logged and skipped — it must NOT abort the remaining
+         * tasks nor the remaining stages of finalSteps(). Previously the failing task was
+         * re-run inside the catch block, the second throw escaped the loop, finalSteps() was
+         * abandoned and `ensureDatatypeExtracted` was never called: the address space was
+         * left half-initialised (no DataTypeManager) and any later use of a structured
+         * DataType failed with an opaque
+         * "Cannot read properties of undefined (reading 'getExtensionObjectConstructorFromDataType')".
+         */
+        async function performPostLoadingTasks(stage: string, tasks: Task[]): Promise<void> {
             for (const task of tasks) {
                 try {
                     await task(addressSpace1);
@@ -1168,9 +1180,11 @@ function makeNodeSetParserEngine(addressSpace: IAddressSpace, options: NodeSetLo
                     // c8 ignore next
                     // tslint:disable:no-console
                     if (types.isNativeError(err)) {
-                        errorLog(" performPostLoadingTasks Err  => ", err.message, "\n", err);
+                        errorLog(
+                            `[NODE-OPCUA-W36] generateAddressSpace: post-loading task failed during "${stage}" and was skipped: ${err.message}`
+                        );
+                        doDebug && debugLog(err);
                     }
-                    await task(addressSpace1);
                 }
             }
             tasks.splice(0);
@@ -1179,11 +1193,11 @@ function makeNodeSetParserEngine(addressSpace: IAddressSpace, options: NodeSetLo
             /// ----------------------------------------------------------------------------------------
             // perform post task
             doDebug && debugLog(chalk.bgGreenBright("Performing post loading tasks -------------------------------------------"));
-            await performPostLoadingTasks(postTasks);
+            await performPostLoadingTasks("post tasks", postTasks);
 
             doDebug &&
                 debugLog(chalk.bgGreenBright("Performing post loading task: Initializing Simple Variables ---------------------"));
-            await performPostLoadingTasks(postTasks0_InitializeVariable);
+            await performPostLoadingTasks("initializing simple variables", postTasks0_InitializeVariable);
 
             doDebug && debugLog(chalk.bgGreenBright("Performing DataType extraction -------------------------------------------"));
             assert(!addressSpace1.suspendBackReference);
@@ -1202,14 +1216,17 @@ function makeNodeSetParserEngine(addressSpace: IAddressSpace, options: NodeSetLo
             pendingSimpleTypeToRegister.splice(0);
 
             doDebug && debugLog(chalk.bgGreenBright("Performing post loading task: Decoding Pojo String (parsing XML objects) -"));
-            await performPostLoadingTasks(postTasks0_DecodePojoString);
+            await performPostLoadingTasks("decoding XML extension objects", postTasks0_DecodePojoString);
 
             doDebug &&
                 debugLog(chalk.bgGreenBright("Performing post loading task: Initializing Complex Variables ---------------------"));
-            await performPostLoadingTasks(postTasks1_InitializeVariable);
+            await performPostLoadingTasks("initializing complex variables", postTasks1_InitializeVariable);
 
             doDebug && debugLog(chalk.bgGreenBright("Performing post loading tasks: (assigning Extension Object to Variables) -"));
-            await performPostLoadingTasks(postTasks2_AssignedExtensionObjectToDataValue);
+            await performPostLoadingTasks(
+                "assigning extension objects to variables",
+                postTasks2_AssignedExtensionObjectToDataValue
+            );
 
             doDebug && debugLog(chalk.bgGreenBright("Performing post variable initialization ---------------------"));
             promoteObjectsAndVariables(addressSpace);
@@ -1218,7 +1235,13 @@ function makeNodeSetParserEngine(addressSpace: IAddressSpace, options: NodeSetLo
         try {
             await finalSteps();
         } catch (err) {
-            renderError(err);
+            // `renderError` was a no-op here, so a failure in the final steps (DataType extraction,
+            // promotion of objects/variables, ...) used to be silently swallowed and the caller was
+            // handed back a half-initialised address space. Surface it: log and re-throw so that
+            // generateAddressSpace() rejects.
+            const message = types.isNativeError(err) ? err.message : String(err);
+            errorLog(`[NODE-OPCUA-E30] generateAddressSpace: final post-loading steps failed: ${message}`);
+            throw err;
         }
     }
     async function addNodeSet(xmlData: string): Promise<void> {

--- a/packages/node-opcua-address-space/src/address_space.ts
+++ b/packages/node-opcua-address-space/src/address_space.ts
@@ -1028,7 +1028,15 @@ export class AddressSpace implements AddressSpacePrivate {
         }
         assert(_dataType.isSubtypeOf(this.findDataType("Structure")!));
         if (!_dataType._extensionObjectConstructor) {
-            const dataTypeManager = (this as any).$$extraDataTypeManager as ExtraDataTypeManager;
+            const addressSpacePriv: any = this as any;
+            if (!addressSpacePriv.$$extraDataTypeManager) {
+                throw new Error(
+                    `getExtensionObjectConstructor: cannot build a constructor for ${_dataType.browseName.toString()} (${_dataType.nodeId.toString()}): ` +
+                        "the DataType manager is not initialised. " +
+                        "Make sure generateAddressSpace() completed successfully and/or that ensureDatatypeExtracted(addressSpace) was awaited before using structured DataTypes."
+                );
+            }
+            const dataTypeManager = addressSpacePriv.$$extraDataTypeManager as ExtraDataTypeManager;
             _dataType._extensionObjectConstructor = dataTypeManager.getExtensionObjectConstructorFromDataType(
                 _dataType.nodeId
             ) as ExtensionObjectConstructorFuncWithSchema;

--- a/packages/node-opcua-address-space/test/test_load_nodeset2_resilience.ts
+++ b/packages/node-opcua-address-space/test/test_load_nodeset2_resilience.ts
@@ -1,0 +1,93 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { nodesets } from "node-opcua-nodesets";
+import { StatusCodes } from "node-opcua-status-code";
+import { DataType } from "node-opcua-variant";
+import should from "should";
+import { AddressSpace, type UAVariable } from "..";
+import { generateAddressSpace } from "../nodeJS";
+
+/**
+ * A nodeset carrying a single malformed <Value> (declared DataType="UInt32" but the value is a
+ * ListOfInt32 — as shipped in Opc.Ua.PADIM.NodeSet2.xml) used to abort *all* remaining post-loading
+ * steps: the failing task was re-run inside the catch block of performPostLoadingTasks, the second
+ * throw escaped, finalSteps() was abandoned and swallowed by a no-op renderError(), so
+ * ensureDatatypeExtracted() never ran. generateAddressSpace() resolved normally, but the address
+ * space had no DataTypeManager and any later use of a structured DataType (EURange, EUInformation,
+ * ...) failed with
+ *   "Cannot read properties of undefined (reading 'getExtensionObjectConstructorFromDataType')".
+ */
+describe("generateAddressSpace resilience to malformed <Value> in a nodeset", () => {
+    const xmlFile = path.join(__dirname, "../test_helpers/test_fixtures/nodeset_with_mismatched_value_datatype.xml");
+    fs.existsSync(xmlFile).should.eql(true, `should find ${xmlFile}`);
+
+    let addressSpace: AddressSpace;
+    beforeEach(() => {
+        addressSpace = AddressSpace.create();
+        addressSpace.registerNamespace("urn:own");
+    });
+    afterEach(() => {
+        addressSpace.dispose();
+    });
+
+    it("RES-1 should skip the malformed value, still initialise the other variables and still build the DataTypeManager", async () => {
+        await generateAddressSpace(addressSpace, [nodesets.standard, xmlFile]);
+
+        const nsIndex = addressSpace.getNamespaceIndex("http://A");
+        nsIndex.should.be.greaterThan(0);
+
+        // the good variable next to the bad one must have been initialised
+        const good = addressSpace.findNode(`ns=${nsIndex};i=1001`) as UAVariable;
+        should.exist(good);
+        const goodValue = good.readValue();
+        goodValue.statusCode.should.eql(StatusCodes.Good);
+        goodValue.value.dataType.should.eql(DataType.UInt32);
+        goodValue.value.value.should.eql(42);
+
+        // the bad variable exists, but its mismatched value was not applied
+        const bad = addressSpace.findNode(`ns=${nsIndex};i=1000`) as UAVariable;
+        should.exist(bad);
+        bad.readValue().statusCode.should.not.eql(StatusCodes.Good);
+
+        // and, crucially, the DataTypeManager must be available
+        should.exist((addressSpace as any).$$extraDataTypeManager, "DataTypeManager must be initialised");
+        should.doesNotThrow(() => (addressSpace as any).getDataTypeManager());
+    });
+
+    it("RES-2 should still allow structured values (EURange) to be set after loading such a nodeset", async () => {
+        await generateAddressSpace(addressSpace, [nodesets.standard, xmlFile]);
+
+        const namespace = addressSpace.getOwnNamespace();
+        const analogItem = namespace.addAnalogDataItem({
+            browseName: "Temperature",
+            dataType: "Float",
+            engineeringUnitsRange: { low: -40, high: 125 }
+        });
+        const euRange = analogItem.euRange.readValue();
+        euRange.statusCode.should.eql(StatusCodes.Good);
+        euRange.value.dataType.should.eql(DataType.ExtensionObject);
+        euRange.value.value.low.should.eql(-40);
+        euRange.value.value.high.should.eql(125);
+    });
+
+    it("RES-3 getExtensionObjectConstructor should raise an explicit error when the DataTypeManager is missing", async () => {
+        await generateAddressSpace(addressSpace, [nodesets.standard]);
+
+        // simulate an address space whose DataType extraction never ran
+        const priv = addressSpace as any;
+        const saved = priv.$$extraDataTypeManager;
+        priv.$$extraDataTypeManager = undefined;
+        try {
+            const range = addressSpace.findDataType("Range")!;
+            should.exist(range);
+            (range as any)._extensionObjectConstructor = undefined;
+            should.throws(
+                () => addressSpace.getExtensionObjectConstructor(range),
+                /DataType manager is not initialised.*ensureDatatypeExtracted/
+            );
+        } finally {
+            priv.$$extraDataTypeManager = saved;
+        }
+    });
+});

--- a/packages/node-opcua-address-space/test_helpers/test_fixtures/nodeset_with_mismatched_value_datatype.xml
+++ b/packages/node-opcua-address-space/test_helpers/test_fixtures/nodeset_with_mismatched_value_datatype.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  A nodeset whose first variable carries a <Value> that does not match its declared DataType
+  (DataType="UInt32" ValueRank="1" but the value is a ListOfInt32). This is exactly what ships in
+  Opc.Ua.PADIM.NodeSet2.xml (ns=3;i=6016 / ns=3;i=6031 ValveSwitchingCyclesCounter).
+
+  Loading must tolerate this single bad node: the other variables must still be initialised and the
+  address space must still end up with a working DataTypeManager (see test_load_nodeset2_resilience).
+-->
+<UANodeSet xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd">
+    <NamespaceUris>
+        <Uri>http://A</Uri>
+    </NamespaceUris>
+    <Models>
+        <Model ModelUri="http://A" PublicationDate="2021-01-01T00:00:00Z" Version="1.00">
+            <RequiredModel ModelUri="http://opcfoundation.org/UA/" Version="1.03" PublicationDate="2013-12-02T00:00:00Z" />
+        </Model>
+    </Models>
+    <Aliases/>
+    <UAVariable DataType="UInt32" ValueRank="1" ArrayDimensions="0" ParentNodeId="ns=0;i=2253" NodeId="ns=1;i=1000" BrowseName="1:BadValueVariable" AccessLevel="3">
+        <DisplayName>BadValueVariable</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+        <Value>
+            <uax:ListOfInt32>
+                <uax:Int32>0</uax:Int32>
+            </uax:ListOfInt32>
+        </Value>
+    </UAVariable>
+    <UAVariable DataType="UInt32" ParentNodeId="ns=0;i=2253" NodeId="ns=1;i=1001" BrowseName="1:GoodValueVariable" AccessLevel="3">
+        <DisplayName>GoodValueVariable</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+        </References>
+        <Value>
+            <uax:UInt32>42</uax:UInt32>
+        </Value>
+    </UAVariable>
+</UANodeSet>


### PR DESCRIPTION
## Problem

Loading a nodeset that contains a single malformed `<Value>` silently leaves the whole address space half-initialised.

Real-world trigger shipped in `node-opcua-nodesets`: `Opc.Ua.PADIM.NodeSet2.xml` has two `ValveSwitchingCyclesCounter` variables (`ns=3;i=6016`, `ns=3;i=6031`) declared `DataType="UInt32" ValueRank="1"` whose value is a `<uax:ListOfInt32>`. `verifyVariantCompatibility` rightly rejects the Int32/UInt32 mismatch, and then:

1. `performPostLoadingTasks` (`load_nodeset2.ts`) caught the error, logged it… and **re-ran the same task inside the `catch`**. The second throw escaped the loop.
2. `finalSteps()` was abandoned right there — before `ensureDatatypeExtracted()`, before `postTasks1_InitializeVariable`, `postTasks2_AssignedExtensionObjectToDataValue` and `promoteObjectsAndVariables()`.
3. The outer `catch (err) { renderError(err); }` swallowed everything: `renderError` in `node-opcua-assert` is literally `return err;`. `generateAddressSpace()` resolved normally.
4. Any later use of a structured DataType — e.g. `namespace.addAnalogDataItem({ engineeringUnitsRange })`, or instantiating any PADIM `AnalogSignalVariableType` subtype (`EURange`) — died in `AddressSpace.getExtensionObjectConstructor` with the opaque
   `TypeError: Cannot read properties of undefined (reading 'getExtensionObjectConstructorFromDataType')`
   because it read `$$extraDataTypeManager` directly instead of going through the guarded `getDataTypeManager()` accessor.

Minimal repro on `master` (no custom nodeset needed):

```ts
const a = AddressSpace.create();
a.registerNamespace("urn:test");
await generateAddressSpace(a, [nodesets.standard, nodesets.di, nodesets.padim, nodesets.irdi], {});
console.log(!!(a as any).$$extraDataTypeManager);          // false  (true with [standard, di])
a.getOwnNamespace().addAnalogDataItem({ browseName: "T", dataType: "Float", engineeringUnitsRange: { low: 0, high: 100 } });
// TypeError: Cannot read properties of undefined (reading 'getExtensionObjectConstructorFromDataType')
```

## Fix

- **`load_nodeset2.ts` — `performPostLoadingTasks(stage, tasks)`**: a task that throws is logged once (`[NODE-OPCUA-W36] … post-loading task failed during "<stage>" and was skipped: <message>`) and skipped. No more retry-in-catch, so one bad `<Value>` can no longer abort the rest of the pipeline. Each stage is labelled at the call site so the log says *which* stage failed.
- **`load_nodeset2.ts` — outer `finalSteps()` catch**: log `[NODE-OPCUA-E30] … final post-loading steps failed: <message>` and **re-throw**, so `generateAddressSpace()` rejects instead of handing back a half-initialised address space. (`renderError` import removed — it was a no-op.)
- **`address_space.ts` — `getExtensionObjectConstructor`**: explicit error when `$$extraDataTypeManager` is missing, naming the DataType and pointing at `generateAddressSpace()` / `ensureDatatypeExtracted()`, instead of a `TypeError` on `undefined`.

## Tests

`test/test_load_nodeset2_resilience.ts` + fixture `test_helpers/test_fixtures/nodeset_with_mismatched_value_datatype.xml` (a UInt32 array variable with a `ListOfInt32` value next to a good UInt32 variable):

- RES-1: loading succeeds, the good variable is initialised (`42`, `Good`), the bad one is not `Good`, and the DataTypeManager exists.
- RES-2: `addAnalogDataItem({ engineeringUnitsRange })` works after loading such a nodeset (the exact downstream failure).
- RES-3: `getExtensionObjectConstructor` raises the explicit message when the manager is missing.

## Not in this PR

The PADIM nodeset data issue itself (`ListOfInt32` for a `UInt32` array). Arguably the XML variant reader could coerce compatible integer lists to the declared DataType; that's a separate, broader change. With this PR those two counters simply stay uninitialised (logged as W36) and everything else works.
