### PR TITLE
build(lerna): force-publish so every package ships in lockstep

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,10 @@
   ],
   "version": "2.178.0",
   "npmClient": "pnpm",
-  "exact": true
+  "exact": true,
+  "command": {
+    "version": {
+      "forcePublish": true
+    }
+  }
 }


### PR DESCRIPTION
## Problem

`lerna.json` is in **fixed** mode with `exact: true` — the intent is that every package of the family ships at the same version. But the `version:lerna` script runs plain `lerna version`, which in fixed mode only bumps packages that have commits since the last tag. `lerna publish from-package` then publishes only what isn't already on npm.

Result for **v2.178.0**: every package without changes since 2.177.0 stayed at 2.177.0 and was silently skipped — `node-opcua-alias-name-common`, `node-opcua-nodeid`, `node-opcua-types`, `node-opcua-extension-object`, `node-opcua-role-set-common` and more. At tag `v2.178.0`, `packages/node-opcua-alias-name-common/package.json` still reads `2.177.0`; npm has no 2.178.0 for it.

Downstream consumers that pin the whole family at one version (the GDS console does, and its dependency-rules test caught this) then have nothing to resolve.

## Fix

`command.version.forcePublish: true` in `lerna.json`, so `lerna version` bumps **all** packages on every release regardless of change detection — enforced by config rather than by remembering a CLI flag. `from-package` publishing then ships the full set.

Trade-off, deliberate: every release publishes every package, including unchanged ones. That is exactly what fixed/lockstep mode promises, and what `exact` pins downstream rely on.

## Note

This does not retroactively fix 2.178.0 — the next `lerna version` (e.g. 2.178.1, which would also carry #1567) will publish the full family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)