### PR TITLE
perf(server): clone each sampled value once, and once properly

### DIFF
--- a/packages/node-opcua-basic-types/source/byte_string.ts
+++ b/packages/node-opcua-basic-types/source/byte_string.ts
@@ -39,5 +39,15 @@ export function coerceByteString(value: number[] | string | ByteString): ByteStr
     if (typeof value === "string") {
         return Buffer.from(value, "base64");
     }
+    // Copy rather than adopt the caller's Buffer. A structure built from an existing
+    // ByteString used to alias it, so cloning an ExtensionObject that carries one - which
+    // is how the server records a sampled value - produced a "clone" that still followed
+    // later writes to the original buffer.
+    //
+    // The decode path does not come through here (decodeByteString reads from the stream
+    // directly), so this costs nothing on the wire path.
+    if (Buffer.isBuffer(value)) {
+        return Buffer.from(value);
+    }
     return value;
 }

--- a/packages/node-opcua-data-value/source/datavalue.ts
+++ b/packages/node-opcua-data-value/source/datavalue.ts
@@ -357,14 +357,27 @@ export class DataValue extends BaseUAObject {
     }
 
     public clone(): DataValue {
-        return new DataValue({
-            serverPicoseconds: this.serverPicoseconds,
-            serverTimestamp: this.serverTimestamp,
-            sourcePicoseconds: this.sourcePicoseconds,
-            sourceTimestamp: this.sourceTimestamp,
-            statusCode: this.statusCode,
-            value: this.value ? this.value.clone() : undefined
-        });
+        // Assign the fields rather than routing them back through the constructor. Passing
+        // an already-cloned Variant as `options.value` made the constructor clone it a
+        // second time - `new Variant(variant)` copies the value, typed arrays included - so
+        // every DataValue.clone() copied its payload twice. The server clones each sampled
+        // value on the monitored-item path, so that duplicate was paid per value.
+        //
+        // The remaining Variant.clone() is the one that matters and is deliberately kept:
+        // the result must not share mutable state with the source, or a later write to the
+        // address space would retroactively alter an already-recorded sample.
+        //
+        // The other fields are copied exactly as the constructor would: statusCode is
+        // already a StatusCode, and the timestamps are already Date | null, so the coercion
+        // being skipped here is a no-op on both.
+        const dataValue = new DataValue(null);
+        dataValue.value = this.value ? this.value.clone() : new Variant(null);
+        dataValue.statusCode = this.statusCode;
+        dataValue.sourceTimestamp = this.sourceTimestamp;
+        dataValue.sourcePicoseconds = this.sourcePicoseconds;
+        dataValue.serverTimestamp = this.serverTimestamp;
+        dataValue.serverPicoseconds = this.serverPicoseconds;
+        return dataValue;
     }
 }
 

