### PR TITLE
FEAT-0: ESM migration safety net (top-level-await gate, consumer smoke tests, exports correction)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -265,6 +265,14 @@ jobs:
       # is gitignored; the lean `build` (tsc only) doesn't produce it. Nodeset
       # generation is deliberately NOT part of it: that output is committed.
       - run: pnpm run build:all
+      # Load the built tree the way the two kinds of consumer do, before spending 30
+      # minutes on the suite. The suite itself proves nothing here: it loads packages by
+      # relative path with a TypeScript loader, never through the published entry point,
+      # so it cannot see a broken `main`, a wrong exports condition, a named export
+      # cjs-module-lexer failed to find, or the ERR_REQUIRE_ASYNC_MODULE that a
+      # top-level await would introduce. These two files are the only thing in CI that
+      # exercises `require("node-opcua")` and `import ... from "node-opcua"`.
+      - run: pnpm run check:consumers
       - run: pnpm run pretest
       # Leak detection stays ON everywhere, and MEM_LEAK_DETECTION_DISABLED is
       # deliberately not set on any job. The detector is not only a measurement: its

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -73,6 +73,13 @@ jobs:
       # relative path into `require`. Cheap to check here, and the alternative is
       # finding out from a package that will not start - which is how the last one went.
       - run: pnpm run check:mocharc
+      # Module-scope await anywhere in the graph makes `require("node-opcua")` throw
+      # ERR_REQUIRE_ASYNC_MODULE, which is how every CommonJS consumer loads us. The test
+      # suite would not notice: it loads packages with `import`, where top-level await is
+      # legal. Only a consumer's application finds out. Checked here so it cannot happen.
+      - run: pnpm run check:tla
+      - name: Unit tests for the top-level-await detector
+        run: node tools/check-no-tla/test/test_detector.js
 
   # A gate rather than a lint step, because what it guards is not style. Two test files
   # holding one fixed port collide as soon as the runner schedules them together, and the

--- a/fixtures/consumer-cjs/index.cjs
+++ b/fixtures/consumer-cjs/index.cjs
@@ -1,0 +1,41 @@
+/**
+ * CommonJS consumer smoke test.
+ *
+ * This is the shape the overwhelming majority of node-opcua users have, and the shape the
+ * ESM migration must not break. Node 22.12 and later can require() an ES module, which is
+ * the whole reason the migration can be ESM-only rather than dual, but that interop is
+ * conditional: a graph containing top-level await cannot be required at all. This fixture
+ * is what notices, on the matrix, rather than a consumer noticing in production.
+ *
+ * Run: node fixtures/consumer-cjs/index.cjs
+ */
+
+const assert = require("node:assert/strict");
+
+const opcua = require("node-opcua");
+
+// 1. the module loaded at all. Under a half-migrated graph this is where
+//    ERR_REQUIRE_ASYNC_MODULE would land.
+assert.ok(opcua && typeof opcua === "object", "require('node-opcua') must return the namespace");
+
+// 2. named exports survive. CJS today, and after the flip they come from
+//    cjs-module-lexer reading the ESM entry - which is exactly the step that can
+//    silently drop names.
+const { OPCUAClient, NodeId, resolveNodeId, StatusCodes, DataType } = opcua;
+for (const [name, value] of Object.entries({ OPCUAClient, NodeId, resolveNodeId, StatusCodes, DataType })) {
+    assert.ok(value !== undefined, `named export ${name} is missing from require('node-opcua')`);
+}
+assert.equal(typeof OPCUAClient.create, "function", "OPCUAClient.create must be callable");
+
+// 3. usable, not merely present: build a value and check its identity.
+//    resolveNodeId lives in node-opcua-nodeid, so an instanceof that holds here proves the
+//    class reaching the consumer is the same class the graph constructed internally. That
+//    is the dual-package hazard this migration deliberately avoids, and the reason we
+//    rejected dual publishing: 725 instanceof checks would start returning false.
+const nodeId = resolveNodeId("ns=0;i=85");
+assert.ok(nodeId instanceof NodeId, "resolveNodeId must return an instance of the exported NodeId class");
+assert.equal(nodeId.value, 85);
+assert.equal(StatusCodes.Good.value, 0);
+assert.equal(DataType.Double, 11);
+
+console.log(`consumer-cjs: ok (node ${process.version})`);

