### PR TITLE
test(utils): stop asserting the countUpperCase micro-benchmark

### DIFF
--- a/packages/node-opcua-utils/test/test_string_utils.js
+++ b/packages/node-opcua-utils/test/test_string_utils.js
@@ -80,17 +80,26 @@ function isInstrumented() {
 }
 
 describe("benchmark", () => {
-    it("countUpperCase should be faster than countUpperCaseSlow", function () {
-        // A wall-clock comparison is meaningless under instrumentation: istanbul adds a counter
-        // increment per branch, which penalises the two implementations by different factors and has
-        // been observed to invert the result entirely (965ms vs 175ms).
-        if (isInstrumented()) {
-            this.skip();
-        }
-
+    it("countUpperCase agrees with countUpperCaseSlow (timings reported, never asserted)", function () {
         const LONG = "qkldjqsld lqskdjql skdjlqksd azoirjapzoeazpx oqskQPDKQSD¨QSDPQS¨D kLAEAZJ EL121232";
         const SHORT = "qkldjqsld";
         const ITERATIONS = 200000;
+
+        // The two implementations must agree - that is the invariant worth gating on.
+        for (const s of ["", SHORT, LONG, "ABC", "aBc123", "¨É é"]) {
+            countUpperCase(s).should.eql(countUpperCaseSlow(s), `countUpperCase("${s}")`);
+        }
+
+        // The relative-speed assertion that used to live here is gone for good: a shared CI
+        // runner under load lost the comparison at 1.2x, then again at 1.5x (build_on_windows,
+        // 2026-08-29: 333ms vs a 308ms limit), despite warm-up and best-of-three. Wall-clock
+        // ratios are information, not an invariant - so they are printed, never asserted.
+        // Under instrumentation even the printed numbers are meaningless: istanbul adds a
+        // counter per branch, penalising the two implementations by different factors (an
+        // observed inversion: 965ms vs 175ms) - skip the measurement entirely.
+        if (isInstrumented()) {
+            return;
+        }
 
         // elapsed milliseconds — hrtime() returns [seconds, nanoseconds] and the seconds field must be
         // folded in: the previous version used only [1], so any run longer than 1s was reported modulo
@@ -118,10 +127,5 @@ describe("benchmark", () => {
             d2 = Math.min(d2, measure(countUpperCase));
         }
         console.log(`countUpperCaseSlow: ${d1.toFixed(3)} ms, countUpperCase: ${d2.toFixed(3)} ms`);
-
-        
-        // should not be more than 50% slower than the optimized version
-        d2.should.be.lessThan(d1 * 1.5);
-
     });
 });


### PR DESCRIPTION
## What

Removes the relative-speed assertion from the `countUpperCase` benchmark test in node-opcua-utils; the timings are still measured (warm-up + best-of-three) and printed, just never asserted. In its place the test now gates the invariant that actually matters: `countUpperCase` and `countUpperCaseSlow` agree on the count over a set of representative strings (previously untested).

## Why

The speed comparison is inherently flaky on shared CI runners. It lost at the original 1.2x threshold, was loosened to 1.5x on 2026-08-26 (73889f119), and lost again on 2026-08-29 (`build_on_windows (22.x)`: 333ms vs a 308ms limit), taking a master run red - despite the warm-up, best-of-three sampling, hrtime fix, and instrumentation skip already layered onto it. A wall-clock ratio under scheduler contention is information, not an invariant.

The instrumentation skip is kept for the measurement (istanbul penalises the two implementations by different factors - an observed inversion of 965ms vs 175ms), but the equivalence assertion now runs everywhere, including under coverage.

## Verification

node-opcua-utils suite: 35 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)