--- a/packages/node-opcua-data-value/source/datavalue.ts
+++ b/packages/node-opcua-data-value/source/datavalue.ts
@@ -391,7 +391,11 @@ function w(n: number): string {
 }
 
 function _partial_clone(dataValue: DataValue): DataValue {
-    const cloneDataValue = new DataValue({ value: undefined });
+    // `new DataValue({ value: undefined })` builds a fully initialised Null Variant that
+    // the next line throws away; the null form skips that. The Variant is deliberately
+    // shared rather than copied - the caller only adjusts timestamps and the status code,
+    // which are DataValue fields, so the payload is never written through this alias.
+    const cloneDataValue = new DataValue(null);
     cloneDataValue.value = dataValue.value;
     cloneDataValue.statusCode = dataValue.statusCode;
     return cloneDataValue;

--- a/packages/node-opcua-data-value/test/test_datavalue_clone.ts
+++ b/packages/node-opcua-data-value/test/test_datavalue_clone.ts
@@ -80,12 +80,35 @@ describe("DataValue.clone", () => {
     });
 
     it("should isolate a ByteString from later writes to the source", () => {
+        // A ByteString is a Buffer, and a server that fills a Buffer in place rather than
+        // replacing it would otherwise rewrite a sample that was already recorded and
+        // queued. The clone has to own its bytes.
         const buffer = Buffer.from([1, 2, 3]);
         const source = new DataValue({ value: new Variant({ dataType: DataType.ByteString, value: buffer }) });
 
         const clone = source.clone();
-
         clone.value.value.should.eql(buffer);
+
+        buffer[0] = 99;
+
+        clone.value.value[0].should.eql(1, "writing the source Buffer must not change the clone");
+        clone.value.value.should.not.equal(buffer, "the clone must own its Buffer");
+    });
+
+    it("should isolate an array of ByteStrings from later writes to the source", () => {
+        const first = Buffer.from([1, 2]);
+        const source = new DataValue({
+            value: new Variant({
+                dataType: DataType.ByteString,
+                arrayType: VariantArrayType.Array,
+                value: [first, Buffer.from([3, 4])]
+            })
+        });
+
+        const clone = source.clone();
+        first[0] = 99;
+
+        clone.value.value[0][0].should.eql(1, "writing an element Buffer must not change the clone");
     });
 
     it("should tolerate a DataValue with no value", () => {

--- a/packages/node-opcua-data-value/test/test_datavalue_clone.ts
+++ b/packages/node-opcua-data-value/test/test_datavalue_clone.ts
@@ -1,0 +1,128 @@
+import { StatusCodes } from "node-opcua-status-code";
+import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
+import should from "should";
+import { DataValue } from "..";
+
+//
+// DataValue.clone() is load-bearing on the server's sampling path: MonitoredItem records
+// a clone of the sampled value and keeps it (as oldDataValue) and hands it to the queued
+// notification. If the clone shared any mutable state with the source, a later write to
+// the address space would retroactively change a value that was already recorded - the
+// client would be told the wrong thing happened at that timestamp.
+//
+// So the clone must be a *true* clone. These tests pin that, independently of how the
+// clone is implemented, so the implementation can be made cheaper without weakening it.
+//
+
+describe("DataValue.clone", () => {
+    it("should copy every field", () => {
+        const source = new DataValue({
+            value: new Variant({ dataType: DataType.Double, value: 42.5 }),
+            statusCode: StatusCodes.BadWaitingForInitialData,
+            sourceTimestamp: new Date(Date.UTC(2026, 1, 2, 3, 4, 5)),
+            sourcePicoseconds: 1234,
+            serverTimestamp: new Date(Date.UTC(2026, 1, 2, 3, 4, 6)),
+            serverPicoseconds: 5678
+        });
+
+        const clone = source.clone();
+
+        clone.value.dataType.should.eql(source.value.dataType);
+        clone.value.value.should.eql(source.value.value);
+        clone.statusCode.should.eql(source.statusCode);
+        (clone.sourceTimestamp as Date).getTime().should.eql((source.sourceTimestamp as Date).getTime());
+        clone.sourcePicoseconds.should.eql(source.sourcePicoseconds);
+        (clone.serverTimestamp as Date).getTime().should.eql((source.serverTimestamp as Date).getTime());
+        clone.serverPicoseconds.should.eql(source.serverPicoseconds);
+    });
+
+    it("should not share the Variant instance with the source", () => {
+        const source = new DataValue({ value: new Variant({ dataType: DataType.Double, value: 1.5 }) });
+
+        const clone = source.clone();
+
+        clone.value.should.not.equal(source.value, "the clone must own its Variant");
+    });
+
+    it("should isolate a scalar value from later writes to the source", () => {
+        const source = new DataValue({ value: new Variant({ dataType: DataType.Double, value: 1.5 }) });
+        const clone = source.clone();
+
+        source.value.value = 99;
+
+        clone.value.value.should.eql(1.5);
+    });
+
+    it("should isolate a typed array from later writes to the source", () => {
+        // the case that actually costs: the array must be copied, not aliased, or the
+        // recorded sample mutates under the client
+        const array = new Float64Array([1, 2, 3, 4]);
+        const source = new DataValue({
+            value: new Variant({ dataType: DataType.Double, arrayType: VariantArrayType.Array, value: array })
+        });
+
+        const clone = source.clone();
+        source.value.value[0] = 999;
+
+        clone.value.value[0].should.eql(1, "the clone must not see writes made to the source array");
+        clone.value.value.buffer.should.not.equal(source.value.value.buffer, "the clone must own its ArrayBuffer");
+    });
+
+    it("should isolate a plain array from later writes to the source", () => {
+        const source = new DataValue({
+            value: new Variant({ dataType: DataType.String, arrayType: VariantArrayType.Array, value: ["a", "b"] })
+        });
+
+        const clone = source.clone();
+        source.value.value[0] = "changed";
+
+        clone.value.value[0].should.eql("a");
+    });
+
+    it("should isolate a ByteString from later writes to the source", () => {
+        const buffer = Buffer.from([1, 2, 3]);
+        const source = new DataValue({ value: new Variant({ dataType: DataType.ByteString, value: buffer }) });
+
+        const clone = source.clone();
+
+        clone.value.value.should.eql(buffer);
+    });
+
+    it("should tolerate a DataValue with no value", () => {
+        const source = new DataValue({ statusCode: StatusCodes.BadNodeIdUnknown });
+
+        const clone = source.clone();
+
+        should.exist(clone.value);
+        clone.value.dataType.should.eql(DataType.Null);
+        clone.statusCode.should.eql(StatusCodes.BadNodeIdUnknown);
+    });
+
+    it("should leave the source untouched", () => {
+        const source = new DataValue({
+            value: new Variant({ dataType: DataType.Double, arrayType: VariantArrayType.Array, value: new Float64Array([7, 8]) }),
+            statusCode: StatusCodes.Good,
+            sourceTimestamp: new Date(Date.UTC(2026, 0, 1))
+        });
+        const before = source.toString();
+
+        source.clone();
+
+        source.toString().should.eql(before);
+    });
+
+    it("should survive a round of clone-of-clone without aliasing", () => {
+        // MonitoredItem clones what it was given and keeps the result; a second clone of
+        // that must still be independent
+        const source = new DataValue({
+            value: new Variant({ dataType: DataType.Int32, arrayType: VariantArrayType.Array, value: new Int32Array([1, 2, 3]) })
+        });
+
+        const first = source.clone();
+        const second = first.clone();
+        first.value.value[0] = 42;
+
+        second.value.value[0].should.eql(1);
+        source.value.value[0].should.eql(1);
+    });
+});

--- a/packages/node-opcua-server/source/monitored_item.ts
+++ b/packages/node-opcua-server/source/monitored_item.ts
@@ -1320,10 +1320,19 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
             }
         }
         dataValue = apply_timestamps(dataValue, this.timestampsToReturn, attributeId);
-        return new MonitoredItemNotification({
-            clientHandle: this.clientHandle,
-            value: dataValue
-        });
+        // Assign rather than pass through the options constructor: DataValue is registered
+        // with a coerce that always builds a new instance, so `{ value: dataValue }` would
+        // deep-copy the payload a second time - typed arrays included - immediately after
+        // recordValue already cloned it.
+        //
+        // Handing over apply_timestamps' result directly is safe because that is itself a
+        // fresh DataValue: the notification owns its statusCode and timestamps (which
+        // _setOverflowBit and the timestamp handling do write), and shares only the Variant
+        // with oldDataValue, which nothing mutates in place.
+        const notification = new MonitoredItemNotification(null);
+        notification.clientHandle = this.clientHandle;
+        notification.value = dataValue;
+        return notification;
     }
 
     /**

--- a/packages/node-opcua-server/source/node_sampler.ts
+++ b/packages/node-opcua-server/source/node_sampler.ts
@@ -13,8 +13,15 @@ import type { MonitoredItem } from "./monitored_item";
 
 interface ITimer {
     _samplingId: NodeJS.Timeout | false;
-    monitoredItems: Record<string, MonitoredItem>;
-    monitoredItemsCount: number;
+    /**
+     * a Map, not a plain object: this is walked in full on every sampling tick, and a
+     * subscription may hold up to maxMonitoredItemsPerSubscription (100 000 by default)
+     * items on the same interval. At that size a plain object goes into dictionary mode
+     * and every lookup becomes a hash probe, on top of the per-key Object.hasOwn that
+     * `for...in` requires. Map also makes the count intrinsic, so the parallel counter
+     * that had to be kept in step is gone.
+     */
+    monitoredItems: Map<number, MonitoredItem>;
 }
 const timers: Record<string, ITimer> = {};
 const NS_PER_SEC = 1e9;
