### PR TITLE
fix(server-configuration): compare against CertificateManager's cached key, not a fresh disk read

### DIFF
--- a/packages/node-opcua-server-configuration/source/server/push_certificate_manager/update_certificate.ts
+++ b/packages/node-opcua-server-configuration/source/server/push_certificate_manager/update_certificate.ts
@@ -3,10 +3,10 @@ import path from "node:path";
 import { assert } from "node-opcua-assert";
 import type { ByteString } from "node-opcua-basic-types";
 import type { CertificateManager, OPCUACertificateManager } from "node-opcua-certificate-manager";
-import { exploreCertificate, readPrivateKey } from "node-opcua-crypto";
+import { exploreCertificate } from "node-opcua-crypto";
 import {
-    certificateMatchesPrivateKey,
     type Certificate,
+    certificateMatchesPrivateKey,
     coercePEMorDerToPrivateKey,
     coercePrivateKeyPem,
     combine_der,
@@ -170,9 +170,14 @@ export async function executeUpdateCertificate(
         }
 
         if (!hasPrivateKeyFormat && !hasPrivateKey) {
-            const privateKeyObj = readPrivateKey(
-                serverImpl.tmpCertificateManager ? serverImpl.tmpCertificateManager.privateKey : certificateManager.privateKey
-            );
+            // CertificateManager.getPrivateKey() caches the decoded key for the lifetime of the
+            // instance (see node-opcua-pki). createCertificateRequest()/createSelfSignedCertificate()
+            // both go through that cache, so the CSR that produced `certificate` was necessarily
+            // signed with the *cached* key. Comparing against a fresh disk read here (readPrivateKey
+            // on the file path) would compare against whatever is currently on disk instead — which
+            // can differ right after a previous updateCertificate() call replaced the private key
+            // file directly (bypassing the cache), causing a spurious BadSecurityChecksFailed.
+            const privateKeyObj = await (serverImpl.tmpCertificateManager || certificateManager).getPrivateKey();
 
             if (!certificateMatchesPrivateKey(certificate, privateKeyObj)) {
                 warningLog("certificate doesn't match privateKey");


### PR DESCRIPTION
## Problem

`updateCertificate should store multiple issuer certificates correctly` in `node-opcua-server-configuration` fails deterministically (not flaky — reproduces every run, in isolation, standalone outside mocha) whenever it runs after a prior test that rotates the application group's private key via `updateCertificate(..., privateKeyFormat, privateKey)` + `applyChanges()`. This is what makes CI red on unrelated PRs, e.g. #1564.

## Root cause

`executeUpdateCertificate()`'s no-explicit-key branch validated the certificate against a **fresh disk read** of the private key:

```ts
const privateKeyObj = readPrivateKey(
    serverImpl.tmpCertificateManager ? serverImpl.tmpCertificateManager.privateKey : certificateManager.privateKey
);
```

But the CSR that produced the certificate being validated was generated by `createCertificateRequest()` on the *same* `CertificateManager`, which signs using `getPrivateKey()` — and `node-opcua-pki`'s `CertificateManager.getPrivateKey()` caches the decoded key **for the lifetime of the instance**, by design, with no invalidation hook (see its docstring: "read and decrypted once and then cached for the lifetime of this instance").

So the two calls disagree once the on-disk key has been replaced (by a prior `updateCertificate(..., privateKey)` + `applyChanges()`, which writes the new key straight to the file via `FileTransactionManager`, bypassing the `CertificateManager`'s own cache entirely):
- CSR generation → signs with the **old cached** key (via `getPrivateKey()`)
- Validation → reads the **new** key from disk (via `readPrivateKey(path)`)
- Mismatch → `BadSecurityChecksFailed`, 0 issuer files written

Standalone repro (outside mocha, traced with instrumentation) confirmed this exact sequence: the private-key file changes after the first `updateCertificate`+`applyChanges`, `createSigningRequest()` afterward does *not* change the file further, yet the very next `updateCertificate()` call (no explicit key) still fails the match — because `getPrivateKey()`'s cache, not the file, is what CSR generation actually used.

## Fix

Compare against `certificateManager.getPrivateKey()` (or `tmpCertificateManager.getPrivateKey()`) instead of a raw disk read, so the comparison uses the exact same key material that `createCertificateRequest()` used to sign the CSR in the first place. Removes the now-unused `readPrivateKey` import.

## Tests

- `node-opcua-server-configuration/test/server/test_push_certificate_manager_server_impl.ts` in isolation: 71/71 passing (was 1 failing, deterministically, every run).
- Full `node-opcua-server-configuration` package suite: 136/136 passing, 0 failures.

## Note

This does not address the deeper (separate, pre-existing, likely intentional) behavior that `CertificateManager`'s cached private key is never invalidated after an external file replacement — so `createCertificateRequest()`/`createSelfSignedCertificate()` keep signing with the *old* key until the process restarts or a fresh instance is created, unless a `privateKeyProvider` is configured (which is consulted fresh on every call by design). That's a `node-opcua-pki` question, not in scope here — this PR only fixes the self-inconsistency inside `executeUpdateCertificate()` that was causing the test failure.
