### PR TITLE
Enforce a maximum array length and bound decode nesting depth

### DIFF
--- a/packages/node-opcua-basic-types/source/array.ts
+++ b/packages/node-opcua-basic-types/source/array.ts
@@ -37,6 +37,11 @@ export function decodeArray<T>(stream: BinaryStream, decodeElementFunc: (stream:
     if (length === 0xffffffff) {
         return null;
     }
+    // The length came straight off the wire as a UInt32; without a ceiling a 12-byte
+    // message can declare ~4.29e9 elements and drive that many iterations and allocation.
+    // The Variant value path has always capped this; the generic structured-type path
+    // never did.
+    stream.checkArrayLength(length);
     const arr: T[] = [];
     for (let i = 0; i < length; i++) {
         arr.push(decodeElementFunc(stream));

--- a/packages/node-opcua-basic-types/test/test_decode_array_limits.ts
+++ b/packages/node-opcua-basic-types/test/test_decode_array_limits.ts
@@ -1,0 +1,57 @@
+import { BinaryStream, BinaryStreamArrayLengthExceededError } from "node-opcua-binary-stream";
+import should from "should";
+import { decodeArray, encodeArray } from "..";
+
+//
+// decodeArray is the decoder for every structured-type array field on the wire
+// (ReadRequest.nodesToRead, BrowseRequest.nodesToBrowse, ...). It must refuse an array
+// length that the remaining bytes cannot back, rather than loop over it.
+//
+
+describe("decodeArray length guard", () => {
+    it("round-trips a normal array unchanged", () => {
+        const out = new BinaryStream(64);
+        encodeArray([10, 20, 30, 40], out, (v, s) => s.writeUInt8(v));
+
+        const input = new BinaryStream(out.buffer.subarray(0, out.length));
+        decodeArray(input, (s) => s.readUInt8()).should.eql([10, 20, 30, 40]);
+    });
+
+    it("preserves the null-array sentinel (length 0xffffffff)", () => {
+        const out = new BinaryStream(16);
+        encodeArray(null, out, () => {
+            /* never called */
+        });
+        const input = new BinaryStream(out.buffer.subarray(0, out.length));
+        should(decodeArray(input, () => 0)).eql(null);
+    });
+
+    it("rejects an implausibly large length without decoding a single element", () => {
+        // length prefix 0x7ffffffe behind an 8-byte body
+        const buf = Buffer.alloc(12);
+        buf.writeUInt32LE(0x7ffffffe, 0);
+        const input = new BinaryStream(buf);
+
+        let elementsDecoded = 0;
+        should(() =>
+            decodeArray(input, (s) => {
+                elementsDecoded++;
+                return s.readUInt8();
+            })
+        ).throw(BinaryStreamArrayLengthExceededError);
+        elementsDecoded.should.eql(0, "must reject before the loop, not after exhausting the buffer");
+    });
+
+    it("honours a lowered BinaryStream.maxArrayLength ceiling", () => {
+        const saved = BinaryStream.maxArrayLength;
+        BinaryStream.maxArrayLength = 3;
+        try {
+            const buf = Buffer.alloc(64);
+            buf.writeUInt32LE(4, 0); // 4 elements, ceiling is 3
+            const input = new BinaryStream(buf);
+            should(() => decodeArray(input, (s) => s.readUInt8())).throw(BinaryStreamArrayLengthExceededError);
+        } finally {
+            BinaryStream.maxArrayLength = saved;
+        }
+    });
+});

--- a/packages/node-opcua-binary-stream/source/binaryStream.ts
+++ b/packages/node-opcua-binary-stream/source/binaryStream.ts
@@ -23,6 +23,35 @@ export class BinaryStreamMaxSizeExceededError extends Error {
 }
 
 /**
+ * raised when a decoder descends past BinaryStream.maxNestingLevel while reading a
+ * recursive type (ExtensionObject, Variant, DiagnosticInfo).
+ *
+ * Distinct from a size error on purpose: a message can be well within its size limit yet
+ * still nest deeply enough to exhaust the call stack, so a caller needs to tell "the peer
+ * nested too deep" apart from "the message is too big".
+ */
+export class BinaryStreamMaxNestingLevelExceededError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "BinaryStreamMaxNestingLevelExceededError";
+    }
+}
+
+/**
+ * raised when a wire array length is refused before any element is decoded - it exceeds
+ * either BinaryStream.maxArrayLength or the number of bytes left to read.
+ *
+ * Named distinctly so a caller can map it to Bad_EncodingLimitsExceeded (Part 4 §5.3)
+ * rather than mistaking it for a genuine parse error.
+ */
+export class BinaryStreamArrayLengthExceededError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "BinaryStreamArrayLengthExceededError";
+    }
+}
+
+/**
  * a BinaryStream can be use to perform sequential read or write
  * inside a buffer.
  * The BinaryStream maintains a cursor up to date as the caller
@@ -49,6 +78,36 @@ export class BinaryStream {
     public static maxByteStringLength = 16 * 1024 * 1024;
     public static maxStringLength = 16 * 1024 * 1024;
     /**
+     * how deep decoders may nest recursive types (ExtensionObject, Variant,
+     * DiagnosticInfo) while reading from this stream.
+     *
+     * These types can nest without ever making the message larger than the negotiated
+     * limit, so a message well under the size cap can still drive the decoder deep enough
+     * to exhaust the call stack. OPC UA Part 6 §5.1.8/§5.1.9 anticipates this and requires
+     * a decoder to support at least 100 levels and to report an error beyond what it
+     * supports; §5.2.2.12 says the same for the self-recursive DiagnosticInfo. One shared
+     * budget across the three types bounds what actually matters - total stack depth -
+     * regardless of how a message mixes them.
+     *
+     * Set to 128, comfortably above the 100 the spec requires us to support (so a message
+     * that legitimately nests 100 deep still decodes whichever way you count the outermost
+     * level) and far below the depth at which the call stack would actually overflow.
+     */
+    public static maxNestingLevel = 128;
+
+    /**
+     * hard ceiling on the number of elements a single array length prefix may declare.
+     *
+     * The length is read straight off the wire as a UInt32, so without a ceiling a tiny
+     * message can declare billions of elements and drive the decoder to loop and allocate
+     * to match. Mirrors the cap the Variant value path has always enforced
+     * (Variant.maxArrayLength); the generic path that decodes every structured-type array
+     * field never had one. Adjustable so a deployment that legitimately exchanges larger
+     * arrays can raise it.
+     */
+    public static maxArrayLength = 1 * 1024 * 1024;
+
+    /**
      * the current position inside the buffer
      */
     public length: number;