@@ -42,18 +49,15 @@ export function appendToTimer(monitoredItem: MonitoredItem): string {
     if (!_t) {
         _t = {
             _samplingId: false,
-            monitoredItems: {},
-            monitoredItemsCount: 0
+            monitoredItems: new Map()
         };
 
         _t._samplingId = setInterval(() => {
             const start = doDebug ? hrtime() : undefined;
             let counter = 0;
-            for (const m in _t.monitoredItems) {
-                if (Object.hasOwn(_t.monitoredItems, m)) {
-                    sampleMonitoredItem(_t.monitoredItems[m]);
-                    counter++;
-                }
+            for (const monitoredItem of _t.monitoredItems.values()) {
+                sampleMonitoredItem(monitoredItem);
+                counter++;
             }
             // c8 ignore next
             if (doDebug) {
@@ -67,9 +71,8 @@ export function appendToTimer(monitoredItem: MonitoredItem): string {
         }, samplingInterval);
         timers[key] = _t;
     }
-    assert(!_t.monitoredItems[monitoredItem.monitoredItemId]);
-    _t.monitoredItems[monitoredItem.monitoredItemId] = monitoredItem;
-    _t.monitoredItemsCount++;
+    assert(!_t.monitoredItems.has(monitoredItem.monitoredItemId));
+    _t.monitoredItems.set(monitoredItem.monitoredItemId, monitoredItem);
     return key;
 }
 
@@ -85,11 +88,9 @@ export function removeFromTimer(monitoredItem: MonitoredItem): void {
         return;
     }
     assert(_t);
-    assert(_t.monitoredItems[monitoredItem.monitoredItemId]);
-    delete _t.monitoredItems[monitoredItem.monitoredItemId];
-    _t.monitoredItemsCount--;
-    assert(_t.monitoredItemsCount >= 0);
-    if (_t.monitoredItemsCount === 0) {
+    assert(_t.monitoredItems.has(monitoredItem.monitoredItemId));
+    _t.monitoredItems.delete(monitoredItem.monitoredItemId);
+    if (_t.monitoredItems.size === 0) {
         if (_t._samplingId !== false) {
             clearInterval(_t._samplingId);
         }

--- a/packages/node-opcua-server/source/server_subscription.ts
+++ b/packages/node-opcua-server/source/server_subscription.ts
@@ -590,7 +590,7 @@ export class Subscription extends EventEmitter {
     public _pending_notifications: Queue<InternalNotification>;
     private _sent_notification_messages: NotificationMessage[];
     private readonly _sequence_number_generator: SequenceNumberGenerator;
-    private readonly monitoredItems: { [key: number]: MonitoredItem };
+    private readonly monitoredItems: Map<number, MonitoredItem>;
     private timerId: ReturnType<typeof setTimeout> | null;
     private _hasUncollectedMonitoredItemNotifications = false;
 
@@ -637,7 +637,7 @@ export class Subscription extends EventEmitter {
 
         this.publishIntervalCount = 0;
 
-        this.monitoredItems = {}; // monitored item map
+        this.monitoredItems = new Map(); // monitored item map
 
         this.monitoredItemIdCounter = 0;
 
@@ -821,10 +821,8 @@ export class Subscription extends EventEmitter {
         doDebug && debugLog("terminating Subscription  ", this.id, " with ", this.monitoredItemCount, " monitored items");
 
         // dispose all monitoredItem
-        const keys = Object.keys(this.monitoredItems);
-
-        for (const key of keys) {
-            const status = this.removeMonitoredItem(parseInt(key, 10));
+        for (const monitoredItemId of [...this.monitoredItems.keys()]) {
+            const status = this.removeMonitoredItem(monitoredItemId);
             assert(status === StatusCodes.Good);
         }
         assert(this.monitoredItemCount === 0);
@@ -959,16 +957,18 @@ export class Subscription extends EventEmitter {
      * number of monitored items handled by this subscription
      */
     public get monitoredItemCount(): number {
-        return Object.keys(this.monitoredItems).length;
+        return this.monitoredItems.size;
     }
 
     /**
      * number of disabled monitored items.
      */
     public get disabledMonitoredItemCount(): number {
-        return Object.values(this.monitoredItems).reduce((sum: number, monitoredItem: MonitoredItem) => {
-            return sum + (monitoredItem.monitoringMode === MonitoringMode.Disabled ? 1 : 0);
-        }, 0);
+        let count = 0;
+        for (const monitoredItem of this.monitoredItems.values()) {
+            count += monitoredItem.monitoringMode === MonitoringMode.Disabled ? 1 : 0;
+        }
+        return count;
     }
 
     /**
@@ -1126,7 +1126,7 @@ export class Subscription extends EventEmitter {
     }
 
     public async applyOnMonitoredItem(functor: (monitoredItem: MonitoredItem) => Promise<void>): Promise<void> {
-        for (const m of Object.values(this.monitoredItems)) {
+        for (const m of this.monitoredItems.values()) {
             await functor(m);
         }
     }
@@ -1161,7 +1161,7 @@ export class Subscription extends EventEmitter {
      * @return the monitored item matching monitoredItemId
      */
     public getMonitoredItem(monitoredItemId: number): MonitoredItem | null {
-        return this.monitoredItems[monitoredItemId] || null;
+        return this.monitoredItems.get(monitoredItemId) || null;
     }
 
     /**
@@ -1171,11 +1171,10 @@ export class Subscription extends EventEmitter {
     public removeMonitoredItem(monitoredItemId: number): StatusCode {
         // c8 ignore next
         doDebug && debugLog("Removing monitoredIem ", monitoredItemId);
-        if (!Object.hasOwn(this.monitoredItems, monitoredItemId.toString())) {
+        const monitoredItem = this.monitoredItems.get(monitoredItemId);
+        if (!monitoredItem) {
             return StatusCodes.BadMonitoredItemIdInvalid;
         }
-
-        const monitoredItem = this.monitoredItems[monitoredItemId];
 
         monitoredItem.terminate();
 
@@ -1188,7 +1187,7 @@ export class Subscription extends EventEmitter {
 
         monitoredItem.dispose();
 
-        delete this.monitoredItems[monitoredItemId];
+        this.monitoredItems.delete(monitoredItemId);
         this.globalCounter.totalMonitoredItemCount -= 1;
 
         this._removePendingNotificationsFor(monitoredItemId);
@@ -1204,11 +1203,7 @@ export class Subscription extends EventEmitter {
         if (this._hasUncollectedMonitoredItemNotifications) {
             return true;
         }
-        const keys = Object.keys(this.monitoredItems);
-        const n = keys.length;
-        for (let i = 0; i < n; i++) {
-            const key = parseInt(keys[i], 10);
-            const monitoredItem = this.monitoredItems[key];
+        for (const monitoredItem of this.monitoredItems.values()) {
             if (monitoredItem.hasMonitoredItemNotifications) {
                 this._hasUncollectedMonitoredItemNotifications = true;
                 return true;
@@ -1284,7 +1279,7 @@ export class Subscription extends EventEmitter {
      *
      */
     public getMonitoredItems(): GetMonitoredItemsResult {
-        const monitoredItems = Object.keys(this.monitoredItems);
+        const monitoredItems = [...this.monitoredItems.keys()];
         const monitoredItemCount = monitoredItems.length;
         const result: GetMonitoredItemsResult = {
             clientHandles: new Uint32Array(monitoredItemCount),
@@ -1292,8 +1287,7 @@ export class Subscription extends EventEmitter {
             statusCode: StatusCodes.Good
         };
         for (let index = 0; index < monitoredItemCount; index++) {
-            const monitoredItemId = monitoredItems[index];
-            const serverHandle = parseInt(monitoredItemId, 10);
+            const serverHandle = monitoredItems[index];
             const monitoredItem = this.getMonitoredItem(serverHandle);
             // c8 ignore next
             if (!monitoredItem) {
@@ -1317,7 +1311,7 @@ export class Subscription extends EventEmitter {
 
         try {
             const promises: Promise<void>[] = [];
-            for (const monitoredItem of Object.values(this.monitoredItems)) {
+            for (const monitoredItem of this.monitoredItems.values()) {
                 promises.push(
                     (async () => {
                         try {
@@ -1921,7 +1915,7 @@ export class Subscription extends EventEmitter {
 
         assert(monitoredItem.monitoredItemId === monitoredItemId);
 
-        this.monitoredItems[monitoredItemId] = monitoredItem;
+        this.monitoredItems.set(monitoredItemId, monitoredItem);
         this.globalCounter.totalMonitoredItemCount += 1;
 
         assert(monitoredItem.clientHandle !== 4294967295);
@@ -1960,7 +1954,7 @@ export class Subscription extends EventEmitter {
     }
 
     public _harvestMonitoredItems() {
-        for (const monitoredItem of Object.values(this.monitoredItems)) {
+        for (const monitoredItem of this.monitoredItems.values()) {
             const notifications_chunks = monitoredItem.extractMonitoredItemNotifications();
             for (const chunk of notifications_chunks) {
                 this._addNotificationMessage(chunk, monitoredItem.monitoredItemId);

--- a/packages/node-opcua-server/test/helper.ts
+++ b/packages/node-opcua-server/test/helper.ts
@@ -8,7 +8,7 @@ interface M2 {
 }
 
 interface ISubscriptionWithMonitoredItems {
-    monitoredItems: Record<number, MonitoredItem>;
+    monitoredItems: Map<number, MonitoredItem>;
 }
 
 export function add_mock_monitored_item(subscription: Subscription) {
@@ -41,7 +41,7 @@ export function add_mock_monitored_item(subscription: Subscription) {
         }
     );
 
-    (subscription as unknown as ISubscriptionWithMonitoredItems).monitoredItems[1] = monitoredItem as unknown as MonitoredItem;
+    (subscription as unknown as ISubscriptionWithMonitoredItems).monitoredItems.set(1, monitoredItem as unknown as MonitoredItem);
 
     let counter = 1;
 

--- a/packages/node-opcua-server/test/test_monitored_item_captures_mutable_extension_object.ts
+++ b/packages/node-opcua-server/test/test_monitored_item_captures_mutable_extension_object.ts
@@ -1,0 +1,157 @@
+import type { IAddressSpace, UAVariable, UAVariableType } from "node-opcua-address-space";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { nodesets } from "node-opcua-nodesets";
+import { TimestampsToReturn } from "node-opcua-service-read";
+import type { ServiceCounterDataType } from "node-opcua-types";
+import { DataType } from "node-opcua-variant";
+import should from "should";
+import { MonitoredItem, type MonitoredItemOptions, ServerEngine } from "../source";
+
+//
+// The end-to-end version of the clone contract.
+//
+// bindExtensionObject() hands back a *live* ExtensionObject: the address space keeps that
+// instance and a server mutates its fields in place, which is immediately visible through
+// readValue(). When a MonitoredItem samples such a variable it must capture a deep copy -
+// otherwise the value sitting in the notification queue keeps tracking the live object,
+// and by the time it is published it reports the current state rather than the state at
+// the moment it was sampled. The timestamp would say one thing and the payload another.
+//
+// This drives a real UAVariable, a real bound ExtensionObject and a real MonitoredItem,
+// rather than asserting on DataValue.clone() in isolation.
+//
+
+describe("MonitoredItem capturing a mutable ExtensionObject", function (this: Mocha.Suite) {
+    this.timeout(Math.max(60000, this.timeout()));
+
+    let engine: ServerEngine;
+    let addressSpace: IAddressSpace;
+    let extensionObjectVar: UAVariable;
+    let liveExtensionObject: ServiceCounterDataType;
+
+    before((done) => {
+        engine = new ServerEngine();
+        engine.initialize({ nodeset_filename: nodesets.standard }, () => {
+            addressSpace = engine.addressSpace as IAddressSpace;
+
+            const baseVariableType = addressSpace.findVariableType("BaseDataVariableType") as UAVariableType;
+            const serviceCounterDataType = addressSpace.findDataType("ServiceCounterDataType");
+            should.exist(baseVariableType);
+            should.exist(serviceCounterDataType);
+
+            extensionObjectVar = baseVariableType.instantiate({
+                browseName: "SomeServiceCounter",
+                dataType: serviceCounterDataType?.nodeId,
+                valueRank: -1,
+                minimumSamplingInterval: 0,
+                organizedBy: addressSpace.rootFolder.objects
+            }) as UAVariable;
+
+            // the live instance the address space will keep handing out
+            liveExtensionObject = extensionObjectVar.bindExtensionObject() as ServiceCounterDataType;
+            done();
+        });
+    });
+
+    after(async () => {
+        await engine.shutdown();
+        engine.dispose();
+    });
+
+    function createMonitoredItem() {
+        const monitoredItem = new MonitoredItem({
+            clientHandle: 1,
+            samplingInterval: 100,
+            discardOldest: true,
+            queueSize: 100,
+            monitoredItemId: 100,
+            timestampsToReturn: TimestampsToReturn.Both,
+            itemToMonitor: { nodeId: extensionObjectVar.nodeId, attributeId: 13 }
+        } as unknown as MonitoredItemOptions);
+        return monitoredItem as MonitoredItem & { queue: { value: { value: { value: ServiceCounterDataType } } }[] };
+    }
+
+    it("should record the value as it was at sampling time, not as it becomes later", () => {
+        liveExtensionObject.totalCount = 1;
+        const monitoredItem = createMonitoredItem();
+        try {
+            monitoredItem.setNode(extensionObjectVar);
+
+            // sample: this is what the sampler feeds to the monitored item
+            const sampled = extensionObjectVar.readValue();
+            monitoredItem.recordValue(sampled, true);
+            monitoredItem.queue.length.should.eql(1, "the sample should have been queued");
+
+            // now the server mutates the *live* extension object, as it is entitled to
+            liveExtensionObject.totalCount = 42;
+
+            // the queued notification must still report what was sampled
+            monitoredItem.queue[0].value.value.value.totalCount.should.eql(
+                1,
+                "the queued notification followed the live object instead of keeping its own copy"
+            );
+        } finally {
+            monitoredItem.terminate();
+            monitoredItem.dispose();
+        }
+    });
+
+    it("should keep successive samples independent of one another", () => {
+        liveExtensionObject.totalCount = 10;
+        const monitoredItem = createMonitoredItem();
+        try {
+            monitoredItem.setNode(extensionObjectVar);
+
+            monitoredItem.recordValue(extensionObjectVar.readValue(), true);
+            liveExtensionObject.totalCount = 20;
+            monitoredItem.recordValue(extensionObjectVar.readValue(), true);
+            liveExtensionObject.totalCount = 30;
+
+            monitoredItem.queue.length.should.eql(2);
+            monitoredItem.queue[0].value.value.value.totalCount.should.eql(10, "first sample was overwritten");
+            monitoredItem.queue[1].value.value.value.totalCount.should.eql(20, "second sample was overwritten");
+        } finally {
+            monitoredItem.terminate();
+            monitoredItem.dispose();
+        }
+    });
+
+    it("should not let the recorded value alias the live extension object", () => {
+        liveExtensionObject.totalCount = 7;
+        const monitoredItem = createMonitoredItem();
+        try {
+            monitoredItem.setNode(extensionObjectVar);
+            monitoredItem.recordValue(extensionObjectVar.readValue(), true);
+
+            const queued = monitoredItem.queue[0].value.value.value;
+
+            queued.should.not.equal(liveExtensionObject, "the queued value must not be the live instance");
+        } finally {
+            monitoredItem.terminate();
+            monitoredItem.dispose();
+        }
+    });
+
+    it("should report the sampled value even after the variable's timestamp is touched", () => {
+        // a fresh sourceTimestamp on the variable must not drag the already-queued payload
+        // forward with it
+        liveExtensionObject.totalCount = 3;
+        const monitoredItem = createMonitoredItem();
+        try {
+            monitoredItem.setNode(extensionObjectVar);
+            monitoredItem.recordValue(extensionObjectVar.readValue(), true);
+
+            liveExtensionObject.totalCount = 99;
+            extensionObjectVar.setValueFromSource(
+                { dataType: DataType.ExtensionObject, value: liveExtensionObject },
+                undefined,
+                new Date()
+            );
+
+            monitoredItem.queue[0].value.value.value.totalCount.should.eql(3);
+        } finally {
+            monitoredItem.terminate();
+            monitoredItem.dispose();
+        }
+    });
+});

--- a/packages/node-opcua-types/test/test_datavalue_clone_extension_object.ts
+++ b/packages/node-opcua-types/test/test_datavalue_clone_extension_object.ts
@@ -1,0 +1,129 @@
+import { DataValue } from "node-opcua-data-value";
+import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
+import should from "should";
+import { Argument, EUInformation, Range } from "..";
+
+//
+// The server clones every sampled DataValue on the monitored-item path and keeps the
+// clone, so the clone must not share mutable state with the source. That is easy to
+// believe for a scalar and easy to get wrong for an ExtensionObject, whose fields may
+// themselves be arrays or further ExtensionObjects.
+//
+// node-opcua-data-value cannot depend on node-opcua-types, so the ExtensionObject half of
+// the clone contract is pinned here, against real generated types.
+//
+
+describe("DataValue.clone with ExtensionObject payloads", () => {
+    it("should give the clone its own ExtensionObject instance", () => {
+        const argument = new Argument({ name: "original" });
+        const source = new DataValue({ value: new Variant({ dataType: DataType.ExtensionObject, value: argument }) });
+
+        const clone = source.clone();
+
+        clone.value.value.should.not.equal(argument, "the clone must not reference the source ExtensionObject");
+    });
+
+    it("should isolate a simple field of the ExtensionObject", () => {
+        const source = new DataValue({
+            value: new Variant({ dataType: DataType.ExtensionObject, value: new Argument({ name: "original" }) })
+        });
+
+        const clone = source.clone();
+        source.value.value.name = "mutated";
+
+        clone.value.value.name.should.eql("original");
+    });
+
+    it("should isolate an array field of the ExtensionObject", () => {
+        // arrayDimensions is a UInt32[]; sharing the array would let a later write to the
+        // source rewrite an already-recorded sample
+        const source = new DataValue({
+            value: new Variant({
+                dataType: DataType.ExtensionObject,
+                value: new Argument({ name: "a", arrayDimensions: [1, 2, 3] })
+            })
+        });
+
+        const clone = source.clone();
+        clone.value.value.arrayDimensions.should.not.equal(source.value.value.arrayDimensions);
+
+        source.value.value.arrayDimensions[0] = 999;
+
+        clone.value.value.arrayDimensions[0].should.eql(1);
+    });
+
+    it("should isolate a nested structure field of the ExtensionObject", () => {
+        const source = new DataValue({
+            value: new Variant({
+                dataType: DataType.ExtensionObject,
+                value: new Argument({ name: "a", description: { text: "original" } })
+            })
+        });
+
+        const clone = source.clone();
+        source.value.value.description.text = "mutated";
+
+        clone.value.value.description.text.should.eql("original");
+    });
+
+    it("should isolate every element of an ExtensionObject array", () => {
+        const source = new DataValue({
+            value: new Variant({
+                dataType: DataType.ExtensionObject,
+                arrayType: VariantArrayType.Array,
+                value: [new Argument({ name: "first" }), new Argument({ name: "second" })]
+            })
+        });
+
+        const clone = source.clone();
+
+        clone.value.value.should.not.equal(source.value.value, "the outer array must be copied");
+        clone.value.value[0].should.not.equal(source.value.value[0], "each element must be copied");
+
+        source.value.value[0].name = "mutated";
+
+        clone.value.value[0].name.should.eql("first");
+        clone.value.value[1].name.should.eql("second");
+    });
+
+    it("should isolate a deeply nested ExtensionObject", () => {
+        const source = new DataValue({
+            value: new Variant({
+                dataType: DataType.ExtensionObject,
+                value: new EUInformation({ displayName: { text: "original" }, description: { text: "d" } })
+            })
+        });
+
+        const clone = source.clone();
+        source.value.value.displayName.text = "mutated";
+
+        clone.value.value.displayName.text.should.eql("original");
+    });
+
+    it("should preserve the values it copies", () => {
+        const range = new Range({ low: 1.5, high: 9.5 });
+        const source = new DataValue({ value: new Variant({ dataType: DataType.ExtensionObject, value: range }) });
+
+        const clone = source.clone();
+
+        clone.value.value.low.should.eql(1.5);
+        clone.value.value.high.should.eql(9.5);
+        clone.value.dataType.should.eql(DataType.ExtensionObject);
+    });
+
+    it("should still encode to the same bytes as the source", () => {
+        // the clone has to be interchangeable with the source on the wire, not merely
+        // structurally similar
+        const source = new DataValue({
+            value: new Variant({
+                dataType: DataType.ExtensionObject,
+                value: new Argument({ name: "wire", valueRank: 2, arrayDimensions: [4, 5] })
+            })
+        });
+
+        const clone = source.clone();
+
+        should(clone.binaryStoreSize()).eql(source.binaryStoreSize());
+        clone.toString().should.eql(source.toString());
+    });
+});

--- a/packages/node-opcua-variant/source/variant.ts
+++ b/packages/node-opcua-variant/source/variant.ts
@@ -92,8 +92,20 @@ function cloneVariantElement(dataType: DataType, value: unknown): unknown {
     switch (dataType) {
         case DataType.ByteString:
             return Buffer.isBuffer(value) ? Buffer.from(value as Buffer) : value;
-        case DataType.DateTime:
-            return value instanceof Date ? new Date(value.getTime()) : value;
+        case DataType.DateTime: {
+            if (!(value instanceof Date)) {
+                return value;
+            }
+            const copy = new Date(value.getTime());
+            // node-opcua carries sub-millisecond precision as a `picoseconds` property
+            // hung on the Date instance itself, so a plain new Date(getTime()) silently
+            // drops it - the historical-access nodes compare on it.
+            const picoseconds = (value as Date & { picoseconds?: number }).picoseconds;
+            if (picoseconds !== undefined) {
+                (copy as Date & { picoseconds?: number }).picoseconds = picoseconds;
+            }
+            return copy;
+        }
         case DataType.NodeId:
         case DataType.ExpandedNodeId: {
             const nodeId = value as NodeId;
@@ -104,10 +116,28 @@ function cloneVariantElement(dataType: DataType, value: unknown): unknown {
             const identifier = Buffer.isBuffer(nodeId.value) ? Buffer.from(nodeId.value) : nodeId.value;
             return new NodeId(nodeId.identifierType, identifier, nodeId.namespace);
         }
-        case DataType.LocalizedText:
-            return value instanceof LocalizedText ? new LocalizedText(value) : value;
-        case DataType.QualifiedName:
-            return value instanceof QualifiedName ? new QualifiedName(value) : value;
+        // LocalizedText and QualifiedName are copied field by field rather than through
+        // their option constructors: those default with `options.text || null`, so an
+        // empty string - a perfectly valid value, and what an uncommented Condition
+        // carries - would come back as null.
+        case DataType.LocalizedText: {
+            if (!(value instanceof LocalizedText)) {
+                return value;
+            }
+            const localizedText = new LocalizedText(null);
+            localizedText.locale = value.locale;
+            localizedText.text = value.text;
+            return localizedText;
+        }
+        case DataType.QualifiedName: {
+            if (!(value instanceof QualifiedName)) {
+                return value;
+            }
+            const qualifiedName = new QualifiedName(null);
+            qualifiedName.namespaceIndex = value.namespaceIndex;
+            qualifiedName.name = value.name;
+            return qualifiedName;
+        }
         case DataType.Variant:
             return value instanceof Variant ? value.clone() : value;
         case DataType.ExtensionObject: {
@@ -1261,6 +1291,14 @@ export function sameVariant(v1: Variant, v2: Variant): boolean {
         }
         if (Buffer.isBuffer(v1.value) && Buffer.isBuffer(v2.value)) {
             return v1.value.equals(v2.value);
+        }
+        // NodeId, LocalizedText, QualifiedName and DateTime are objects too, and without
+        // this they fall through to `return false` below - two equal values would always
+        // look different. That was masked as long as clone() shared the instance, so the
+        // `v1.value === v2.value` shortcut above matched; it was already wrong for values
+        // that arrive separately, such as anything just decoded off the wire.
+        if (v1.value !== null && typeof v1.value === "object") {
+            return __check_same_object(v1.value, v2.value);
         }
     }
     if (v1.arrayType === VariantArrayType.Array) {

--- a/packages/node-opcua-variant/source/variant.ts
+++ b/packages/node-opcua-variant/source/variant.ts
@@ -75,6 +75,80 @@ const schemaVariant = buildStructuredType({
     name: "Variant"
 });
 
+/**
+ * copy one element of a Variant deeply enough that writing the original cannot be seen
+ * through the copy.
+ *
+ * Only the DataTypes whose values are mutable objects need work here. Numbers, strings and
+ * booleans are immutable, and a StatusCode is a shared constant, so they are returned
+ * as-is. Everything else is a live object that a server may well write in place - the
+ * address space does exactly that with a bound ExtensionObject - and sharing it would let
+ * a later write rewrite a sample that has already been recorded and queued.
+ */
+function cloneVariantElement(dataType: DataType, value: unknown): unknown {
+    if (value === null || value === undefined) {
+        return value;
+    }
+    switch (dataType) {
+        case DataType.ByteString:
+            return Buffer.isBuffer(value) ? Buffer.from(value as Buffer) : value;
+        case DataType.DateTime:
+            return value instanceof Date ? new Date(value.getTime()) : value;
+        case DataType.NodeId:
+        case DataType.ExpandedNodeId: {
+            const nodeId = value as NodeId;
+            if (!(nodeId instanceof NodeId)) {
+                return value;
+            }
+            // a ByteString identifier is itself a Buffer and needs copying too
+            const identifier = Buffer.isBuffer(nodeId.value) ? Buffer.from(nodeId.value) : nodeId.value;
+            return new NodeId(nodeId.identifierType, identifier, nodeId.namespace);
+        }
+        case DataType.LocalizedText:
+            return value instanceof LocalizedText ? new LocalizedText(value) : value;
+        case DataType.QualifiedName:
+            return value instanceof QualifiedName ? new QualifiedName(value) : value;
+        case DataType.Variant:
+            return value instanceof Variant ? value.clone() : value;
+        case DataType.ExtensionObject: {
+            const extensionObject = value as { constructor: new (options: unknown) => unknown };
+            return extensionObject?.constructor ? new extensionObject.constructor(value) : value;
+        }
+        default:
+            // Boolean, the integer and floating point families, String, Guid, StatusCode:
+            // immutable values, nothing to copy
+            return value;
+    }
+}
+
+/** deep-copy the payload of a Variant, preserving its shape (scalar, typed array or array) */
+function cloneVariantValue(dataType: DataType, value: unknown): unknown {
+    if (value === null || value === undefined) {
+        return value;
+    }
+    // a Buffer is both a typed array and the representation of a scalar ByteString, so it
+    // has to be tested before the generic typed-array branch below
+    if (Buffer.isBuffer(value)) {
+        return Buffer.from(value);
+    }
+    if (ArrayBuffer.isView(value)) {
+        // Float64Array and friends: copy the elements, never the view onto the source
+        const typed = value as unknown as BufferedArray2;
+        const copy = new (typed.constructor as BufferedArrayConstructor)(typed.length);
+        copy.set(typed as never);
+        return copy;
+    }
+    if (Array.isArray(value)) {
+        const n = value.length;
+        const copy = new Array(n);
+        for (let i = 0; i < n; i++) {
+            copy[i] = cloneVariantElement(dataType, value[i]);
+        }
+        return copy;
+    }
+    return cloneVariantElement(dataType, value);
+}
+
 function _coerceVariant(variantLike: VariantOptions | Variant): Variant {
     const value = variantLike instanceof Variant ? variantLike : new Variant(variantLike);
     return value;
@@ -178,7 +252,12 @@ export class Variant extends BaseUAObject {
     }
 
     public clone(): Variant {
-        return new Variant(this);
+        const variant = new Variant(null);
+        variant.dataType = this.dataType;
+        variant.arrayType = this.arrayType;
+        variant.dimensions = this.dimensions ? this.dimensions.slice() : null;
+        variant.value = cloneVariantValue(this.dataType, this.value);
+        return variant;
     }
 }
 

--- a/packages/node-opcua-variant/test/test_variant_clone.ts
+++ b/packages/node-opcua-variant/test/test_variant_clone.ts
@@ -1,0 +1,154 @@
+import { LocalizedText, QualifiedName } from "node-opcua-data-model";
+import { coerceNodeId, type NodeId } from "node-opcua-nodeid";
+import should from "should";
+import { DataType, Variant, VariantArrayType } from "..";
+
+//
+// Variant.clone() has to be a true deep copy. The server records a clone of every sampled
+// value and keeps it while the notification sits in the queue, so anything the clone still
+// shares with the source can be rewritten afterwards - the client would then be told a
+// different thing happened at a timestamp already gone by.
+//
+// Numbers, strings and booleans are immutable and need no copying. Everything whose value
+// is a live object does: Buffers, Dates, NodeIds, LocalizedTexts, QualifiedNames and
+// ExtensionObjects, whether they appear on their own or inside an array.
+//
+
+/** for each mutable DataType: how to build one, how to write it, and what to read back */
+const mutableTypes: {
+    name: string;
+    dataType: DataType;
+    make: () => unknown;
+    mutate: (value: never) => void;
+    read: (value: never) => unknown;
+}[] = [
+    {
+        name: "ByteString",
+        dataType: DataType.ByteString,
+        make: () => Buffer.from([1, 2, 3]),
+        mutate: (v: Buffer) => {
+            v[0] = 99;
+        },
+        read: (v: Buffer) => v[0]
+    },
+    {
+        name: "DateTime",
+        dataType: DataType.DateTime,
+        make: () => new Date(Date.UTC(2026, 0, 1)),
+        mutate: (v: Date) => v.setUTCFullYear(1999),
+        read: (v: Date) => v.getUTCFullYear()
+    },
+    {
+        name: "NodeId",
+        dataType: DataType.NodeId,
+        make: () => coerceNodeId("ns=1;i=42"),
+        mutate: (v: NodeId) => {
+            v.value = 99;
+        },
+        read: (v: NodeId) => v.value
+    },
+    {
+        name: "LocalizedText",
+        dataType: DataType.LocalizedText,
+        make: () => new LocalizedText({ text: "original" }),
+        mutate: (v: LocalizedText) => {
+            v.text = "mutated";
+        },
+        read: (v: LocalizedText) => v.text
+    },
+    {
+        name: "QualifiedName",
+        dataType: DataType.QualifiedName,
+        make: () => new QualifiedName({ name: "original" }),
+        mutate: (v: QualifiedName) => {
+            v.name = "mutated";
+        },
+        read: (v: QualifiedName) => v.name
+    }
+];
+
+describe("Variant.clone deep-copy guarantees", () => {
+    for (const { name, dataType, make, mutate, read } of mutableTypes) {
+        it(`should isolate a scalar ${name} from later writes to the source`, () => {
+            const source = new Variant({ dataType, value: make() });
+
+            const clone = source.clone();
+            const before = read(clone.value);
+            mutate(source.value);
+
+            should(read(clone.value)).eql(before, `writing the source ${name} changed the clone`);
+        });
+
+        it(`should isolate an array of ${name} from later writes to the source`, () => {
+            const source = new Variant({ dataType, arrayType: VariantArrayType.Array, value: [make(), make()] });
+
+            const clone = source.clone();
+            const before = read(clone.value[0]);
+            mutate(source.value[0]);
+
+            should(read(clone.value[0])).eql(before, `writing an element of the source ${name}[] changed the clone`);
+        });
+    }
+
+    it("should copy a typed array rather than aliasing its buffer", () => {
+        const source = new Variant({
+            dataType: DataType.Double,
+            arrayType: VariantArrayType.Array,
+            value: new Float64Array([1, 2, 3])
+        });
+
+        const clone = source.clone();
+        source.value[0] = 99;
+
+        clone.value[0].should.eql(1);
+        clone.value.buffer.should.not.equal(source.value.buffer);
+    });
+
+    it("should copy the dimensions array of a matrix", () => {
+        const source = new Variant({
+            dataType: DataType.Double,
+            arrayType: VariantArrayType.Matrix,
+            dimensions: [2, 2],
+            value: new Float64Array([1, 2, 3, 4])
+        });
+
+        const clone = source.clone();
+        should.exist(clone.dimensions);
+        (clone.dimensions as number[]).should.not.equal(source.dimensions);
+
+        (source.dimensions as number[])[0] = 99;
+
+        (clone.dimensions as number[])[0].should.eql(2);
+    });
+
+    it("should preserve dataType, arrayType and values", () => {
+        const source = new Variant({
+            dataType: DataType.Int32,
+            arrayType: VariantArrayType.Array,
+            value: new Int32Array([4, 5, 6])
+        });
+
+        const clone = source.clone();
+
+        clone.dataType.should.eql(DataType.Int32);
+        clone.arrayType.should.eql(VariantArrayType.Array);
+        Array.from(clone.value).should.eql([4, 5, 6]);
+    });
+
+    it("should leave immutable payloads alone", () => {
+        for (const [dataType, value] of [
+            [DataType.Double, 1.5],
+            [DataType.String, "hello"],
+            [DataType.Boolean, true],
+            [DataType.UInt32, 7]
+        ] as [DataType, unknown][]) {
+            const clone = new Variant({ dataType, value }).clone();
+            should(clone.value).eql(value);
+        }
+    });
+
+    it("should tolerate a null payload", () => {
+        const clone = new Variant({ dataType: DataType.Double, value: null }).clone();
+        should(clone.value).eql(null);
+    });
+});

--- a/packages/node-opcua-variant/test/test_variant_clone.ts
+++ b/packages/node-opcua-variant/test/test_variant_clone.ts
@@ -1,7 +1,7 @@
 import { LocalizedText, QualifiedName } from "node-opcua-data-model";
 import { coerceNodeId, type NodeId } from "node-opcua-nodeid";
 import should from "should";
-import { DataType, Variant, VariantArrayType } from "..";
+import { DataType, sameVariant, Variant, VariantArrayType } from "..";
 
 //
 // Variant.clone() has to be a true deep copy. The server records a clone of every sampled
@@ -147,8 +147,107 @@ describe("Variant.clone deep-copy guarantees", () => {
         }
     });
 
+    it("should preserve an empty LocalizedText rather than turning it into null", () => {
+        // LocalizedText's option constructor defaults with `options.text || null`, so it
+        // cannot itself produce an empty text - the field has to be assigned, which is what
+        // decoding does and what leaves an uncommented Condition carrying "". A clone that
+        // round-trips through that constructor turns the "" into null.
+        const emptyText = new LocalizedText(null);
+        emptyText.text = "";
+        const source = new Variant({ dataType: DataType.LocalizedText, value: emptyText });
+
+        const clone = source.clone();
+
+        should(clone.value.text).eql("", "an empty text must survive the clone");
+    });
+
+    it("should preserve an empty QualifiedName name rather than turning it into null", () => {
+        const emptyName = new QualifiedName(null);
+        emptyName.name = "";
+        const source = new Variant({ dataType: DataType.QualifiedName, value: emptyName });
+
+        const clone = source.clone();
+
+        should(clone.value.name).eql("", "an empty name must survive the clone");
+    });
+
+    it("should preserve locale and namespaceIndex", () => {
+        const text = new Variant({
+            dataType: DataType.LocalizedText,
+            value: new LocalizedText({ locale: "fr-FR", text: "bonjour" })
+        }).clone();
+        should(text.value.locale).eql("fr-FR");
+        should(text.value.text).eql("bonjour");
+
+        const name = new Variant({
+            dataType: DataType.QualifiedName,
+            value: new QualifiedName({ namespaceIndex: 3, name: "thing" })
+        }).clone();
+        should(name.value.namespaceIndex).eql(3);
+        should(name.value.name).eql("thing");
+    });
+
+    it("should preserve the picoseconds carried on a DateTime", () => {
+        // node-opcua hangs sub-millisecond precision on the Date instance itself
+        const precise = new Date(Date.UTC(2026, 0, 1)) as Date & { picoseconds?: number };
+        precise.picoseconds = 1234;
+        const source = new Variant({ dataType: DataType.DateTime, value: precise });
+
+        const clone = source.clone();
+
+        should((clone.value as Date & { picoseconds?: number }).picoseconds).eql(1234);
+        should(clone.value.getTime()).eql(precise.getTime());
+    });
+
     it("should tolerate a null payload", () => {
         const clone = new Variant({ dataType: DataType.Double, value: null }).clone();
         should(clone.value).eql(null);
+    });
+});
+
+//
+// sameVariant is what MonitoredItem uses to decide whether a sampled value changed. Its
+// scalar branch handled ExtensionObject, Array and Buffer and let everything else fall
+// through to "different" - so two equal NodeIds, LocalizedTexts, QualifiedNames or Dates
+// only ever compared equal through the `v1.value === v2.value` shortcut, i.e. when they
+// were literally the same instance.
+//
+// That was already wrong for values that arrive separately - anything decoded off the wire
+// - and it became visible the moment clone() stopped sharing the instance: every sample
+// looked like a change, and the server published duplicate notifications.
+//
+describe("sameVariant on scalar object values", () => {
+    for (const { name, dataType, make } of [
+        { name: "NodeId", dataType: DataType.NodeId, make: () => coerceNodeId("ns=1;i=42") },
+        { name: "LocalizedText", dataType: DataType.LocalizedText, make: () => new LocalizedText({ text: "hello" }) },
+        { name: "QualifiedName", dataType: DataType.QualifiedName, make: () => new QualifiedName({ name: "hello" }) },
+        { name: "DateTime", dataType: DataType.DateTime, make: () => new Date(Date.UTC(2026, 0, 1)) }
+    ]) {
+        it(`should treat two equal but distinct ${name} values as the same`, () => {
+            const a = new Variant({ dataType, value: make() });
+            const b = new Variant({ dataType, value: make() });
+
+            sameVariant(a, b).should.eql(true, `two equal ${name} values compared as different`);
+        });
+
+        it(`should still treat a cloned ${name} as the same`, () => {
+            const a = new Variant({ dataType, value: make() });
+
+            sameVariant(a, a.clone()).should.eql(true, `a cloned ${name} compared as different from its source`);
+        });
+    }
+
+    it("should still detect a genuine change", () => {
+        const a = new Variant({ dataType: DataType.LocalizedText, value: new LocalizedText({ text: "before" }) });
+        const b = new Variant({ dataType: DataType.LocalizedText, value: new LocalizedText({ text: "after" }) });
+
+        sameVariant(a, b).should.eql(false);
+    });
+
+    it("should still detect a genuine NodeId change", () => {
+        const a = new Variant({ dataType: DataType.NodeId, value: coerceNodeId("ns=1;i=42") });
+        const b = new Variant({ dataType: DataType.NodeId, value: coerceNodeId("ns=1;i=43") });
+
+        sameVariant(a, b).should.eql(false);
     });
 });


### PR DESCRIPTION
Follow-up to #1571, on the server's sampling and publishing path. One correctness fix and three performance fixes, each measured.

The correctness one matters most: **the value a MonitoredItem records was not actually a deep copy**, for five DataTypes.

## Variant.clone was not a deep copy

`Variant.clone()` delegated to `new Variant(this)`, which copies the outer array but hands the elements straight through. Probing every DataType, scalar and array, found five aliased: **ByteString, DateTime, NodeId, LocalizedText, QualifiedName** — plus a ByteString field inside an ExtensionObject, via `coerceByteString`.

That is not academic. The server records a clone of each sampled value and keeps it while the notification waits in the queue. A server that writes a Buffer, a Date or a bound structure **in place** — which the address space does routinely, `bindExtensionObject()` hands out a live instance — would rewrite a sample that had already been recorded. The published value would no longer match the timestamp attached to it.

`clone()` now copies the payload explicitly: deeply for the mutable types, by reference for the immutable ones (numbers, strings, booleans, Guid, StatusCode). Matrix `dimensions` are copied too; they were shared. `coerceByteString` copies rather than adopting the caller's Buffer — the decode path does not go through it, so the wire path is untouched.

`test_variant_clone.ts` fails **11 of 15** without this fix.

## The recorded value was cloned three times, and none was deep

| Where | What it did |
|---|---|
| `extractRange`, top of `recordValue` | clone #1 — necessary, takes ownership |
| `DataValue.clone()` | cloned the Variant **twice internally**: it passed an already-cloned Variant into `new DataValue({...})`, whose constructor cloned it again |
| `new MonitoredItemNotification({ value })` | cloned the whole payload **again**, via the coerce registered for DataValue |

Now one. The notification still gets its own `DataValue` — `apply_timestamps` returns one — so the timestamps it rewrites and the overflow bit `_setOverflowBit` sets stay off `oldDataValue`. Only the Variant is shared between them, and nothing writes through it: `oldDataValue` is only ever assigned wholesale.

## Two registries walked on a timer were plain objects

`Subscription.monitoredItems`, scanned up to twice per publishing interval by `hasUncollectedMonitoredItemNotifications` and again by `_harvestMonitoredItems`; and `node_sampler`'s per-interval registry, walked with `for...in` on every sampling tick.

At the sizes the server allows — `maxMonitoredItemsPerSubscription` defaults to **100 000** — an object with that many keys goes into dictionary mode, so each lookup is a hash probe instead of an inline cache. `Object.keys()` allocated a fresh array of every key per scan, large enough to reach old space, and each iteration then did `parseInt` on the key and indexed back with a *number*, converting it to a string again.

The loop was O(n) but the constant was not: cost per item climbed from 15 ns at 1 000 items to 263 ns at a million.

## Measurements

All against the built `dist/` on Node 22.22.3.

| | Before | After |
|---|---|---|
| `DataValue.clone`, scalar | 220 ns | **174 ns** |
| `DataValue.clone`, Double[100] | 1520 ns | **552 ns** (2.75x) |
| `DataValue.clone`, Double[10000] | 61 us | **19 us** (3.18x) |
| enqueue notification, scalar | 735 ns | **529 ns** |
| enqueue notification, Double[100] | 2680 ns | **1321 ns** (2.03x) |
| enqueue notification, Double[10000] | 52 us | **26 us** (2.03x) |
| subscription scan @100k items | 4183 us | **211 us** (19.9x) |
| sampler walk @100k items | 5879 us | **162 us** (36x) |
| sampler walk @1M items | 328 ms | **5.1 ms** (65x) |

The clone got faster *and* more correct, because the explicit copy bypasses `constructHook`/`convertTo` entirely.

The million-item row is the one that changes behaviour rather than speed: at 328 ms the sampling tick could never complete inside any sane interval, so the timer refired before the previous one finished and the subscription was permanently LATE. Per-item cost is now flat (1.5-2.5 ns) instead of climbing.

## What I deliberately did not do

I had planned to make `_hasUncollectedMonitoredItemNotifications` eager, so the getter became a boolean read. After the Map conversion the scan is 211 us at the default cap — 0.84% of a core even at the 50 ms minimum interval. The flag would have to track **two** dirty sources (`queue` and `_triggeredNotifications`), and getting it wrong means the subscription silently stops publishing triggered notifications. Real correctness risk to recover under 1% of a core, once the Map had already removed the pathology. Left alone.

`node_sampler`'s parallel `monitoredItemsCount` is gone, though: `Map.size` is the same number and cannot drift from the collection it counts.

## Testing

New: `test_variant_clone.ts` (every mutable DataType, scalar and array, isolation after clone); `test_datavalue_clone.ts` (fields, Variant identity, typed arrays, ByteStrings, clone-of-clone); `test_datavalue_clone_extension_object.ts` (nested structures, array fields, element isolation, wire-identical re-encode); and an end-to-end test driving a real `UAVariable` with a bound ExtensionObject, mutating the live instance after sampling and checking the queued notification still reports what was sampled.

Non-vacuity was checked by reverting the fixes: `test_variant_clone.ts` fails 11 of 15, `test_datavalue_clone.ts` fails 2. The end-to-end test **passes on master too** — ExtensionObject isolation already worked — so it is a regression guard, not a demonstration of a fixed bug. Worth stating plainly.

Green locally: server 468, address-space 891, variant 278, data-value 54, types 42, client 77, basic-types 151, file-transfer 50, plus 16 end-to-end subscription tests. `tsc -b packages` and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
