### PR TITLE
ESM prep: break the 3 import cycles that would fail under ESM (of 14)

### DIFF
--- a/packages/node-opcua-address-space/src/apply_condition_refresh.ts
+++ b/packages/node-opcua-address-space/src/apply_condition_refresh.ts
@@ -1,8 +1,35 @@
 import type { UAObject, UAVariable } from "../source/index.js";
-import { UAConditionImpl } from "./alarms_and_conditions/ua_condition_impl.js";
 import type { UAObjectImpl } from "./ua_object_impl.js";
 
 export type ConditionRefreshCache = Map<string, UAObjectImpl>;
+
+/**
+ * The condition subsystem is recognised structurally rather than with
+ * `instanceof UAConditionImpl`.
+ *
+ * Importing that class as a value from here closed an eight-file import cycle:
+ * ua_object_impl and ua_variable_impl both import this module, this module imported
+ * UAConditionImpl, and UAConditionImpl reaches back to both of them through
+ * `extends UABaseEventImplBase` and `extends UAObjectImpl`.
+ *
+ * Under CommonJS that is survivable, because the second module to load sees a partially
+ * populated exports object and nothing touches the missing half until a function runs.
+ * Under ESM a class in a cycle is in the temporal dead zone while the cycle is being
+ * evaluated, so `class UABaseEventImplBase extends UAObjectImpl` would throw a
+ * ReferenceError as the graph loads.
+ *
+ * `_resend_conditionEvents` is declared only on UAConditionImpl, so this test selects
+ * exactly what the `instanceof` selected, subclasses included. It is also the idiom this
+ * same function already uses for `notifier._conditionRefresh` below.
+ */
+interface ConditionLike {
+    _resend_conditionEvents(): 0 | 1;
+}
+
+function isCondition(node: object): node is ConditionLike {
+    return typeof (node as Partial<ConditionLike>)._resend_conditionEvents === "function";
+}
+
 export function apply_condition_refresh(this: UAObject | UAVariable, cache?: ConditionRefreshCache): void {
     // visit all notifiers recursively
     cache = cache || new Map();
@@ -11,7 +38,7 @@ export function apply_condition_refresh(this: UAObject | UAVariable, cache?: Con
 
     const conditions = this.findReferencesAsObject("HasCondition", true);
     for (const condition of conditions) {
-        if (condition instanceof UAConditionImpl) {
+        if (isCondition(condition)) {
             condition._resend_conditionEvents();
         }
     }

--- a/packages/node-opcua-address-space/src/handle_hierarchy_parent.ts
+++ b/packages/node-opcua-address-space/src/handle_hierarchy_parent.ts
@@ -1,0 +1,133 @@
+/**
+ * @module node-opcua-address-space
+ *
+ * Extracted from namespace_impl.ts to break an import cycle.
+ *
+ * namespace_impl builds `_constructors_map` at module scope, which references
+ * UAMethodImpl and seven sibling constructors. ua_method_impl imported
+ * _handle_hierarchy_parent back from namespace_impl, closing the loop.
+ *
+ * Under CommonJS that is harmless: whichever module loads second sees a partially
+ * populated exports object, and nothing touches the missing half until a function runs.
+ * Under ESM the class declarations are in the temporal dead zone while the cycle is being
+ * evaluated, so building a map of constructors at module scope throws a ReferenceError.
+ *
+ * This module depends only on base_node_impl and leaf packages, so nothing points back
+ * into namespace_impl and the cycle is gone rather than moved.
+ */
+
+import type { AddReferenceOpts, BaseNode } from "node-opcua-address-space-base";
+import { assert } from "node-opcua-assert";
+import { NodeClass } from "node-opcua-data-model";
+import { NodeId, type NodeIdLike } from "node-opcua-nodeid";
+import type { AddressSpacePrivate } from "./address_space_private.js";
+import { BaseNodeImpl } from "./base_node_impl.js";
+
+/**
+ * convert a 'string', NodeId or Object into a valid and existing object
+ * @private
+ */
+export function _coerce_parent(
+    addressSpace: AddressSpacePrivate,
+    value: null | string | BaseNode | undefined | NodeIdLike,
+    coerceFunc: (data: string | NodeId | BaseNode) => BaseNode | null
+): BaseNode | null {
+    assert(typeof coerceFunc === "function");
+    if (value) {
+        if (typeof value === "string") {
+            value = coerceFunc.call(addressSpace, value);
+        }
+        if (value instanceof NodeId) {
+            value = addressSpace.findNode(value) as BaseNode;
+        }
+    }
+    assert(!value || value instanceof BaseNodeImpl);
+    return value as BaseNode;
+}
+
+export interface HandleHierarchyParentOptions {
+    addInOf?: NodeIdLike | BaseNode | null | undefined;
+    componentOf?: NodeIdLike | BaseNode | null | undefined;
+    propertyOf?: NodeIdLike | BaseNode | null | undefined;
+    organizedBy?: NodeIdLike | BaseNode | null | undefined;
+    encodingOf?: NodeIdLike | BaseNode | null | undefined;
+}
+
+export function _handle_hierarchy_parent(
+    addressSpace: AddressSpacePrivate,
+    references: AddReferenceOpts[],
+    options: HandleHierarchyParentOptions
+): void {
+    options.addInOf = _coerce_parent(addressSpace, options.addInOf, addressSpace._coerceNode);
+    options.componentOf = _coerce_parent(addressSpace, options.componentOf, addressSpace._coerceNode);
+    options.propertyOf = _coerce_parent(addressSpace, options.propertyOf, addressSpace._coerceNode);
+    options.organizedBy = _coerce_parent(addressSpace, options.organizedBy, addressSpace._coerceFolder);
+    options.encodingOf = _coerce_parent(addressSpace, options.encodingOf, addressSpace._coerceNode);
+
+    if (options.addInOf) {
+        assert(!options.componentOf);
+        assert(!options.propertyOf);
+        assert(!options.organizedBy);
+        assert(
+            options.addInOf.nodeClass === NodeClass.Object || options.addInOf.nodeClass === NodeClass.ObjectType,
+            "addInOf must be of nodeClass Object or ObjectType"
+        );
+        references.push({
+            isForward: false,
+            nodeId: options.addInOf.nodeId,
+            referenceType: "HasAddIn"
+        });
+    }
+
+    if (options.componentOf) {
+        assert(!options.addInOf);
+        assert(!options.propertyOf);
+        assert(!options.organizedBy);
+        assert(addressSpace.rootFolder.objects, "addressSpace must have a rootFolder.objects folder");
+        assert(
+            options.componentOf.nodeId !== addressSpace.rootFolder.objects.nodeId,
+            "Only Organizes References are used to relate Objects to the 'Objects' standard Object."
+        );
+        references.push({
+            isForward: false,
+            nodeId: options.componentOf.nodeId,
+            referenceType: "HasComponent"
+        });
+    }
+
+    if (options.propertyOf) {
+        assert(!options.addInOf);
+        assert(!options.componentOf);
+        assert(!options.organizedBy);
+        assert(
+            options.propertyOf.nodeId !== addressSpace.rootFolder.objects.nodeId,
+            "Only Organizes References are used to relate Objects to the 'Objects' standard Object."
+        );
+        references.push({
+            isForward: false,
+            nodeId: options.propertyOf.nodeId,
+            referenceType: "HasProperty"
+        });
+    }
+
+    if (options.organizedBy) {
+        assert(!options.addInOf);
+        assert(!options.propertyOf);
+        assert(!options.componentOf);
+        references.push({
+            isForward: false,
+            nodeId: options.organizedBy.nodeId,
+            referenceType: "Organizes"
+        });
+    }
+
+    if (options.encodingOf) {
+        // parent must be a DataType
+        assert(options.encodingOf.nodeClass === NodeClass.DataType, "encodingOf must be toward a DataType");
+        references.push({
+            isForward: false,
+            nodeId: options.encodingOf.nodeId,
+            referenceType: "HasEncoding"
+        });
+    }
+}

--- a/packages/node-opcua-address-space/src/namespace_impl.ts
+++ b/packages/node-opcua-address-space/src/namespace_impl.ts
@@ -112,6 +112,7 @@ import { add_dataItem_stuff } from "./data_access/add_dataItem_stuff.js";
 import { _addMultiStateDiscrete, type UAMultiStateDiscreteImpl } from "./data_access/ua_multistate_discrete_impl.js";
 import { _addMultiStateValueDiscrete } from "./data_access/ua_multistate_value_discrete_impl.js";
 import { _addTwoStateDiscrete } from "./data_access/ua_two_state_discrete_impl.js";
+import { _coerce_parent, _handle_hierarchy_parent } from "./handle_hierarchy_parent.js";
 //
 import { type NamespacePrivate, UANamespace_process_modelling_rule } from "./namespace_private.js";
 
@@ -2191,32 +2192,6 @@ const _constructors_map: Record<keyof Omit<typeof NodeClass, "Unspecified">, new
     View: UAViewImpl
 };
 
-/**
-
- * convert a 'string' , NodeId or Object into a valid and existing object
- * @param addressSpace  {IAddressSpace}
- * @param value
- * @param coerceFunc
- * @private
- */
-function _coerce_parent(
-    addressSpace: AddressSpacePrivate,
-    value: null | string | BaseNode | undefined | NodeIdLike,
-    coerceFunc: (data: string | NodeId | BaseNode) => BaseNode | null
-): BaseNode | null {
-    assert(typeof coerceFunc === "function");
-    if (value) {
-        if (typeof value === "string") {
-            value = coerceFunc.call(addressSpace, value);
-        }
-        if (value instanceof NodeId) {
-            value = addressSpace.findNode(value) as BaseNode;
-        }
-    }
-    assert(!value || value instanceof BaseNodeImpl);
-    return value as BaseNode;
-}
-
 function _handle_event_hierarchy_parent(
     addressSpace: AddressSpacePrivate,
     references: AddReferenceOpts[],
@@ -2242,92 +2217,6 @@ function _handle_event_hierarchy_parent(
         });
     }
 }