--- a/fixtures/consumer-cjs/package.json
+++ b/fixtures/consumer-cjs/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "@sterfive/consumer-cjs",
+    "version": "1.0.0",
+    "private": true,
+    "description": "smoke test: node-opcua loaded the way a CommonJS consumer loads it",
+    "type": "commonjs",
+    "scripts": {
+        "smoke": "node index.cjs"
+    },
+    "dependencies": {
+        "node-opcua": "workspace:*"
+    }
+}

--- a/fixtures/consumer-esm/index.mjs
+++ b/fixtures/consumer-esm/index.mjs
@@ -1,0 +1,32 @@
+/**
+ * ESM consumer smoke test.
+ *
+ * The mirror of consumer-cjs. Today this resolves to the CommonJS build and works through
+ * Node's interop, where named exports depend on cjs-module-lexer statically finding them.
+ * After the migration it resolves to real ESM and the names are declared. Both must work,
+ * and the point of having this fixture from the first commit is that the day the entry
+ * point flips, the difference shows up here rather than in someone's application.
+ *
+ * Run: node fixtures/consumer-esm/index.mjs
+ */
+
+import assert from "node:assert/strict";
+
+import { OPCUAClient, NodeId, resolveNodeId, StatusCodes, DataType } from "node-opcua";
+
+// A named import that cannot be resolved is a load-time error, so reaching this line
+// already proves more than the CJS fixture does at the equivalent point.
+for (const [name, value] of Object.entries({ OPCUAClient, NodeId, resolveNodeId, StatusCodes, DataType })) {
+    assert.ok(value !== undefined, `named export ${name} resolved to undefined`);
+}
+assert.equal(typeof OPCUAClient.create, "function", "OPCUAClient.create must be callable");
+
+// Same identity check as the CJS side. If the two fixtures ever disagree here, the graph
+// is being loaded twice and instanceof is no longer trustworthy across packages.
+const nodeId = resolveNodeId("ns=0;i=85");
+assert.ok(nodeId instanceof NodeId, "resolveNodeId must return an instance of the exported NodeId class");
+assert.equal(nodeId.value, 85);
+assert.equal(StatusCodes.Good.value, 0);
+assert.equal(DataType.Double, 11);
+
+console.log(`consumer-esm: ok (node ${process.version})`);

--- a/fixtures/consumer-esm/package.json
+++ b/fixtures/consumer-esm/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "@sterfive/consumer-esm",
+    "version": "1.0.0",
+    "private": true,
+    "description": "smoke test: node-opcua loaded the way an ESM consumer loads it",
+    "type": "module",
+    "scripts": {
+        "smoke": "node index.mjs"
+    },
+    "dependencies": {
+        "node-opcua": "workspace:*"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "check:mocharc": "node tools/check-mocharc.js",
     "check:mocharc:fix": "node tools/check-mocharc.js --fix",
     "check:tla": "node tools/check-no-tla.mjs",
+    "check:consumers": "node fixtures/consumer-cjs/index.cjs && node fixtures/consumer-esm/index.mjs",
     "preinstall": "node prevent_npm_install.js",
     "lint": "biome check --reporter=summary --no-errors-on-unmatched .",
     "build": "tsc -b packages",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "check:ports:ai": "node tools/check-test-ports.mjs --ai",
     "check:mocharc": "node tools/check-mocharc.js",
     "check:mocharc:fix": "node tools/check-mocharc.js --fix",
+    "check:tla": "node tools/check-no-tla.mjs",
     "preinstall": "node prevent_npm_install.js",
     "lint": "biome check --reporter=summary --no-errors-on-unmatched .",
     "build": "tsc -b packages",

--- a/packages/node-opcua-common/package.json
+++ b/packages/node-opcua-common/package.json
@@ -18,7 +18,6 @@
                 "default": "./dist/index.browser.js"
             },
             "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
             "require": "./dist/index.js",
             "default": "./dist/index.js"
         }

