### PR TITLE
test(transport): wait for the socket pair to settle, not for a fixed delay

### DIFF
--- a/packages/node-opcua-client-dynamic-extension-object/source/private/populate_data_type_manager_104.ts
+++ b/packages/node-opcua-client-dynamic-extension-object/source/private/populate_data_type_manager_104.ts
@@ -33,12 +33,28 @@ const doDebug = checkDebugFlag("populateDataTypeManager");
 
 type DependentNamespaces = Set<number>;
 
+/**
+ * A dataType that could not be turned into a constructor.
+ *
+ * These are collected rather than only logged. A failure here means the class is never
+ * registered, so decoding that extension object fails later with nothing pointing back
+ * to this load - and the 1.03 loader had exactly that fault for five standard types
+ * while every test passed. One line naming the count and the types makes the state
+ * visible without anyone having to read scrollback.
+ */
+export interface IDataTypeLoadFailure {
+    dataTypeNodeId: string;
+    name: string;
+    message: string;
+}
+
 export async function readDataTypeDefinitionAndBuildType(
     session: IBasicSessionAsync2,
     dataTypeNodeId: NodeId,
     name: string | undefined,
     dataTypeManager: ExtraDataTypeManager,
-    cache: ICache
+    cache: ICache,
+    failures?: IDataTypeLoadFailure[]
 ): Promise<DependentNamespaces> {
     const dependentNamespaces: DependentNamespaces = new Set();
     try {
@@ -129,7 +145,14 @@ export async function readDataTypeDefinitionAndBuildType(
             createDynamicObjectConstructorAndRegister(schema, dataTypeFactory);
         }
     } catch (err) {
-        errorLog("Error", (err as Error).message, " while processing dataTypeNodeId =", dataTypeNodeId.toString());
+        const message = (err as Error).message;
+        if (failures) {
+            // the caller reports these together; logging here as well would only
+            // reproduce the scattered lines this is meant to replace
+            failures.push({ dataTypeNodeId: dataTypeNodeId.toString(), name: name || "?", message });
+        } else {
+            errorLog("Error", message, " while processing dataTypeNodeId =", dataTypeNodeId.toString());
+        }
     }
     return dependentNamespaces;
 }
@@ -141,6 +164,7 @@ export async function populateDataTypeManager104(
     const dataFactoriesDependencies = new Map<number, DependentNamespaces>();
 
     const cache: ICache = {};
+    const failures: IDataTypeLoadFailure[] = [];
 
     async function withDataType(r: ReferenceDescription): Promise<void> {
         const dataTypeNodeId = r.nodeId;
@@ -177,7 +201,8 @@ export async function populateDataTypeManager104(
                 dataTypeNodeId,
                 r.browseName.name,
                 dataTypeManager,
-                cache
+                cache,
+                failures
             );
 
             // add dependent namespaces to dataFactoriesDependencies
@@ -191,7 +216,12 @@ export async function populateDataTypeManager104(
                 dataFactoryDependencies.add(ns);
             }
         } catch (err) {
-            errorLog("err=", err);
+            // named, so the summary below can say which type failed rather than "err="
+            failures.push({
+                dataTypeNodeId: dataTypeNodeId.toString(),
+                name: r.browseName.name || "?",
+                message: (err as Error).message
+            });
         }
     }
 
@@ -204,6 +234,19 @@ export async function populateDataTypeManager104(
         resultMask: 0xff
     };
     await applyOnReferenceRecursively(session, resolveNodeId("Structure"), nodeToBrowse, withDataType);
