### PR TITLE
fix(address-space): honour namespace default role permissions on the enforcement path

### DIFF
--- a/packages/node-opcua-address-space/source/session_context.ts
+++ b/packages/node-opcua-address-space/source/session_context.ts
@@ -245,28 +245,36 @@ function getDefaultUserRolePermissionsOnNamespace(
     }
 
     const namespaces = namespace.addressSpace.rootFolder?.objects?.server?.namespaces;
-    if (!namespaces) {
-        return null;
-    }
-    const uaNamespaceObject = namespaces.getChildByName(namespace.namespaceUri);
-    if (!uaNamespaceObject) {
-        return null;
-    }
-    const defaultUserRolePermissions = uaNamespaceObject.getChildByName("DefaultUserRolePermissions") as UAVariable;
-    if (defaultUserRolePermissions) {
-        const dataValue = defaultUserRolePermissions.readValue();
-        if (dataValue?.statusCode.isGood() && dataValue.value.value && dataValue.value.value.length > 0) {
-            return dataValue.value.value as RolePermissionType[];
+    const uaNamespaceObject = namespaces?.getChildByName(namespace.namespaceUri);
+    if (uaNamespaceObject) {
+        // DefaultUserRolePermissions is the user-specific policy and wins when it carries a value.
+        const defaultUserRolePermissions = uaNamespaceObject.getChildByName("DefaultUserRolePermissions") as UAVariable;
+        if (defaultUserRolePermissions) {
+            const dataValue = defaultUserRolePermissions.readValue();
+            if (dataValue?.statusCode.isGood() && dataValue.value.value && dataValue.value.value.length > 0) {
+                return dataValue.value.value as RolePermissionType[];
+            }
+        }
+        const defaultRolePermissions = uaNamespaceObject.getChildByName("DefaultRolePermissions") as UAVariable;
+        if (defaultRolePermissions) {
+            const dataValue = defaultRolePermissions.readValue();
+            const value = dataValue?.value?.value as RolePermissionType[] | null | undefined;
+            // Honour a real value only. The metadata node is left Null-typed (value === null)
+            // unless setNamespaceMetaData() bound it, so a null must fall through to the
+            // namespace policy below instead of short-circuiting the whole lookup to null.
+            if (dataValue?.statusCode.isGood() && value !== null && value !== undefined) {
+                return value;
+            }
         }
     }
-    const defaultRolePermissions = uaNamespaceObject.getChildByName("DefaultRolePermissions") as UAVariable;
-    if (defaultRolePermissions) {
-        const dataValue = defaultRolePermissions.readValue();
-        if (dataValue?.statusCode.isGood()) {
-            return dataValue.value.value as RolePermissionType[] | null;
-        }
-    }
-    return null;
+
+    // Fall back to the policy configured programmatically via Namespace.setDefaultRolePermissions().
+    // The NamespaceMetadata node is only bound to that field when setNamespaceMetaData() is called
+    // (which throws on NodeSet2-loaded namespaces), and is absent entirely for a programmatically
+    // created namespace. Consulting the field here keeps the configured default consistent between
+    // the local getter (BaseNode.getRolePermissions(inherited=true)) and this enforcement path,
+    // so setDefaultRolePermissions() takes effect without also requiring setNamespaceMetaData().
+    return namespace.getDefaultRolePermissions();
 }
 
 /**

--- a/packages/node-opcua-address-space/test/test_session_context_namespace_default_permissions.ts
+++ b/packages/node-opcua-address-space/test/test_session_context_namespace_default_permissions.ts
@@ -1,0 +1,71 @@
+import { makePermissionFlag } from "node-opcua-data-model";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { PermissionType } from "node-opcua-types";
+import { DataType } from "node-opcua-variant";
+import should from "should";
+import { type AddressSpace, makeRoles, type Namespace, type UAVariable, WellKnownRoles } from "..";
+import { getMiniAddressSpace, makeMockSessionContext } from "../testHelpers";
+
+/**
+ * A namespace default set through Namespace.setDefaultRolePermissions() must be honoured by the
+ * permission-enforcement path, not only by the local BaseNode.getRolePermissions(inherited=true)
+ * getter.
+ *
+ * A programmatically created namespace has no NamespaceMetadata node under Server/Namespaces, so
+ * the enforcement path used to resolve the namespace default to null and fall back to its
+ * unresolved-permission default (permissive), ignoring the configured policy entirely. The two
+ * resolution paths — the configuration field and the enforcement lookup — are now consistent.
+ */
+describe("SessionContext - namespace DefaultRolePermissions on the enforcement path", () => {
+    let addressSpace: AddressSpace;
+    let namespace: Namespace;
+    let variable: UAVariable;
+
+    beforeEach(async () => {
+        addressSpace = await getMiniAddressSpace();
+        namespace = addressSpace.getOwnNamespace();
+        // a Variable that carries no per-node RolePermissions and therefore relies on the
+        // namespace default for its access control
+        variable = namespace.addVariable({
+            browseName: "RelyingOnNamespaceDefault",
+            dataType: DataType.Double,
+            accessLevel: "CurrentRead | CurrentWrite",
+            userAccessLevel: "CurrentRead | CurrentWrite"
+        });
+    });
+    afterEach(() => addressSpace.dispose());
+
+    const anonymous = () => makeMockSessionContext({ userName: "anonymous" });
+    const operator = () =>
+        makeMockSessionContext({
+            userName: "op",
+            server: { userManager: { getUserRoles: () => makeRoles([WellKnownRoles.Operator]) } }
+        });
+
+    it("NSDP-1 grants an anonymous Session everything when no namespace default is configured (unchanged default)", () => {
+        // documents the historical permissive default: with no policy anywhere, the request is
+        // resolved by the unresolved-permission default, which is permissive out of the box.
+        anonymous().checkPermission(variable, PermissionType.Write).should.eql(true);
+    });
+
+    it("NSDP-2 denies an anonymous Session once the namespace default excludes it", () => {
+        namespace.setDefaultRolePermissions([{ roleId: WellKnownRoles.Operator, permissions: makePermissionFlag("Read | Write") }]);
+        const ctx = anonymous();
+        // the configured default now reaches enforcement: Anonymous matches no entry -> no bits
+        ctx.getApplicableRolePermissions(variable).should.not.eql(null);
+        ctx.checkPermission(variable, PermissionType.Write).should.eql(false);
+    });
+
+    it("NSDP-3 still grants the role named in the namespace default", () => {
+        namespace.setDefaultRolePermissions([{ roleId: WellKnownRoles.Operator, permissions: makePermissionFlag("Read | Write") }]);
+        operator().checkPermission(variable, PermissionType.Write).should.eql(true);
+    });
+
+    it("NSDP-4 lets a per-node RolePermissions override the namespace default", () => {
+        namespace.setDefaultRolePermissions([{ roleId: WellKnownRoles.Operator, permissions: makePermissionFlag("Read | Write") }]);
+        // grant the Variable itself to Operator only, explicitly
+        variable.setRolePermissions([{ roleId: WellKnownRoles.Operator, permissions: makePermissionFlag("Read | Write") }]);
+        anonymous().checkPermission(variable, PermissionType.Write).should.eql(false);
+        operator().checkPermission(variable, PermissionType.Write).should.eql(true);
+    });
+});

--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -30,7 +30,8 @@ import {
     type UAObject,
     type UAObjectType,
     type UAVariable,
-    type UAView
+    type UAView,
+    type UnresolvedPermissionPolicy
 } from "node-opcua-address-space";
 import { assert } from "node-opcua-assert";
 import type { ByteString, UAString } from "node-opcua-basic-types";
@@ -913,6 +914,22 @@ export interface OPCUAServerOptions extends OPCUABaseServerOptions, OPCUAServerE
      */
     userManager?: UserManagerOptions;
 
+    /**
+     * how a Session's permission is resolved when neither the target Node nor its namespace
+     * declares any RolePermissions:
+     *
+     *  - `"allow"` (default): grant every permission. This is how node-opcua has always behaved,
+     *    and what most address spaces expect, since almost no server declares RolePermissions on
+     *    its own Nodes.
+     *  - `"deny"` : grant nothing. Fail-closed, for products that drive access entirely from
+     *    declared policy. Expect to set DefaultRolePermissions on every namespace, otherwise the
+     *    address space becomes unreadable to remote Sessions.
+     *
+     * This governs remote Sessions only. In-process callers keep every permission regardless.
+     * @default "allow"
+     */
+    unresolvedPermissionPolicy?: UnresolvedPermissionPolicy;
+
     /** resource Path is a string added at the end of the url such as "/UA/Server" */
     resourcePath?: string;
 
@@ -1385,6 +1402,13 @@ export class OPCUAServer extends OPCUABaseServer<OPCUAServerEvents> {
      */
     public roleResolvers: IRoleResolver[] = [];
 
+    /**
+     * how a remote Session's permission is resolved when no RolePermissions apply.
+     * @default "allow"
+     * @see OPCUAServerOptions.unresolvedPermissionPolicy
+     */
+    public unresolvedPermissionPolicy: UnresolvedPermissionPolicy;
+
     public readonly options: OPCUAServerOptions;
 
     private objectFactory?: Factory;
@@ -1427,6 +1451,8 @@ export class OPCUAServer extends OPCUABaseServer<OPCUAServerEvents> {
         this.serverInfo.productUri = this.serverInfo.productUri || buildInfo.productUri;
 
         this.userManager = makeUserManager(options.userManager);
+
+        this.unresolvedPermissionPolicy = options.unresolvedPermissionPolicy ?? "allow";
 
         options.allowAnonymous = options.allowAnonymous === undefined ? true : !!options.allowAnonymous;
         /**

--- a/packages/node-opcua-server/source/server_engine.ts
+++ b/packages/node-opcua-server/source/server_engine.ts
@@ -970,20 +970,28 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
                     set: null // read only
                 });
 
-                // fix DefaultUserRolePermissions and DefaultUserRolePermissions
-                // of namespaces
+                // Make each namespace's DefaultRolePermissions / DefaultUserRolePermissions
+                // Property readable. A Property loaded from a NodeSet2 without a Value reads back
+                // uninitialized; give it a Good, Null value so a client can read it. A Property
+                // that already carries a value (a default declared by the nodeset) is left as is,
+                // since overwriting it would silently drop the declared namespace default.
                 const namespaces = makeNodeId(ObjectIds.Server_Namespaces);
                 const namespacesNode = addressSpace.findNode(namespaces) as UAObject;
                 if (namespacesNode) {
+                    const initializeIfUnset = (variable: UAVariable | null) => {
+                        if (!variable) {
+                            return;
+                        }
+                        const dataValue = variable.readValue();
+                        const value = dataValue?.value?.value;
+                        const hasValue = dataValue?.statusCode.isGood() && value !== null && value !== undefined;
+                        if (!hasValue) {
+                            variable.setValueFromSource({ dataType: DataType.Null });
+                        }
+                    };
                     for (const ns of namespacesNode.getComponents()) {
-                        const defaultUserRolePermissions = ns.getChildByName("DefaultUserRolePermissions") as UAVariable | null;
-                        if (defaultUserRolePermissions) {
-                            defaultUserRolePermissions.setValueFromSource({ dataType: DataType.Null });
-                        }
-                        const defaultRolePermissions = ns.getChildByName("DefaultRolePermissions") as UAVariable | null;
-                        if (defaultRolePermissions) {
-                            defaultRolePermissions.setValueFromSource({ dataType: DataType.Null });
-                        }
+                        initializeIfUnset(ns.getChildByName("DefaultUserRolePermissions") as UAVariable | null);
+                        initializeIfUnset(ns.getChildByName("DefaultRolePermissions") as UAVariable | null);
                     }
                 }
 

--- a/packages/node-opcua-server/test/test_server_engine_namespace_default_permissions.ts
+++ b/packages/node-opcua-server/test/test_server_engine_namespace_default_permissions.ts
@@ -1,0 +1,69 @@
+import {
+    type AddressSpace,
+    makeRoles,
+    type Namespace,
+    SessionContext,
+    type UAObject,
+    type UAVariable,
+    WellKnownRoles
+} from "node-opcua-address-space";
+import { makePermissionFlag } from "node-opcua-data-model";
+import { nodesets } from "node-opcua-nodesets";
+import { PermissionType } from "node-opcua-types";
+import { DataType } from "node-opcua-variant";
+import should from "should";
+import { ServerEngine } from "../source";
+
+/**
+ * A namespace default configured with Namespace.setDefaultRolePermissions() must reach the
+ * permission-enforcement path through a fully initialized ServerEngine, i.e. across the real
+ * Server/Namespaces structure — not only the mini address space used by the unit tests.
+ *
+ * ServerEngine.initialize() normalizes the DefaultRolePermissions / DefaultUserRolePermissions
+ * Property of each namespace so it is readable; that normalization must leave an already
+ * declared value in place and must not sever the configured default from enforcement.
+ */
+describe("ServerEngine - namespace DefaultRolePermissions on the enforcement path", function (this: Mocha.Suite) {
+    let engine: ServerEngine;
+
+    before((done) => {
+        engine = new ServerEngine({ applicationUri: "application:uri" });
+        engine.initialize({ nodeset_filename: nodesets.standard }, () => done());
+    });
+
+    after(async () => {
+        await engine.shutdown();
+    });
+
+    const addressSpace = () => engine.addressSpace as AddressSpace;
+
+    const contextForRole = (role: WellKnownRoles): SessionContext => {
+        const ctx = new SessionContext();
+        ctx.getCurrentUserRoles = () => makeRoles([role]);
+        return ctx;
+    };
+
+    it("SNDP-1 leaves each namespace's DefaultRolePermissions Property readable after initialize()", () => {
+        const server = addressSpace().rootFolder.objects.server;
+        const namespacesNode = server.getComponentByName("Namespaces") as UAObject;
+        should.exist(namespacesNode, "Server/Namespaces should exist");
+        const ns0 = namespacesNode.getChildByName("http://opcfoundation.org/UA/") as UAObject;
+        should.exist(ns0, "the namespace-0 metadata node should exist");
+        const defaultRolePermissions = ns0.getChildByName("DefaultRolePermissions") as UAVariable;
+        should.exist(defaultRolePermissions, "DefaultRolePermissions Property should exist");
+        defaultRolePermissions.readValue().statusCode.isGood().should.eql(true);
+    });
+
+    it("SNDP-2 enforces a namespace default set via setDefaultRolePermissions() against an anonymous Session", () => {
+        const namespace = addressSpace().getOwnNamespace() as Namespace;
+        namespace.setDefaultRolePermissions([{ roleId: WellKnownRoles.Operator, permissions: makePermissionFlag("Read | Write") }]);
+        const variable = namespace.addVariable({
+            browseName: "SNDP_RelyingOnNamespaceDefault",
+            dataType: DataType.Double,
+            accessLevel: "CurrentRead | CurrentWrite",
+            userAccessLevel: "CurrentRead | CurrentWrite"
+        });
+        contextForRole(WellKnownRoles.Anonymous).checkPermission(variable, PermissionType.Write).should.eql(false);
+        contextForRole(WellKnownRoles.Operator).checkPermission(variable, PermissionType.Write).should.eql(true);
+    });
+});

--- a/packages/node-opcua-server/test/test_server_unresolved_permission_policy_option.ts
+++ b/packages/node-opcua-server/test/test_server_unresolved_permission_policy_option.ts
@@ -1,0 +1,23 @@
+import "should";
+import { OPCUAServer } from "../source";
+
+/**
+ * unresolvedPermissionPolicy is settable as a first-class OPCUAServer option and lands on the
+ * server instance, which is the IServerBase a remote Session's SessionContext reads its policy
+ * from (see test_session_context_server_wiring). It stays "allow" by default, preserving the
+ * historical permissive behaviour. The deny/allow semantics themselves are covered by the
+ * address-space SCUP tests (test_session_context_unresolved_permissions).
+ */
+describe("OPCUAServer - unresolvedPermissionPolicy option", () => {
+    // These only read a constructor option off the instance; the server is never started, so no
+    // endpoint is opened and no port is needed.
+    it('UPP-1 defaults to "allow"', () => {
+        const server = new OPCUAServer({});
+        server.unresolvedPermissionPolicy.should.eql("allow");
+    });
+
+    it('UPP-2 carries a configured "deny" through to the server instance', () => {
+        const server = new OPCUAServer({ unresolvedPermissionPolicy: "deny" });
+        server.unresolvedPermissionPolicy.should.eql("deny");
+    });
+});


### PR DESCRIPTION
## Summary

When a Node carries no per-node `RolePermissions`, OPC UA resolves its access control from the namespace `DefaultRolePermissions` (Part 3 §5.2.9). Two inconsistencies meant a namespace default configured through the public API did not take effect on the permission-enforcement path.

1. **Configuration and enforcement read different places.** `Namespace.setDefaultRolePermissions()` stores the policy in a namespace field, and `BaseNode.getRolePermissions(inherited)` reads it there, but the permission check (`SessionContext.getApplicableRolePermissions`) read the `DefaultRolePermissions` metadata `UAVariable` node instead. The two were only connected when the operator also called `setNamespaceMetaData()`, which additionally throws on NodeSet2-loaded namespaces.
2. **Initialization discarded declared values.** `ServerEngine.initialize()` unconditionally reset every namespace's `DefaultRolePermissions` / `DefaultUserRolePermissions` Property to a Null value, dropping any default a nodeset had declared.

## Changes

| Area | Change |
|---|---|
| `session_context.ts` | `getDefaultUserRolePermissionsOnNamespace` falls back to the namespace's configured default when the metadata node is absent or Null-typed, so `setDefaultRolePermissions()` reaches enforcement and stays consistent with `getRolePermissions(inherited)`. Existing node / user-permission precedence is preserved. |
| `server_engine.ts` | The Property normalization on init now initializes only *unset* Properties to a readable Null; a Property that already carries a value is left in place. |
| `opcua_server.ts` | `unresolvedPermissionPolicy` becomes a documented `OPCUAServer` constructor option (default `"allow"`, unchanged). `"deny"` lets a deployment drive access entirely from declared policy. |

## Compatibility

- Default behaviour is unchanged: with no namespace default configured, resolution stays permissive (`"allow"`).
- The change only affects servers that configure a namespace default via `setDefaultRolePermissions()` or ship one in a nodeset. That default now applies to remote Sessions as intended, instead of being silently ignored.

## Tests

- `test_session_context_namespace_default_permissions.ts` (4): a namespace default reaches enforcement, a per-node `RolePermissions` still overrides it. Confirmed to fail against the pre-change resolver.
- `test_server_engine_namespace_default_permissions.ts` (2): through a fully initialized `ServerEngine`, the Property stays readable and a configured default is enforced end to end.
- `test_server_unresolved_permission_policy_option.ts` (2): the new option defaults to `"allow"` and carries a configured `"deny"`.
- Existing permission suites stay green: `ServerDiagnostics` (16), `test_server_engine` (113), the address-space permission suite (34), server-wiring (3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
