### PR TITLE
feat(server-configuration): push-certificate-management over an opaque key

### DIFF
--- a/packages/node-opcua-server-configuration/source/server/install_push_certificate_management.ts
+++ b/packages/node-opcua-server-configuration/source/server/install_push_certificate_management.ts
@@ -113,7 +113,15 @@ async function resolvePrivateKeyAfterRotation(certificateManager: OPCUACertifica
  */
 async function reresolveServerCertificateProvider(server: OPCUAServer): Promise<void> {
     const certificateManager = server.serverCertificateManager;
-    const isManaged = certificateManager instanceof OPCUACertificateManager && certificateManager.isPrivateKeyManaged();
+    // An opaque (HSM/KMS-held) key counts as "managed" in pki, but there is no
+    // key material to re-resolve here - the key itself never rotates through
+    // push-certificate-management (regeneratePrivateKey and key installation
+    // both answer BadNotSupported). The OpaqueCertificateKeyPairProvider
+    // re-reads its certificate chain from disk on invalidate(), so the plain
+    // invalidate path below is exactly what a certificate-only rotation needs.
+    const isOpaque = certificateManager instanceof OPCUACertificateManager && certificateManager.isPrivateKeyOpaque();
+    const isManaged =
+        !isOpaque && certificateManager instanceof OPCUACertificateManager && certificateManager.isPrivateKeyManaged();
     if (isManaged) {
         const privateKey = await resolvePrivateKeyAfterRotation(certificateManager, server.privateKeyFile);
         server.setProvider(new ResolvedCertificateKeyPairProvider(server.certificateFile, server.privateKeyFile, privateKey));

--- a/packages/node-opcua-server-configuration/source/server/push_certificate_manager/create_signing_request.ts
+++ b/packages/node-opcua-server-configuration/source/server/push_certificate_manager/create_signing_request.ts
@@ -91,6 +91,17 @@ export async function executeCreateSigningRequest(
 
     // Regenerate Private Key Logic
     if (regeneratePrivateKey) {
+        if (certificateManager.isPrivateKeyOpaque()) {
+            // The key lives in an HSM/KMS behind IKeyOperations: the server can
+            // neither generate nor install private-key material. Certificate
+            // renewal over the EXISTING key (regeneratePrivateKey=false) stays
+            // supported; key rotation belongs to the key store itself.
+            warningLog(
+                "createSigningRequest: regeneratePrivateKey is not supported when the private key is opaque (HSM/KMS-held);" +
+                    " renew the certificate over the existing key instead"
+            );
+            return { statusCode: StatusCodes.BadNotSupported };
+        }
         if (!nonce || nonce.length < 32) {
             warningLog("nonce should be provided when regeneratePrivateKey is set, and length shall be at least 32 bytes");
             return { statusCode: StatusCodes.BadInvalidArgument };

--- a/packages/node-opcua-server-configuration/source/server/push_certificate_manager/update_certificate.ts
+++ b/packages/node-opcua-server-configuration/source/server/push_certificate_manager/update_certificate.ts
@@ -1,3 +1,4 @@
+import { createPublicKey } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { assert } from "node-opcua-assert";
@@ -10,6 +11,7 @@ import {
     coercePEMorDerToPrivateKey,
     coercePrivateKeyPem,
     combine_der,
+    extractPublicKeyFromCertificateSync,
     makeSHA1Thumbprint,
     type PrivateKey,
     toPem
@@ -191,6 +193,38 @@ export async function executeUpdateCertificate(
         }
 
         if (!hasPrivateKeyFormat && !hasPrivateKey) {
+            if (!serverImpl.tmpCertificateManager && certificateManager.isPrivateKeyOpaque()) {
+                // Opaque (HSM/KMS-held) key: there is no material to compare, so the
+                // certificate is checked against the provider's public half (SPKI)
+                // instead. A provider without getPublicKey could not have produced
+                // the CSR in the first place (the opaque CSR path needs the public
+                // key), so an unverifiable certificate is refused rather than
+                // installed blind - a mismatched pair would break every handshake.
+                const keyOperations = certificateManager.getKeyOperations();
+                if (!keyOperations.getPublicKey) {
+                    warningLog(
+                        "updateCertificate: the key-operations provider does not implement getPublicKey():" +
+                            " cannot verify that the certificate matches the (opaque) private key"
+                    );
+                    await serverImpl.fileTransactionManager.abortTransaction();
+                    return { statusCode: StatusCodes.BadNotSupported, applyChangesRequired: false };
+                }
+                const providerSpki = Buffer.from(await keyOperations.getPublicKey());
+                const certificateSpki = createPublicKey(extractPublicKeyFromCertificateSync(certificate)).export({
+                    type: "spki",
+                    format: "der"
+                });
+                if (!providerSpki.equals(certificateSpki)) {
+                    warningLog("certificate doesn't match the (opaque) private key");
+                    await serverImpl.fileTransactionManager.abortTransaction();
+                    return { statusCode: StatusCodes.BadSecurityChecksFailed, applyChangesRequired: false };
+                }
+
+                await preInstallIssuerCertificates(serverImpl, certificateManager, issuerCertificates);
+                await preInstallCertificate(serverImpl, certificateManager, certificate, issuerCertificates);
+                serverImpl.emit("certificateUpdated", certificateGroupId, certificate);
+                return { statusCode: StatusCodes.Good, applyChangesRequired: true };
+            }
             // Resolve via getPrivateKey(), for two independent reasons:
             // - CertificateManager.getPrivateKey() caches the decoded key for the lifetime of the
             //   instance (see node-opcua-pki). createCertificateRequest()/createSelfSignedCertificate()
@@ -214,6 +248,13 @@ export async function executeUpdateCertificate(
             serverImpl.emit("certificateUpdated", certificateGroupId, certificate);
             return { statusCode: StatusCodes.Good, applyChangesRequired: true };
         } else {
+            if (certificateManager.isPrivateKeyOpaque()) {
+                // The server's key is inside an HSM/KMS: private-key material
+                // cannot be installed, only certificates over the existing key.
+                warningLog("updateCertificate: cannot install a private key when the server's key is opaque (HSM/KMS-held)");
+                await serverImpl.fileTransactionManager.abortTransaction();
+                return { statusCode: StatusCodes.BadNotSupported, applyChangesRequired: false };
+            }
             if (privateKeyFormat !== "PEM" && privateKeyFormat !== "PFX") {
                 warningLog(` the private key format is invalid privateKeyFormat =${privateKeyFormat}`);
                 await serverImpl.fileTransactionManager.abortTransaction();

--- a/packages/node-opcua-server-configuration/test/server/test_push_certificate_manager_opaque_key.ts
+++ b/packages/node-opcua-server-configuration/test/server/test_push_certificate_manager_opaque_key.ts
@@ -1,0 +1,220 @@
+Error.stackTraceLimit = Infinity;
+
+import crypto from "node:crypto";
+import path from "node:path";
+import "should";
+
+import { CertificateManager } from "node-opcua-certificate-manager";
+import { type IKeyOperations, keyOperationsFromPrivateKey } from "node-opcua-crypto";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { StatusCodes } from "node-opcua-status-code";
+import { PushCertificateManagerServerImpl, type UpdateCertificateResult } from "../../dist/index.js";
+import { _getFakeAuthorityCertificate, initializeHelpers, produceCertificate } from "../helpers/fake_certificate_authority.js";
+import { getCertificateDER } from "../helpers/tools.js";
+
+interface CountingOps {
+    ops: IKeyOperations;
+    signCount: () => number;
+}
+
+/**
+ * A KMS-style provider: async-only (no sync fast path), counts sign
+ * operations, backed by an in-memory key so results stay verifiable.
+ */
+function makeCountingOpaqueOps(withPublicKey: boolean): CountingOps {
+    const { privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const local = keyOperationsFromPrivateKey({ hidden: privateKey.export({ type: "pkcs8", format: "pem" }).toString() });
+    let signs = 0;
+    const ops: IKeyOperations = {
+        sign: (data, params) => {
+            signs += 1;
+            return local.sign(data, params);
+        },
+        decryptBlock: (block, params) => local.decryptBlock(block, params),
+        getKeyMetadata: () => local.getKeyMetadata(),
+        ...(withPublicKey ? { getPublicKey: () => local.getPublicKey() } : {})
+    };
+    return { ops, signCount: () => signs };
+}
+
+describe("Testing Server Side PushCertificateManager with an OPAQUE (HSM/KMS-held) key", () => {
+    let pushManager: PushCertificateManagerServerImpl;
+    let serverKey: CountingOps;
+    let _folder: string;
+
+    before(async () => {
+        await CertificateManager.disposeAll();
+
+        _folder = await initializeHelpers("OPQ", 1);
+
+        serverKey = makeCountingOpaqueOps(true);
+        const applicationGroup = new CertificateManager({
+            location: path.join(_folder, "application"),
+            keyOperations: serverKey.ops
+        });
+        const userTokenGroup = new CertificateManager({
+            location: path.join(_folder, "user")
+        });
+
+        pushManager = new PushCertificateManagerServerImpl({
+            applicationGroup,
+            userTokenGroup,
+            applicationUri: "urn:NodeOPCUA-Server-Opaque"
+        });
+        await pushManager.initialize();
+
+        const { certificate: caCertificate, crl } = await _getFakeAuthorityCertificate(_folder);
+        await applicationGroup.trustCertificate(caCertificate);
+        await applicationGroup.addIssuer(caCertificate);
+        await applicationGroup.addRevocationList(crl);
+    });
+
+    after(async () => {
+        await CertificateManager.disposeAll();
+        CertificateManager.checkAllDisposed();
+    });
+
+    it("OPQ-1 createSigningRequest with regeneratePrivateKey should return BadNotSupported", async () => {
+        // When I ask the server to regenerate its private key while the key is opaque
+        const result = await pushManager.createSigningRequest(
+            "DefaultApplicationGroup",
+            "",
+            "/O=NodeOPCUA/CN=urn:NodeOPCUA-Server-Opaque",
+            /* regeneratePrivateKey */ true,
+            crypto.randomBytes(32)
+        );
+        // Then the server refuses: it can neither generate nor install key material
+        result.statusCode.should.eql(StatusCodes.BadNotSupported);
+    });
+
+    it("OPQ-2 createSigningRequest over the existing opaque key should succeed, signed by the provider", async () => {
+        const signsBefore = serverKey.signCount();
+        const result = await pushManager.createSigningRequest(
+            "DefaultApplicationGroup",
+            "",
+            "/O=NodeOPCUA/CN=urn:NodeOPCUA-Server-Opaque"
+        );
+        result.statusCode.should.eql(StatusCodes.Good);
+        result.certificateSigningRequest?.should.be.instanceOf(Buffer);
+        serverKey.signCount().should.be.greaterThan(signsBefore, "the CSR must have been signed by the opaque provider");
+    });
+
+    it("OPQ-3 the full renew cycle works: CSR over the opaque key, CA-signed certificate installed", async () => {
+        // Given a CSR produced over the (kept) opaque key
+        const resultCSR = await pushManager.createSigningRequest(
+            "DefaultApplicationGroup",
+            "",
+            "/O=NodeOPCUA/CN=urn:NodeOPCUA-Server-Opaque"
+        );
+        resultCSR.statusCode.should.eql(StatusCodes.Good);
+
+        // and Given a certificate emitted by the Certificate Authority for it
+        const certificateFullChain = await produceCertificate(_folder, resultCSR.certificateSigningRequest ?? Buffer.alloc(0));
+        const certificate = certificateFullChain[0];
+        const issuerCertificates = certificateFullChain.slice(1);
+
+        // When I update the certificate (no private key travels: the key stays in the "HSM")
+        const result: UpdateCertificateResult = await pushManager.updateCertificate(
+            "DefaultApplicationGroup",
+            "",
+            certificate,
+            issuerCertificates
+        );
+        result.statusCode.should.eql(StatusCodes.Good);
+        result.applyChangesRequired?.should.eql(true);
+
+        // and When I apply the changes
+        await pushManager.applyChanges();
+
+        // Then the installed certificate is the CA-issued one
+        const installed = await getCertificateDER(pushManager.applicationGroup ?? (null as never));
+        installed.toString("hex").should.eql(certificate.toString("hex"));
+    });
+
+    it("OPQ-4 updateCertificate refuses a pushed private key with BadNotSupported", async () => {
+        const resultCSR = await pushManager.createSigningRequest(
+            "DefaultApplicationGroup",
+            "",
+            "/O=NodeOPCUA/CN=urn:NodeOPCUA-Server-Opaque"
+        );
+        const certificateFullChain = await produceCertificate(_folder, resultCSR.certificateSigningRequest ?? Buffer.alloc(0));
+
+        // When a client pushes a certificate WITH new private-key material
+        const { privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+        const somePrivateKeyPEM = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+        const result: UpdateCertificateResult = await pushManager.updateCertificate(
+            "DefaultApplicationGroup",
+            "",
+            certificateFullChain[0],
+            certificateFullChain.slice(1),
+            "PEM",
+            somePrivateKeyPEM
+        );
+        // Then the server refuses: key material cannot be installed into an HSM
+        result.statusCode.should.eql(StatusCodes.BadNotSupported);
+    });
+
+    it("OPQ-5 updateCertificate rejects a certificate that does not match the opaque key", async () => {
+        // Given a trusted certificate built over a DIFFERENT key pair
+        const wrongCertificateManager = new CertificateManager({
+            location: path.join(_folder, "wrong")
+        });
+        await wrongCertificateManager.initialize();
+        const csrFile = await wrongCertificateManager.createCertificateRequest({
+            startDate: new Date(),
+            validity: 365,
+            subject: "/O=NodeOPCUA/CN=urn:NodeOPCUA-Server-Opaque",
+            applicationUri: "urn:NodeOPCUA-Server-Opaque"
+        });
+        const { readFile } = await import("node:fs/promises");
+        const { convertPEMtoDER } = await import("node-opcua-crypto");
+        const csrPEM = await readFile(csrFile, "utf-8");
+        const wrongChain = await produceCertificate(_folder, convertPEMtoDER(csrPEM));
+
+        // When I try to install it on the opaque-key group
+        const result: UpdateCertificateResult = await pushManager.updateCertificate(
+            "DefaultApplicationGroup",
+            "",
+            wrongChain[0],
+            wrongChain.slice(1)
+        );
+        // Then the SPKI comparison against the provider's public key refuses it
+        result.statusCode.should.eql(StatusCodes.BadSecurityChecksFailed);
+    });
+
+    it("OPQ-6 updateCertificate returns BadNotSupported when the provider cannot expose its public key", async () => {
+        // Given a group whose provider has NO getPublicKey (nothing to verify against)
+        const blindKey = makeCountingOpaqueOps(false);
+        const blindGroup = new CertificateManager({
+            location: path.join(_folder, "blind"),
+            keyOperations: blindKey.ops
+        });
+        const blindPushManager = new PushCertificateManagerServerImpl({
+            applicationGroup: blindGroup,
+            applicationUri: "urn:NodeOPCUA-Server-Opaque-Blind"
+        });
+        await blindPushManager.initialize();
+        const { certificate: caCertificate, crl } = await _getFakeAuthorityCertificate(_folder);
+        await blindGroup.trustCertificate(caCertificate);
+        await blindGroup.addIssuer(caCertificate);
+        await blindGroup.addRevocationList(crl);
+
+        // and Given some CA-issued certificate (the main manager's CSR will do)
+        const resultCSR = await pushManager.createSigningRequest(
+            "DefaultApplicationGroup",
+            "",
+            "/O=NodeOPCUA/CN=urn:NodeOPCUA-Server-Opaque"
+        );
+        const chain = await produceCertificate(_folder, resultCSR.certificateSigningRequest ?? Buffer.alloc(0));
+
+        // When I try to install it: the server cannot verify certificate/key
+        // consistency, so it refuses rather than installing blind
+        const result: UpdateCertificateResult = await blindPushManager.updateCertificate(
+            "DefaultApplicationGroup",
+            "",
+            chain[0],
+            chain.slice(1)
+        );
+        result.statusCode.should.eql(StatusCodes.BadNotSupported);
+    });
+});


### PR DESCRIPTION
## What

Completes the opaque key-operations project (FEAT-5, org project 3): push-certificate-management now behaves correctly when the server's application key is HSM/KMS-held behind `IKeyOperations`.

| Operation | Opaque-key behavior |
|---|---|
| `CreateSigningRequest(regeneratePrivateKey=true)` | **BadNotSupported** - the server can neither generate nor install key material; key rotation belongs to the key store |
| `CreateSigningRequest(regeneratePrivateKey=false)` | **Supported** - the CSR is signed by the provider (renew certificate, keep HSM key) |
| `UpdateCertificate` with pushed `privateKey` | **BadNotSupported** - material cannot be installed into an HSM |
| `UpdateCertificate` (certificate only) | **Supported** - the certificate is verified against the provider's public key (SPKI) instead of key material |
| `UpdateCertificate`, provider without `getPublicKey` | **BadNotSupported** - refuses rather than installing an unverifiable certificate (a mismatched pair would break every handshake) |
| `ApplyChanges` rotation refresh | takes the invalidate path: the `OpaqueCertificateKeyPairProvider` re-reads its chain from disk; previously the managed-key branch called `getPrivateKey()` and would have thrown `PrivateKeyUnavailableError` |

## Tests

New suite `test_push_certificate_manager_opaque_key.ts` (OPQ-1..6) with a KMS-style async-only counting provider: refusal cases, CSR-signed-by-provider assertion, the full renew cycle (CSR over kept key, CA-signed certificate installed via ApplyChanges), SPKI mismatch rejection, and the no-getPublicKey refusal.

Full node-opcua-server-configuration suite: **145 passing**. Gates: `check:privatekey`, `check:testtypes` (0 grandfathered), biome - all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)