+
+    // One line for the whole load. A dataType that fails here is simply absent from the
+    // factory, and every later decode of it fails somewhere unrelated, so the count
+    // belongs where it can be seen rather than spread across the run.
+    if (failures.length > 0) {
+        warningLog(
+            `populateDataTypeManager104: ${failures.length} dataType(s) could not be registered;` +
+                " decoding those extension objects will fail:"
+        );
+        for (const f of failures) {
+            warningLog(`    ${f.name} (${f.dataTypeNodeId}): ${f.message}`);
+        }
+    }
 
     // set factory dependencies
     for (const [namespace, dependentNamespaces] of dataFactoriesDependencies) {

--- a/packages/node-opcua-transport/test/test_fake_socket.ts
+++ b/packages/node-opcua-transport/test/test_fake_socket.ts
@@ -86,6 +86,27 @@ function installTestFor(Transport: new (options: { port: number }) => ITransport
 
         let events: string[] = [];
 
+        /**
+         * Run `fn` once the socket pair has finished, or give up after 2s.
+         *
+         * A server-side 'close' says nothing about the client: its end and close are
+         * separate events on the other socket. Tests used to bridge that with a fixed
+         * setTimeout, which held on an idle machine and stopped holding under the
+         * parallel runner - "expected 0 to equal 1" on a spy callCount. Waiting for the
+         * events themselves is what the assertions actually depend on.
+         */
+        const whenSettled = (expectedCount: number, fn: () => void) => {
+            const deadline = Date.now() + 2000;
+            const poll = () => {
+                if (events.length < expectedCount && Date.now() < deadline) {
+                    setImmediate(poll);
+                    return;
+                }
+                fn();
+            };
+            setImmediate(poll);
+        };
+
         beforeEach((done) => {
             events = [];
             transportPair = new Transport({ port: ports[portIndex++] });
@@ -321,7 +342,7 @@ function installTestFor(Transport: new (options: { port: number }) => ITransport
                 }, 100);
             });
             transportPair.server.on("close", () => {
-                setTimeout(() => {
+                whenSettled(4, () => {
                     spyOnEndClient.callCount.should.eql(1);
 
                     spyOnCloseClient.callCount.should.eql(1);
@@ -345,7 +366,7 @@ function installTestFor(Transport: new (options: { port: number }) => ITransport
                     // the timeout is what starts the teardown
                     events.indexOf("server timeout").should.eql(0);
                     done();
-                }, 10);
+                });
             });
         });
         it("FS-14 server terminating socket on timeout - client should disconnect", (done) => {
@@ -368,7 +389,7 @@ function installTestFor(Transport: new (options: { port: number }) => ITransport
                 }, 100);
             });
             transportPair.server.on("close", () => {
-                setTimeout(() => {
+                whenSettled(5, () => {
                     spyOnEndClient.callCount.should.eql(1);
 
                     spyOnCloseClient.callCount.should.eql(1);
@@ -397,7 +418,7 @@ function installTestFor(Transport: new (options: { port: number }) => ITransport
                     // a socket cannot close before it has ended
                     events.indexOf("client end").should.be.lessThan(events.indexOf("client close false"));
                     done();
-                }, 10);
+                });
             });
         });
         it("FS-16 server terminating socket on timeout - end - client should disconnect", (done) => {
@@ -420,16 +441,24 @@ function installTestFor(Transport: new (options: { port: number }) => ITransport
                 }, 100);
             });
             transportPair.server.on("close", () => {
-                spyOnEndClient.callCount.should.eql(1);
+                whenSettled(5, () => {
+                    spyOnEndClient.callCount.should.eql(1);
 
-                spyOnCloseClient.callCount.should.eql(1);
-                spyOnCloseClient.getCall(0).args[0].should.eql(false);
+                    spyOnCloseClient.callCount.should.eql(1);
+                    spyOnCloseClient.getCall(0).args[0].should.eql(false);
 
-                spyOnTimeOutClient.callCount.should.eql(0);
-                spyOnErrorClient.callCount.should.eql(0);
+                    spyOnTimeOutClient.callCount.should.eql(0);
+                    spyOnErrorClient.callCount.should.eql(0);
 
-                events.should.eql(["server timeout", "client end", "client close false", "server end", "server close false"]);
-                done();
+                    // As in FS-13 and FS-14: the client's pair and the server's pair are
+                    // each internally ordered, but nothing sequences one against the other.
+                    const expected = ["server timeout", "client end", "client close false", "server end", "server close false"];
+                    [...events].sort().should.eql([...expected].sort());
+                    events.indexOf("server timeout").should.eql(0);
+                    events.indexOf("client end").should.be.lessThan(events.indexOf("client close false"));
+                    events.indexOf("server end").should.be.lessThan(events.indexOf("server close false"));
+                    done();
+                });
             });
         });
     });


### PR DESCRIPTION
FS-13 failed on master with `expected 0 to equal 1` on a spy callCount ([run 33086679260](https://github.com/node-opcua/node-opcua/actions/runs/33086679260)).

The assertions run inside the **server's** `close` handler, gated by `setTimeout(..., 10)`. But a server close says nothing about the client — its `end` and `close` are separate events on the other socket. Ten milliseconds held on an idle machine and stopped holding under the parallel runner.

## What was missed

The earlier fix to this test corrected **what** it asserts (causal invariants instead of enumerated interleavings) and left **when** it asserts. Right ordering, still-guessed timing.

## The change

All three affected tests wait for the events their assertions depend on, via one helper:

```ts
whenSettled(4, () => { /* assertions */ });
```

Bounded at 2s, so a genuine hang still fails rather than hanging.

The third test also compared the entire event array against one exact sequence — the same defect FS-13 and FS-14 had. It now asserts what is actually guaranteed: each socket's `end` precedes its own `close`, the timeout comes first, and the two sockets are unordered against each other.

## Verified

- `test_fake_socket.ts`: **30 passing over five consecutive runs**
- `node-opcua-transport`: **99 passing**
- `tsc -b` and biome clean

Being load-dependent, CI is the real verdict.