@@ -65,6 +124,69 @@ export class BinaryStream {
      * overwhelming majority - pays exactly one compare per write.
      */
     #maxLength = 0;
+
+    /**
+     * current recursive-decode depth. Bumped by enterNestingLevel/exitNestingLevel as a
+     * decoder descends into nested ExtensionObject/Variant/DiagnosticInfo values.
+     */
+    #nestingLevel = 0;
+
+    /**
+     * signal that the decoder is about to descend one level into a recursive type.
+     * Throws BinaryStreamMaxNestingLevelExceededError once the depth passes
+     * BinaryStream.maxNestingLevel, before the recursive call is made and before any
+     * further stack frame is consumed. Every successful call must be paired with
+     * exitNestingLevel, which is why callers use try/finally.
+     */
+    public enterNestingLevel(): void {
+        // Check before incrementing: a refused entry must leave the depth untouched.
+        // Callers put enterNestingLevel() outside their try/finally, so a throw here is
+        // never paired with an exitNestingLevel - incrementing first would leak a level
+        // every time the guard trips (e.g. when decodeExtensionObject swallows the throw)
+        // and slowly starve the budget for the rest of the message.
+        if (this.#nestingLevel >= BinaryStream.maxNestingLevel) {
+            throw new BinaryStreamMaxNestingLevelExceededError(
+                `BinaryStream: maximum nesting level of ${BinaryStream.maxNestingLevel} exceeded while decoding a recursive type`
+            );
+        }
+        this.#nestingLevel++;
+    }
+
+    /**
+     * mark that the decoder has finished one level of a recursive type. Pair with a
+     * preceding successful enterNestingLevel via try/finally so the depth is restored
+     * even when the nested decode throws.
+     */
+    public exitNestingLevel(): void {
+        this.#nestingLevel--;
+    }
+
+    /**
+     * validate a wire array length before a decoder loops over it.
+     *
+     * Two independent bounds:
+     *  - it may not exceed BinaryStream.maxArrayLength;
+     *  - it may not exceed the bytes left in the stream, since every encoded element
+     *    occupies at least one byte. This tight check alone rejects an implausible length
+     *    (0x7FFFFFFE elements behind a 100-byte body) immediately, and also catches a
+     *    length that sits under the ceiling yet is still far larger than the remaining
+     *    payload can back.
+     *
+     * @param length the element count just read from the stream
+     */
+    public checkArrayLength(length: number): void {
+        if (length > BinaryStream.maxArrayLength) {
+            throw new BinaryStreamArrayLengthExceededError(
+                `BinaryStream: array length ${length} exceeds the maximum allowed length of ${BinaryStream.maxArrayLength}`
+            );
+        }
+        const remaining = this.buffer.length - this.length;
+        if (length > remaining) {
+            throw new BinaryStreamArrayLengthExceededError(
+                `BinaryStream: array length ${length} exceeds the ${remaining} bytes remaining in the stream`
+            );
+        }
+    }
 
     /**
      * create a stream that reallocates its buffer as needed, up to maxLength bytes.

--- a/packages/node-opcua-binary-stream/test/test_decode_limits.ts
+++ b/packages/node-opcua-binary-stream/test/test_decode_limits.ts
@@ -1,0 +1,111 @@
+import should from "should";
+import { BinaryStream, BinaryStreamArrayLengthExceededError, BinaryStreamMaxNestingLevelExceededError } from "..";
+
+//
+// Two decode-side guards live on BinaryStream so that every decoder - across packages -
+// shares one implementation and one budget:
+//
+//   * checkArrayLength: refuses a wire array length that could not possibly be backed by
+//     the remaining bytes, or that exceeds the configured ceiling. Without it a 12-byte
+//     message can drive billions of decode iterations.
+//
+//   * enterNestingLevel / exitNestingLevel: bound how deep a recursive type may nest, so
+//     a small message cannot exhaust the call stack (OPC UA Part 6 §5.1.8/§5.1.9).
+//
+// They are tested here in isolation, with no wire framing, because the value they protect
+// is arithmetic, not any particular message shape.
+//
+
+describe("BinaryStream.checkArrayLength", () => {
+    // A fresh 100-byte stream positioned at the start: 100 bytes remain to be read.
+    function streamWithRemaining(remaining: number): BinaryStream {
+        return new BinaryStream(Buffer.alloc(remaining));
+    }
+
+    let savedMax: number;
+    beforeEach(() => {
+        savedMax = BinaryStream.maxArrayLength;
+    });
+    afterEach(() => {
+        BinaryStream.maxArrayLength = savedMax;
+    });
+
+    it("accepts a length that fits within both the ceiling and the remaining bytes", () => {
+        const stream = streamWithRemaining(100);
+        should(() => stream.checkArrayLength(100)).not.throw();
+        should(() => stream.checkArrayLength(0)).not.throw();
+    });
+
+    it("rejects a length larger than the bytes remaining, even when under the ceiling", () => {
+        const stream = streamWithRemaining(100);
+        // 101 elements cannot be backed by 100 bytes: every element is at least one byte.
+        should(() => stream.checkArrayLength(101)).throw(BinaryStreamArrayLengthExceededError);
+    });
+
+    it("rejects an implausibly large length instantly (huge length, tiny body)", () => {
+        const stream = streamWithRemaining(8);
+        should(() => stream.checkArrayLength(0x7ffffffe)).throw(BinaryStreamArrayLengthExceededError);
+    });
+
+    it("rejects a length above the configured ceiling", () => {
+        BinaryStream.maxArrayLength = 10;
+        // Give it plenty of bytes so only the ceiling can be the reason it is refused.
+        const stream = streamWithRemaining(1000);
+        should(() => stream.checkArrayLength(11)).throw(BinaryStreamArrayLengthExceededError, {
+            message: /maximum allowed length of 10/
+        });
+        should(() => stream.checkArrayLength(10)).not.throw();
+    });
+
+    it("accounts for bytes already consumed", () => {
+        const stream = streamWithRemaining(100);
+        stream.readUInt32(); // consume 4 bytes -> 96 remain
+        should(() => stream.checkArrayLength(96)).not.throw();
+        should(() => stream.checkArrayLength(97)).throw(BinaryStreamArrayLengthExceededError);
+    });
+});
+
+describe("BinaryStream nesting-level guard", () => {
+    let savedMax: number;
+    beforeEach(() => {
+        savedMax = BinaryStream.maxNestingLevel;
+    });
+    afterEach(() => {
+        BinaryStream.maxNestingLevel = savedMax;
+    });
+
+    it("allows exactly maxNestingLevel levels and refuses the next", () => {
+        BinaryStream.maxNestingLevel = 3;
+        const stream = new BinaryStream(Buffer.alloc(16));
+        stream.enterNestingLevel();
+        stream.enterNestingLevel();
+        stream.enterNestingLevel();
+        should(() => stream.enterNestingLevel()).throw(BinaryStreamMaxNestingLevelExceededError);
+    });
+
+    it("restores the budget as levels are exited", () => {
+        BinaryStream.maxNestingLevel = 2;
+        const stream = new BinaryStream(Buffer.alloc(16));
+        stream.enterNestingLevel();
+        stream.enterNestingLevel();
+        should(() => stream.enterNestingLevel()).throw(BinaryStreamMaxNestingLevelExceededError);
+        stream.exitNestingLevel();
+        // one level was freed, so one more entry must now be allowed again
+        should(() => stream.enterNestingLevel()).not.throw();
+    });
+
+    it("does not leak a level when an entry is refused", () => {
+        // A refused enterNestingLevel is never paired with an exitNestingLevel (callers
+        // put it before their try/finally). If it leaked, repeated refusals would starve
+        // the budget permanently; this asserts the budget is unchanged after a refusal.
+        BinaryStream.maxNestingLevel = 1;
+        const stream = new BinaryStream(Buffer.alloc(16));
+        stream.enterNestingLevel();
+        for (let i = 0; i < 5; i++) {
+            should(() => stream.enterNestingLevel()).throw(BinaryStreamMaxNestingLevelExceededError);
+        }
+        stream.exitNestingLevel();
+        // back to zero depth despite five refusals -> a full level is available again
+        should(() => stream.enterNestingLevel()).not.throw();
+    });
+});

--- a/packages/node-opcua-data-model/source/diagnostic_info.ts
+++ b/packages/node-opcua-data-model/source/diagnostic_info.ts
@@ -133,7 +133,16 @@ export class DiagnosticInfo extends BaseUAObject {
     }
 
     public decode(stream: BinaryStream): void {
-        decode_DiagnosticInfo(this, stream);
+        // DiagnosticInfo is self-recursive through innerDiagnosticInfo: a chain of nested
+        // masks can nest the decoder as deep as the message has bytes, exhausting the
+        // stack on a message well under the size limit. Count each level against the shared
+        // budget and refuse to descend further (Part 6 §5.2.2.12).
+        stream.enterNestingLevel();
+        try {
+            decode_DiagnosticInfo(this, stream);
+        } finally {
+            stream.exitNestingLevel();
+        }
     }
 
     public decodeDebug(stream: BinaryStream, options: DecodeDebugOptions): void {

--- a/packages/node-opcua-data-model/test/test_diagnostic_info_nesting.ts
+++ b/packages/node-opcua-data-model/test/test_diagnostic_info_nesting.ts
@@ -1,0 +1,63 @@
+import { BinaryStream, BinaryStreamMaxNestingLevelExceededError } from "node-opcua-binary-stream";
+import should from "should";
+import { DiagnosticInfo } from "..";
+
+//
+// DiagnosticInfo is self-recursive through innerDiagnosticInfo. A chain of nested masks
+// costs one byte per level on the wire, so a small message can nest the decoder deep
+// enough to exhaust the call stack (OPC UA Part 6 §5.2.2.12). DiagnosticInfo.decode
+// counts each level against BinaryStream's shared nesting budget and refuses to descend
+// past it.
+//
+// The end-to-end path (build -> encode -> decode) is exercised here; the counter's own
+// arithmetic is unit-tested in node-opcua-binary-stream. The limit is lowered so the test
+// stays small and readable instead of building a 128-deep object graph.
+//
+
+function buildChain(totalLevels: number): DiagnosticInfo {
+    let di = new DiagnosticInfo({ symbolicId: 1 });
+    for (let i = 1; i < totalLevels; i++) {
+        di = new DiagnosticInfo({ innerDiagnosticInfo: di });
+    }
+    return di;
+}
+
+function encode(di: DiagnosticInfo): BinaryStream {
+    const stream = new BinaryStream(Buffer.alloc(64 * 1024));
+    di.encode(stream);
+    return new BinaryStream(stream.buffer.subarray(0, stream.length));
+}
+
+describe("DiagnosticInfo nesting guard", () => {
+    let savedMax: number;
+    beforeEach(() => {
+        savedMax = BinaryStream.maxNestingLevel;
+        BinaryStream.maxNestingLevel = 5;
+    });
+    afterEach(() => {
+        BinaryStream.maxNestingLevel = savedMax;
+    });
+
+    it("decodes a chain up to the nesting limit", () => {
+        const input = encode(buildChain(5));
+        const decoded = new DiagnosticInfo({});
+        should(() => decoded.decode(input)).not.throw();
+        // innermost symbolicId survived the round-trip through all five levels
+        let di: DiagnosticInfo | undefined = decoded;
+        for (let i = 1; i < 5; i++) di = di?.innerDiagnosticInfo;
+        di?.symbolicId.should.eql(1);
+    });
+
+    it("refuses a chain deeper than the nesting limit", () => {
+        const input = encode(buildChain(6));
+        const decoded = new DiagnosticInfo({});
+        should(() => decoded.decode(input)).throw(BinaryStreamMaxNestingLevelExceededError);
+    });
+
+    it("does not reject a very deep chain when the limit is left at its generous default", () => {
+        BinaryStream.maxNestingLevel = savedMax; // back to the shipped 128
+        const input = encode(buildChain(100));
+        const decoded = new DiagnosticInfo({});
+        should(() => decoded.decode(input)).not.throw();
+    });
+});

--- a/packages/node-opcua-extension-object/source/extension_object.ts
+++ b/packages/node-opcua-extension-object/source/extension_object.ts
@@ -148,6 +148,19 @@ export interface IDataTypeFactory {
     constructObject(dataTypeNodeId: NodeId): BaseUAObject | null;
 }
 export function decodeExtensionObject(stream: BinaryStream, _value?: ExtensionObject | null): ExtensionObject | null {
+    // An ExtensionObject body can itself contain ExtensionObjects (directly, or via a
+    // Variant), so a deeply nested value graph can descend arbitrarily far on a message
+    // that stays within its size limit. Count the descent and refuse to go past the shared
+    // limit before the recursive call consumes another stack frame (Part 6 §5.1.8).
+    stream.enterNestingLevel();
+    try {
+        return _decodeExtensionObject(stream, _value);
+    } finally {
+        stream.exitNestingLevel();
+    }
+}
+
+function _decodeExtensionObject(stream: BinaryStream, _value?: ExtensionObject | null): ExtensionObject | null {
     const nodeId = decodeNodeId(stream);
     const encodingType = stream.readUInt8();
 

--- a/packages/node-opcua-schemas/source/dynamic_extension_object.ts
+++ b/packages/node-opcua-schemas/source/dynamic_extension_object.ts
@@ -182,6 +182,7 @@ function decodeArrayOrElement(
         if (nbElements === 0xffffffff) {
             obj[field.name] = null;
         } else {
+            stream.checkArrayLength(nbElements);
             for (let i = 0; i < nbElements; i++) {
                 const element = decodeElement(dataTypeFactory, field, stream, decodeFunc);
                 array.push(element);

--- a/packages/node-opcua-server/source/server_capabilities.ts
+++ b/packages/node-opcua-server/source/server_capabilities.ts
@@ -231,6 +231,14 @@ export class ServerCapabilities implements IServerCapabilities {
 
         this.maxArrayLength = options.maxArrayLength || defaultServerCapabilities.maxArrayLength;
 
+        // The generic array decoder refuses any array longer than BinaryStream.maxArrayLength.
+        // Raise that ceiling to cover what this server advertises, so it never rejects an array a
+        // client was told it may send. Only ever raised, never lowered, so configuring one server
+        // cannot shrink a limit another already relies on.
+        if (BinaryStream.maxArrayLength < this.maxArrayLength) {
+            BinaryStream.maxArrayLength = this.maxArrayLength;
+        }
+
         this.maxStringLength = options.maxStringLength || defaultServerCapabilities.maxStringLength;
         this.maxByteStringLength = options.maxByteStringLength || defaultServerCapabilities.maxByteStringLength;
 

--- a/packages/node-opcua-server/source/server_engine.ts
+++ b/packages/node-opcua-server/source/server_engine.ts
@@ -1237,7 +1237,15 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
                     );
 
                     bindStandardScalar(VariableIds.Server_ServerCapabilities_MaxArrayLength, DataType.UInt32, () => {
-                        return Math.min(this.serverCapabilities.maxArrayLength, Variant.maxArrayLength);
+                        // Advertise the smallest of the three ceilings that actually apply: the
+                        // configured value, the Variant value-array cap, and the generic
+                        // structured-array cap. Reporting more than any of them enforces would let
+                        // a client send an array the decoder then refuses.
+                        return Math.min(
+                            this.serverCapabilities.maxArrayLength,
+                            Variant.maxArrayLength,
+                            BinaryStream.maxArrayLength
+                        );
                     });
 
                     bindStandardScalar(VariableIds.Server_ServerCapabilities_MaxStringLength, DataType.UInt32, () => {

--- a/packages/node-opcua-variant/source/variant.ts
+++ b/packages/node-opcua-variant/source/variant.ts
@@ -267,7 +267,16 @@ export class Variant extends BaseUAObject {
     }
 
     public decode(stream: BinaryStream): void {
-        internalDecodeVariant(this, stream);
+        // A Variant can hold an ExtensionObject whose body holds another Variant, so the
+        // value graph can nest without the message growing. Count each Variant level
+        // against the shared budget so a deep chain cannot exhaust the stack (Part 6
+        // §5.1.9).
+        stream.enterNestingLevel();
+        try {
+            internalDecodeVariant(this, stream);
+        } finally {
+            stream.exitNestingLevel();
+        }
     }
 
     public decodeDebug(stream: BinaryStream, options: DecodeDebugOptions): void {


### PR DESCRIPTION
## Summary

The generic array decoder looped over a wire-supplied `UInt32` length with no ceiling, and `ExtensionObject` / `Variant` / `DiagnosticInfo` could nest without a bound. This adds decode-side limits so a single message cannot drive unbounded iteration/allocation or unbounded recursion.

## What changed

- **`BinaryStream.maxArrayLength` + `checkArrayLength()`** — refuses an array length above the ceiling, and also one the remaining bytes cannot back (every element is at least one byte). Wired into the generic `decodeArray` (all structured-type array fields) and the dynamic extension-object decoder.
- **Shared nesting budget** — `enterNestingLevel()` / `exitNestingLevel()` on `BinaryStream`, used by `DiagnosticInfo.decode`, `Variant.decode`, and `decodeExtensionObject`. Default 128; OPC UA Part 6 §5.1.8/§5.1.9 requires supporting at least 100 levels and reporting an error beyond.
- **`ServerCapabilities`** — the `MaxArrayLength` node now advertises the effective ceiling (`min` of the configured, Variant, and generic caps) and the constructor raises the codec ceiling to cover its configured value (raise-only).

## Tests

New unit tests in `node-opcua-binary-stream`, `node-opcua-basic-types`, and `node-opcua-data-model` (array-length bounds, nesting counter incl. the no-leak-on-refusal case, and an end-to-end nested `DiagnosticInfo` round-trip). All existing suites pass, including `node-opcua-secure-channel`'s end-to-end message tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