--- a/packages/node-opcua-transport/package.json
+++ b/packages/node-opcua-transport/package.json
@@ -11,7 +11,6 @@
                 "default": "./dist/source/index.browser.js"
             },
             "types": "./dist/source/index.d.ts",
-            "import": "./dist/source/index.js",
             "require": "./dist/source/index.js",
             "default": "./dist/source/index.js"
         },

--- a/packages/node-opcua-utils/package.json
+++ b/packages/node-opcua-utils/package.json
@@ -11,7 +11,6 @@
                 "default": "./dist/index.browser.js"
             },
             "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
             "require": "./dist/index.js",
             "default": "./dist/index.js"
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,18 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  fixtures/consumer-cjs:
+    dependencies:
+      node-opcua:
+        specifier: workspace:*
+        version: link:../../packages/node-opcua
+
+  fixtures/consumer-esm:
+    dependencies:
+      node-opcua:
+        specifier: workspace:*
+        version: link:../../packages/node-opcua
+
   packages/node-opcua:
     dependencies:
       '@types/semver':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4204,6 +4204,12 @@ importers:
 
   tools/check-mocharc: {}
 
+  tools/check-no-tla:
+    devDependencies:
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
   tools/check-test-ports: {}
 
   tools/fix-tsconfigs:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,9 @@ packages:
   - packages/*
   - packages_extra/node-opcua-example
   - tools/*
+  # consumer smoke tests: they must resolve node-opcua the way a real consumer does,
+  # which means being real packages with a real dependency on it
+  - fixtures/*
   # all packages in subdirs of components/
   # - 'packages_extra/*'
 

--- a/tools/check-no-tla.mjs
+++ b/tools/check-no-tla.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+/** launcher for tools/check-no-tla - see tools/README.md */
+import "./check-no-tla/src/index.js";

--- a/tools/check-no-tla/README.md
+++ b/tools/check-no-tla/README.md
@@ -1,0 +1,86 @@
+# check-no-tla
+
+Fails the build if any shipped source file contains **module-scope `await`**.
+
+```bash
+node tools/check-no-tla.mjs           # report, exit 1 on any finding
+node tools/check-no-tla.mjs --list    # every file scanned
+pnpm run check:tla                    # same thing, via the root script
+```
+
+## Why this is a gate and not a convention
+
+`node-opcua` is migrating to ESM. The migration only works because Node 22.12 and later
+allow `require()` of an ES module, which is what keeps every existing CommonJS consumer
+working after the switch. That interop has exactly one disqualifying condition: **a module
+graph containing top-level `await` cannot be `require()`d**, and Node throws
+`ERR_REQUIRE_ASYNC_MODULE`.
+
+So one `await` added at module scope, anywhere in the graph, turns
+`require("node-opcua")` from working into throwing, for everyone. Nothing in the type
+checker, the linter or the test suite notices: the suite loads packages with `import`,
+where top-level await is legal and works. The failure only shows up in a consumer's
+application.
+
+It costs nothing to make that impossible, so it is checked here rather than remembered.
+
+## What counts
+
+Flagged: `await` evaluated when the module body runs, including inside `if`, `try` or a
+bare block, and `for await (... )` at module scope.
+
+Not flagged: `await` inside any function scope. Async functions, async class methods,
+async object-literal methods, callbacks, and the async-IIFE workaround:
+
+```ts
+// legal, and the usual way to keep an eager operation out of the module body
+(async () => {
+    await main();
+})();
+```
+
+Scope is decided by parsing with the TypeScript compiler, not by matching text. A regex
+cannot tell `if (c) { await x }` from `(async () => { await x })()`, and a false negative
+here is silent: it does not fail the build, it breaks `require()` for consumers later.
+
+## What is scanned
+
+`packages/*/source` and `packages/*/src`, for `.ts .tsx .mts .cts .js .mjs .cjs .jsx`.
+
+Declaration files are skipped, as are `node_modules`, `dist`, `dist-esm`, `coverage`,
+`build`, and the test trees. Test code is not shipped and is never `require()`d by a
+consumer, so top-level await there is free to use.
+
+## Layout
+
+`src/detector.js` is pure and takes source text or a root path, so the tests hand it
+strings and fixture trees instead of shelling out and matching printed output.
+`src/index.js` is the command line around it.
+
+```bash
+node tools/check-no-tla/test/test_detector.js
+```
+
+## Fixing a finding
+
+Move the `await` inside an async function, or export something the caller awaits:
+
+```ts
+// before: breaks require() for every CJS consumer
+export const namespace = await loadNamespace();
+
+// after
+export async function getNamespace() {
+    return await loadNamespace();
+}
+```
+
+A lazily-initialised singleton works too, when callers should not care:
+
+```ts
+let cached: Namespace | undefined;
+export async function getNamespace(): Promise<Namespace> {
+    cached ??= await loadNamespace();
+    return cached;
+}
+```