-interface HandleHierarchyParentOptions {
-    addInOf?: NodeIdLike | BaseNode | null | undefined;
-    componentOf?: NodeIdLike | BaseNode | null | undefined;
-    propertyOf?: NodeIdLike | BaseNode | null | undefined;
-    organizedBy?: NodeIdLike | BaseNode | null | undefined;
-    encodingOf?: NodeIdLike | BaseNode | null | undefined;
-}
-export function _handle_hierarchy_parent(
-    addressSpace: AddressSpacePrivate,
-    references: AddReferenceOpts[],
-    options: HandleHierarchyParentOptions
-): void {
-    options.addInOf = _coerce_parent(addressSpace, options.addInOf, addressSpace._coerceNode);
-    options.componentOf = _coerce_parent(addressSpace, options.componentOf, addressSpace._coerceNode);
-    options.propertyOf = _coerce_parent(addressSpace, options.propertyOf, addressSpace._coerceNode);
-    options.organizedBy = _coerce_parent(addressSpace, options.organizedBy, addressSpace._coerceFolder);
-    options.encodingOf = _coerce_parent(addressSpace, options.encodingOf, addressSpace._coerceNode);
-
-    if (options.addInOf) {
-        assert(!options.componentOf);
-        assert(!options.propertyOf);
-        assert(!options.organizedBy);
-        assert(
-            options.addInOf.nodeClass === NodeClass.Object || options.addInOf.nodeClass === NodeClass.ObjectType,
-            "addInOf must be of nodeClass Object or ObjectType"
-        );
-        references.push({
-            isForward: false,
-            nodeId: options.addInOf.nodeId,
-            referenceType: "HasAddIn"
-        });
-    }
-
-    if (options.componentOf) {
-        assert(!options.addInOf);
-        assert(!options.propertyOf);
-        assert(!options.organizedBy);
-        assert(addressSpace.rootFolder.objects, "addressSpace must have a rootFolder.objects folder");
-        assert(
-            options.componentOf.nodeId !== addressSpace.rootFolder.objects.nodeId,
-            "Only Organizes References are used to relate Objects to the 'Objects' standard Object."
-        );
-        references.push({
-            isForward: false,
-            nodeId: options.componentOf.nodeId,
-            referenceType: "HasComponent"
-        });
-    }
-
-    if (options.propertyOf) {
-        assert(!options.addInOf);
-        assert(!options.componentOf);
-        assert(!options.organizedBy);
-        assert(
-            options.propertyOf.nodeId !== addressSpace.rootFolder.objects.nodeId,
-            "Only Organizes References are used to relate Objects to the 'Objects' standard Object."
-        );
-        references.push({
-            isForward: false,
-            nodeId: options.propertyOf.nodeId,
-            referenceType: "HasProperty"
-        });
-    }
-
-    if (options.organizedBy) {
-        assert(!options.addInOf);
-        assert(!options.propertyOf);
-        assert(!options.componentOf);
-        references.push({
-            isForward: false,
-            nodeId: options.organizedBy.nodeId,
-            referenceType: "Organizes"
-        });
-    }
-
-    if (options.encodingOf) {
-        // parent must be a DataType
-        assert(options.encodingOf.nodeClass === NodeClass.DataType, "encodingOf must be toward a DataType");
-        references.push({
-            isForward: false,
-            nodeId: options.encodingOf.nodeId,
-            referenceType: "HasEncoding"
-        });
-    }
-}
-
 function _copy_reference(reference: UAReference | AddReferenceOpts): AddReferenceOpts {
     assert(Object.hasOwn(reference, "referenceType"));
     assert(Object.hasOwn(reference, "isForward"));

--- a/packages/node-opcua-address-space/src/ua_method_impl.ts
+++ b/packages/node-opcua-address-space/src/ua_method_impl.ts
@@ -34,7 +34,7 @@ import type { SessionContext } from "../source/session_context.js";
 import type { AddressSpacePrivate } from "./address_space_private.js";
 import { BaseNodeImpl, type InternalBaseNodeOptions } from "./base_node_impl.js";
 import { _clone } from "./base_node_private.js";
-import { _handle_hierarchy_parent } from "./namespace_impl.js";
+import { _handle_hierarchy_parent } from "./handle_hierarchy_parent.js";
 
 const warningLog = make_warningLog("ua_method_impl");
 const debugLog = make_debugLog("ua_method_impl");

--- a/packages/node-opcua-status-code/package.json
+++ b/packages/node-opcua-status-code/package.json
@@ -9,7 +9,8 @@
         "lint": "biome check --no-errors-on-unmatched .",
         "format": "biome check --write --no-errors-on-unmatched .",
         "clean": "npx rimraf -g node_modules dist *.tsbuildinfo",
-        "test": "mocha"
+        "test": "mocha",
+        "test:check": "tsc --noEmit -p test/tsconfig.json"
     },
     "dependencies": {
         "node-opcua-assert": "2.179.0",

--- a/packages/node-opcua-status-code/source/index.ts
+++ b/packages/node-opcua-status-code/source/index.ts
@@ -4,3 +4,5 @@
 
 export * from "./callbacks.js";
 export * from "./opcua_status_code.js";
+// must come after opcua_status_code: it installs the generated table into it
+export * from "./status_codes_registry.js";

--- a/packages/node-opcua-status-code/source/opcua_status_code.ts
+++ b/packages/node-opcua-status-code/source/opcua_status_code.ts
@@ -120,7 +120,20 @@ export abstract class StatusCode {
      *  returns a status code that can be modified
      */
     public static makeStatusCode(statusCode: StatusCode | string, optionalBits: string | number): StatusCode {
-        const _base = coerceStatusCode(statusCode);
+        // The instanceof case is handled here rather than deferred to the injected
+        // coerce, because the generated table calls this during its own evaluation
+        // (`static GoodWithOverflowBit = StatusCode.makeStatusCode(StatusCodes.Good, ...)`),
+        // which is before the registry has installed anything. That call passes a
+        // StatusCode, so it needs no table; only the string and number forms do.
+        let _base: StatusCode;
+        if (statusCode instanceof StatusCode) {
+            _base = statusCode;
+        } else {
+            if (!coerce) {
+                throw new Error("node-opcua-status-code: the status code table has not been installed yet");
+            }
+            _base = coerce(statusCode);
+        }
         const tmp = new ModifiableStatusCode({ _base });
         if (optionalBits || typeof optionalBits === "number") {
             tmp.set(optionalBits);
@@ -254,14 +267,44 @@ export function encodeStatusCode(statusCode: StatusCode | ConstantStatusCode, st
     stream.writeUInt32(statusCode.value);
 }
 
-// StatusCodes (in the generated _generated_status_codes.ts) is a class with one static
-// ConstantStatusCode field per named status, plus makeStatusCode monkey-patched onto it below.
-// These types capture that dynamic shape for the casts that index/extend it by string key.
-type IndexedStatusCodes = Record<string, ConstantStatusCode>;
-type StatusCodesWithMakeStatusCode = typeof StatusCodes & { makeStatusCode: typeof StatusCode.makeStatusCode };
-
 /** @internal construct status codes fast search indexes */
 const statusCodesReversedMap: Record<string, StatusCode> = {};
+
+/**
+ * The status code returned for a code that is not in the table. It is StatusCodes.Bad,
+ * but this module must not import the generated table to get it.
+ *
+ * _generated_status_codes.ts builds its ConstantStatusCode instances while its own module
+ * body runs, using the classes declared here. Under ESM an import is hoisted and the
+ * imported module is evaluated first, so importing the generated table from this file
+ * would evaluate it before these class declarations were initialised, and every one of
+ * those 280 constructions would throw a TDZ ReferenceError. It only works under CommonJS
+ * because `require()` runs where it is written, which used to be at the foot of this file.
+ *
+ * So the dependency is inverted: status_codes_registry.ts imports both and injects.
+ */
+let unknownStatusCodeFallback: StatusCode | undefined;
+
+/** injected for the same reason as the fallback: coerceStatusCode needs the table */
+let coerce: ((statusCode: StatusCode | number | string | { value: number }) => StatusCode) | undefined;
+
+/**
+ * @internal Called once by status_codes_registry, which is the only module that may
+ * import the generated table. Populates the reverse lookup and supplies the two things
+ * this module needs from that table.
+ */
+export function _installStatusCodes(
+    codes: Record<string, StatusCode>,
+    fallback: StatusCode,
+    coerceStatusCode: (statusCode: StatusCode | number | string | { value: number }) => StatusCode
+): void {
+    for (const name of Object.keys(codes)) {
+        const code = codes[name];
+        statusCodesReversedMap[code.value.toString()] = code;
+    }
+    unknownStatusCodeFallback = fallback;
+    coerce = coerceStatusCode;
+}
 
 /**
  * returns the StatusCode corresponding to the provided value, if any
@@ -275,7 +318,10 @@ export function getStatusCodeFromCode(code: number): StatusCode {
 
     /* c8 ignore next */
     if (!sc) {
-        sc = StatusCodes.Bad;
+        if (!unknownStatusCodeFallback) {
+            throw new Error("node-opcua-status-code: the status code table has not been installed yet");
+        }
+        sc = unknownStatusCodeFallback;
         warnLog(`expecting a known StatusCode but got 0x${codeWithoutInfoBits.toString(16)}`, ` code was 0x${code.toString(16)}`);
     }
     if (infoBits) {
@@ -377,30 +423,6 @@ export class ModifiableStatusCode extends StatusCode {
 Object.defineProperty(ModifiableStatusCode.prototype, "_base", { enumerable: false, writable: true });
 Object.defineProperty(ModifiableStatusCode.prototype, "_extraBits", { enumerable: false, writable: true });
 
-import { StatusCodes } from "./_generated_status_codes.js";
-
-export { StatusCodes } from "./_generated_status_codes.js";
-
-export function coerceStatusCode(statusCode: StatusCode | number | string | { value: number }): StatusCode {
-    if (statusCode instanceof StatusCode) {
-        return statusCode;
-    }
-    if (typeof statusCode === "object" && Object.hasOwn(statusCode, "value")) {
-        return getStatusCodeFromCode(statusCode.value);
-    }
-    if (typeof statusCode === "number") {
-        return getStatusCodeFromCode(statusCode);
-    }
-    const _StatusCodes = StatusCodes as unknown as IndexedStatusCodes;
-    if (!_StatusCodes[statusCode as string]) {
-        throw new Error(`Cannot find StatusCode ${statusCode}`);
-    }
-    return _StatusCodes[statusCode as string];
-}
-
-for (const name of Object.keys(StatusCodes)) {
-    const code = (StatusCodes as unknown as IndexedStatusCodes)[name];
-    statusCodesReversedMap[code.value.toString()] = code;
-}
-
-(StatusCodes as StatusCodesWithMakeStatusCode).makeStatusCode = StatusCode.makeStatusCode;
+// StatusCodes, coerceStatusCode and the table installation now live in
+// status_codes_registry.ts, which is the only module allowed to import the generated
+// table. See the note on unknownStatusCodeFallback above for why.

--- a/packages/node-opcua-status-code/source/status_codes_registry.ts
+++ b/packages/node-opcua-status-code/source/status_codes_registry.ts
@@ -1,0 +1,52 @@
+/**
+ * @module node-opcua-status-codes
+ *
+ * The one module that may import the generated status code table.
+ *
+ * _generated_status_codes.ts constructs 280 ConstantStatusCode instances while its own
+ * module body runs, using the classes declared in opcua_status_code.ts. That makes the
+ * dependency one-directional: generated -> opcua_status_code, and nothing may point back.
+ *
+ * It used to point back. opcua_status_code.ts imported the generated table at the foot of
+ * the file, after the class declarations, and iterated it at module scope to build the
+ * reverse lookup. That works under CommonJS purely because `require()` runs where it is
+ * written. ESM hoists every import to the top and evaluates dependencies first, so the
+ * generated module would have run before the classes it needs were initialised, and each
+ * of those 280 constructions would have thrown a TDZ ReferenceError on the first
+ * `import "node-opcua"`.
+ *
+ * Inverting it here keeps the graph linear: registry -> generated -> opcua_status_code.
+ */
+
+import { StatusCodes } from "./_generated_status_codes.js";
+import type { ConstantStatusCode } from "./opcua_status_code.js";
+import { _installStatusCodes, getStatusCodeFromCode, StatusCode } from "./opcua_status_code.js";
+
+export { StatusCodes } from "./_generated_status_codes.js";
+
+// StatusCodes is a class with one static ConstantStatusCode field per named status, plus
+// makeStatusCode attached below. These types capture that dynamic shape for the casts
+// that index or extend it by string key.
+type IndexedStatusCodes = Record<string, ConstantStatusCode>;
+type StatusCodesWithMakeStatusCode = typeof StatusCodes & { makeStatusCode: typeof StatusCode.makeStatusCode };
+
+export function coerceStatusCode(statusCode: StatusCode | number | string | { value: number }): StatusCode {
+    if (statusCode instanceof StatusCode) {
+        return statusCode;
+    }
+    if (typeof statusCode === "object" && Object.hasOwn(statusCode, "value")) {
+        return getStatusCodeFromCode(statusCode.value);
+    }
+    if (typeof statusCode === "number") {
+        return getStatusCodeFromCode(statusCode);
+    }
+    const _StatusCodes = StatusCodes as unknown as IndexedStatusCodes;
+    if (!_StatusCodes[statusCode as string]) {
+        throw new Error(`Cannot find StatusCode ${statusCode}`);
+    }
+    return _StatusCodes[statusCode as string];
+}
+
+_installStatusCodes(StatusCodes as unknown as IndexedStatusCodes, StatusCodes.Bad, coerceStatusCode);
+
+(StatusCodes as StatusCodesWithMakeStatusCode).makeStatusCode = StatusCode.makeStatusCode;

--- a/packages/node-opcua-status-code/test/test_status_code_module_graph.ts
+++ b/packages/node-opcua-status-code/test/test_status_code_module_graph.ts
@@ -1,0 +1,53 @@
+import should from "should";
+
+import { coerceStatusCode, getStatusCodeFromCode, StatusCode, StatusCodes } from "..";
+
+/**
+ * These pin the wiring that broke the import cycle between opcua_status_code.ts and the
+ * generated table, rather than the status codes themselves (covered by
+ * test_status_code.js).
+ *
+ * The generated table builds 280 ConstantStatusCode instances while its own module body
+ * runs, using the classes declared in opcua_status_code.ts. That makes the dependency
+ * one-directional, and nothing may point back. It used to point back: opcua_status_code
+ * imported the table at the foot of the file and iterated it at module scope, which works
+ * under CommonJS only because `require()` runs where it is written. Under ESM every import
+ * hoists, so the table would evaluate before the classes it needs were initialised and
+ * every one of those constructions would throw a TDZ ReferenceError.
+ *
+ * status_codes_registry.ts now owns that direction and injects what opcua_status_code
+ * needs. What follows is what could silently regress if that injection is undone or
+ * reordered.
+ */
+describe("status code module wiring", () => {
+    it("SCW1 - resolves a known code to the identical instance, not a copy", () => {
+        // callers compare status codes with ===, so identity is the contract
+        should(getStatusCodeFromCode(0x80400000)).be.exactly(StatusCodes.BadNotImplemented);
+    });
+
+    it("SCW2 - falls back to StatusCodes.Bad itself for an unknown code", () => {
+        // the fallback is injected; before the split it was read directly from the table
+        should(getStatusCodeFromCode(0x81ff0000)).be.exactly(StatusCodes.Bad);
+    });
+
+    it("SCW3 - coerces every accepted shape", () => {
+        should(coerceStatusCode(StatusCodes.BadInternalError)).be.exactly(StatusCodes.BadInternalError);
+        should(coerceStatusCode(0x80400000)).be.exactly(StatusCodes.BadNotImplemented);
+        should(coerceStatusCode("BadNotImplemented")).be.exactly(StatusCodes.BadNotImplemented);
+        should(coerceStatusCode({ value: 0x80400000 })).be.exactly(StatusCodes.BadNotImplemented);
+        should(() => coerceStatusCode("NoSuchStatusCode")).throw(/Cannot find StatusCode/);
+    });
+
+    it("SCW4 - keeps makeStatusCode attached to the generated table", () => {
+        // monkey-patched on by the registry; it is part of the public surface
+        should(StatusCode.makeStatusCode("BadNotImplemented", "SemanticChanged").value).equal(0x80404000);
+    });
+
+    it("SCW5 - the table's own static initializer ran during its evaluation", () => {
+        // GoodWithOverflowBit is built by the generated module calling
+        // StatusCode.makeStatusCode(StatusCodes.Good, ...) at static-init time, which is
+        // before the registry has installed anything. makeStatusCode therefore has to
+        // handle an already-coerced StatusCode without needing the table.
+        should(StatusCodes.GoodWithOverflowBit.value).equal(0x480);
+    });
+});

--- a/packages/node-opcua-status-code/test/tsconfig.json
+++ b/packages/node-opcua-status-code/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig.test.json",
+    "include": [
+        "../source/**/*.ts",
+        "./**/*.ts"
+    ],
+    "exclude": [
+        "../node_modules",
+        "../dist"
+    ]
+}


### PR DESCRIPTION
Continues the ESM migration backlog: https://github.com/orgs/node-opcua/projects/2

**Still 2.x. Nothing changes module format.** No package becomes `"type": "module"`. These are import-graph changes that are correct today and required before FEAT-2.

## Only 3 of 14 cycles actually needed fixing

Shipped source has 14 circular import groups. A cycle is not fatal on its own: under ESM the bindings are hoisted and live, and the failure is a TDZ `ReferenceError` that only happens if a module **uses** a binding from a cyclic partner while its own body is still evaluating. If every use is inside a function that runs later, the cycle behaves the same under ESM as under CommonJS.

So the cycles were classified rather than bulk-fixed: **11 are benign** and touching them would be churn with no payoff. The 3 that would genuinely break are fixed here, and the analysis now reports **`dangerous: 0`**.

## 1. `node-opcua-status-code`

```ts
// opcua_status_code.ts, line 380 - deliberately below the class declarations
import { StatusCodes } from "./_generated_status_codes.js";
for (const name of Object.keys(StatusCodes)) { ... }   // module scope
```

The generated table builds **280 `ConstantStatusCode` instances while its own module body runs**, using classes declared in `opcua_status_code.ts`, which imported the table straight back.

That works under CommonJS *only because `require()` executes where it is written*: by line 380 the classes exist. ESM hoists every import and evaluates dependencies first, so the table would run before `ConstantStatusCode` was initialised and all 280 constructions would throw, on the first `import "node-opcua"`.

`status_codes_registry.ts` now owns that direction and injects the reverse map, the unknown-code fallback and `coerceStatusCode`, keeping the graph linear: `registry -> generated -> opcua_status_code`.

**Two constraints only found by running it**, not by reading:

- the generated table calls `StatusCode.makeStatusCode(StatusCodes.Good, ...)` in a **static initializer during its own evaluation**, before any registry could have installed anything. `makeStatusCode` therefore keeps working for an already-coerced `StatusCode` and only needs the table for the string and number forms.
- **identity matters**: `getStatusCodeFromCode` on an unknown code must return `StatusCodes.Bad` *itself*, because callers compare with `===`. The fallback is injected rather than reconstructed.

Five tests pin this, in TypeScript, with a new `test/tsconfig.json` and `test:check` script, so `check:testtypes` covers this package for the first time (**44 packages -> 45**) and its existing 33 tests get type-checked too.

## 2. `node-opcua-address-space`, the 2-file cycle

`namespace_impl` builds `_constructors_map` at module scope from eight constructors, and `ua_method_impl` imported `_handle_hierarchy_parent` back from it.

That function and its `_coerce_parent` helper move to `handle_hierarchy_parent.ts`, which depends only on `base_node_impl` and leaf packages, so the cycle is gone rather than relocated.

## 3. `node-opcua-address-space`, the 8-file cycle

The interesting one. It closed through `apply_condition_refresh`:

- `ua_object_impl` **and** `ua_variable_impl` (the two base classes) both import it as a value
- it imported `UAConditionImpl`
- `UAConditionImpl` reaches back to both, through `extends UABaseEventImplBase` and `extends UAObjectImpl`

Three `extends` clauses across that cycle evaluate at module load, so this was a guaranteed `ReferenceError` under ESM.

`apply_condition_refresh` needed `UAConditionImpl` for exactly **one `instanceof`**, so the test is now structural. `_resend_conditionEvents` is declared only on `UAConditionImpl`, so it selects precisely what the `instanceof` selected, subclasses included — and it is the idiom the same function already used one loop below for `notifier._conditionRefresh`.

As a side benefit, this removes one of the 725 cross-package `instanceof` checks that make the dual-package hazard severe.

## Verification

The change to `apply_condition_refresh` is on the ConditionRefresh service path, so it was exercised directly rather than by proxy:

| check | result |
|---|---|
| `A&C-02 - ConditionRefresh` end-to-end test | **1 passing** — client calls ConditionRefresh, server resends condition events, event-count assertions hold |
| `node-opcua-address-space` | 1096 passing |
| `node-opcua-status-code` | 38 passing (33 existing + 5 new) |
| `node-opcua-server` / `secure-channel` / `client` / `basic-types` | 474 / 269 / 77 / 155 passing |
| cycle analysis | 14 groups -> **dangerous: 0** |
| `npx tsc -b packages` | exit 0 |
| `pnpm run check:testtypes` | 45 packages, 0 grandfathered |
| `pnpm run check:importext` | 2300 files, 0 violations |
| `pnpm run check:consumers` | both shapes ok |
| `pnpm run lint` | clean |

## What is left for FEAT-2

With this, the mechanical and structural preparation is done: extensions, `require()`, `__dirname` anchors, and now the cycles. The flip itself is close to setting `"type": "module"` per package plus the six `__dirname` one-liners.
