### PR TITLE
FEAT-1: remove __filename from the debug loggers, concentrate the remaining __dirname (+ check-debug-name tool)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -80,6 +80,13 @@ jobs:
       - run: pnpm run check:tla
       - name: Unit tests for the top-level-await detector
         run: node tools/check-no-tla/test/test_detector.js
+      # The logger factories take a module-name literal, never __filename. Those globals
+      # do not exist in ESM or in a browser bundle, and the value was only ever reduced
+      # to a basename anyway - so the literal is what the DEBUG env var already matches
+      # on. Gated because 207 call sites drifted into the old shape once already.
+      - run: pnpm run check:debugname
+      - name: Unit tests for the debug-name rule
+        run: node tools/check-debug-name/test/test_rule.js
 
   # A gate rather than a lint step, because what it guards is not style. Two test files
   # holding one fixed port collide as soon as the runner schedules them together, and the

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "check:mocharc": "node tools/check-mocharc.js",
     "check:mocharc:fix": "node tools/check-mocharc.js --fix",
     "check:tla": "node tools/check-no-tla.mjs",
+    "check:debugname": "node tools/check-debug-name.mjs",
+    "check:debugname:fix": "node tools/check-debug-name.mjs --fix",
     "check:consumers": "node fixtures/consumer-cjs/index.cjs && node fixtures/consumer-esm/index.mjs",
     "preinstall": "node prevent_npm_install.js",
     "lint": "biome check --reporter=summary --no-errors-on-unmatched .",

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/helpers.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/helpers.ts
@@ -10,9 +10,9 @@ import { checkDebugFlag, make_debugLog, make_warningLog } from "node-opcua-debug
 import { findBuiltInType } from "node-opcua-factory";
 import { buildVariantArray, DataType, Variant, VariantArrayType } from "node-opcua-variant";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
-const warningLog = make_warningLog(__filename);
+const debugLog = make_debugLog("helpers");
+const doDebug = checkDebugFlag("helpers");
+const warningLog = make_warningLog("helpers");
 
 // ─── Validators & Random Generators ─────────────────────────────────────
 

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/static_variables.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/static_variables.ts
@@ -12,6 +12,11 @@ import { typeAndDefaultValue } from "./type_defaults";
 
 const errorLog = make_errorLog("static_variables");
 