--- a/tools/check-no-tla/package.json
+++ b/tools/check-no-tla/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "@sterfive/check-no-tla",
+    "version": "1.0.0",
+    "private": true,
+    "description": "fail the build on module-scope await, which would make a package unloadable from require()",
+    "bin": {
+        "check-no-tla": "src/index.js"
+    },
+    "type": "module",
+    "scripts": {
+        "check": "node src/index.js",
+        "test": "node test/test_detector.js"
+    },
+    "devDependencies": {
+        "typescript": "5.9.3"
+    }
+}

--- a/tools/check-no-tla/src/detector.js
+++ b/tools/check-no-tla/src/detector.js
@@ -1,0 +1,148 @@
+/**
+ * detector - find module-scope `await` in shipped source.
+ *
+ * Kept separate from the CLI and free of process/exit so the unit tests can hand it
+ * strings and assert on findings, rather than shelling out and matching printed text.
+ *
+ * Why a real parser and not a regex: the question "is this await at module scope?"
+ * is a scope question, not a text question. `(async () => { await x })()` is legal and
+ * must not be flagged; `if (c) { await x }` is illegal and must be. Telling those apart
+ * with brace counting means reimplementing a parser badly, and a false negative here is
+ * invisible - it does not fail the build, it breaks `require()` for every CJS consumer
+ * at some later date. TypeScript is already a build dependency, so we use its parser.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+
+/** shipped source only: test trees may use whatever they like, they are never required by a consumer */
+export const SCAN_DIRS = ["source", "src"];
+
+/** directories that never contain shipped source */
+const SKIP_DIRS = new Set(["node_modules", "dist", "dist-esm", "coverage", "build", "test", "test_helpers", "test-fixtures"]);
+
+const SCRIPT_KIND = {
+    ".ts": ts.ScriptKind.TS,
+    ".tsx": ts.ScriptKind.TSX,
+    ".mts": ts.ScriptKind.TS,
+    ".cts": ts.ScriptKind.TS,
+    ".js": ts.ScriptKind.JS,
+    ".mjs": ts.ScriptKind.JS,
+    ".cjs": ts.ScriptKind.JS,
+    ".jsx": ts.ScriptKind.JSX
+};
+
+/** true for any node that opens a new function scope, so an await below it is not module-scope */
+function opensFunctionScope(node) {
+    return (
+        ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isArrowFunction(node) ||
+        ts.isMethodDeclaration(node) ||
+        ts.isConstructorDeclaration(node) ||
+        ts.isGetAccessorDeclaration(node) ||
+        ts.isSetAccessorDeclaration(node) ||
+        ts.isClassStaticBlockDeclaration(node)
+    );
+}
+
+/**
+ * Every module-scope await in one file's text.
+ * Returns [{ line, column, kind, text }] with 1-based line numbers.
+ */
+export function findTopLevelAwait(text, fileName = "input.ts") {
+    const ext = path.extname(fileName).toLowerCase();
+    const sourceFile = ts.createSourceFile(fileName, text, ts.ScriptTarget.ESNext, true, SCRIPT_KIND[ext] ?? ts.ScriptKind.TS);
+
+    const findings = [];
+    const record = (node, kind) => {
+        const { line, character } = ts.getLineAndCharacterOfPosition(sourceFile, node.getStart(sourceFile));
+        findings.push({
+            line: line + 1,
+            column: character + 1,
+            kind,
+            text: (sourceFile.text.split("\n")[line] ?? "").trim().slice(0, 100)
+        });
+    };
+
+    const visit = (node, insideFunction) => {
+        const nested = insideFunction || opensFunctionScope(node);
+        if (!nested) {
+            if (ts.isAwaitExpression(node)) {
+                record(node, "await");
+            } else if (ts.isForOfStatement(node) && node.awaitModifier) {
+                record(node, "for await");
+            }
+        }
+        ts.forEachChild(node, (child) => visit(child, nested));
+    };
+    ts.forEachChild(sourceFile, (child) => visit(child, false));
+
+    return findings;
+}
+
+/** every shipped source file under `root`, as paths relative to the process cwd */
+export function findSourceFiles(root = "packages") {
+    const files = [];
+    if (!fs.existsSync(root)) {
+        return files;
+    }
+    for (const pkg of fs.readdirSync(root, { withFileTypes: true })) {
+        if (!pkg.isDirectory() || SKIP_DIRS.has(pkg.name)) {
+            continue;
+        }
+        for (const dir of SCAN_DIRS) {
+            walk(path.join(root, pkg.name, dir), files);
+        }
+    }
+    return files;
+}
+
+function walk(dir, out) {
+    if (!fs.existsSync(dir)) {
+        return;
+    }
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            if (!SKIP_DIRS.has(entry.name)) {
+                walk(full, out);
+            }
+        } else if (SCRIPT_KIND[path.extname(entry.name).toLowerCase()] && !entry.name.endsWith(".d.ts")) {
+            out.push(full);
+        }
+    }
+}
+
+/** scan a tree; returns { scanned, findings: [{ file, line, column, kind, text }] } */
+export function analyze(root = "packages") {
+    const findings = [];
+    const files = findSourceFiles(root);
+    for (const file of files) {
+        for (const hit of findTopLevelAwait(fs.readFileSync(file, "utf8"), file)) {
+            findings.push({ file: file.replace(/\\/g, "/"), ...hit });
+        }
+    }
+    return { scanned: files.length, findings };
+}
+
+export function exitCode(result) {
+    return result.findings.length > 0 ? 1 : 0;
+}
+
+export function formatReport(result) {
+    if (result.findings.length === 0) {
+        return `check-no-tla: ${result.scanned} files scanned, no module-scope await.`;
+    }
+    const lines = [`check-no-tla: ${result.findings.length} module-scope await in ${result.scanned} files scanned`, ""];
+    for (const f of result.findings) {
+        lines.push(`  ${f.file}:${f.line}:${f.column}  (${f.kind})`);
+        lines.push(`      ${f.text}`);
+    }
+    lines.push("");
+    lines.push("Module-scope await makes a package unloadable from require(), which is how");
+    lines.push("every CommonJS consumer of node-opcua loads it. Move the await inside an");
+    lines.push("async function, or export a factory the caller awaits.");
+    return lines.join("\n");
+}

