### PR TITLE
fix(server): let endpoint shutdown wait for the listener to be released

### DIFF
--- a/packages/node-opcua-server/source/server_end_point.ts
+++ b/packages/node-opcua-server/source/server_end_point.ts
@@ -379,6 +379,9 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
     private _started = false;
     private _counter = OPCUAServerEndPointCounter++;
     private _policy_deduplicator: { [key: string]: number } = {};
+    // every accepted socket, channel or not, so shutdown() can destroy the
+    // survivors and let the listener's 'close' event fire
+    #acceptedSockets = new Set<Socket>();
 
     private transportSettings?: IServerTransportSettings;
     constructor(options: OPCUAServerEndPointOptions) {
@@ -831,6 +834,29 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
         callback();
     }
 
+    /**
+     * Stops the server accepting new connections and returns a promise that
+     * settles once node has emitted the 'close' event - the point where the
+     * listening handle is genuinely released and the port can be bound again.
+     * close() is asynchronous and finishes only once every accepted
+     * connection has ended, so callers decide what to do with the still
+     * connected sockets before (or while) awaiting the returned promise.
+     */
+    private _initiateListenerRelease(): Promise<void> {
+        this._started = false;
+        const server = this._server;
+        if (!server) {
+            return Promise.resolve();
+        }
+        return new Promise<void>((resolve) => {
+            server.close(() => {
+                // c8 ignore next
+                doDebug && debugLog(`Connection has been closed !${this.port}`);
+                resolve();
+            });
+        });
+    }
+
     public suspendConnection(callback: (err?: Error) => void): void {
         if (!this._started || !this._server) {
             callback(new Error("Connection already suspended !!"));
@@ -848,7 +874,6 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
         // suspend deliberately keeps existing connections alive, and a channel that
         // stays open would otherwise hold close() - and the caller - open with it.
         // Waiting a bounded time is what the caller needs; hanging is not.
-        this._started = false;
         let notified = false;
         const notify = () => {
             if (notified) {
@@ -863,10 +888,8 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
             notify();
         }, 1000);
         guard.unref();
-        this._server.close(() => {
+        this._initiateListenerRelease().then(() => {
             clearTimeout(guard);
-            // c8 ignore next
-            doDebug && debugLog(`Connection has been closed !${this.port}`);
             notify();
         });
     }
@@ -887,39 +910,51 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
         // c8 ignore next
         doDebug && debugLog("OPCUAServerEndPoint#shutdown ");
 
-        if (this._started) {
-            // make sure we don't accept new connection any more ...
-            this.suspendConnection(() => {
-                // shutdown all opened channels ...
-                const _channels = Object.values(this._channels);
-                const promises = _channels.map(
-                    (channel) =>
-                        new Promise<void>((resolve, reject) => {
-                            this.shutdown_channel(channel, (err?: Error) => {
-                                if (err) {
-                                    reject(err);
-                                } else {
-                                    resolve();
-                                }
-                            });
-                        })
-                );
-                Promise.all(promises)
-                    .then(() => {
-                        /* c8 ignore next */
-                        if (!(Object.keys(this._channels).length === 0)) {
-                            errorLog(" Bad !");
-                        }
-                        assert(Object.keys(this._channels).length === 0, "channel must have unregistered themselves");
-                        callback();
-                    })
-                    .catch((err) => {
-                        callback(err);
-                    });
-            });
-        } else {
+        if (!this._started) {
             callback();
+            return;
         }
+        // Stop accepting new connections and start releasing the listening
+        // socket. Node emits 'close' only once every accepted socket has
+        // ended, so the release is awaited after the channels are shut down:
+        // calling back on the channels alone lets the next listen() race the
+        // still-held handle - an intermittent EADDRINUSE on rapid
+        // stop/start cycles, mostly seen on Windows where the release lags.
+        const listenerReleased = this._initiateListenerRelease();
+        const _channels = Object.values(this._channels);
+        const promises = _channels.map(
+            (channel) =>
+                new Promise<void>((resolve, reject) => {
+                    this.shutdown_channel(channel, (err?: Error) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve();
+                        }
+                    });
+                })
+        );
+        Promise.all(promises)
+            .then(() => {
+                /* c8 ignore next */
+                if (!(Object.keys(this._channels).length === 0)) {
+                    errorLog(" Bad !");
+                }
+                assert(Object.keys(this._channels).length === 0, "channel must have unregistered themselves");
+                // sockets that never completed the handshake are not in
+                // _channels yet still hold the 'close' event; sweep them so
+                // the wait below cannot hang.
+                for (const socket of this.#acceptedSockets) {
+                    socket.destroy();
+                }
+                return listenerReleased;
+            })
+            .then(() => {
+                callback();
+            })
+            .catch((err) => {
+                callback(err);
+            });
     }
 
     /**
@@ -992,6 +1027,8 @@ export class OPCUAServerEndPoint extends EventEmitter implements ServerSecureCha
         this._listen_callback = undefined;
         this._server
             .on("connection", (socket: Socket) => {
+                this.#acceptedSockets.add(socket);
+                socket.on("close", () => this.#acceptedSockets.delete(socket));
                 // c8 ignore next
                 if (doDebug) {
                     this._dump_statistics();


### PR DESCRIPTION
## Problem

Intermittent `EADDRINUSE :::12401` on the Windows CI (run 33241533968), in `DISCO4-J - should perform start/stop cycle efficiently even with many connected clients and server close before clients`. The test loops `await createServer()` / `await shutdownServer()` on the same port with sub-250 ms pauses, so it is a self-collision: the next bind happens before the previous listener is genuinely released. The test awaits the documented API, so the gap is inside the server.

## Root cause

`OPCUAServerEndPoint#shutdown` resolved on the wrong signal:

1. It called `suspendConnection()`, which initiates `net.Server#close()`. With clients still connected, `close()` cannot finish, so the 1 s guard from 5dc151d82 fires and suspend calls back with the handle still held.
2. It then shut down the channels and called back when the last **channel** closed.
3. The listener's `'close'` event, the actual release of the handle, fires slightly later. The next `listen()` on the same port races it, and Windows (slower release) loses intermittently. Same defect class as 5dc151d82, one level up.

## Fix

- New `_initiateListenerRelease()`: marks the endpoint stopped, calls `close()`, returns a promise resolved on the `'close'` event.
- `shutdown()` initiates the close immediately (no longer paying the 1 s suspend guard, so shutdown with connected clients got faster), shuts the channels down, destroys any surviving accepted socket, and calls back only once `'close'` has fired.
- Surviving sockets are the ones `close()` would otherwise wait on forever: connections that never completed the HEL/ACK handshake, and refused sockets left half-closed by `socket.end()`. They are tracked in a `#acceptedSockets` set fed by the `'connection'` handler (`net.Server` has no `closeAllConnections()`; that API is `http.Server` only).
- `suspendConnection()` keeps its bounded-wait semantics, delegating to the shared helper.

## Verification (Windows 11, Node 22)

| Check | Result |
| --- | --- |
| `tsc -b packages` | clean |
| DISCO4-J, 4 consecutive runs | all passing (68 s / 57 s / 53 s / 53 s) |
| Full DISCO4 suite (bail) | exit 0 |
| `test_server_with_push_certificate_management` | 5 passing, SCT-3/SCT-5 rotation included |

🤖 Generated with [Claude Code](https://claude.com/claude-code)