### PR TITLE
test: fix flaky GZZE3 reconnection test (backoff-count race)

### DIFF
--- a/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_connection_reconnection_with_server_that_close_session_too_early.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_connection_reconnection_with_server_that_close_session_too_early.ts
@@ -6,7 +6,7 @@ import {
     type ClientMonitoredItem,
     type ClientSession,
     ClientSubscription,
-    ClientTCP_transport,
+    type ClientTCP_transport,
     type ConnectionStrategyOptions,
     coerceNodeId,
     DataType,
@@ -311,42 +311,88 @@ describeWithLeakDetector(
             await when_the_server_restart();
         }
 
+        // Armed by every given_* step, BEFORE the connection is broken, so
+        // that a reconnection completing on the very first retry attempt can
+        // never slip past the then_* steps: on a fast/local network the
+        // simulated 10s outage can leave the transport connect merely
+        // stalling (not failing), in which case ZERO backoff events ever fire
+        // (backoff only fires on a *failed* attempt) and session_restored is
+        // emitted exactly once, possibly before a then_* step gets to attach
+        // its own listener. Counting from the start makes both observations
+        // race-free.
+        let session_restored_count = 0;
+        function arm_session_restored_counter() {
+            session_restored_count = 0;
+            session.on("session_restored", () => {
+                session_restored_count += 1;
+                debugLog("session has been restored (count = ", session_restored_count, ")");
+            });
+        }
+
         async function given_a_active_client_with_subscription_and_monitored_items() {
             // Default reconnection strategy (infinite retry)
             await start_active_client({ maxRetry: -1, initialDelay: 100, maxDelay: 200 });
+            arm_session_restored_counter();
         }
         async function given_a_active_client() {
             await start_active_client_no_subscription({ maxRetry: -1, initialDelay: 100, maxDelay: 200 });
+            arm_session_restored_counter();
         }
 
         async function given_a_active_client_with_subscription_and_monitored_items_AND_short_retry_strategy() {
             // Fail-fast initial strategy (client logic should still retry indefinitely after connection loss)
             await start_active_client({ maxRetry: 2, initialDelay: 100, maxDelay: 200 });
+            arm_session_restored_counter();
         }
 
         async function then_client_should_detect_failure_and_enter_reconnection_mode() {
             let backoff_counter = 0;
             if (!client) throw new Error("Client not started");
+            // Resolve on EITHER 2 backoff events OR the session having been
+            // restored (see arm_session_restored_counter) — requiring a fixed
+            // backoff count alone hangs forever when the first retry succeeds.
+            if (session_restored_count > 0) {
+                return;
+            }
             await new Promise<void>((resolve) => {
+                let settled = false;
+                const settle = () => {
+                    if (settled) return;
+                    settled = true;
+                    client?.removeListener("backoff", backoff_detector);
+                    session.removeListener("session_restored", on_session_restored);
+                    resolve();
+                };
                 const backoff_detector = () => {
                     backoff_counter += 1;
                     if (backoff_counter === 2) {
                         if (doDebug) {
                             debugLog("Bingo !  Client has detected disconnection and is currently trying to reconnect");
                         }
-                        client?.removeListener("backoff", backoff_detector);
-                        resolve();
+                        settle();
                     }
                 };
+                const on_session_restored = () => {
+                    if (doDebug) {
+                        debugLog("Bingo !  session was restored before 2 backoff events were observed");
+                    }
+                    settle();
+                };
                 client?.on("backoff", backoff_detector);
+                session.on("session_restored", on_session_restored);
             });
         }
 
         async function then_client_should_reconnect() {
+            // The restoration may already have happened while the previous
+            // step was still waiting (session_restored fires exactly once per
+            // reconnection) — check the counter armed before the break first.
+            if (session_restored_count > 0) {
+                return;
+            }
             await new Promise<void>((resolve) => {
                 const on_session_restored = () => {
                     session.removeListener("session_restored", on_session_restored);
-                    debugLog("session has been restored");
                     resolve();
                 };
                 session.on("session_restored", on_session_restored);


### PR DESCRIPTION
## Summary

`GZZE3 should reconnect when network is broken` (in `test_e2e_connection_reconnection_with_server_that_close_session_too_early.ts`) is flaky on `master` — reproduced 3/3 on a fast machine, timing out at 100 s while the client had actually recovered fine.

**Root cause (two stacked races):**
1. The step `then_client_should_detect_failure_and_enter_reconnection_mode` waited for exactly **2 `backoff` events**. But `backoff` only fires on a *failed* retry attempt — and after `break_connection` (which triggers the server's 10 s `SimulateNetworkOutage` and destroys the client socket), a fast local reconnection can simply stall in the server's backlog and then succeed on the very first attempt. Zero backoff events, step hangs forever. `DEBUG=RECONNECTION` tracing confirms the session was reactivated successfully ~10 s after the break while the test still waited.
2. Fixing (1) alone exposed the second race: `session_restored` fires **exactly once** per reconnection, and the next step (`then_client_should_reconnect`) attached its listener only after the previous step resolved — by which time the event was already gone.

**Fix (test-only):** a `session_restored` counter is armed in the `given_*` steps — *before* the connection is broken — and both `then_*` steps resolve on either their original condition or the already-observed restoration. GZZE1/GZZE2 keep their semantics (a genuinely crashed server still produces the backoffs they observe), they just gain the same race protection.

Same class of fix as the SCT-3 de-flake in #1563 (poll/event instead of a fixed expectation).

## Test plan

- [x] GZZE3 standalone: pass (36 s, previously 100 s timeout)
- [x] Full file (GZZE1+2+3) × 3 clean runs: 3/3 passing each, ~2 min per run
- [x] `tsc -b` + biome clean
- (Two additional runs were invalidated by the machine suspending mid-run — mocha reported "1h"/"56m" elapsed inside a 550 s window; failures in those runs were GZZE1 with the fixture server's inactivity watchdog firing on resume, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)