--- a/tools/check-no-tla/src/index.js
+++ b/tools/check-no-tla/src/index.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * check-no-tla - command line around src/detector.js.
+ *
+ * Usage:
+ *     node tools/check-no-tla.mjs           # report, exit 1 on any module-scope await
+ *     node tools/check-no-tla.mjs --list    # every file scanned
+ *     node tools/check-no-tla.mjs <root>    # scan a tree other than packages/
+ */
+
+import process from "node:process";
+import { analyze, findSourceFiles, exitCode, formatReport } from "./detector.js";
+
+function main() {
+    const argv = process.argv.slice(2);
+    const root = argv.find((a) => !a.startsWith("--")) ?? "packages";
+
+    if (argv.includes("--list")) {
+        for (const f of findSourceFiles(root)) {
+            console.log(f.replace(/\\/g, "/"));
+        }
+        return 0;
+    }
+
+    const result = analyze(root);
+    console.log(formatReport(result));
+    return exitCode(result);
+}
+
+process.exit(main());

--- a/tools/check-no-tla/test/test_detector.js
+++ b/tools/check-no-tla/test/test_detector.js
@@ -1,0 +1,244 @@
+/**
+ * Unit tests for the top-level-await detector.
+ *
+ * The negative fixtures matter more than the positive ones. Anything can find the word
+ * "await"; the job here is to not flag the shapes this repo is full of - async IIFEs,
+ * async class methods, callbacks passed to map/forEach - because a tool that cries wolf
+ * gets its CI step deleted, and then the real one goes unnoticed.
+ *
+ * Run: node test/test_detector.js   (node:test needs no --test flag)
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { findTopLevelAwait, analyze, findSourceFiles, exitCode, formatReport } from "../src/detector.js";
+
+// --- flagged: await that really is evaluated at module scope ---------------------
+
+const POSITIVE = {
+    "bare statement": `
+import { load } from "./load";
+const config = await load();
+export { config };
+`,
+    "inside an if": `
+import { probe } from "./probe";
+if (process.env.X) {
+    await probe();
+}
+`,
+    "inside a try": `
+try {
+    await import("./optional");
+} catch {
+    // ignore
+}
+`,
+    "inside a bare block": `
+{
+    await ready();
+}
+`,
+    "for await at module scope": `
+for await (const chunk of stream) {
+    console.log(chunk);
+}
+`,
+    "in an exported initializer": `
+export const nodesets = await readNodesets();
+`,
+    "inside a top-level arrow's default argument position": `
+const later = await Promise.resolve(1);
+export default later;
+`
+};
+
+for (const [name, source] of Object.entries(POSITIVE)) {
+    test(`flags: ${name}`, () => {
+        const found = findTopLevelAwait(source, "a.ts");
+        assert.ok(found.length >= 1, `expected a finding in:\n${source}`);
+    });
+}
+
+// --- not flagged: await inside some function scope -------------------------------
+
+const NEGATIVE = {
+    "async function declaration": `
+export async function connect() {
+    await socket.open();
+}
+`,
+    "async arrow IIFE, the legitimate workaround": `
+(async () => {
+    await main();
+})();
+`,
+    "async class method": `
+export class Client {
+    async connect() {
+        await this.channel.open();
+    }
+}
+`,
+    "async method in an object literal": `
+export const api = {
+    async read() {
+        await fetch("/x");
+    }
+};
+`,
+    "callback passed to map": `
+const results = items.map(async (item) => await handle(item));
+`,
+    "await inside a getter": `
+class C {
+    get value() {
+        return (async () => await compute())();
+    }
+}
+`,
+    "nested function inside a top-level call": `
+register(function () {
+    return (async function inner() {
+        await tick();
+    })();
+});
+`,
+    "the word await in a string and a comment": `
+// we deliberately await nothing here
+const message = "await the server";
+const template = \`please await \${name}\`;
+`,
+    "a property named await": `
+const o = { await: 1 };
+console.log(o.await);
+`,
+    "async generator method": `
+class S {
+    async *stream() {
+        for await (const c of src) {
+            yield c;
+        }
+    }
+}
+`,
+    "constructor delegating to an async helper": `
+class C {
+    constructor() {
+        this.ready = (async () => {
+            await init();
+        })();
+    }
+}
+`
+};
+
+for (const [name, source] of Object.entries(NEGATIVE)) {
+    test(`does not flag: ${name}`, () => {
+        const found = findTopLevelAwait(source, "a.ts");
+        assert.deepEqual(found, [], `unexpected finding in:\n${source}\ngot ${JSON.stringify(found)}`);
+    });
+}
+
+// --- reported position and kind --------------------------------------------------
+
+test("reports a 1-based line, the source line, and the kind", () => {
+    const found = findTopLevelAwait("const a = 1;\nconst b = await c();\n", "a.ts");
+    assert.equal(found.length, 1);
+    assert.equal(found[0].line, 2);
+    assert.equal(found[0].kind, "await");
+    assert.equal(found[0].text, "const b = await c();");
+});
+
+test("distinguishes for-await from a plain await", () => {
+    const found = findTopLevelAwait("for await (const x of y) {}\n", "a.ts");
+    assert.equal(found.length, 1);
+    assert.equal(found[0].kind, "for await");
+});
+
+test("finds every occurrence, not just the first", () => {
+    const found = findTopLevelAwait("const a = await x();\nconst b = await y();\n", "a.ts");
+    assert.equal(found.length, 2);
+});
+
+// --- plain JavaScript, not only TypeScript ---------------------------------------
+
+test("parses .mjs as well as .ts", () => {
+    assert.equal(findTopLevelAwait("const a = await x();\n", "a.mjs").length, 1);
+    assert.equal(findTopLevelAwait("async function f() { await x(); }\n", "a.mjs").length, 0);
+});
+
+test("TypeScript-only syntax does not derail the parse", () => {
+    const source = `
+interface Options { port: number }
+type Handler = (o: Options) => Promise<void>;
+enum Kind { A, B }
+export const value = await load<Options>();
+`;
+    const found = findTopLevelAwait(source, "a.ts");
+    assert.equal(found.length, 1);
+});
+
+// --- tree walking -----------------------------------------------------------------
+
+function withFixtureTree(files, fn) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "check-no-tla-"));
+    try {
+        for (const [rel, content] of Object.entries(files)) {
+            const full = path.join(root, rel);
+            fs.mkdirSync(path.dirname(full), { recursive: true });
+            fs.writeFileSync(full, content);
+        }
+        return fn(root);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+}
+
+test("scans source/ and src/, skipping tests, dist and .d.ts", () => {
+    withFixtureTree(
+        {
+            "pkg-a/source/index.ts": "const a = await x();\n",
+            "pkg-b/src/index.ts": "const b = await y();\n",
+            "pkg-c/source/index.d.ts": "declare const c: number;\n",
+            "pkg-c/source/ok.ts": "async function f() { await z(); }\n",
+            "pkg-d/test/test_thing.ts": "const d = await w();\n",
+            "pkg-e/dist/index.js": "const e = await v();\n"
+        },
+        (root) => {
+            const result = analyze(root);
+            const hit = result.findings.map((f) => f.file.replace(/\\/g, "/"));
+            assert.equal(hit.length, 2, `got ${JSON.stringify(hit)}`);
+            assert.ok(hit.some((f) => f.endsWith("pkg-a/source/index.ts")));
+            assert.ok(hit.some((f) => f.endsWith("pkg-b/src/index.ts")));
+
+            const scanned = findSourceFiles(root).map((f) => f.replace(/\\/g, "/"));
+            assert.ok(!scanned.some((f) => f.includes("/test/")), "test trees must not be scanned");
+            assert.ok(!scanned.some((f) => f.includes("/dist/")), "dist must not be scanned");
+            assert.ok(!scanned.some((f) => f.endsWith(".d.ts")), "declarations must not be scanned");
+        }
+    );
+});
+
+test("a clean tree exits 0, a dirty one exits 1", () => {
+    withFixtureTree({ "pkg/source/index.ts": "async function f() { await x(); }\n" }, (root) => {
+        const result = analyze(root);
+        assert.equal(exitCode(result), 0);
+        assert.match(formatReport(result), /no module-scope await/);
+    });
+    withFixtureTree({ "pkg/source/index.ts": "const a = await x();\n" }, (root) => {
+        const result = analyze(root);
+        assert.equal(exitCode(result), 1);
+        assert.match(formatReport(result), /pkg\/source\/index\.ts:1/);
+    });
+});
+
+test("a missing root is not an error, it is an empty scan", () => {
+    const result = analyze(path.join(os.tmpdir(), "check-no-tla-does-not-exist"));
+    assert.equal(result.scanned, 0);
+    assert.equal(exitCode(result), 0);
+});


### PR DESCRIPTION
FEAT-0 of the ESM migration backlog: https://github.com/orgs/node-opcua/projects/2

This is the safety net. It ships no format change and is a 2.x minor. Its whole purpose is that the later phases have something that can detect a regression, so it lands before anything moves.

Three independent commits, in the order they can be reviewed or reverted.

## 1. `fix(exports)`: drop the import condition that resolves to CommonJS

`node-opcua-transport`, `node-opcua-common` and `node-opcua-utils` each declared `"import"`, `"require"` and `"default"` all pointing at the same CommonJS file. That reads as dual-format support the packages do not have: an ESM consumer was always getting the CJS file through interop, so named exports depended on `cjs-module-lexer` guessing right.

Resolution is unchanged, because `"default"` already answers whatever `"import"` did. Verified rather than asserted, with `require.resolve` and `import.meta.resolve` from `packages/node-opcua`, captured before and after:

```
node-opcua-transport   require: node-opcua-transport/dist/source/index.js
                       import : node-opcua-transport/dist/source/index.js
node-opcua-common      require: node-opcua-common/dist/index.js
                       import : node-opcua-common/dist/index.js
node-opcua-utils       require: node-opcua-utils/dist/index.js
                       import : node-opcua-utils/dist/index.js
```

Byte-identical across the change.

**Correction to the plan:** it listed `node-opcua-client-browser` as a fourth package. That was wrong, and it is deliberately excluded. Its `"import"` points at `./dist-esm/index.js`, a genuinely separate build produced by `tsc -p tsconfig.esm.json` with `module: ES2022`. That package really is dual, on purpose.

## 2. `feat(tools)`: fail the build on module-scope await

The migration can be ESM-only, rather than dual, because Node 22.12+ can `require()` an ES module. That interop has exactly one disqualifying condition: **a module graph containing top-level `await` cannot be `require()`d at all**, and Node throws `ERR_REQUIRE_ASYNC_MODULE`.

So a single `await` added at module scope, anywhere in the graph, would turn `require("node-opcua")` from working into throwing, for every CommonJS consumer. Nothing currently notices: the type checker is happy, and the suite loads packages with `import`, where top-level await is legal and works. It would surface in someone's application.

Scope is decided by parsing with the TypeScript compiler, not by matching text. A regex cannot distinguish `if (c) { await x }` from `(async () => { await x })()`, and getting it wrong in that direction is silent: it does not fail the build, it breaks consumers later.

- 26 unit tests, weighted toward the negative cases (async IIFE, async class method, async object-literal method, callbacks, async generator, `await` inside strings and comments), because a tool that cries wolf gets its CI step deleted
- Runs in the `lint` job, alongside `check:mocharc`
- Current state of the tree: **2296 files scanned, zero findings**

## 3. `test(fixtures)`: load node-opcua the way consumers actually load it

Nothing in CI went through the published entry point. The suite loads packages by relative path with a TypeScript loader, so it is structurally incapable of catching a broken `main`, a wrong exports condition, a named export `cjs-module-lexer` failed to find, or the `ERR_REQUIRE_ASYNC_MODULE` above.

Two fixtures, one per consumer shape, added as real workspace packages depending on `node-opcua` (resolving it any other way would not be testing what a consumer does). They run in the `build` job right after `build:all`, so they fail in seconds rather than after the 30-minute suite.

Both assert that `resolveNodeId("ns=0;i=85")` returns something `instanceof` the exported `NodeId`. That is the check that catches the module graph being loaded twice, which is the dual-package hazard the migration avoids by staying single-format. There are 725 `instanceof` checks in shipped source, 93 of them on `NodeId`; under a duplicated graph they would all start returning `false` silently.

## Verification

Run locally on the committed tree, all passing:

| gate | result |
|---|---|
| `pnpm run check:tla` | 2296 files, 0 findings |
| `node tools/check-no-tla/test/test_detector.js` | 26/26 |
| `pnpm run check:consumers` | both shapes ok |
| `pnpm run check:mocharc` | pass |
| `pnpm run check:ports` | pass |
| `pnpm run lint` | pass |
| `npx tsc -b packages` | exit 0 |
| `pnpm install --frozen-lockfile` | pass |

The one biome warning visible locally (`noUnusedImports` in `test_session_context_namespace_default_permissions.ts`) is pre-existing on master, unrelated to this branch, and is a warning rather than an error, so `lint` still exits 0.

## Not in this PR

Nothing changes module format. No package becomes `"type": "module"`, and `require("node-opcua")` keeps resolving exactly where it did. FEAT-1 (removing the 206 `__filename` debug call sites) is the next 2.x step; the format flip is FEAT-2, and that is where 3.0 begins.
