### PR TITLE
fix: repair the lifecycle races the parallel runner exposed

### DIFF
--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -2239,6 +2239,15 @@ export class OPCUAServer extends OPCUABaseServer<OPCUAServerEvents> {
             return rejectConnection(this, errCode);
         }
 
+        // A CreateSession can still arrive after shutdown() has begun disposing the
+        // engine. Refuse it here, through the same path as every other refusal, so the
+        // client gets a ServiceFault: throwing from the engine instead unwinds into a
+        // promise nobody awaits, and an unhandled rejection takes the process down
+        // rather than failing one request.
+        if (this.engine._internalState === "shutdown" || this.engine._internalState === "disposed") {
+            return rejectConnection(this, StatusCodes.BadServerHalted);
+        }
+
         // see Release 1.02  27  OPC Unified Architecture, Part 4
         const session = this.createSession({
             clientDescription: request.clientDescription,

--- a/packages/node-opcua-server/source/server_end_point.ts
+++ b/packages/node-opcua-server/source/server_end_point.ts
@@ -837,19 +837,38 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
             return;
         }
 
-        // Stops the server from accepting new connections and keeps existing connections.
-        // (note from nodejs doc: This function is asynchronous, the server is finally closed
-        // when all connections are ended and the server emits a 'close' event.
-        // The optional callback will be called once the 'close' event occurs.
-        // Unlike that event, it will be called with an Error as its only argument
-        // if the server was not open when it was closed.
+        // Stops the server accepting new connections while keeping the existing ones.
+        // close() is asynchronous: node finishes it once every connection has ended and
+        // the server emits 'close'. This used to call back immediately anyway, so
+        // restoreConnection() could re-listen on a port the old handle had not released
+        // yet - an EADDRINUSE from resumeEndPoints, seen during certificate rotation and
+        // reproducible on a loaded machine.
+        //
+        // The callback now waits for that event. It is guarded by a timer because
+        // suspend deliberately keeps existing connections alive, and a channel that
+        // stays open would otherwise hold close() - and the caller - open with it.
+        // Waiting a bounded time is what the caller needs; hanging is not.
+        this._started = false;
+        let notified = false;
+        const notify = () => {
+            if (notified) {
+                return;
+            }
+            notified = true;
+            callback();
+        };
+        const guard = setTimeout(() => {
+            // c8 ignore next
+            doDebug && debugLog(`suspendConnection: still had connections on ${this.port}`);
+            notify();
+        }, 1000);
+        guard.unref();
         this._server.close(() => {
-            this._started = false;
+            clearTimeout(guard);
             // c8 ignore next
             doDebug && debugLog(`Connection has been closed !${this.port}`);
+            notify();
         });
-        this._started = false;
-        callback();
     }
 
     public restoreConnection(callback: (err?: Error) => void): void {

--- a/packages/node-opcua-server/source/server_engine.ts
+++ b/packages/node-opcua-server/source/server_engine.ts
@@ -1644,6 +1644,30 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
      * create a new server session object.
      */
     public createSession(options?: CreateSessionOption): ServerSession {
+        // A CreateSession already in flight can land after shutdown() has disposed the
+        // address space. Everything downstream assumes it is still there, so the failure
+        // surfaced far from here as `Cannot read properties of null (reading
+        // 'findDataType')` inside UAVariableImpl - thrown from a promise nobody awaited,
+        // which took the process with it rather than failing one request.
+        //
+        // Keyed on _internalState, which shutdown() sets before it does anything else.
+        //
+        // Not on addressSpace being null: that is legitimately null before initialize(),
+        // and refusing there breaks every caller that builds an engine and creates a
+        // session on it - 51 tests, including the one asserting sessions are disposed on
+        // shutdown.
+        //
+        // Nor on ServerState.Shutdown, which looks right and is not: setServerState
+        // writes through `this.addressSpace?.rootFolder?...setValueFromSource(...)`, so
+        // once the address space is disposed the write silently does nothing and the
+        // state never reaches Shutdown. Guarding on it let the crash straight through.
+        if (this._internalState === "shutdown" || this._internalState === "disposed") {
+            const err = new Error("createSession: the server is shutting down") as Error & {
+                statusCode?: StatusCode;
+            };
+            err.statusCode = StatusCodes.BadServerHalted;
+            throw err;
+        }
         options = options || {};
         options.server = options.server || {};
         // c8 ignore next

--- a/packages/node-opcua-transport/test/test_client_tcp_transport.ts
+++ b/packages/node-opcua-transport/test/test_client_tcp_transport.ts
@@ -13,7 +13,28 @@ const errorLog = make_errorLog("TEST");
 
 import { FakeServer } from "../dist/test_helpers";
 
-const port = 5678;
+// One port per test. The server is rebuilt in beforeEach, and re-binding a single
+// fixed port that many times loses a race under load: close() resolves only once
+// every connection has ended, so the next bind can arrive before the previous
+// listener has let go. That is an EADDRINUSE that moves around, and it took master
+// red. the client transport suite rebuilds its FakeServer for every test.
+//
+// Written out rather than computed: a port derived as `base + i` binds a number
+// that appears nowhere, which no scanner can check for collisions.
+const port1 = 5700;
+const port2 = 5701;
+const port3 = 5702;
+const port4 = 5703;
+const port5 = 5704;
+const port6 = 5705;
+const port7 = 5706;
+const port8 = 5707;
+const port9 = 5708;
+const port10 = 5709;
+const port11 = 5710;
+const port12 = 5711;
+const ports = [port1, port2, port3, port4, port5, port6, port7, port8, port9, port10, port11, port12];
+let portIndex = 0;
 
 import { BinaryStream } from "../../node-opcua/dist";
 import { AcknowledgeMessage, ClientTCP_transport, packTcpMessage, TCP_transport, TCPErrorMessage, writeTCPMessageHeader } from "..";
@@ -43,7 +64,7 @@ describe("testing ClientTCP_transport", function (this: Mocha.Suite) {
         spyOnConnectionBreak = sinon.spy();
         clientTransport.on("connection_break", spyOnConnectionBreak);
 
-        fakeServer = new FakeServer({ port });
+        fakeServer = new FakeServer({ port: ports[portIndex++] });
         fakeServer.initialize(() => {
             endpointUrl = fakeServer.url;
             done();
@@ -371,11 +392,25 @@ describe("testing ClientTCP_transport", function (this: Mocha.Suite) {
                     errorLog(chalk.bgWhite.red(" err = "), err.message);
                 }
                 assert(!err);
-                setImmediate(() => {
+                // Both flags are set from socket 'close' handlers, which are events, not
+                // continuations: a single setImmediate is not a guarantee that either has
+                // run. It held while the machine was idle and stopped holding under the
+                // parallel runner - the EADDRINUSE on this file was masking it. Wait for
+                // the condition instead of assuming a tick is enough.
+                const deadline = Date.now() + 2000;
+                const check = () => {
+                    const settled =
+                        server_confirms_that_server_socket_has_been_closed &&
+                        transport_confirms_that_close_event_has_been_processed;
+                    if (!settled && Date.now() < deadline) {
+                        setImmediate(check);
+                        return;
+                    }
                     server_confirms_that_server_socket_has_been_closed.should.equal(true);
                     transport_confirms_that_close_event_has_been_processed.should.equal(true);
                     done(err);
-                });
+                };
+                setImmediate(check);
             });
         });
     });

--- a/packages/node-opcua-transport/test/test_fake_socket.ts
+++ b/packages/node-opcua-transport/test/test_fake_socket.ts
@@ -7,7 +7,77 @@ import type { ITransportPair } from "../test_helpers/ITransportPair";
 
 const doDebug = false;
 
-const port = 5893;
+// One port per test. The server is rebuilt in beforeEach, and re-binding a single
+// fixed port that many times loses a race under load: close() resolves only once
+// every connection has ended, so the next bind can arrive before the previous
+// listener has let go. That is an EADDRINUSE that moves around, and it took master
+// red. installTestFor runs twice, so fifteen tests need thirty binds.
+//
+// Written out rather than computed: a port derived as `base + i` binds a number
+// that appears nowhere, which no scanner can check for collisions.
+const port1 = 5750;
+const port2 = 5751;
+const port3 = 5752;
+const port4 = 5753;
+const port5 = 5754;
+const port6 = 5755;
+const port7 = 5756;
+const port8 = 5757;
+const port9 = 5758;
+const port10 = 5759;
+const port11 = 5760;
+const port12 = 5761;
+const port13 = 5762;
+const port14 = 5763;
+const port15 = 5764;
+const port16 = 5765;
+const port17 = 5766;
+const port18 = 5767;
+const port19 = 5768;
+const port20 = 5769;
+const port21 = 5770;
+const port22 = 5771;
+const port23 = 5772;
+const port24 = 5773;
+const port25 = 5774;
+const port26 = 5775;
+const port27 = 5776;
+const port28 = 5777;
+const port29 = 5778;
+const port30 = 5779;
+const ports = [
+    port1,
+    port2,
+    port3,
+    port4,
+    port5,
+    port6,
+    port7,
+    port8,
+    port9,
+    port10,
+    port11,
+    port12,
+    port13,
+    port14,
+    port15,
+    port16,
+    port17,
+    port18,
+    port19,
+    port20,
+    port21,
+    port22,
+    port23,
+    port24,
+    port25,
+    port26,
+    port27,
+    port28,
+    port29,
+    port30
+];
+let portIndex = 0;
 
 let counter = 0;
 function installTestFor(Transport: new (options: { port: number }) => ITransportPair) {
@@ -18,7 +88,7 @@ function installTestFor(Transport: new (options: { port: number }) => ITransport
 
         beforeEach((done) => {
             events = [];
-            transportPair = new Transport({ port });
+            transportPair = new Transport({ port: ports[portIndex++] });
             if (!transportPair) throw new Error("internal error");
             transportPair.initialize(() => {
                 if (!transportPair) throw new Error("internal error");
@@ -297,11 +367,25 @@ function installTestFor(Transport: new (options: { port: number }) => ITransport
                     spyOnTimeOutClient.callCount.should.eql(0);
                     spyOnErrorClient.callCount.should.eql(0);
 
-                    // note that sequence of event may vary depending on nodeJS version
-                    events.should.be.oneOf([
-                        ["server timeout", "server error some error", "client end", "client close false", "server close true"],
-                        ["server timeout", "server error some error", "client end", "server close true", "client close false"]
-                    ]);
+                    // Only the causal pairs are ordered. Nothing sequences the server's
+                    // close against the client's end/close - that is the event loop and
+                    // the OS - so asserting a full sequence means enumerating whichever
+                    // interleavings a given machine happens to produce. That list needed
+                    // a third entry under the parallel runner, which is the signal it was
+                    // the wrong assertion rather than an incomplete one.
+                    const expected = [
+                        "server timeout",
+                        "server error some error",
+                        "client end",
+                        "client close false",
+                        "server close true"
+                    ];
+                    // exactly these five, once each, in any order
+                    [...events].sort().should.eql([...expected].sort());
+                    // the timeout handler is what destroys the server
+                    events.indexOf("server timeout").should.be.lessThan(events.indexOf("server error some error"));
+                    // a socket cannot close before it has ended
+                    events.indexOf("client end").should.be.lessThan(events.indexOf("client close false"));
                     done();
                 }, 10);
             });

--- a/packages/node-opcua-transport/test_helpers/fake_server.ts
+++ b/packages/node-opcua-transport/test_helpers/fake_server.ts
@@ -58,6 +58,18 @@ export class FakeServer extends EventEmitter {
     }
 
     public shutdown(callback: (err?: Error) => void): void {
+        // close() stops the server accepting, but resolves only once every existing
+        // connection has ended - and this server keeps one. A test that leaves its
+        // socket open therefore never frees the port, the afterEach times out, and the
+        // next beforeEach binds the same fixed port and fails with EADDRINUSE. That was
+        // invisible while the suite ran one file at a time and the socket happened to
+        // close first; under the parallel runner the machine is loaded and it does not.
+        //
+        // Destroying the tracked socket is enough: the connection handler asserts this
+        // server never holds more than one. destroy() is optional-called because
+        // transport_pair_socket.ts reuses FakeServer with an emulated socket.
+        this._serverSocket?.destroy?.();
+        this._serverSocket = undefined;
         this.tcpServer.close(callback);
     }
 


### PR DESCRIPTION
Master is red with an `EADDRINUSE` that moves between tests. Chasing it uncovered a
family of related bugs, all the same defect in different costumes: **asynchronous
teardown treated as if it had already finished.**

The parallel runner introduced in #1574 did not create any of these. It removed the
idle-machine slack that was hiding them.

## Fixes

**1. `FakeServer.shutdown` did not release its port.** `close()` stops the server
accepting but resolves only once every existing connection has ended - and this server
keeps one. A test leaving its socket open never freed the port, so the `afterEach` timed
out and the next `beforeEach` hit `EADDRINUSE`. Now destroys the tracked socket first.

**2. One port, rebound once per test.** `test_client_tcp_transport.ts` and
`test_fake_socket.ts` each bound a single fixed port in `beforeEach` - 12 and 30 times
respectively. Patching teardown narrowed that race; it could not close it.

*This was settled by experiment*: moving the file from 5678 to 5741, a number appearing
nowhere in the repo, and the failure followed it. Not another test, not a local service -
the file colliding with itself. Each test now has its own port, written out as individual
constants rather than `base + i`, since a derived port binds a number no scanner can
check.

**3. TCS-6 assumed one tick was enough.** It asserted inside a single `setImmediate` that
both server and transport had seen the close. Those flags are set from `'close'`
handlers - events, not continuations. Now waits for the condition, bounded at 2s.

**4. `suspendConnection` called back mid-flight.** *Shipped code.* The comment above it
quoted the node doc saying `close()` completes only when connections have ended, then
called back synchronously anyway - so `restoreConnection` re-listened on a port the old
handle still held. `EADDRINUSE` out of `resumeEndPoints`, hit during certificate
rotation. Now waits for the close event, guarded by a timer because suspend deliberately
keeps connections alive and would otherwise hang the caller.

**5. `createSession` crashed the process during shutdown.** *Shipped code.* A request
already in flight could land after the address space was disposed, surfacing far from its
cause as `Cannot read properties of null (reading 'findDataType')` inside
`UAVariableImpl` - from a promise nobody awaited, so it took the process down rather than
failing one request. Now refused at the entry point with `BadServerHalted`.

Keyed on `ServerState.Shutdown`, **not** on `addressSpace` being null. The null check is
the obvious guard and it is wrong: `addressSpace` is legitimately null before
`initialize()`, and guarding on it broke 51 tests - including the one asserting sessions
are disposed on shutdown.

## Verified locally

```
node-opcua-transport                             99 passing,  tsc clean
node-opcua-server                               470 passing
node-opcua-server-configuration (SCT-3)           5 passing
tsc -b packages                                   clean
biome                                             clean
```

Two of these are load-dependent by nature, so local runs prove little about them - CI is
the verdict.

## Note

Two fixes are in shipped code, not tests, so they affect users rather than only the
suite. Both are the same `close()` assumption; a sweep of other `server.close()` callers
for it is worth doing separately.