+// The one place this module learns where it sits on disk. `import.meta.dirname`
+// cannot be used while this package emits CommonJS (TS1470), so the ESM migration
+// has this single line to change rather than several scattered uses.
+const here = __dirname;
+
 export async function addStaticVariables(namespace: Namespace, scalarFolder: UAObject): Promise<void> {
     const staticScalarFolder = namespace.addObject({
         organizedBy: scalarFolder,
@@ -30,7 +35,7 @@ export async function addStaticVariables(namespace: Namespace, scalarFolder: UAO
 
     // Load images
     async function setImage(imageType: string, filename: string): Promise<void> {
-        const fullPath = path.join(__dirname, "../../data", filename);
+        const fullPath = path.join(here, "../../data", filename);
         const imageNode = namespace.findNode(`s=Static_Scalar_Image${imageType}`) as UAVariable;
         try {
             const data = await fs.promises.readFile(fullPath);

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/static_variables.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/static_variables.ts
@@ -10,7 +10,7 @@ import { DataType, Variant } from "node-opcua-variant";
 import { addArrayVariable, addMultiDimensionalArrayVariable, addScalarVariable } from "./helpers";
 import { typeAndDefaultValue } from "./type_defaults";
 
-const errorLog = make_errorLog(__filename);
+const errorLog = make_errorLog("static_variables");
 
 export async function addStaticVariables(namespace: Namespace, scalarFolder: UAObject): Promise<void> {
     const staticScalarFolder = namespace.addObject({

--- a/packages/node-opcua-address-space/source/continuation_points/continuation_point_manager.ts
+++ b/packages/node-opcua-address-space/source/continuation_points/continuation_point_manager.ts
@@ -13,7 +13,7 @@ import { make_warningLog } from "node-opcua-debug";
 import { StatusCodes } from "node-opcua-status-code";
 import type { ReferenceDescription } from "node-opcua-types";
 
-const _warningLog = make_warningLog(__filename);
+const _warningLog = make_warningLog("continuation_point_manager");
 
 let counter = 0;
 

--- a/packages/node-opcua-address-space/source/helpers/argument_list.ts
+++ b/packages/node-opcua-address-space/source/helpers/argument_list.ts
@@ -15,9 +15,9 @@ import type { Argument } from "node-opcua-service-call";
 import { type StatusCode, StatusCodes } from "node-opcua-status-code";
 import { DataType, type Variant, VariantArrayType } from "node-opcua-variant";
 
-const debugLog = make_debugLog(__filename);
-const warningLog = make_warningLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("argument_list");
+const warningLog = make_warningLog("argument_list");
+const doDebug = checkDebugFlag("argument_list");
 
 function myfindBuiltInType(dataType: DataType): BasicTypeDefinition {
     return findBuiltInType(DataType[dataType]);

--- a/packages/node-opcua-address-space/source/helpers/multiform_func.ts
+++ b/packages/node-opcua-address-space/source/helpers/multiform_func.ts
@@ -1,7 +1,7 @@
 import { make_warningLog } from "node-opcua-debug";
 import type { CallbackT } from "node-opcua-status-code";
 
-const warningLog = make_warningLog(__filename);
+const warningLog = make_warningLog("multiform_func");
 
 export type StraightFunc<T, This> = (this: This) => T;
 export type PromiseFunc<T, This> = (this: This) => Promise<T>;

--- a/packages/node-opcua-address-space/source/loader/decode_xml_extension_object.ts
+++ b/packages/node-opcua-address-space/source/loader/decode_xml_extension_object.ts
@@ -7,9 +7,9 @@ import { Xml2Json } from "node-opcua-xml2json";
 
 import { type DefinitionMap2, makeXmlExtensionObjectReader, type TypeInfo } from "./make_xml_extension_object_parser";
 
-const doDebug = checkDebugFlag(__filename);
-const debugLog = make_debugLog(__filename);
-const _errorLog = make_errorLog(__filename);
+const doDebug = checkDebugFlag("decode_xml_extension_object");
+const debugLog = make_debugLog("decode_xml_extension_object");
+const _errorLog = make_errorLog("decode_xml_extension_object");
 
 function encodingNodeIdToDataTypeNode(addressSpace: IAddressSpace, encodingNodeId: NodeId): UADataType {
     const encodingNode = addressSpace.findNode(encodingNodeId);

--- a/packages/node-opcua-address-space/source/loader/ensure_datatype_extracted.ts
+++ b/packages/node-opcua-address-space/source/loader/ensure_datatype_extracted.ts
@@ -16,8 +16,8 @@ import {
 } from "../../src/nodeset_tools/construct_namespace_dependency";
 import { PseudoSession } from "../pseudo_session";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("ensure_datatype_extracted");
+const doDebug = checkDebugFlag("ensure_datatype_extracted");
 
 interface UADataTypePriv extends UADataType {
     $partialDefinition?: StructureField[];

--- a/packages/node-opcua-address-space/source/loader/generateAddressSpaceRaw.ts
+++ b/packages/node-opcua-address-space/source/loader/generateAddressSpaceRaw.ts
@@ -8,9 +8,9 @@ import { adjustNamespaceArray } from "../../src/nodeset_tools/adjust_namespace_a
 import type { NodeSetLoaderOptions } from "../interfaces/nodeset_loader_options";
 import { NodeSetLoader } from "./load_nodeset2";
 
-const doDebug = checkDebugFlag(__filename);
-const debugLog = make_debugLog(__filename);
-const errorLog = make_errorLog(__filename);
+const doDebug = checkDebugFlag("generateAddressSpaceRaw");
+const debugLog = make_debugLog("generateAddressSpaceRaw");
+const errorLog = make_errorLog("generateAddressSpaceRaw");
 
 interface Model extends RequiredModel {
     requiredModel: RequiredModel[];

--- a/packages/node-opcua-address-space/source/loader/load_nodeset2.ts
+++ b/packages/node-opcua-address-space/source/loader/load_nodeset2.ts
@@ -46,9 +46,9 @@ import { makeSemverCompatible } from "./make_semver_compatible";
 import { promoteObjectsAndVariables } from "./namespace_post_step";
 import { makeVariantReader } from "./parsers/variant_parser";
 
-const doDebug = checkDebugFlag(__filename);
-const debugLog = make_debugLog(__filename);
-const errorLog = make_errorLog(__filename);
+const doDebug = checkDebugFlag("load_nodeset2");
+const debugLog = make_debugLog("load_nodeset2");
+const errorLog = make_errorLog("load_nodeset2");
 
 function __make_back_references(namespace: INamespace) {
     const namespaceP = namespace as NamespacePrivate;

--- a/packages/node-opcua-address-space/source/loader/make_xml_extension_object_parser.ts
+++ b/packages/node-opcua-address-space/source/loader/make_xml_extension_object_parser.ts
@@ -29,9 +29,9 @@ import { localizedText_parser } from "./parsers/localized_text_parser";
 import { makeQualifiedNameParser } from "./parsers/qualified_name_parser";
 import { makeVariantReader } from "./parsers/variant_parser";
 
-const warningLog = make_warningLog(__filename);
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const warningLog = make_warningLog("make_xml_extension_object_parser");
+const debugLog = make_debugLog("make_xml_extension_object_parser");
+const doDebug = checkDebugFlag("make_xml_extension_object_parser");
 
 // textual form of an ExpandedNodeId, as found in <ExpandedNodeId><Identifier>...</Identifier></ExpandedNodeId>:
 // an optional server index, an optional namespace uri, then a plain nodeId. see OPC UA part 6.

--- a/packages/node-opcua-address-space/source/loader/namespace_post_step.ts
+++ b/packages/node-opcua-address-space/source/loader/namespace_post_step.ts
@@ -3,8 +3,8 @@ import { NodeClass } from "node-opcua-data-model";
 import { checkDebugFlag, make_debugLog } from "node-opcua-debug";
 import type { NamespacePrivate } from "../../src/namespace_private";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("namespace_post_step");
+const doDebug = checkDebugFlag("namespace_post_step");
 
 export type Promoter = ((node: UAVariable) => UAVariable) | ((node: UAObject) => UAObject);
 

--- a/packages/node-opcua-address-space/source/loader/parsers/variant_parser.ts
+++ b/packages/node-opcua-address-space/source/loader/parsers/variant_parser.ts
@@ -22,8 +22,8 @@ import { type LocalizedTextParserLikeL1, localizedText_parser } from "./localize
 import { makeNodeIdParser } from "./nodeid_parser";
 import { makeQualifiedNameParser, type QualifiedNameParserL1 } from "./qualified_name_parser";
 
-const debugLog = make_debugLog(__dirname);
-const doDebug = checkDebugFlag(__dirname);
+const debugLog = make_debugLog("variant_parser");
+const doDebug = checkDebugFlag("variant_parser");
 
 export type Task = (addressSpace2: IAddressSpace) => Promise<void>;
 

--- a/packages/node-opcua-address-space/src/_mandatory_child_or_requested_optional_filter.ts
+++ b/packages/node-opcua-address-space/src/_mandatory_child_or_requested_optional_filter.ts
@@ -11,10 +11,10 @@ import { assert } from "node-opcua-assert";
 import { BrowseDirection } from "node-opcua-data-model";
 import { checkDebugFlag, make_errorLog, make_warningLog } from "node-opcua-debug";
 
-// const debugLog = make_debugLog(__filename);
-const _doDebug = checkDebugFlag(__filename);
-const warningLog = make_warningLog(__filename);
-const errorLog = make_errorLog(__filename);
+// const debugLog = make_debugLog("_mandatory_child_or_requested_optional_filter");
+const _doDebug = checkDebugFlag("_mandatory_child_or_requested_optional_filter");
+const warningLog = make_warningLog("_mandatory_child_or_requested_optional_filter");
+const errorLog = make_errorLog("_mandatory_child_or_requested_optional_filter");
 const doTrace = checkDebugFlag("INSTANTIATE");
 const traceLog = errorLog;
 

--- a/packages/node-opcua-address-space/src/address_space.ts
+++ b/packages/node-opcua-address-space/src/address_space.ts
@@ -73,9 +73,9 @@ import { UAReferenceTypeImpl } from "./ua_reference_type_impl";
 import type { UAVariableImpl } from "./ua_variable_impl";
 
 const doDebug = false;
-const errorLog = make_errorLog(__filename);
-const debugLog = make_debugLog(__filename);
-const warningLog = make_warningLog(__filename);
+const errorLog = make_errorLog("address_space");
+const debugLog = make_debugLog("address_space");
+const warningLog = make_warningLog("address_space");
 
 const Dequeue = require("dequeue");
 

--- a/packages/node-opcua-address-space/src/alarms_and_conditions/condition_snapshot_impl.ts
+++ b/packages/node-opcua-address-space/src/alarms_and_conditions/condition_snapshot_impl.ts
@@ -21,8 +21,8 @@ import { EventData } from "../event_data";
 import { UATwoStateVariableImpl } from "../state_machine/ua_two_state_variable";
 import { UAConditionImpl } from "./ua_condition_impl";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("condition_snapshot_impl");
+const doDebug = checkDebugFlag("condition_snapshot_impl");
 
 function normalizeName(str: string): string {
     // return str.split(".").map(utils.lowerFirstLetter).join(".");

--- a/packages/node-opcua-address-space/src/alarms_and_conditions/ua_acknowledgeable_condition_impl.ts
+++ b/packages/node-opcua-address-space/src/alarms_and_conditions/ua_acknowledgeable_condition_impl.ts
@@ -20,7 +20,7 @@ import { _install_TwoStateVariable_machinery } from "../state_machine/ua_two_sta
 import { ConditionSnapshotImpl } from "./condition_snapshot_impl";
 import { type UAConditionImpl, UAConditionImplBase } from "./ua_condition_impl";
 
-const debugLog = make_debugLog(__filename);
+const debugLog = make_debugLog("ua_acknowledgeable_condition_impl");
 const doDebug = false;
 
 const $ = (a: UAAcknowledgeableConditionImplBase): UAAcknowledgeableConditionEx => a as unknown as UAAcknowledgeableConditionEx;

--- a/packages/node-opcua-address-space/src/alarms_and_conditions/ua_alarm_condition_impl.ts
+++ b/packages/node-opcua-address-space/src/alarms_and_conditions/ua_alarm_condition_impl.ts
@@ -23,8 +23,8 @@ import { _install_TwoStateVariable_machinery } from "../state_machine/ua_two_sta
 import { ConditionInfoImpl } from "./condition_info_impl";
 import { UAAcknowledgeableConditionImpl, UAAcknowledgeableConditionImplBase } from "./ua_acknowledgeable_condition_impl";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("ua_alarm_condition_impl");
+const doDebug = checkDebugFlag("ua_alarm_condition_impl");
 
 function _update_suppressedOrShelved(alarmNode: UAAlarmConditionImpl) {
     alarmNode.suppressedOrShelved.setValueFromSource({

--- a/packages/node-opcua-address-space/src/alarms_and_conditions/ua_condition_impl.ts
+++ b/packages/node-opcua-address-space/src/alarms_and_conditions/ua_condition_impl.ts
@@ -45,10 +45,10 @@ import type { UAVariableImpl } from "../ua_variable_impl";
 import { ConditionSnapshotImpl } from "./condition_snapshot_impl";
 import { UABaseEventImplBase } from "./ua_base_event_impl";
 
-const debugLog = make_debugLog(__filename);
-const errorLog = make_errorLog(__filename);
-const doDebug = checkDebugFlag(__filename);
-const warningLog = make_warningLog(__filename);
+const debugLog = make_debugLog("ua_condition_impl");
+const errorLog = make_errorLog("ua_condition_impl");
+const doDebug = checkDebugFlag("ua_condition_impl");
+const warningLog = make_warningLog("ua_condition_impl");
 
 /**
  *

--- a/packages/node-opcua-address-space/src/base_node_impl.ts
+++ b/packages/node-opcua-address-space/src/base_node_impl.ts
@@ -87,9 +87,9 @@ import { coerceRolePermissions } from "./role_permissions";
 type ApplyFunc = { apply: (...args: unknown[]) => void };
 
 const doDebug = false;
-const warningLog = make_warningLog(__filename);
-const errorLog = make_errorLog(__filename);
-const debugLog = make_debugLog(__filename);
+const warningLog = make_warningLog("base_node_impl");
+const errorLog = make_errorLog("base_node_impl");
+const debugLog = make_debugLog("base_node_impl");
 
 const HasEventSourceReferenceType = resolveNodeId("HasEventSource");
 const HasNotifierReferenceType = resolveNodeId("HasNotifier");

--- a/packages/node-opcua-address-space/src/extension_object_array_node.ts
+++ b/packages/node-opcua-address-space/src/extension_object_array_node.ts
@@ -11,10 +11,10 @@ import type { NodeId } from "node-opcua-nodeid";
 import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
 import { UAVariableImpl } from "./ua_variable_impl";
 
-const _doDebug = checkDebugFlag(__filename);
-const _debugLog = make_debugLog(__filename);
-const errorLog = make_errorLog(__filename);
-const warningLog = make_warningLog(__filename);
+const _doDebug = checkDebugFlag("extension_object_array_node");
+const _debugLog = make_debugLog("extension_object_array_node");
+const errorLog = make_errorLog("extension_object_array_node");
+const warningLog = make_warningLog("extension_object_array_node");
 
 /*
  * define a complex Variable containing a array of extension objects

--- a/packages/node-opcua-address-space/src/historical_access/address_space_historical_data_node.ts
+++ b/packages/node-opcua-address-space/src/historical_access/address_space_historical_data_node.ts
@@ -32,7 +32,7 @@ import { AddressSpace } from "../../source/address_space_ts";
 import type { AddressSpacePrivate } from "../address_space_private";
 import { UAVariableImpl } from "../ua_variable_impl";
 
-const warningLog = make_warningLog(__filename);
+const warningLog = make_warningLog("address_space_historical_data_node");
 
 interface DequeueItem<T> {
     data: T | null;

--- a/packages/node-opcua-address-space/src/nodeid_manager.ts
+++ b/packages/node-opcua-address-space/src/nodeid_manager.ts
@@ -6,8 +6,8 @@ import { makeNodeId, NodeId, type NodeIdLike, NodeIdType, resolveNodeId, sameNod
 import { BaseNodeImpl } from "./base_node_impl";
 import { type ReferenceImpl, resolveReferenceType } from "./reference_impl";
 
-const _debugLog = make_debugLog(__filename);
-const _warningLog = make_warningLog(__filename);
+const _debugLog = make_debugLog("nodeid_manager");
+const _warningLog = make_warningLog("nodeid_manager");
 
 export const NamespaceOptions = {
     nodeIdNameSeparator: "-"

--- a/packages/node-opcua-address-space/src/nodeset_tools/construct_namespace_dependency.ts
+++ b/packages/node-opcua-address-space/src/nodeset_tools/construct_namespace_dependency.ts
@@ -11,8 +11,8 @@ import { type BaseNodeImpl, getReferenceType } from "../base_node_impl";
 import type { NamespacePrivate } from "../namespace_private";
 import type { UAVariableImpl } from "../ua_variable_impl";
 
-const warningLog = make_warningLog(__filename);
-const _debugLog = make_debugLog(__filename);
+const warningLog = make_warningLog("construct_namespace_dependency");
+const _debugLog = make_debugLog("construct_namespace_dependency");
 
 interface RequiredModel {
     requiredNamespaceIndexes: number[];

--- a/packages/node-opcua-address-space/src/nodeset_tools/nodeset_to_xml.ts
+++ b/packages/node-opcua-address-space/src/nodeset_tools/nodeset_to_xml.ts
@@ -57,9 +57,9 @@ import {
 
 const XMLWriter = require("xml-writer");
 
-const debugLog = make_debugLog(__filename);
-const warningLog = make_warningLog(__filename);
-const errorLog = make_errorLog(__filename);
+const debugLog = make_debugLog("nodeset_to_xml");
+const warningLog = make_warningLog("nodeset_to_xml");
+const errorLog = make_errorLog("nodeset_to_xml");
 const doDebug = false;
 
 function _hash(node: BaseNode | UAReference): string {

--- a/packages/node-opcua-address-space/src/state_machine/finite_state_machine.ts
+++ b/packages/node-opcua-address-space/src/state_machine/finite_state_machine.ts
@@ -29,10 +29,10 @@ import { BaseNodeImpl } from "../base_node_impl";
 import { UAObjectImpl } from "../ua_object_impl";
 import { UAObjectTypeImpl } from "../ua_object_type_impl";
 
-const warningLog = make_warningLog(__filename);
+const warningLog = make_warningLog("finite_state_machine");
 
 const doDebug = false;
-const debugLog = make_debugLog(__filename);
+const debugLog = make_debugLog("finite_state_machine");
 
 export class UATransitionImplBase extends BaseNodeImpl {
     /* intentionnaly empty */

--- a/packages/node-opcua-address-space/src/state_machine/ua_shelving_state_machine_ex.ts
+++ b/packages/node-opcua-address-space/src/state_machine/ua_shelving_state_machine_ex.ts
@@ -20,8 +20,8 @@ import { UAAlarmConditionImpl, UAAlarmConditionImplBase } from "../alarms_and_co
 
 import { promoteToStateMachine, UAStateMachineImpl } from "./finite_state_machine";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("ua_shelving_state_machine_ex");
+const doDebug = checkDebugFlag("ua_shelving_state_machine_ex");
 
 export interface UAShelvedStateMachineHelper {
     _timer: NodeJS.Timeout | null;

--- a/packages/node-opcua-address-space/src/ua_method_impl.ts
+++ b/packages/node-opcua-address-space/src/ua_method_impl.ts
@@ -36,10 +36,10 @@ import { BaseNodeImpl, type InternalBaseNodeOptions } from "./base_node_impl";
 import { _clone } from "./base_node_private";
 import { _handle_hierarchy_parent } from "./namespace_impl";
 
-const warningLog = make_warningLog(__filename);
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
-const errorLog = make_errorLog(__filename);
+const warningLog = make_warningLog("ua_method_impl");
+const debugLog = make_debugLog("ua_method_impl");
+const doDebug = checkDebugFlag("ua_method_impl");
+const errorLog = make_errorLog("ua_method_impl");
 
 function default_check_valid_argument(arg: unknown): boolean {
     return (arg as object) instanceof Argument;

--- a/packages/node-opcua-address-space/src/ua_object_impl.ts
+++ b/packages/node-opcua-address-space/src/ua_object_impl.ts
@@ -36,7 +36,7 @@ import { apply_condition_refresh, type ConditionRefreshCache } from "./apply_con
 import { BaseNodeImpl, type InternalBaseNodeOptions } from "./base_node_impl";
 import { _clone, ToStringBuilder, UAObject_toString } from "./base_node_private";
 
-const errorLog = make_errorLog(__filename);
+const errorLog = make_errorLog("ua_object_impl");
 
 export class UAObjectImpl<T extends UAObjectEvents & ListenerSignature<T> = UAObjectEvents>
     extends BaseNodeImpl<T>

--- a/packages/node-opcua-address-space/src/ua_variable_impl.ts
+++ b/packages/node-opcua-address-space/src/ua_variable_impl.ts
@@ -91,10 +91,10 @@ import {
 } from "./ua_variable_impl_ext_obj";
 import { validateDataTypeCorrectness } from "./validate_data_type_correctness";
 
-const debugLog = make_debugLog(__filename);
-const warningLog = make_warningLog(__filename);
-const doDebug = checkDebugFlag(__filename);
-const errorLog = make_errorLog(__filename);
+const debugLog = make_debugLog("ua_variable_impl");
+const warningLog = make_warningLog("ua_variable_impl");
+const doDebug = checkDebugFlag("ua_variable_impl");
+const errorLog = make_errorLog("ua_variable_impl");
 
 const plainChalk = new Proxy(chalk, { get: () => (s: string) => s }) as typeof chalk;
 

--- a/packages/node-opcua-address-space/src/ua_variable_impl_ext_obj.ts
+++ b/packages/node-opcua-address-space/src/ua_variable_impl_ext_obj.ts
@@ -15,10 +15,10 @@ import { IndexIterator } from "./idx_iterator";
 import type { UADataTypeImpl } from "./ua_data_type_impl";
 import { UAVariableImpl } from "./ua_variable_impl";
 
-const doDebug = checkDebugFlag(__filename);
-const debugLog = make_debugLog(__filename);
-const warningLog = make_warningLog(__filename);
-const errorLog = make_errorLog(__filename);
+const doDebug = checkDebugFlag("ua_variable_impl_ext_obj");
+const debugLog = make_debugLog("ua_variable_impl_ext_obj");
+const warningLog = make_warningLog("ua_variable_impl_ext_obj");
+const errorLog = make_errorLog("ua_variable_impl_ext_obj");
 
 function _w(str: string, n: number): string {
     return str.padEnd(n).substring(n);

--- a/packages/node-opcua-address-space/src/ua_variable_type_impl.ts
+++ b/packages/node-opcua-address-space/src/ua_variable_type_impl.ts
@@ -40,10 +40,10 @@ import { checkValueRankCompatibility } from "./check_value_rank_compatibility";
 import { _getBasicDataType } from "./get_basic_datatype";
 import { construct_isSubtypeOf, get_subtypeOf, get_subtypeOfObj } from "./tool_isSubtypeOf";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
-const warningLog = make_warningLog(__filename);
-const errorLog = make_errorLog(__filename);
+const debugLog = make_debugLog("ua_variable_type_impl");
+const doDebug = checkDebugFlag("ua_variable_type_impl");
+const warningLog = make_warningLog("ua_variable_type_impl");
+const errorLog = make_errorLog("ua_variable_type_impl");
 
 interface InstantiateS {
     propertyOf?: NodeIdLike | UAObject | UAObjectType | UAVariable | UAVariableType | UAMethod;

--- a/packages/node-opcua-address-space/src/validate_data_type_correctness.ts
+++ b/packages/node-opcua-address-space/src/validate_data_type_correctness.ts
@@ -5,8 +5,8 @@ import { DataType } from "node-opcua-basic-types";
 import { checkDebugFlag, make_debugLog } from "node-opcua-debug";
 import type { NodeId } from "node-opcua-nodeid";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("validate_data_type_correctness");
+const doDebug = checkDebugFlag("validate_data_type_correctness");
 
 function _dataType_toUADataType(addressSpace: IAddressSpace, dataType: DataType): UADataType {
     assert(addressSpace);

--- a/packages/node-opcua-alarm-condition/source/acknowledge_all_conditions.ts
+++ b/packages/node-opcua-alarm-condition/source/acknowledge_all_conditions.ts
@@ -11,9 +11,9 @@ import { acknowledgeCondition, confirmCondition } from "./call_method_condition"
 import { type EventStuff, fieldsToJson } from "./event_stuff";
 import { extractConditionFields } from "./extract_condition_fields";
 
-const doDebug = checkDebugFlag(__filename);
-const debugLog = make_debugLog(__filename);
-const errorLog = make_errorLog(__filename);
+const doDebug = checkDebugFlag("acknowledge_all_conditions");
+const debugLog = make_debugLog("acknowledge_all_conditions");
+const errorLog = make_errorLog("acknowledge_all_conditions");
 
 /**
  *

--- a/packages/node-opcua-alarm-condition/source/event_stuff.ts
+++ b/packages/node-opcua-alarm-condition/source/event_stuff.ts
@@ -3,7 +3,7 @@ import type { NodeId } from "node-opcua-nodeid";
 import { lowerFirstLetter } from "node-opcua-utils";
 import type { Variant } from "node-opcua-variant";
 
-const warningLog = make_warningLog(__filename);
+const warningLog = make_warningLog("event_stuff");
 
 export interface TVariant<T> extends Variant {
     value: T;

--- a/packages/node-opcua-certificate-manager/source/certificate_manager.ts
+++ b/packages/node-opcua-certificate-manager/source/certificate_manager.ts
@@ -20,9 +20,9 @@ import { type StatusCode, type StatusCodeCallback, StatusCodes } from "node-opcu
 
 const paths = envPaths("node-opcua-default");
 
-const debugLog = make_debugLog(__filename);
-const errorLog = make_errorLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("certificate_manager");
+const errorLog = make_errorLog("certificate_manager");
+const doDebug = checkDebugFlag("certificate_manager");
 
 export interface ICertificateManager {
     getTrustStatus(certificate: Certificate): Promise<StatusCode>;

--- a/packages/node-opcua-client-crawler/source/node_crawler.ts
+++ b/packages/node-opcua-client-crawler/source/node_crawler.ts
@@ -10,7 +10,7 @@ import { type CacheNode, CacheNodeVariable, CacheNodeVariableType } from "./cach
 import { NodeCrawlerBase, type NodeCrawlerClientSession, type ObjectMap, type Pojo, type UserData } from "./node_crawler_base";
 import { type EmptyCallback, removeCycle, type TaskReconstruction } from "./private";
 
-const warningLog = make_warningLog(__filename);
+const warningLog = make_warningLog("node_crawler");
 
 type Queue = async.QueueObject<TaskReconstruction>;
 

--- a/packages/node-opcua-client-crawler/source/node_crawler_base.ts
+++ b/packages/node-opcua-client-crawler/source/node_crawler_base.ts
@@ -58,10 +58,10 @@ import {
     type TaskProcessBrowseResponse
 } from "./private";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("node_crawler_base");
+const doDebug = checkDebugFlag("node_crawler_base");
 const doDebug1 = doDebug && false;
-const warningLog = make_warningLog(__filename);
+const warningLog = make_warningLog("node_crawler_base");
 
 console.log("+-------------------------------------------------------------------------------------+");
 console.log("| Warning:                                                                            |");

--- a/packages/node-opcua-client-dynamic-extension-object/source/convert_data_type_definition_to_structuretype_schema.ts
+++ b/packages/node-opcua-client-dynamic-extension-object/source/convert_data_type_definition_to_structuretype_schema.ts
@@ -46,9 +46,9 @@ import { DataType } from "node-opcua-variant";
 import type { ExtraDataTypeManager } from "./extra_data_type_manager";
 import { _findEncodings } from "./private/find_encodings";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
-const errorLog = make_errorLog(__filename);
+const debugLog = make_debugLog("convert_data_type_definition_to_structuretype_schema");
+const doDebug = checkDebugFlag("convert_data_type_definition_to_structuretype_schema");
+const errorLog = make_errorLog("convert_data_type_definition_to_structuretype_schema");
 
 export interface CacheForFieldResolution {
     fieldTypeName: string;

--- a/packages/node-opcua-client-dynamic-extension-object/source/get_extra_data_type_manager.ts
+++ b/packages/node-opcua-client-dynamic-extension-object/source/get_extra_data_type_manager.ts
@@ -6,9 +6,9 @@ import { clearSessionCache, type IBasicSessionAsync2, readNamespaceArray } from 
 import { ExtraDataTypeManager } from "./extra_data_type_manager";
 import { DataTypeExtractStrategy, populateDataTypeManager } from "./populate_data_type_manager";
 
-const doDebug = checkDebugFlag(__filename);
-const debugLog = make_debugLog(__filename);
-const errorLog = make_errorLog(__filename);
+const doDebug = checkDebugFlag("get_extra_data_type_manager");
+const debugLog = make_debugLog("get_extra_data_type_manager");
+const errorLog = make_errorLog("get_extra_data_type_manager");
 const warningLog = errorLog;
 
 export interface IBasicSessionAsync2Private extends IBasicSessionAsync2 {

--- a/packages/node-opcua-client-dynamic-extension-object/source/private/populate_data_type_manager_103.ts
+++ b/packages/node-opcua-client-dynamic-extension-object/source/private/populate_data_type_manager_103.ts
@@ -35,10 +35,10 @@ import {
 } from "../convert_data_type_definition_to_structuretype_schema";
 import type { ExtraDataTypeManager } from "../extra_data_type_manager";
 
-const doDebug = checkDebugFlag(__filename);
-const debugLog = make_debugLog(__filename);
-const errorLog = make_errorLog(__filename);
-const warningLog = make_warningLog(__filename);
+const doDebug = checkDebugFlag("populate_data_type_manager_103");
+const debugLog = make_debugLog("populate_data_type_manager_103");
+const errorLog = make_errorLog("populate_data_type_manager_103");
+const warningLog = make_warningLog("populate_data_type_manager_103");
 
 // DataType
 //    | 1

--- a/packages/node-opcua-client-dynamic-extension-object/source/resolve_dynamic_extension_object.ts
+++ b/packages/node-opcua-client-dynamic-extension-object/source/resolve_dynamic_extension_object.ts
@@ -7,7 +7,7 @@ import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
 //
 import type { ExtraDataTypeManager } from "./extra_data_type_manager";
 
-const warningLog = make_warningLog(__filename);
+const warningLog = make_warningLog("resolve_dynamic_extension_object");
 
 export async function resolveOpaqueStructureInExtensionObject(
     session: IBasicSessionAsync2,

--- a/packages/node-opcua-client-proxy/source/proxy_manager.ts
+++ b/packages/node-opcua-client-proxy/source/proxy_manager.ts
@@ -27,8 +27,8 @@ interface ProxyObjectWithDynamicFields extends ProxyObject {
     [dynamicChildName: string]: unknown;
 }
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("proxy_manager");
+const doDebug = checkDebugFlag("proxy_manager");
 
 export interface IProxy1 {
     nodeId: NodeId;

--- a/packages/node-opcua-client/source/client_monitored_item_toolbox.ts
+++ b/packages/node-opcua-client/source/client_monitored_item_toolbox.ts
@@ -25,8 +25,8 @@ import type { ClientSubscription } from "./client_subscription";
 import type { ClientMonitoredItemImpl } from "./private/client_monitored_item_impl";
 import type { ClientSessionImpl } from "./private/client_session_impl";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("client_monitored_item_toolbox");
+const doDebug = checkDebugFlag("client_monitored_item_toolbox");
 
 export interface ClientMonitoredItemBaseEx extends ClientMonitoredItemBase {
     internalSetMonitoringMode(monitoringMode: MonitoringMode): void;

--- a/packages/node-opcua-client/source/client_session_keepalive_manager.ts
+++ b/packages/node-opcua-client/source/client_session_keepalive_manager.ts
@@ -18,9 +18,9 @@ import type { IClientBase } from "./private/i_private_client";
 
 const serverStatusStateNodeId = coerceNodeId(VariableIds.Server_ServerStatus_State);
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
-const warningLog = make_warningLog(__filename);
+const debugLog = make_debugLog("client_session_keepalive_manager");
+const doDebug = checkDebugFlag("client_session_keepalive_manager");
+const warningLog = make_warningLog("client_session_keepalive_manager");
 
 export interface ClientSessionKeepAliveManagerEvents {
     on(event: "keepalive", eventHandler: (lastKnownServerState: ServerState, count: number) => void): this;

--- a/packages/node-opcua-client/source/private/client_base_impl.ts
+++ b/packages/node-opcua-client/source/private/client_base_impl.ts
@@ -78,10 +78,10 @@ import { performCertificateSanityCheck } from "../verify";
 import type { ClientSessionImpl } from "./client_session_impl";
 import type { IClientBase } from "./i_private_client";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
-const errorLog = make_errorLog(__filename);
-const warningLog = make_warningLog(__filename);
+const debugLog = make_debugLog("client_base_impl");
+const doDebug = checkDebugFlag("client_base_impl");
+const errorLog = make_errorLog("client_base_impl");
+const warningLog = make_warningLog("client_base_impl");
 
 function makeCertificateThumbPrint(certificate: Certificate | Certificate[] | null | undefined): Buffer | null {
     if (!certificate) return null;

--- a/packages/node-opcua-client/source/private/client_monitored_item_group_impl.ts
+++ b/packages/node-opcua-client/source/private/client_monitored_item_group_impl.ts
@@ -16,7 +16,7 @@ import type { ClientSubscription } from "../client_subscription";
 import { ClientMonitoredItemImpl } from "./client_monitored_item_impl";
 import type { ClientSubscriptionImpl } from "./client_subscription_impl";
 
-const warningLog = make_warningLog(__filename);
+const warningLog = make_warningLog("client_monitored_item_group_impl");
 
 /**
  * ClientMonitoredItemGroup

--- a/packages/node-opcua-client/source/private/client_monitored_item_impl.ts
+++ b/packages/node-opcua-client/source/private/client_monitored_item_impl.ts
@@ -25,9 +25,9 @@ import { type ClientMonitoredItemBaseEx, ClientMonitoredItemToolbox } from "../c
 import type { ClientSubscription } from "../client_subscription";
 import { ClientMonitoredItem_create, type ClientSubscriptionImpl } from "./client_subscription_impl";
 
-const _debugLog = make_debugLog(__filename);
-const warningLog = make_warningLog(__filename);
-const _doDebug = checkDebugFlag(__filename);
+const _debugLog = make_debugLog("client_monitored_item_impl");
+const warningLog = make_warningLog("client_monitored_item_impl");
+const _doDebug = checkDebugFlag("client_monitored_item_impl");
 
 export type PrepareForMonitoringResult =
     | { error: string }

--- a/packages/node-opcua-client/source/private/client_publish_engine.ts
+++ b/packages/node-opcua-client/source/private/client_publish_engine.ts
@@ -14,9 +14,9 @@ import type { ClientSubscription } from "../client_subscription";
 import type { ClientSessionImpl } from "../private/client_session_impl";
 import type { ClientSubscriptionImpl } from "./client_subscription_impl";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
-const warningLog = make_warningLog(__filename);
+const debugLog = make_debugLog("client_publish_engine");
+const doDebug = checkDebugFlag("client_publish_engine");
+const warningLog = make_warningLog("client_publish_engine");
 /**
  * A client side implementation to deal with publish service.
  *

--- a/packages/node-opcua-client/source/private/client_session_impl.ts
+++ b/packages/node-opcua-client/source/private/client_session_impl.ts
@@ -143,10 +143,10 @@ import type { IClientBase } from "./i_private_client";
 import { repair_client_session } from "./reconnection/reconnection";
 
 const helpAPIChange = process.env.DEBUG?.match(/API/);
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
-const warningLog = make_warningLog(__filename);
-const _errorLog = make_errorLog(__filename);
+const debugLog = make_debugLog("client_session_impl");
+const doDebug = checkDebugFlag("client_session_impl");
+const warningLog = make_warningLog("client_session_impl");
+const _errorLog = make_errorLog("client_session_impl");
 
 let pendingTransactionMessageDisplayed = false;
 

--- a/packages/node-opcua-client/source/private/opcua_client_impl.ts
+++ b/packages/node-opcua-client/source/private/opcua_client_impl.ts
@@ -71,10 +71,10 @@ interface TokenAndSignature {
     userTokenSignature: SignatureDataOptions;
 }
 
-const doDebug = checkDebugFlag(__filename);
-const debugLog = make_debugLog(__filename);
-const errorLog = make_errorLog(__filename);
-const warningLog = make_warningLog(__filename);
+const doDebug = checkDebugFlag("opcua_client_impl");
+const debugLog = make_debugLog("opcua_client_impl");
+const errorLog = make_errorLog("opcua_client_impl");
+const warningLog = make_warningLog("opcua_client_impl");
 
 function validateServerNonce(serverNonce: Nonce | null): boolean {
     return !(serverNonce && serverNonce.length < 32) || (serverNonce && serverNonce.length === 0);

--- a/packages/node-opcua-client/source/verify.ts
+++ b/packages/node-opcua-client/source/verify.ts
@@ -3,10 +3,10 @@ import type { ICertificateStore, OPCUASecureObject } from "node-opcua-common";
 import { type Certificate, exploreCertificate, explorePrivateKey, publicKeyAndPrivateKeyMatches } from "node-opcua-crypto/web";
 import { checkDebugFlag, make_debugLog, make_errorLog, make_warningLog } from "node-opcua-debug";
 
-const _doDebug = checkDebugFlag(__filename);
-const _debugLog = make_debugLog(__filename);
-const errorLog = make_errorLog(__filename);
-const warningLog = make_warningLog(__filename);
+const _doDebug = checkDebugFlag("verify");
+const _debugLog = make_debugLog("verify");
+const errorLog = make_errorLog("verify");
+const warningLog = make_warningLog("verify");
 
 export function verifyIsOPCUAValidCertificate(
     certificate: Certificate,

--- a/packages/node-opcua-convert-nodeset-to-javascript/source/convert_namespace_to_typescript.ts
+++ b/packages/node-opcua-convert-nodeset-to-javascript/source/convert_namespace_to_typescript.ts
@@ -4,6 +4,7 @@ import { DataTypeIds } from "node-opcua-constants";
 import type { IBasicSessionAsync } from "node-opcua-pseudo-session";
 import { convertTypeToTypescript } from "./convert_to_typescript";
 import type { Options } from "./options";
+import { packageRoot } from "./package_root";
 import { constructCache } from "./private/cache";
 import { writeFileSyncRetry } from "./private/fs_retry";
 import {
@@ -15,7 +16,7 @@ import {
 
 function findPackageJson(dependency: string, options: Options): string | undefined {
     const l = [...(options.lookupFolders || [])];
-    l.push(path.join(__dirname, "../../"));
+    l.push(options.baseFolder);
     for (const folder of l) {
         const d = path.join(folder, `${dependency}/package.json`);
         if (!fs.existsSync(d)) {
@@ -33,7 +34,7 @@ function getPackageFolder(dependency: string, options: Options) {
     }
     //
     console.log("cannot find package.json for ", dependency, " : creating it");
-    const packageoFolder = path.join(__dirname, "../../", dependency);
+    const packageoFolder = path.join(options.baseFolder, dependency);
     if (!fs.existsSync(packageoFolder)) {
         fs.mkdirSync(packageoFolder);
     }
@@ -88,7 +89,7 @@ function getGeneratedPackageVersion(info: Info, options: Options): string {
 // Monorepo release version (lerna.json), used only to seed a package that has no
 // version of its own yet.
 function getReleaseVersion(options: Options): string {
-    let folder = __dirname;
+    let folder = packageRoot;
     for (let i = 0; i < 6; i++) {
         if (path.basename(folder) === "node_modules") {
             // installed as a dependency: the lerna.json above us belongs to someone else.

--- a/packages/node-opcua-convert-nodeset-to-javascript/source/main.ts
+++ b/packages/node-opcua-convert-nodeset-to-javascript/source/main.ts
@@ -7,6 +7,7 @@ import { generateAddressSpace } from "node-opcua-address-space/nodeJS";
 import { constructNodesetFilename, nodesetCatalog } from "node-opcua-nodesets";
 
 import { convertNamespaceTypeToTypescript } from "./convert_namespace_to_typescript";
+import { packagesFolder } from "./package_root";
 import { cleanUpTypescriptModule } from "./remove_unused";
 import { updateParentTSConfig } from "./update_parent_tsconfig";
 
@@ -30,7 +31,7 @@ async function main() {
 
     const session = new PseudoSession(addressSpace);
     const options = {
-        baseFolder: path.join(__dirname, "../../"),
+        baseFolder: packagesFolder,
         prefix: "node-opcua-nodeset-"
     };
     // const nodesetCatalog2 = nodesetCatalog.filter((meta) => meta.name == "scales");

--- a/packages/node-opcua-convert-nodeset-to-javascript/source/package_root.ts
+++ b/packages/node-opcua-convert-nodeset-to-javascript/source/package_root.ts
@@ -1,0 +1,21 @@
+import path from "node:path";
+
+/**
+ * The one place this package learns where it sits on disk.
+ *
+ * Everything else derives from `packagesFolder` rather than recomputing it, so the
+ * ESM migration has a single line to change here instead of five scattered across
+ * four files. `import.meta.dirname` cannot be used while this package emits CommonJS
+ * (TS1470), which is why the flip has to wait for the package to become "type": "module".
+ *
+ * Deliberately not `process.cwd()`: this package declares a `bin`, so it can be invoked
+ * as a CLI from any directory, and cwd would then resolve somewhere else entirely.
+ * A tool has to find its own files relative to itself.
+ */
+const here = __dirname;
+
+/** this package's own root, one level above the compiled output */
+export const packageRoot = path.join(here, "..");
+
+/** the monorepo's packages/ folder, which is where generated nodeset packages are written */
+export const packagesFolder = path.join(here, "../../");

--- a/packages/node-opcua-convert-nodeset-to-javascript/source/private/utils.ts
+++ b/packages/node-opcua-convert-nodeset-to-javascript/source/private/utils.ts
@@ -7,8 +7,8 @@ import type { IBasicSessionBrowseAsyncSimple, IBasicSessionReadAsyncSimple } fro
 import { type BrowseResult, type DataTypeDefinition, ReferenceDescription } from "node-opcua-types";
 import { DataType } from "node-opcua-variant";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("utils");
+const doDebug = checkDebugFlag("utils");
 
 export async function getDefinition(session: IBasicSessionReadAsyncSimple, nodeId: NodeId): Promise<DataTypeDefinition | null> {
     const dataValue = await session.read({ nodeId, attributeId: AttributeIds.DataTypeDefinition });

--- a/packages/node-opcua-convert-nodeset-to-javascript/source/update_parent_tsconfig.ts
+++ b/packages/node-opcua-convert-nodeset-to-javascript/source/update_parent_tsconfig.ts
@@ -6,14 +6,12 @@ import { existsSync, promises as fsPromises } from "node:fs";
 const { readFile, writeFile } = fsPromises;
 
 import path from "node:path";
-// Uncomment the following to get __dirname equivalent when compiling to ESM
-//import { fileURLToPath } from 'url';
-//const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 import { nodesetCatalog } from "node-opcua-nodesets";
 
+import { packagesFolder } from "./package_root";
+
 export async function updateParentTSConfig() {
-    const packagesFolder = path.join(__dirname, "..", "..");
     const parentTSConfigFile = path.join(packagesFolder, "tsconfig.json");
     console.log(`Updating parent tsconfig.json file: ${parentTSConfigFile}`);
     const content = await readFile(parentTSConfigFile, "utf8");

--- a/packages/node-opcua-data-value/source/datavalue.ts
+++ b/packages/node-opcua-data-value/source/datavalue.ts
@@ -42,7 +42,7 @@ import {
 import { DataValueEncodingByte } from "./DataValueEncodingByte_enum";
 import { TimestampsToReturn } from "./TimestampsToReturn_enum";
 
-const errorLog = make_errorLog(__filename);
+const errorLog = make_errorLog("datavalue");
 
 type NumericalRange = NumericRange;
 

--- a/packages/node-opcua-debug/source/make_loggers.ts
+++ b/packages/node-opcua-debug/source/make_loggers.ts
@@ -156,7 +156,7 @@ export function checkDebugFlag(scriptFullPath: string): boolean {
     let doDebug: boolean = debugFlags[filename];
     if (sTraceFlag && !Object.hasOwn(debugFlags, filename)) {
         doDebug = sTraceFlag.indexOf(filename) >= 0 || sTraceFlag.indexOf("ALL") >= 0;
-        setDebugFlag(filename, doDebug);
+        setDebugFlag(filename, doDebug); // check-debug-name: ok - already a basename
     }
     return doDebug;
 }

--- a/packages/node-opcua-extension-object/source/extension_object.ts
+++ b/packages/node-opcua-extension-object/source/extension_object.ts
@@ -14,9 +14,9 @@ import {
 } from "node-opcua-factory";
 import { makeNodeId, type NodeId } from "node-opcua-nodeid";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
-const warningLog = make_warningLog(__filename);
+const debugLog = make_debugLog("extension_object");
+const doDebug = checkDebugFlag("extension_object");
+const warningLog = make_warningLog("extension_object");
 
 import chalk from "chalk";
 

--- a/packages/node-opcua-factory/source/base_ua_object.ts
+++ b/packages/node-opcua-factory/source/base_ua_object.ts
@@ -25,7 +25,7 @@ import {
     type StructuredTypeField
 } from "./types";
 
-const errorLog = make_errorLog(__filename);
+const errorLog = make_errorLog("base_ua_object");
 
 function r(str: string, length = 30) {
     return `${str}                                `.substring(0, length);

--- a/packages/node-opcua-factory/source/datatype_factory.ts
+++ b/packages/node-opcua-factory/source/datatype_factory.ts
@@ -12,9 +12,9 @@ import { getBuiltInType, hasBuiltInType } from "./builtin_types";
 import { type EnumerationDefinitionSchema, getBuiltInEnumeration, hasBuiltInEnumeration } from "./enumerations";
 import type { CommonInterface, ConstructorFunc, ConstructorFuncWithSchema, IBaseUAObject, IStructuredTypeSchema } from "./types";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
-const warningLog = make_warningLog(__filename);
+const debugLog = make_debugLog("datatype_factory");
+const doDebug = checkDebugFlag("datatype_factory");
+const warningLog = make_warningLog("datatype_factory");
 
 export interface StructureInfo {
     constructor: ConstructorFuncWithSchema | null; // null if abstract

--- a/packages/node-opcua-factory/source/schema_helpers.ts
+++ b/packages/node-opcua-factory/source/schema_helpers.ts
@@ -8,8 +8,8 @@ import { BaseUAObject } from "./base_ua_object";
 import type { DataTypeFactory } from "./datatype_factory";
 import { FieldCategory, type FieldType, type IStructuredTypeSchema, type StructuredTypeField } from "./types";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("schema_helpers");
+const doDebug = checkDebugFlag("schema_helpers");
 
 /**
  * ensure correctness of a schema object.

--- a/packages/node-opcua-factory/source/structured_type_schema.ts
+++ b/packages/node-opcua-factory/source/structured_type_schema.ts
@@ -22,8 +22,8 @@ import {
     type StructuredTypeOptions
 } from "./types";
 
-const warningLog = make_warningLog(__filename);
-const errorLog = make_errorLog(__filename);
+const warningLog = make_warningLog("structured_type_schema");
+const errorLog = make_errorLog("structured_type_schema");
 
 function figureOutFieldCategory(field: FieldInterfaceOptions, dataTypeFactory: DataTypeFactory): FieldCategory {
     const fieldType = field.fieldType;

--- a/packages/node-opcua-generator/source/generate_extension_object_code.ts
+++ b/packages/node-opcua-generator/source/generate_extension_object_code.ts
@@ -29,8 +29,8 @@ import { writeStructuredType } from "./factory_code_generator";
 import { LineFile1 } from "./utils/line_file";
 import { makeWrite } from "./utils/write_func";
 
-const doDebug = checkDebugFlag(__filename);
-const debugLog = make_debugLog(__filename);
+const doDebug = checkDebugFlag("generate_extension_object_code");
+const debugLog = make_debugLog("generate_extension_object_code");
 
 const f = new LineFile1();
 

--- a/packages/node-opcua-generator/source/generator.ts
+++ b/packages/node-opcua-generator/source/generator.ts
@@ -15,8 +15,8 @@ import ts from "typescript";
 
 import { get_class_TScript_filename, produce_TScript_code } from "./factory_code_generator";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("generator");
+const doDebug = checkDebugFlag("generator");
 doDebug;
 
 /**

--- a/packages/node-opcua-generator/source/generator.ts
+++ b/packages/node-opcua-generator/source/generator.ts
@@ -15,6 +15,11 @@ import ts from "typescript";
 
 import { get_class_TScript_filename, produce_TScript_code } from "./factory_code_generator";
 
+// The one place this module learns where it sits on disk. `import.meta.dirname`
+// cannot be used while this package emits CommonJS (TS1470), so the ESM migration
+// has this single line to change rather than several scattered uses.
+const here = __dirname;
+
 const debugLog = make_debugLog("generator");
 const doDebug = checkDebugFlag("generator");
 doDebug;
@@ -115,9 +120,9 @@ export async function generateCode(schemaName: string, localSchemaFile: string, 
 
         schemaFileIsNewer = generatedSourceMtime <= schemaFileMtime;
 
-        let codeGeneratorScript = path.join(__dirname, "factory_code_generator.ts");
+        let codeGeneratorScript = path.join(here, "factory_code_generator.ts");
         if (!fs.existsSync(codeGeneratorScript)) {
-            codeGeneratorScript = path.join(__dirname, "factory_code_generator.js");
+            codeGeneratorScript = path.join(here, "factory_code_generator.js");
         }
 
         assert(fs.existsSync(codeGeneratorScript), `cannot get code factory_code_generator${codeGeneratorScript}`);

--- a/packages/node-opcua-nodesets/source/nodeset_nodejs.ts
+++ b/packages/node-opcua-nodesets/source/nodeset_nodejs.ts
@@ -2,8 +2,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { type NodesetMeta, type NodesetName, nodesetCatalog } from "./nodeset_catalog";
 
+// The one place this module learns where it sits on disk. `import.meta.dirname`
+// cannot be used while this package emits CommonJS (TS1470), so the ESM migration
+// has this single line to change rather than several scattered uses.
+const here = __dirname;
+
 export function constructNodesetFilename(filename: string) {
-    const dirname = __dirname;
+    const dirname = here;
     let file = path.join(dirname, "../nodesets", filename);
     if (!fs.existsSync(file)) {
         if (!process.argv[1]) {

--- a/packages/node-opcua-pseudo-session/source/browse_all.ts
+++ b/packages/node-opcua-pseudo-session/source/browse_all.ts
@@ -15,8 +15,8 @@ import type {
     IBasicSessionReadAsyncMultiple
 } from "./basic_session_interface";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("browse_all");
+const doDebug = checkDebugFlag("browse_all");
 
 async function readLimits(session: IBasicSessionReadAsyncMultiple) {
     const dataValues = await session.read([

--- a/packages/node-opcua-pseudo-session/source/extract_fields.ts
+++ b/packages/node-opcua-pseudo-session/source/extract_fields.ts
@@ -10,7 +10,7 @@ import type {
 } from "./basic_session_interface";
 
 const doDebug = false;
-const debugLog = make_debugLog(__filename);
+const debugLog = make_debugLog("extract_fields");
 
 export type ISessionForExtractField = IBasicSessionBrowseAsyncSimple &
     IBasicSessionBrowseAsyncMultiple &

--- a/packages/node-opcua-pseudo-session/source/get_child_by_browse_name.ts
+++ b/packages/node-opcua-pseudo-session/source/get_child_by_browse_name.ts
@@ -4,7 +4,7 @@ import { type NodeId, resolveNodeId } from "node-opcua-nodeid";
 import type { ReferenceDescription } from "node-opcua-types";
 import type { IBasicSessionBrowseAsyncSimple } from "./basic_session_interface";
 
-const warningLog = make_warningLog(__dirname);
+const warningLog = make_warningLog("get_child_by_browse_name");
 
 export async function getChildByBrowseName(
     session: IBasicSessionBrowseAsyncSimple,

--- a/packages/node-opcua-pseudo-session/source/read_operational_limits.ts
+++ b/packages/node-opcua-pseudo-session/source/read_operational_limits.ts
@@ -11,7 +11,7 @@ import { AttributeIds } from "node-opcua-service-read";
 import type { SignedSoftwareCertificate } from "node-opcua-types";
 import type { IBasicSessionReadAsyncMultiple } from "./basic_session_interface";
 
-const warningLog = make_warningLog(__filename);
+const warningLog = make_warningLog("read_operational_limits");
 
 export interface IOperationLimits2 {
     maxNodesPerRead?: number;

--- a/packages/node-opcua-schemas/source/dynamic_extension_object.ts
+++ b/packages/node-opcua-schemas/source/dynamic_extension_object.ts
@@ -21,9 +21,9 @@ import {
 import { coerceNodeId, ExpandedNodeId, type NodeId, NodeIdType, sameNodeId } from "node-opcua-nodeid";
 import { DataType } from "node-opcua-variant";
 
-const debugLog = make_debugLog(__filename);
-const errorLog = make_errorLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("dynamic_extension_object");
+const errorLog = make_errorLog("dynamic_extension_object");
+const doDebug = checkDebugFlag("dynamic_extension_object");
 
 function associateEncoding(
     dataTypeFactory: DataTypeFactory,

--- a/packages/node-opcua-schemas/source/parse_binary_xsd.ts
+++ b/packages/node-opcua-schemas/source/parse_binary_xsd.ts
@@ -17,8 +17,8 @@ import { type ReaderStateParser, Xml2Json, type XmlAttributes } from "node-opcua
 
 import { getOrCreateStructuredTypeSchema } from "./tools";
 
-const doDebug = checkDebugFlag(__filename);
-const debugLog = make_debugLog(__filename);
+const doDebug = checkDebugFlag("parse_binary_xsd");
+const debugLog = make_debugLog("parse_binary_xsd");
 
 function w(s: string, l: number): string {
     return s.padEnd(l).substring(0, l);

--- a/packages/node-opcua-schemas/source/tools.ts
+++ b/packages/node-opcua-schemas/source/tools.ts
@@ -13,7 +13,7 @@ import { ExpandedNodeId } from "node-opcua-nodeid";
 import { createDynamicObjectConstructor } from "./dynamic_extension_object";
 import type { InternalTypeDictionary, MapDataTypeAndEncodingIdProvider, StructureTypeRaw } from "./parse_binary_xsd";
 
-const errorLog = make_errorLog(__filename);
+const errorLog = make_errorLog("tools");
 const _doDebug = false; // process.env.DEBUG && process.env.DEBUG.includes("node-opcua-schemas");
 
 function _removeNamespacePart(str?: string): string {

--- a/packages/node-opcua-secure-channel/source/utils.ts
+++ b/packages/node-opcua-secure-channel/source/utils.ts
@@ -42,7 +42,7 @@ import {
 import { timestamp } from "node-opcua-utils";
 import type { Request, Response } from "./common";
 
-const traceLog = make_traceLog(__filename);
+const traceLog = make_traceLog("utils");
 
 const clientFlag = (process.env?.NODEOPCUADEBUG?.match(/CLIENT{([^}]*)}/) || [])[1] || "";
 const serverFlag = (process.env?.NODEOPCUADEBUG?.match(/SERVER{([^}]*)}/) || [])[1] || "";

--- a/packages/node-opcua-server/source/addressSpace_accessor.ts
+++ b/packages/node-opcua-server/source/addressSpace_accessor.ts
@@ -33,8 +33,8 @@ import {
 import { Variant } from "node-opcua-variant";
 import type { IAddressSpaceAccessor } from "./i_address_space_accessor";
 
-const doDebug = checkDebugFlag(__filename);
-const debugLog = make_debugLog(__filename);
+const doDebug = checkDebugFlag("addressSpace_accessor");
+const debugLog = make_debugLog("addressSpace_accessor");
 
 function checkReadProcessedDetails(historyReadDetails: ReadProcessedDetails): StatusCode {
     if (!historyReadDetails.aggregateConfiguration) {

--- a/packages/node-opcua-server/source/base_server.ts
+++ b/packages/node-opcua-server/source/base_server.ts
@@ -44,10 +44,10 @@ import type { IChannelData } from "./i_channel_data";
 import type { ISocketData } from "./i_socket_data";
 import type { OPCUAServerEndPoint } from "./server_end_point";
 
-const doDebug = checkDebugFlag(__filename);
-const debugLog = make_debugLog(__filename);
-const errorLog = make_errorLog(__filename);
-const warningLog = make_warningLog(__filename);
+const doDebug = checkDebugFlag("base_server");
+const debugLog = make_debugLog("base_server");
+const errorLog = make_errorLog("base_server");
+const warningLog = make_warningLog("base_server");
 
 const default_server_info = {
     // The globally unique identifier for the application instance. This URI is used as

--- a/packages/node-opcua-server/source/monitored_item.ts
+++ b/packages/node-opcua-server/source/monitored_item.ts
@@ -59,7 +59,7 @@ import type { SamplingFunc } from "./sampling_func";
 import type { MonitoredItemBase } from "./server_subscription";
 import { validateFilter } from "./validate_filter";
 
-const errorLog = make_errorLog(__filename);
+const errorLog = make_errorLog("monitored_item");
 
 export type QueueItem = MonitoredItemNotification | EventFieldList;
 
@@ -68,10 +68,10 @@ const defaultItemToMonitor: ReadValueIdOptions = new ReadValueId({
     indexRange: undefined
 });
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("monitored_item");
+const doDebug = checkDebugFlag("monitored_item");
 const doDebug2 = doDebug && false;
-const warningLog = make_warningLog(__filename);
+const warningLog = make_warningLog("monitored_item");
 
 function _adjust_sampling_interval(samplingInterval: number, node_minimumSamplingInterval: number): number {
     assert(typeof node_minimumSamplingInterval === "number", "expecting a number");

--- a/packages/node-opcua-server/source/node_sampler.ts
+++ b/packages/node-opcua-server/source/node_sampler.ts
@@ -6,8 +6,8 @@ import { checkDebugFlag, make_debugLog } from "node-opcua-debug";
 import { MonitoringMode } from "node-opcua-types";
 import { hrtime } from "node-opcua-utils";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("node_sampler");
+const doDebug = checkDebugFlag("node_sampler");
 
 import type { MonitoredItem } from "./monitored_item";
 

--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -179,10 +179,10 @@ function isSubscriptionIdInvalid(subscriptionId: number): boolean {
     return subscriptionId < 0 || subscriptionId >= 0xffffffff;
 }
 const package_info = require("../package.json");
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
-const errorLog = make_errorLog(__filename);
-const warningLog = make_warningLog(__filename);
+const debugLog = make_debugLog("opcua_server");
+const doDebug = checkDebugFlag("opcua_server");
+const errorLog = make_errorLog("opcua_server");
+const warningLog = make_warningLog("opcua_server");
 
 const default_maxConnectionsPerEndpoint = 10;
 

--- a/packages/node-opcua-server/source/server_capabilities.ts
+++ b/packages/node-opcua-server/source/server_capabilities.ts
@@ -7,7 +7,7 @@ import type { QualifiedName } from "node-opcua-data-model";
 import { make_warningLog } from "node-opcua-debug";
 import type { SignedSoftwareCertificate } from "node-opcua-types";
 
-const warningLog = make_warningLog(__filename);
+const warningLog = make_warningLog("server_capabilities");
 
 /**
  */

--- a/packages/node-opcua-server/source/server_end_point.ts
+++ b/packages/node-opcua-server/source/server_end_point.ts
@@ -29,10 +29,10 @@ import type { UserTokenPolicyOptions } from "node-opcua-types";
 import type { IChannelData } from "./i_channel_data";
 import type { ISocketData } from "./i_socket_data";
 
-const debugLog = make_debugLog(__filename);
-const errorLog = make_errorLog(__filename);
-const warningLog = make_warningLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("server_end_point");
+const errorLog = make_errorLog("server_end_point");
+const warningLog = make_warningLog("server_end_point");
+const doDebug = checkDebugFlag("server_end_point");
 
 const UATCP_UASC_UABINARY = "http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary";
 

--- a/packages/node-opcua-server/source/server_engine.ts
+++ b/packages/node-opcua-server/source/server_engine.ts
@@ -88,10 +88,10 @@ import { ServerSession } from "./server_session";
 import { Subscription } from "./server_subscription";
 import { getTransferSessionIdentity, sessionsCompatibleForTransfer } from "./sessions_compatible_for_transfer";
 
-const debugLog = make_debugLog(__filename);
-const errorLog = make_errorLog(__filename);
-const warningLog = make_warningLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("server_engine");
+const errorLog = make_errorLog("server_engine");
+const warningLog = make_warningLog("server_engine");
+const doDebug = checkDebugFlag("server_engine");
 
 function upperCaseFirst(str: string) {
     return str.slice(0, 1).toUpperCase() + str.slice(1);

--- a/packages/node-opcua-server/source/server_publish_engine.ts
+++ b/packages/node-opcua-server/source/server_publish_engine.ts
@@ -16,8 +16,8 @@ import { PublishRequest, PublishResponse, ServiceFault, type SubscriptionAcknowl
 import type { IClosedOrTransferredSubscription, IServerSidePublishEngine } from "./i_server_side_publish_engine";
 import { Subscription, SubscriptionState } from "./server_subscription";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("server_publish_engine");
+const doDebug = checkDebugFlag("server_publish_engine");
 
 function traceLog(...args: [unknown?, ...unknown[]]) {
     if (!doDebug) {

--- a/packages/node-opcua-server/source/server_publish_engine_for_orphan_subscriptions.ts
+++ b/packages/node-opcua-server/source/server_publish_engine_for_orphan_subscriptions.ts
@@ -9,8 +9,8 @@ import { ServerSidePublishEngine } from "./server_publish_engine";
 import type { Subscription } from "./server_subscription";
 import { getTransferSessionIdentity } from "./sessions_compatible_for_transfer";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("server_publish_engine_for_orphan_subscriptions");
+const doDebug = checkDebugFlag("server_publish_engine_for_orphan_subscriptions");
 
 interface ISubscriptionWithExpiredFunc {
     _expired_func?: (this: Subscription) => void;

--- a/packages/node-opcua-server/source/server_session.ts
+++ b/packages/node-opcua-server/source/server_session.ts
@@ -45,9 +45,9 @@ import type { ServerEngine } from "./server_engine";
 import { ServerSidePublishEngine } from "./server_publish_engine";
 import { type Subscription, SubscriptionState } from "./server_subscription";
 
-const debugLog = make_debugLog(__filename);
-const errorLog = make_errorLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("server_session");
+const errorLog = make_errorLog("server_session");
+const doDebug = checkDebugFlag("server_session");
 
 const theWatchDog = new WatchDog();
 

--- a/packages/node-opcua-server/source/server_subscription.ts
+++ b/packages/node-opcua-server/source/server_subscription.ts
@@ -56,9 +56,9 @@ import type { ServerSession } from "./server_session";
 import type { ITransferSessionIdentity } from "./sessions_compatible_for_transfer";
 import { validateFilter } from "./validate_filter";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
-const warningLog = make_warningLog(__filename);
+const debugLog = make_debugLog("server_subscription");
+const doDebug = checkDebugFlag("server_subscription");
+const warningLog = make_warningLog("server_subscription");
 const maxNotificationMessagesInQueue = 100;
 
 export interface SubscriptionDiagnosticsDataTypePriv extends SubscriptionDiagnosticsDataType {

--- a/packages/node-opcua-server/source/user_manager.ts
+++ b/packages/node-opcua-server/source/user_manager.ts
@@ -5,7 +5,7 @@ import type { NodeId } from "node-opcua-nodeid";
 import type { IdentityMappingRuleType } from "node-opcua-types";
 import type { ServerSession } from "./server_session";
 
-const errorLog = make_errorLog(__filename);
+const errorLog = make_errorLog("user_manager");
 
 export type ValidUserFunc = (this: ServerSession, username: string, password: string) => boolean;
 export type ValidUserAsyncFunc = (

--- a/packages/node-opcua-server/source/validate_filter.ts
+++ b/packages/node-opcua-server/source/validate_filter.ts
@@ -14,7 +14,7 @@ import { DeadbandType } from "node-opcua-service-subscription";
 import { type StatusCode, StatusCodes } from "node-opcua-status-code";
 import type { ReadValueIdOptions } from "node-opcua-types";
 
-const warningLog = make_warningLog(__filename);
+const warningLog = make_warningLog("validate_filter");
 
 function isNumberDataType(node: UAVariable): boolean {
     const n = node.dataType as INodeId;

--- a/packages/node-opcua-service-filter/source/check_event_clause.ts
+++ b/packages/node-opcua-service-filter/source/check_event_clause.ts
@@ -9,8 +9,8 @@ import { constructBrowsePathFromQualifiedName } from "node-opcua-service-transla
 import { type StatusCode, StatusCodes } from "node-opcua-status-code";
 import type { SimpleAttributeOperand } from "node-opcua-types";
 
-const debugLog = make_debugLog(__filename);
-const doDebug = checkDebugFlag(__filename);
+const debugLog = make_debugLog("check_event_clause");
+const doDebug = checkDebugFlag("check_event_clause");
 
 /**
 

--- a/packages/node-opcua-test-fixtures/source/index.ts
+++ b/packages/node-opcua-test-fixtures/source/index.ts
@@ -1,5 +1,11 @@
 import path from "node:path";
+
+// The one place this module learns where it sits on disk. `import.meta.dirname`
+// cannot be used while this package emits CommonJS (TS1470), so the ESM migration
+// has this single line to change rather than several scattered uses.
+const here = __dirname;
+
 export function getFixture(relativeName: string) {
-    const filename = path.join(__dirname, "..", relativeName);
+    const filename = path.join(here, "..", relativeName);
     return filename;
 }

--- a/packages/node-opcua-transport/source/client_tcp_transport.ts
+++ b/packages/node-opcua-transport/source/client_tcp_transport.ts
@@ -16,9 +16,9 @@ import type { TransportSettingsOptions } from "./i_client_transport";
 import { getFakeTransport, type ISocketLike } from "./tcp_transport";
 import { parseEndpointUrl } from "./tools";
 
-const doDebug = checkDebugFlag(__filename);
-const debugLog = make_debugLog(__filename);
-const errorLog = make_errorLog(__filename);
+const doDebug = checkDebugFlag("client_tcp_transport");
+const debugLog = make_debugLog("client_tcp_transport");
+const errorLog = make_errorLog("client_tcp_transport");
 const gHostname = os.hostname();
 
 // Re-exported for source-level backwards compatibility: this type used to live in this file.

--- a/packages/node-opcua-types/source/generate.ts
+++ b/packages/node-opcua-types/source/generate.ts
@@ -8,6 +8,11 @@ import { generate } from "node-opcua-generator";
 import { NumericRange } from "node-opcua-numeric-range";
 import { Variant } from "node-opcua-variant";
 
+// The one place this module learns where it sits on disk. `import.meta.dirname`
+// cannot be used while this package emits CommonJS (TS1470), so the ESM migration
+// has this single line to change rather than several scattered uses.
+const here = __dirname;
+
 const _force_inclusion = NumericRange;
 const _force_inclusion_QualifiedName = QualifiedName;
 const _force_inclusion_LocalizedText = LocalizedText;
@@ -17,8 +22,8 @@ const _force_inclusion_DataValue = DataValue;
 async function main() {
     try {
         // await build_generated_folder();
-        const filename = path.join(__dirname, "../xmlschemas/Opc.Ua.Types.bsd");
-        const generatedTypescriptFilename = path.join(__dirname, "_generated_opcua_types.ts");
+        const filename = path.join(here, "../xmlschemas/Opc.Ua.Types.bsd");
+        const generatedTypescriptFilename = path.join(here, "_generated_opcua_types.ts");
         await generate(filename, generatedTypescriptFilename);
     } catch (err) {
         console.log(err);

--- a/packages/node-opcua-variant/source/variant.ts
+++ b/packages/node-opcua-variant/source/variant.ts
@@ -42,7 +42,7 @@ import { VariantArrayType } from "./VariantArrayType_enum";
 
 export { VariantArrayType };
 
-const warningLog = make_warningLog(__filename);
+const warningLog = make_warningLog("variant");
 
 const schemaVariant = buildStructuredType({
     baseType: "BaseUAObject",

--- a/packages/node-opcua-vendor-diagnostic/source/vendor_diagnostic_nodes.ts
+++ b/packages/node-opcua-vendor-diagnostic/source/vendor_diagnostic_nodes.ts
@@ -10,7 +10,7 @@ import { type OPCUAServer, ServerEngine } from "node-opcua-server";
 import { StatusCodes } from "node-opcua-status-code";
 import { DataType, Variant } from "node-opcua-variant";
 
-const warningLog = make_warningLog(__filename);
+const warningLog = make_warningLog("vendor_diagnostic_nodes");
 
 const humanize = require("humanize");
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4214,6 +4214,8 @@ importers:
 
   tools/check-debug-log: {}
 
+  tools/check-debug-name: {}
+
   tools/check-mocharc: {}
 
   tools/check-no-tla:

--- a/tools/check-debug-name.mjs
+++ b/tools/check-debug-name.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+/** launcher for tools/check-debug-name - see tools/README.md */
+import "./check-debug-name/src/index.js";

--- a/tools/check-debug-name/README.md
+++ b/tools/check-debug-name/README.md
@@ -1,0 +1,91 @@
+# check-debug-name
+
+The debug logger factories must be given a **stable string literal naming the module**,
+never `__filename` or `__dirname`.
+
+```bash
+node tools/check-debug-name.mjs                       # report, exit 1 on a violation
+node tools/check-debug-name.mjs --fix                 # rewrite, then report what is left
+node tools/check-debug-name.mjs --package node-opcua-client
+node tools/check-debug-name.mjs --root ../my-project  # any project using these helpers
+pnpm run check:debugname                              # same, via the root script
+```
+
+## Why
+
+`make_debugLog(__filename)` was the house style, 207 call sites of it. Three things are
+wrong with it.
+
+**It does not survive ESM.** `__filename` and `__dirname` do not exist in an ES module or
+in a browser bundle. node-opcua is migrating to ESM, so every one of those call sites was
+a blocker, and the usual replacement, `import.meta.url`, is a syntax error in CommonJS.
+That would have forced the whole tree to flip in one commit.
+
+**The value was never used as a path anyway.** `make_debugLog` and `checkDebugFlag`
+immediately reduce their argument with `extractBasename()`, which strips the directory and
+a trailing `.js`/`.ts`. What survives is a short name used as a key into `debugFlags` and
+matched against the `DEBUG` environment variable. `make_errorLog`, `make_warningLog` and
+`make_traceLog` ignore the argument entirely; their displayed filename comes from the call
+stack at log time.
+
+**So the literal is strictly better.** `extractBasename` is idempotent on an already-bare
+name, which is why passing `"client_session"` needs no change to the helper and keeps
+`DEBUG=client_session` selecting exactly the same module as before. There is precedent
+already in the tree: `client_transport_base.ts` did this by hand, with the comment *"Use a
+string category instead of `__filename` so the module loads in browsers"*.
+
+## What it catches
+
+Flagged and auto-fixable:
+
+```ts
+const debugLog = make_debugLog(__filename);   // -> make_debugLog("client_session")
+const doDebug = checkDebugFlag(__dirname);    // -> checkDebugFlag("variant_parser")
+```
+
+Flagged but never rewritten, because the tool cannot know what the value will be:
+
+```ts
+const debugLog = make_debugLog(computeName());
+```
+
+Not flagged: a string literal, the factory declarations inside `node-opcua-debug`, and
+genuine path uses such as `path.join(__dirname, "../nodesets")`, which are a different
+problem.
+
+To opt one line out, say why:
+
+```ts
+setDebugFlag(filename, doDebug); // check-debug-name: ok - already a basename
+```
+
+## Why regexes here, when check-no-tla uses a parser
+
+`check-no-tla` answers a scope question, which needs a parser: no regex can separate
+`if (c) { await x }` from `(async () => { await x })()`.
+
+This tool answers a much narrower question, and unlike that one it **rewrites source**.
+Being conservative therefore beats being clever. It matches only the exact shapes
+`fn(__filename)`, `fn(__dirname)` and `fn("literal")`, and anything else is reported for a
+human rather than guessed at. A parser would let it rewrite expressions it cannot reason
+about, which is the wrong risk for a `--fix`. It also keeps the tool dependency-free, so
+`--root` can point it at any project that consumes these helpers.
+
+## Layout
+
+`src/rule.js` is pure, so the tests hand it strings and fixture trees rather than shelling
+out and matching printed output. `src/index.js` is the command line around it.
+
+```bash
+node tools/check-debug-name/test/test_rule.js
+```
+
+## Note on `--fix` and the debug key
+
+For `__filename` the rewrite preserves the `DEBUG` key exactly, because the literal is
+what `extractBasename` would have produced.
+
+For `__dirname` it does **not**: the key changes from the directory name to the module
+name. That only ever affected two call sites, both of which were passing a directory to a
+parameter named `scriptFullPath`, and one of which had a debug key of literally
+`"source"`. The report names them rather than silently changing them.

--- a/tools/check-debug-name/package.json
+++ b/tools/check-debug-name/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "@sterfive/check-debug-name",
+    "version": "1.0.0",
+    "private": true,
+    "description": "logger factories must take a module name literal, not __filename",
+    "bin": {
+        "check-debug-name": "src/index.js"
+    },
+    "type": "module",
+    "scripts": {
+        "check": "node src/index.js",
+        "fix": "node src/index.js --fix",
+        "test": "node test/test_rule.js"
+    }
+}

--- a/tools/check-debug-name/src/index.js
+++ b/tools/check-debug-name/src/index.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * check-debug-name - command line around src/rule.js.
+ *
+ * Usage:
+ *     node tools/check-debug-name.mjs                        # report, exit 1 on a violation
+ *     node tools/check-debug-name.mjs --fix                  # rewrite, then report what is left
+ *     node tools/check-debug-name.mjs --package node-opcua-client
+ *     node tools/check-debug-name.mjs --root ../my-project   # any project using these helpers
+ */
+
+import process from "node:process";
+import { analyze, exitCode, formatReport } from "./rule.js";
+
+function valueOf(argv, flag) {
+    const i = argv.indexOf(flag);
+    return i === -1 ? undefined : argv[i + 1];
+}
+
+function main() {
+    const argv = process.argv.slice(2);
+    const result = analyze({
+        repoRoot: valueOf(argv, "--root") ?? ".",
+        packageFilter: valueOf(argv, "--package"),
+        write: argv.includes("--fix")
+    });
+    console.log(formatReport(result));
+    return exitCode(result);
+}
+
+process.exit(main());

--- a/tools/check-debug-name/src/rule.js
+++ b/tools/check-debug-name/src/rule.js
@@ -1,0 +1,205 @@
+/**
+ * rule - the debug-logger naming rule, kept pure so the tests can hand it strings.
+ *
+ * The rule: the logger factories take a stable string literal naming the module, never
+ * `__filename` or `__dirname`.
+ *
+ * Deliberately regex-based rather than parser-based, unlike check-no-tla. This tool
+ * REWRITES source, so being conservative beats being clever: it matches only the exact
+ * shapes `fn(__filename)`, `fn(__dirname)` and `fn("literal")`, and reports anything
+ * else as needing a look rather than guessing at it. A parser would let it rewrite
+ * expressions it cannot reason about, which is the wrong risk to take for a --fix. It
+ * also keeps the tool dependency-free, so it can be pointed at any project using these
+ * helpers.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+/** every factory in node-opcua-debug that takes a module name */
+export const FACTORIES = ["make_debugLog", "checkDebugFlag", "make_errorLog", "make_warningLog", "make_traceLog", "setDebugFlag"];
+
+/** opt out of the rule on one line, with a reason: `// check-debug-name: ok - why` */
+export const IGNORE_MARKER = "check-debug-name: ok";
+
+export const SOURCE_ROOTS = ["packages", "packages_extra"];
+export const SOURCE_DIRS = ["source", "src"];
+
+const SKIP_DIRS = new Set(["node_modules", "dist", "dist-esm", "coverage", "build"]);
+
+/**
+ * The module name for a file: mirrors extractBasename() in
+ * node-opcua-debug/source/make_loggers.ts, which strips the directory and a trailing
+ * .js/.ts. Passing the already-bare result back in is idempotent, which is why the
+ * helper needs no change to accept it.
+ */
+export function moduleNameFor(filePath) {
+    return filePath.replace(/(.*[\\|/])?/g, "").replace(/\.(js|ts)$/, "");
+}
+
+/** a declaration, not a call: `export function make_debugLog(scriptFullPath: string)` */
+function isDeclaration(line, fn) {
+    return new RegExp(`function\\s+${fn}\\s*\\(`).test(line);
+}
+
+/**
+ * Violations in one file's text.
+ * Returns [{ line, fn, arg, suggestion, fixable }] with 1-based line numbers.
+ */
+export function findViolations(text, filePath) {
+    const suggestion = moduleNameFor(filePath);
+    const lines = text.split("\n");
+    const out = [];
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (line.includes(IGNORE_MARKER)) {
+            continue;
+        }
+        for (const fn of FACTORIES) {
+            if (isDeclaration(line, fn)) {
+                continue;
+            }
+            const global = new RegExp(`\\b${fn}\\(\\s*__(filename|dirname)\\s*\\)`).exec(line);
+            if (global) {
+                out.push({ line: i + 1, fn, arg: `__${global[1]}`, suggestion, fixable: true, text: line.trim().slice(0, 100) });
+                continue;
+            }
+            // a call that is neither a string literal nor a filename global: report, never rewrite
+            const call = new RegExp(`\\b${fn}\\(\\s*([^)]*)\\)`).exec(line);
+            if (call && !/^\s*["'`]/.test(call[1]) && call[1].trim() !== "") {
+                out.push({ line: i + 1, fn, arg: call[1].trim().slice(0, 40), suggestion, fixable: false, text: line.trim().slice(0, 100) });
+            }
+        }
+    }
+    return out;
+}
+
+/** rewrite the fixable violations; returns { text, fixed } */
+export function fixText(text, filePath) {
+    const name = moduleNameFor(filePath);
+    let fixed = 0;
+    const out = text
+        .split("\n")
+        .map((line) => {
+            if (line.includes(IGNORE_MARKER)) {
+                return line;
+            }
+            let result = line;
+            for (const fn of FACTORIES) {
+                if (isDeclaration(result, fn)) {
+                    continue;
+                }
+                result = result.replace(new RegExp(`\\b${fn}\\(\\s*__(?:filename|dirname)\\s*\\)`, "g"), () => {
+                    fixed++;
+                    return `${fn}("${name}")`;
+                });
+            }
+            return result;
+        })
+        .join("\n");
+    return { text: out, fixed };
+}
+
+/** every shipped source file under the given roots */
+export function findSourceFiles(repoRoot = ".", packageFilter) {
+    const files = [];
+    for (const root of SOURCE_ROOTS) {
+        const full = path.join(repoRoot, root);
+        if (!fs.existsSync(full)) {
+            continue;
+        }
+        for (const pkg of fs.readdirSync(full, { withFileTypes: true })) {
+            if (!pkg.isDirectory() || SKIP_DIRS.has(pkg.name)) {
+                continue;
+            }
+            if (packageFilter && pkg.name !== packageFilter) {
+                continue;
+            }
+            for (const dir of SOURCE_DIRS) {
+                walk(path.join(full, pkg.name, dir), files);
+            }
+        }
+    }
+    return files;
+}
+
+function walk(dir, out) {
+    if (!fs.existsSync(dir)) {
+        return;
+    }
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            if (!SKIP_DIRS.has(entry.name)) {
+                walk(full, out);
+            }
+        } else if (/\.(ts|js|mts|cts|mjs|cjs)$/.test(entry.name) && !entry.name.endsWith(".d.ts")) {
+            out.push(full);
+        }
+    }
+}
+
+/** scan; with { write: true } the fixable violations are rewritten in place */
+export function analyze({ repoRoot = ".", packageFilter, write = false } = {}) {
+    const files = findSourceFiles(repoRoot, packageFilter);
+    const findings = [];
+    let fixedCount = 0;
+    let fixedFiles = 0;
+
+    for (const file of files) {
+        const original = fs.readFileSync(file, "utf8");
+        let current = original;
+        if (write) {
+            const { text, fixed } = fixText(original, file);
+            if (fixed > 0) {
+                fs.writeFileSync(file, text);
+                fixedCount += fixed;
+                fixedFiles++;
+                current = text;
+            }
+        }
+        for (const v of findViolations(current, file)) {
+            findings.push({ file: file.replace(/\\/g, "/"), ...v });
+        }
+    }
+    return { scanned: files.length, findings, fixedCount, fixedFiles };
+}
+
+export function exitCode(result) {
+    return result.findings.length > 0 ? 1 : 0;
+}
+
+export function formatReport(result) {
+    const lines = [];
+    if (result.fixedFiles > 0) {
+        lines.push(`check-debug-name: rewrote ${result.fixedCount} call sites in ${result.fixedFiles} files`, "");
+    }
+    if (result.findings.length === 0) {
+        lines.push(`check-debug-name: ${result.scanned} files scanned, every logger takes a module name.`);
+        return lines.join("\n");
+    }
+    const fixable = result.findings.filter((f) => f.fixable);
+    const manual = result.findings.filter((f) => !f.fixable);
+
+    lines.push(`check-debug-name: ${result.findings.length} violations in ${result.scanned} files scanned`, "");
+    if (fixable.length) {
+        lines.push(`  ${fixable.length} fixable with --fix:`);
+        for (const f of fixable) {
+            lines.push(`    ${f.file}:${f.line}  ${f.fn}(${f.arg}) -> ${f.fn}("${f.suggestion}")`);
+        }
+        lines.push("");
+    }
+    if (manual.length) {
+        lines.push(`  ${manual.length} need a look (the argument is not a literal, so it is not rewritten):`);
+        for (const f of manual) {
+            lines.push(`    ${f.file}:${f.line}  ${f.fn}(${f.arg})`);
+        }
+        lines.push("");
+    }
+    lines.push("A logger factory must be given a stable string literal naming the module.");
+    lines.push("__filename and __dirname do not exist in ESM or in browser bundles, and the");
+    lines.push("value is only ever reduced to a basename anyway, so the literal is what the");
+    lines.push("DEBUG env var already matches on.");
+    return lines.join("\n");
+}

--- a/tools/check-debug-name/test/test_rule.js
+++ b/tools/check-debug-name/test/test_rule.js
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for the debug-logger naming rule.
+ *
+ * The fixtures are the shapes this repo actually contained before the codemod, including
+ * the two that were passing __dirname to a parameter named scriptFullPath, and the
+ * declarations inside node-opcua-debug itself, which must never be rewritten.
+ *
+ * Run: node test/test_rule.js
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { findViolations, fixText, moduleNameFor, analyze, exitCode, formatReport, IGNORE_MARKER } from "../src/rule.js";
+
+// --- the name derived for a file ------------------------------------------------
+
+test("module name strips directory and extension, and is idempotent", () => {
+    assert.equal(moduleNameFor("packages/node-opcua-client/source/client_session.ts"), "client_session");
+    assert.equal(moduleNameFor("C:\\repo\\packages\\p\\source\\a.js"), "a");
+    assert.equal(moduleNameFor("client_session"), "client_session");
+    // only a trailing .js/.ts is removed, matching extractBasename
+    assert.equal(moduleNameFor("packages/p/source/index.browser.ts"), "index.browser");
+});
+
+// --- flagged ---------------------------------------------------------------------
+
+test("flags every factory called with __filename", () => {
+    const source = `
+const debugLog = make_debugLog(__filename);
+const doDebug = checkDebugFlag(__filename);
+const errorLog = make_errorLog(__filename);
+const warningLog = make_warningLog(__filename);
+const traceLog = make_traceLog(__filename);
+`;
+    const found = findViolations(source, "packages/p/source/thing.ts");
+    assert.equal(found.length, 5);
+    assert.ok(found.every((f) => f.fixable));
+    assert.ok(found.every((f) => f.suggestion === "thing"));
+});
+
+test("flags __dirname too, which is how two sites got a directory as their debug key", () => {
+    const found = findViolations("const debugLog = make_debugLog(__dirname);\n", "packages/p/source/loader/variant_parser.ts");
+    assert.equal(found.length, 1);
+    assert.equal(found[0].arg, "__dirname");
+    assert.equal(found[0].suggestion, "variant_parser");
+});
+
+test("tolerates whitespace inside the call", () => {
+    assert.equal(findViolations("make_debugLog( __filename );\n", "packages/p/source/a.ts").length, 1);
+});
+
+test("reports a non-literal argument but marks it not fixable", () => {
+    const found = findViolations("const debugLog = make_debugLog(someName);\n", "packages/p/source/a.ts");
+    assert.equal(found.length, 1);
+    assert.equal(found[0].fixable, false);
+});
+
+// --- not flagged -----------------------------------------------------------------
+
+test("a string literal is the goal state", () => {
+    assert.deepEqual(findViolations('const debugLog = make_debugLog("client_session");\n', "packages/p/source/a.ts"), []);
+    assert.deepEqual(findViolations("const debugLog = make_debugLog('a');\n", "packages/p/source/a.ts"), []);
+});
+
+test("the declarations in node-opcua-debug are not call sites", () => {
+    const source = `
+export function make_debugLog(scriptFullPath: string): (...arg: unknown[]) => void {
+    const filename = extractBasename(scriptFullPath);
+}
+export function checkDebugFlag(scriptFullPath: string): boolean {}
+export function make_errorLog(_context: string): PrintFunc {}
+`;
+    assert.deepEqual(findViolations(source, "packages/node-opcua-debug/source/make_loggers.ts"), []);
+});
+
+test("an ignore marker opts one line out", () => {
+    const source = `const x = setDebugFlag(filename, doDebug); // ${IGNORE_MARKER} - internal to the helper\n`;
+    assert.deepEqual(findViolations(source, "packages/node-opcua-debug/source/make_loggers.ts"), []);
+});
+
+test("a bare __filename unrelated to the loggers is not this rule's business", () => {
+    const source = 'const p = path.join(__dirname, "../nodesets");\nconst f = __filename;\n';
+    assert.deepEqual(findViolations(source, "packages/p/source/a.ts"), []);
+});
+
+// --- fixing ----------------------------------------------------------------------
+
+test("fix rewrites to the module name and leaves everything else alone", () => {
+    const before = `import { make_debugLog } from "node-opcua-debug";
+const debugLog = make_debugLog(__filename);
+const doDebug = checkDebugFlag(__filename);
+const p = path.join(__dirname, "..");
+`;
+    const { text, fixed } = fixText(before, "packages/p/source/client_session.ts");
+    assert.equal(fixed, 2);
+    assert.match(text, /make_debugLog\("client_session"\)/);
+    assert.match(text, /checkDebugFlag\("client_session"\)/);
+    // the genuine path use is untouched
+    assert.match(text, /path\.join\(__dirname, "\.\."\)/);
+});
+
+test("fix is idempotent", () => {
+    const once = fixText("const d = make_debugLog(__filename);\n", "packages/p/source/a.ts");
+    const twice = fixText(once.text, "packages/p/source/a.ts");
+    assert.equal(twice.fixed, 0);
+    assert.equal(twice.text, once.text);
+});
+
+test("fix never rewrites a declaration or an ignored line", () => {
+    const before = `export function make_debugLog(scriptFullPath: string) {}
+const x = make_debugLog(__filename); // ${IGNORE_MARKER} - deliberate
+`;
+    const { text, fixed } = fixText(before, "packages/node-opcua-debug/source/make_loggers.ts");
+    assert.equal(fixed, 0);
+    assert.equal(text, before);
+});
+
+test("fix does not touch a non-literal it cannot reason about", () => {
+    const before = "const d = make_debugLog(computeName());\n";
+    const { text, fixed } = fixText(before, "packages/p/source/a.ts");
+    assert.equal(fixed, 0);
+    assert.equal(text, before);
+});
+
+// --- tree walking ----------------------------------------------------------------
+
+function withTree(files, fn) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "check-debug-name-"));
+    try {
+        for (const [rel, content] of Object.entries(files)) {
+            const full = path.join(root, rel);
+            fs.mkdirSync(path.dirname(full), { recursive: true });
+            fs.writeFileSync(full, content);
+        }
+        return fn(root);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+}
+
+test("scans packages and packages_extra, skipping tests and dist", () => {
+    withTree(
+        {
+            "packages/a/source/one.ts": "const d = make_debugLog(__filename);\n",
+            "packages_extra/b/src/two.ts": "const d = make_debugLog(__filename);\n",
+            "packages/c/test/three.ts": "const d = make_debugLog(__filename);\n",
+            "packages/d/dist/four.js": "const d = make_debugLog(__filename);\n"
+        },
+        (root) => {
+            const result = analyze({ repoRoot: root });
+            assert.equal(result.findings.length, 2, JSON.stringify(result.findings, null, 2));
+            assert.equal(exitCode(result), 1);
+            assert.ok(result.findings.some((f) => f.file.endsWith("packages/a/source/one.ts")));
+            assert.ok(result.findings.some((f) => f.file.endsWith("packages_extra/b/src/two.ts")));
+        }
+    );
+});
+
+test("--package narrows the scan", () => {
+    withTree(
+        {
+            "packages/a/source/one.ts": "const d = make_debugLog(__filename);\n",
+            "packages/b/source/two.ts": "const d = make_debugLog(__filename);\n"
+        },
+        (root) => {
+            const result = analyze({ repoRoot: root, packageFilter: "a" });
+            assert.equal(result.findings.length, 1);
+            assert.ok(result.findings[0].file.endsWith("packages/a/source/one.ts"));
+        }
+    );
+});
+
+test("write mode fixes the tree and then reports clean", () => {
+    withTree({ "packages/a/source/one.ts": "const d = make_debugLog(__filename);\n" }, (root) => {
+        const result = analyze({ repoRoot: root, write: true });
+        assert.equal(result.fixedCount, 1);
+        assert.equal(result.findings.length, 0);
+        assert.equal(exitCode(result), 0);
+        assert.match(fs.readFileSync(path.join(root, "packages/a/source/one.ts"), "utf8"), /make_debugLog\("one"\)/);
+        assert.match(formatReport(result), /rewrote 1 call sites/);
+    });
+});
+
+test("a clean tree reports clean and exits 0", () => {
+    withTree({ "packages/a/source/one.ts": 'const d = make_debugLog("one");\n' }, (root) => {
+        const result = analyze({ repoRoot: root });
+        assert.equal(exitCode(result), 0);
+        assert.match(formatReport(result), /every logger takes a module name/);
+    });
+});


### PR DESCRIPTION
Part of FEAT-1 on the ESM migration backlog: https://github.com/orgs/node-opcua/projects/2

Still a 2.x minor. Nothing changes module format, and `require("node-opcua")` resolves exactly where it did.

## The idea changed for the better

The plan said: teach the debug helpers to accept `import.meta.url` alongside a path, then migrate 206 call sites to pass it.

Reading the helpers made a simpler answer obvious. `make_debugLog` and `checkDebugFlag` immediately reduce their argument with `extractBasename()`, which strips the directory and a trailing `.js`/`.ts`. What survives is a short name used as a key into `debugFlags` and matched against the `DEBUG` env var. And `make_errorLog`, `make_warningLog` and `make_traceLog` **ignore the argument entirely** (`_context`, unused) - their displayed filename comes from the call stack at log time.

So the value was never a path. A plain string literal is:

- **format-agnostic** - works in CommonJS, ESM and browser bundles alike, where `import.meta.url` is a syntax error in CJS and `__filename` is undefined in ESM
- **free of any helper change** - `extractBasename` is idempotent on an already-bare name, so `make_debugLog("client_session")` behaves identically to `make_debugLog(__filename)`
- **already the convention** - 124 call sites did this by hand, including `client_transport_base.ts` with the comment *"Use a string category instead of `__filename` so the module loads in browsers"*

That also removes the sequencing problem: the original plan needed the helper change to land before the call sites could move. This does not.

## 1. `feat(tools)`: check-debug-name

A checker with `--fix`, in the same shape as `check-mocharc` and `check-test-ports`. Gated in the `lint` job, because 207 call sites drifted into the old shape once already and nothing would stop them doing it again.

It is deliberately **regex-based, not parser-based**, which is the opposite of the choice made for `check-no-tla` in the previous PR. The reason is that this tool *rewrites source*: it matches only the exact shapes `fn(__filename)`, `fn(__dirname)` and `fn("literal")`, and anything else - `make_debugLog(computeName())` - is reported for a human rather than guessed at. A parser would let it rewrite expressions it cannot reason about, which is the wrong risk for a `--fix`. It also keeps the tool dependency-free, so `--root ../other-project` can point it at any codebase consuming these helpers.

17 unit tests, including that `--fix` is idempotent, never touches a declaration, and never touches a non-literal.

## 2. `refactor(debug)`: the codemod result

**207 call sites across 86 files**, produced by `node tools/check-debug-name.mjs --fix`.

Verified rather than eyeballed: I ran the transform by hand first, then reverted, then re-ran it through the committed tool and diffed the two patches. **Byte-for-byte identical.** A second `--fix` is a no-op.

### DEBUG keys

Unchanged for every `__filename` site, because the literal written is exactly what `extractBasename()` produced from the runtime path. Verified at runtime too: `setDebugFlag("/some/path/client_session.js", true)` and `checkDebugFlag("client_session")` observe the same flag.

**Two sites do change**, and they were both passing `__dirname` to a parameter named `scriptFullPath`:

| file | was | now |
|---|---|---|
| `variant_parser.ts` | `"parsers"` | `"variant_parser"` |
| `get_child_by_browse_name.ts` | `"source"` | `"get_child_by_browse_name"` |

The first is a real behaviour change for anyone running `DEBUG=parsers`. The second is not observable at all, because `make_warningLog` ignores its argument. `DEBUG` keys are not documented anywhere in the repo, so this is a diagnostic detail rather than an interface, but it is a change and worth knowing about rather than discovering.

## Verification

| gate | result |
|---|---|
| `pnpm run check:debugname` | 2298 files, 0 violations |
| `node tools/check-debug-name/test/test_rule.js` | 17/17 |
| `pnpm run check:tla` | 0 findings |
| `node tools/check-no-tla/test/test_detector.js` | 26/26 |
| `pnpm run check:consumers` | both shapes ok |
| `pnpm run check:debuglog` / `check:mocharc` / `check:ports` / `lint` | pass |
| `npx tsc -b packages` | exit 0 |
| `pnpm install --frozen-lockfile` | pass |
| `pnpm --filter node-opcua-debug run test` | 5 passing |

The branch is built on `e61409225`, so it includes the endpoint shutdown fix. `server_end_point.ts` was touched by both that fix and this rename and merged cleanly.

## Remaining in FEAT-1

18 genuine `__dirname` path uses are untouched - nodeset and certificate resolution, the code generators, `node-opcua-test-fixtures`. Those need real judgment per site rather than a codemod, and are the next step. The single guarded `__filename` inside `make_loggers.ts` already handles ESM via `typeof __filename === "undefined"`.

---

# Update: the remaining `__dirname` uses, concentrated

## Why they cannot be converted yet

Tested rather than assumed:

```
error TS1470: The 'import.meta' meta-property is not allowed in files which will
build into CommonJS output.
```

`import.meta.dirname` is a hard compile error while a package emits CommonJS, and the `fileURLToPath(import.meta.url)` shim is the same error. So **US-1.3 of the plan is not achievable in 2.x** - each of these sites can only move at the moment its own package flips, in FEAT-2. That is a correction to the backlog, not a deferral of work I could have done.

## What was done instead: 12 -> 6

Of the original 19, six were comments or already ESM-safe. Of the 12 real ones, several were **recomputing a value the package already had**. They are now one anchor per package, all identical:

```ts
// The one place this module learns where it sits on disk. `import.meta.dirname`
// cannot be used while this package emits CommonJS (TS1470), so the ESM migration
// has this single line to change rather than several scattered uses.
const here = __dirname;
```

| package | before | after | kind |
|---|---|---|---|
| `convert-nodeset-to-javascript` | 5 | **1** (`source/package_root.ts`) | build-time |
| `node-opcua-generator` | 2 | **1** | build-time |
| `node-opcua-types` | 2 | **1** | build-time |
| `node-opcua-nodesets` | 1 | 1 | runtime |
| `node-opcua-test-fixtures` | 1 | 1 | runtime |
| `conformance-testing` | 1 | 1 | runtime |

FEAT-2 now changes one line per package instead of hunting twelve.

## What did not change

No path is derived differently. The expressions moved; they were not rewritten. The two real simplifications were removing duplication: `convert_namespace_to_typescript.ts` was rebuilding `path.join(__dirname, "../../")` twice, which is precisely what `main.ts` had already computed and passed as `options.baseFolder` - and both files compile into the same `dist/`, so those were the same string.

**Deliberately not `process.cwd()`.** `convert-nodeset-to-javascript` declares `"bin": "dist/main.js"`, so it can be invoked as a CLI from any directory. Anchoring to cwd would work under `pnpm --filter ... run generate` and silently resolve somewhere else as a CLI. A tool has to find its own files relative to itself.

## The one site worth a reviewer's eye

`getReleaseVersion` walks up looking for `lerna.json`, breaking at `node_modules`. It now starts at `packageRoot` rather than `__dirname`, so the walk begins one level higher: depth 2 instead of 3 to reach the repo root, within the 6-level budget either way, and the `node_modules` guard still trips before it could reach a foreign `lerna.json`. This is the only place a *starting point* changed rather than an expression moving.

## Verification

`pnpm run generate` was run in full and produced **zero drift** in generated output. That exercises `convert-nodeset-to-javascript`, `node-opcua-generator` and `node-opcua-types` end to end - all three of the packages whose path resolution changed - and is a stronger check than any test I could have written. CI's `generated-drift-check` repeats it.

`node-opcua-types`: 42 passing. `node-opcua-nodesets` and `node-opcua-test-fixtures` have no test harness at all (`"test": "echo no test"`, no `.mocharc`), and I did not scaffold two of them: `constructNodesetFilename` is exercised by essentially every address-space and server test in the suite, so a break there fails hundreds of tests immediately.
