### PR TITLE
FEAT-6: gate the import cycles that would throw under ESM

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -94,6 +94,13 @@ jobs:
       - run: pnpm run check:importext
       - name: Unit tests for the import-extension rule
         run: node tools/check-import-extension/test/test_rule.js
+      # Circular imports that would throw under ESM. It classifies rather than counts: a
+      # cycle only fails here when a member uses a cyclic binding while its own body runs
+      # (a class heritage clause, a module-scope initializer). Of the 14 cycles this repo
+      # had, 11 were harmless and flagging those would have made the gate noise.
+      - run: pnpm run check:cycles
+      - name: Unit tests for the cycle rule
+        run: node tools/check-import-cycles/test/test_rule.js
       # Raw private-key access is being migrated to the opaque key-operations
       # path (HSM/KMS capable); the baseline ratchet only ever tightens, so a
       # new .getPrivateKey( call site fails here instead of slipping in.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "check:importext": "node tools/check-import-extension.mjs",
     "check:importext:fix": "node tools/check-import-extension.mjs --fix",
     "check:pack": "node tools/check-pack.mjs",
+    "check:cycles": "node tools/check-import-cycles.mjs",
+    "check:cycles:all": "node tools/check-import-cycles.mjs --all",
     "check:consumers": "node fixtures/consumer-cjs/index.cjs && node fixtures/consumer-esm/index.mjs",
     "preinstall": "node prevent_npm_install.js",
     "lint": "biome check --reporter=summary --no-errors-on-unmatched .",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4220,6 +4220,12 @@ importers:
 
   tools/check-debug-name: {}
 
+  tools/check-import-cycles:
+    devDependencies:
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
   tools/check-import-extension:
     devDependencies:
       typescript:

--- a/tools/check-import-cycles.mjs
+++ b/tools/check-import-cycles.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+/** launcher for tools/check-import-cycles - see tools/README.md */
+import "./check-import-cycles/src/index.js";

--- a/tools/check-import-cycles/README.md
+++ b/tools/check-import-cycles/README.md
@@ -1,0 +1,82 @@
+# check-import-cycles
+
+Fails the build on a circular import that **would throw under ESM**, and stays quiet about
+the ones that would not.
+
+```bash
+node tools/check-import-cycles.mjs           # report, exit 1 on a dangerous cycle
+node tools/check-import-cycles.mjs --all     # list the benign ones too
+node tools/check-import-cycles.mjs --package node-opcua-address-space
+node tools/check-import-cycles.mjs --root ../my-project
+pnpm run check:cycles                        # same, via the root script
+```
+
+## Why classify instead of just counting
+
+A cycle is not a defect on its own. Under ESM the bindings are hoisted and live; the
+failure mode is a TDZ `ReferenceError`, and that only happens when a module **uses** a
+binding from a cyclic partner while its own body is still evaluating. If every use is
+inside a function that runs later, the cycle behaves exactly as it does under CommonJS.
+
+Shipped source had **14 cycles and only 3 could break**. A gate that failed on all 14 would
+have been noise, and noise gets switched off. So this reports every cycle but fails only on
+the ones that matter, and names the exact line that would throw.
+
+## What makes a cycle dangerous
+
+A member uses a cyclic binding at module-evaluation time:
+
+```ts
+// a heritage clause runs when the class declaration runs
+export class UABaseEventImpl extends UAObjectImpl {}
+
+// so does a module-scope initializer
+const _constructors_map = { Method: UAMethodImpl, Object: UAObjectImpl };
+
+// and a module-scope loop
+for (const name of Object.keys(StatusCodes)) { ... }
+```
+
+All three are real: they are the shapes of the three cycles this repo had to fix before
+FEAT-2. Uses inside a function body, including a class *method*, are safe.
+
+## What is an edge
+
+Runtime imports only.
+
+- `import { X } from "./m.js"` and `import X from`, `import * as X from` — an edge
+- `export * from "./m.js"` and `export { X } from` — an edge
+- `import "./m.js"` — an edge, and an easy one to miss: it has no bindings at all but
+  still forces the target to evaluate
+- `import type { X } from "./m.js"` — **not** an edge, it is erased
+- `import { type X } from "./m.js"` — **not** an edge either, when nothing else in the
+  clause survives, because TypeScript elides the whole statement
+
+## Fixing one
+
+Two shapes work, and both were used here:
+
+- **move the shared piece down**, into a module that both sides can depend on.
+  `_handle_hierarchy_parent` came out of `namespace_impl` for this reason.
+- **invert the dependency and inject**. `status_codes_registry` imports both the generated
+  table and the base module, and hands the base module what it needs, rather than the base
+  module importing the table back.
+
+Sometimes the import exists for one `instanceof`, in which case a structural test removes
+the edge entirely — that is how the eight-file address-space cycle was broken.
+
+If a cycle is genuinely intended, say why on any member file:
+
+```ts
+// check-import-cycles: ok - <reason>
+```
+
+## Layout
+
+`src/rule.js` is pure and takes a root path, so the tests build small fixture trees rather
+than shelling out. Tarjan is iterative: the recursive form overflows the default stack on a
+graph this size, and a CI step should not depend on `--stack-size`.
+
+```bash
+node tools/check-import-cycles/test/test_rule.js
+```

--- a/tools/check-import-cycles/package.json
+++ b/tools/check-import-cycles/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "@sterfive/check-import-cycles",
+    "version": "1.0.0",
+    "private": true,
+    "description": "fail the build on circular imports that would throw under ESM",
+    "bin": {
+        "check-import-cycles": "src/index.js"
+    },
+    "type": "module",
+    "scripts": {
+        "check": "node src/index.js",
+        "all": "node src/index.js --all",
+        "test": "node test/test_rule.js"
+    },
+    "devDependencies": {
+        "typescript": "5.9.3"
+    }
+}

--- a/tools/check-import-cycles/src/index.js
+++ b/tools/check-import-cycles/src/index.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * check-import-cycles - command line around src/rule.js.
+ *
+ * Usage:
+ *     node tools/check-import-cycles.mjs                    # report, exit 1 on a dangerous cycle
+ *     node tools/check-import-cycles.mjs --all              # list the benign ones too
+ *     node tools/check-import-cycles.mjs --package node-opcua-address-space
+ *     node tools/check-import-cycles.mjs --root ../my-project
+ */
+
+import process from "node:process";
+import { analyze, exitCode, formatReport } from "./rule.js";
+
+function valueOf(argv, flag) {
+    const i = argv.indexOf(flag);
+    return i === -1 ? undefined : argv[i + 1];
+}
+
+function main() {
+    const argv = process.argv.slice(2);
+    const result = analyze({
+        repoRoot: valueOf(argv, "--root") ?? ".",
+        packageFilter: valueOf(argv, "--package")
+    });
+    console.log(formatReport(result, { showBenign: argv.includes("--all") }));
+    return exitCode(result);
+}
+
+process.exit(main());

--- a/tools/check-import-cycles/src/rule.js
+++ b/tools/check-import-cycles/src/rule.js
@@ -1,0 +1,367 @@
+/**
+ * rule - circular imports that would throw under ESM.
+ *
+ * A cycle is not a defect on its own. Under ESM the bindings are hoisted and live, and
+ * the failure is a TDZ ReferenceError, which happens only if a module *uses* a binding
+ * from a cyclic partner while its own body is still evaluating. If every use is inside a
+ * function that runs later, the cycle behaves exactly as it does under CommonJS.
+ *
+ * That distinction is the whole point of this tool. Shipped source had 14 cycles and only
+ * 3 could break; a gate that failed on all 14 would be noise and would be switched off.
+ *
+ * What counts as a use at module-evaluation time:
+ *   - a reference at module scope, e.g. `const map = { Method: UAMethodImpl }`
+ *   - a heritage clause, `class X extends Y`, even though it sits inside a class body:
+ *     `extends` is evaluated when the class declaration is evaluated
+ *
+ * `import type` and `import { type X }` are erased before runtime, so they create no edge
+ * at all.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+
+export const SOURCE_ROOTS = ["packages", "packages_extra"];
+export const SOURCE_DIRS = ["source", "src"];
+
+const SKIP_DIRS = new Set(["node_modules", "dist", "dist-esm", "coverage", "build"]);
+
+/** opt out of the rule for one cycle, with a reason, on any member file */
+export const IGNORE_MARKER = "check-import-cycles: ok";
+
+const isFile = (p) => {
+    try {
+        return fs.statSync(p).isFile();
+    } catch {
+        return false;
+    }
+};
+
+/** resolve a relative specifier to a file in the tree, tolerating the .js extension */
+export function resolveSpecifier(fromFile, specifier) {
+    const base = path.posix.join(path.posix.dirname(fromFile.replace(/\\/g, "/")), specifier).replace(/\.js$/, "");
+    for (const candidate of [`${base}.ts`, `${base}.tsx`, `${base}/index.ts`]) {
+        if (isFile(candidate)) {
+            return candidate;
+        }
+    }
+    return null;
+}
+
+/** true for any node that opens a function scope: a use inside one happens later */
+function opensFunctionScope(node) {
+    return (
+        ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isArrowFunction(node) ||
+        ts.isMethodDeclaration(node) ||
+        ts.isConstructorDeclaration(node) ||
+        ts.isGetAccessorDeclaration(node) ||
+        ts.isSetAccessorDeclaration(node)
+    );
+}
+
+/** a heritage clause runs when the class declaration runs, even inside a class body */
+function inHeritageClause(node) {
+    let p = node.parent;
+    while (p) {
+        if (ts.isHeritageClause(p)) {
+            return true;
+        }
+        if (opensFunctionScope(p)) {
+            return false;
+        }
+        p = p.parent;
+    }
+    return false;
+}
+
+/**
+ * Parse one file: its runtime edges and the local names each brings in.
+ * Returns { deps: string[], bindings: Map<localName, targetFile>, sourceFile, ignored }.
+ */
+export function readModule(file, text) {
+    const sourceFile = ts.createSourceFile(file, text, ts.ScriptTarget.ESNext, true, ts.ScriptKind.TS);
+    const deps = new Set();
+    const bindings = new Map();
+
+    for (const st of sourceFile.statements) {
+        if (ts.isImportDeclaration(st) && st.moduleSpecifier && ts.isStringLiteral(st.moduleSpecifier)) {
+            const spec = st.moduleSpecifier.text;
+            if (!spec.startsWith(".")) {
+                continue;
+            }
+            const target = resolveSpecifier(file, spec);
+            if (!target) {
+                continue;
+            }
+            const clause = st.importClause;
+
+            // `import "./x.js"` has no clause at all. It is a side-effect import, which is
+            // very much a runtime edge and forces the target to evaluate.
+            if (!clause) {
+                deps.add(target);
+                continue;
+            }
+            // `import type { X } from` is erased whole
+            if (clause.isTypeOnly) {
+                continue;
+            }
+
+            const names = [];
+            if (clause.name) {
+                names.push(clause.name.text);
+            }
+            if (clause.namedBindings) {
+                if (ts.isNamespaceImport(clause.namedBindings)) {
+                    names.push(clause.namedBindings.name.text);
+                } else {
+                    for (const el of clause.namedBindings.elements) {
+                        if (!el.isTypeOnly) {
+                            names.push(el.name.text);
+                        }
+                    }
+                }
+            }
+            // `import { type A, type B } from` has a clause but nothing survives it, so
+            // TypeScript elides the statement and there is no runtime edge either.
+            if (names.length === 0) {
+                continue;
+            }
+            deps.add(target);
+            for (const n of names) {
+                bindings.set(n, target);
+            }
+        } else if (ts.isExportDeclaration(st) && st.moduleSpecifier && ts.isStringLiteral(st.moduleSpecifier) && !st.isTypeOnly) {
+            const spec = st.moduleSpecifier.text;
+            if (!spec.startsWith(".")) {
+                continue;
+            }
+            const target = resolveSpecifier(file, spec);
+            if (target) {
+                deps.add(target);
+            }
+        }
+    }
+    return { deps: [...deps], bindings, sourceFile, ignored: text.includes(IGNORE_MARKER) };
+}
+
+/**
+ * Tarjan, iteratively. The recursive form overflows the default stack on a graph this
+ * size and would make the gate depend on --stack-size, which a CI step should not.
+ */
+export function stronglyConnectedComponents(nodes, edgesOf) {
+    let counter = 0;
+    const index = new Map();
+    const low = new Map();
+    const onStack = new Set();
+    const stack = [];
+    const components = [];
+
+    for (const start of nodes) {
+        if (index.has(start)) {
+            continue;
+        }
+        const work = [{ v: start, i: 0 }];
+        while (work.length > 0) {
+            const frame = work[work.length - 1];
+            const v = frame.v;
+            if (frame.i === 0) {
+                index.set(v, counter);
+                low.set(v, counter);
+                counter++;
+                stack.push(v);
+                onStack.add(v);
+            }
+            const deps = edgesOf(v);
+            let descended = false;
+            while (frame.i < deps.length) {
+                const w = deps[frame.i];
+                frame.i++;
+                if (!index.has(w)) {
+                    work.push({ v: w, i: 0 });
+                    descended = true;
+                    break;
+                }
+                if (onStack.has(w)) {
+                    low.set(v, Math.min(low.get(v), index.get(w)));
+                }
+            }
+            if (descended) {
+                continue;
+            }
+            if (low.get(v) === index.get(v)) {
+                const component = [];
+                let w;
+                do {
+                    w = stack.pop();
+                    onStack.delete(w);
+                    component.push(w);
+                } while (w !== v);
+                if (component.length > 1 || edgesOf(v).includes(v)) {
+                    components.push(component);
+                }
+            }
+            work.pop();
+            if (work.length > 0) {
+                const parent = work[work.length - 1].v;
+                low.set(parent, Math.min(low.get(parent), low.get(v)));
+            }
+        }
+    }
+    return components;
+}
+
+/**
+ * Uses, at module-evaluation time, of a binding imported from another member of the same
+ * cycle. These are what make a cycle fatal.
+ */
+export function dangerousUses(file, module, members) {
+    const cyclic = new Map([...module.bindings].filter(([, target]) => members.has(target) && target !== file));
+    if (cyclic.size === 0) {
+        return [];
+    }
+    const { sourceFile } = module;
+    const found = [];
+    const seen = new Set();
+
+    const visit = (node, insideFunction) => {
+        const nested = insideFunction || opensFunctionScope(node);
+        if (ts.isIdentifier(node) && cyclic.has(node.text)) {
+            const heritage = inHeritageClause(node);
+            if (!nested || heritage) {
+                // the import statement itself is not a use
+                let p = node.parent;
+                let inImport = false;
+                while (p) {
+                    if (ts.isImportDeclaration(p) || ts.isExportDeclaration(p)) {
+                        inImport = true;
+                        break;
+                    }
+                    p = p.parent;
+                }
+                if (!inImport) {
+                    const { line } = ts.getLineAndCharacterOfPosition(sourceFile, node.getStart(sourceFile));
+                    const key = `${line}:${node.text}`;
+                    if (!seen.has(key)) {
+                        seen.add(key);
+                        found.push({ line: line + 1, name: node.text, from: cyclic.get(node.text), heritage });
+                    }
+                }
+            }
+        }
+        ts.forEachChild(node, (child) => visit(child, nested));
+    };
+    ts.forEachChild(sourceFile, (child) => visit(child, false));
+    return found;
+}
+
+export function findSourceFiles(repoRoot = ".", packageFilter) {
+    const files = [];
+    for (const root of SOURCE_ROOTS) {
+        const full = path.join(repoRoot, root);
+        if (!fs.existsSync(full)) {
+            continue;
+        }
+        for (const pkg of fs.readdirSync(full, { withFileTypes: true })) {
+            if (!pkg.isDirectory() || SKIP_DIRS.has(pkg.name)) {
+                continue;
+            }
+            if (packageFilter && pkg.name !== packageFilter) {
+                continue;
+            }
+            for (const dir of SOURCE_DIRS) {
+                walk(path.join(full, pkg.name, dir), files);
+            }
+        }
+    }
+    return files.map((f) => f.replace(/\\/g, "/"));
+}
+
+function walk(dir, out) {
+    if (!fs.existsSync(dir)) {
+        return;
+    }
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            if (!SKIP_DIRS.has(entry.name)) {
+                walk(full, out);
+            }
+        } else if (/\.(ts|tsx)$/.test(entry.name) && !entry.name.endsWith(".d.ts")) {
+            out.push(full);
+        }
+    }
+}
+
+/** scan; returns { scanned, cycles: [{ files, dangerous, uses, ignored }] } */
+export function analyze({ repoRoot = ".", packageFilter } = {}) {
+    const files = findSourceFiles(repoRoot, packageFilter);
+    const modules = new Map();
+    for (const f of files) {
+        modules.set(f, readModule(f, fs.readFileSync(f, "utf8")));
+    }
+    const edgesOf = (v) => modules.get(v)?.deps ?? [];
+    const components = stronglyConnectedComponents([...modules.keys()], edgesOf);
+
+    const cycles = [];
+    for (const component of components) {
+        const members = new Set(component);
+        const uses = [];
+        let ignored = false;
+        for (const f of component) {
+            const m = modules.get(f);
+            if (m.ignored) {
+                ignored = true;
+            }
+            for (const u of dangerousUses(f, m, members)) {
+                uses.push({ file: f, ...u });
+            }
+        }
+        cycles.push({ files: component.sort(), dangerous: uses.length > 0 && !ignored, uses, ignored });
+    }
+    cycles.sort((a, b) => Number(b.dangerous) - Number(a.dangerous) || b.files.length - a.files.length);
+    return { scanned: files.length, cycles };
+}
+
+export function exitCode(result) {
+    return result.cycles.some((c) => c.dangerous) ? 1 : 0;
+}
+
+const short = (f) => f.replace(/^packages(_extra)?\//, "");
+
+export function formatReport(result, { showBenign = false } = {}) {
+    const dangerous = result.cycles.filter((c) => c.dangerous);
+    const benign = result.cycles.filter((c) => !c.dangerous);
+    const lines = [];
+
+    if (dangerous.length === 0) {
+        lines.push(`check-import-cycles: ${result.scanned} files scanned, ${result.cycles.length} cycles, none that ESM would reject.`);
+    } else {
+        lines.push(`check-import-cycles: ${dangerous.length} cycle(s) would throw under ESM, of ${result.cycles.length} in ${result.scanned} files`, "");
+        for (const c of dangerous) {
+            lines.push(`  ${c.files.length} files:`);
+            for (const f of c.files) {
+                lines.push(`      ${short(f)}`);
+            }
+            lines.push(`    used while the module body is still evaluating:`);
+            for (const u of c.uses) {
+                lines.push(`      ${short(u.file)}:${u.line}  ${u.name}${u.heritage ? "   (extends/implements)" : ""}`);
+            }
+            lines.push("");
+        }
+        lines.push("A cycle only breaks under ESM when a member uses a cyclic binding while its");
+        lines.push("own body runs - a class heritage clause, or a module-scope initializer. Move");
+        lines.push("the shared piece into a module both sides can depend on, or invert the");
+        lines.push("dependency so the value is injected rather than imported.");
+    }
+
+    if (showBenign && benign.length > 0) {
+        lines.push("", `${benign.length} benign cycle(s) - every cyclic binding is only used inside a function:`);
+        for (const c of benign) {
+            lines.push(`  ${String(c.files.length).padStart(3)} files  ${short(c.files[0])}${c.ignored ? "   [ignored by marker]" : ""}`);
+        }
+    }
+    return lines.join("\n");
+}

--- a/tools/check-import-cycles/test/test_rule.js
+++ b/tools/check-import-cycles/test/test_rule.js
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for the cycle rule.
+ *
+ * The classification is the whole value of this tool, so most of these are about telling
+ * a dangerous cycle from a benign one. All three shapes below were taken from cycles that
+ * actually existed in this repo:
+ *
+ *   - `class X extends Y` across a cycle          (node-opcua-address-space, 8 files)
+ *   - a module-scope map of constructors          (namespace_impl._constructors_map)
+ *   - a module-scope loop over an imported table  (opcua_status_code + the generated codes)
+ *
+ * Run: node test/test_rule.js
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { analyze, exitCode, formatReport, stronglyConnectedComponents, IGNORE_MARKER } from "../src/rule.js";
+
+function withTree(files, fn) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "check-cycles-"));
+    try {
+        for (const [rel, content] of Object.entries(files)) {
+            const full = path.join(root, rel);
+            fs.mkdirSync(path.dirname(full), { recursive: true });
+            fs.writeFileSync(full, content);
+        }
+        return fn(root);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+}
+
+const P = "packages/p/source";
+
+// --- the graph algorithm ------------------------------------------------------------
+
+test("finds a simple cycle and ignores an acyclic graph", () => {
+    const edges = { a: ["b"], b: ["a"], c: ["d"], d: [] };
+    const comps = stronglyConnectedComponents(Object.keys(edges), (v) => edges[v]);
+    assert.equal(comps.length, 1);
+    assert.deepEqual(comps[0].sort(), ["a", "b"]);
+});
+
+test("handles a deep chain without overflowing the stack", () => {
+    // the recursive form of Tarjan dies here without --stack-size
+    const n = 20000;
+    const edges = {};
+    for (let i = 0; i < n; i++) edges[`n${i}`] = i + 1 < n ? [`n${i + 1}`] : [];
+    const comps = stronglyConnectedComponents(Object.keys(edges), (v) => edges[v]);
+    assert.equal(comps.length, 0);
+});
+
+test("finds a large cycle in a deep chain", () => {
+    const n = 5000;
+    const edges = {};
+    for (let i = 0; i < n; i++) edges[`n${i}`] = [`n${(i + 1) % n}`];
+    const comps = stronglyConnectedComponents(Object.keys(edges), (v) => edges[v]);
+    assert.equal(comps.length, 1);
+    assert.equal(comps[0].length, n);
+});
+
+// --- dangerous: used while the module body runs --------------------------------------
+
+test("flags `class X extends Y` across a cycle", () => {
+    withTree(
+        {
+            [`${P}/a.ts`]: 'import { B } from "./b.js";\nexport class A extends B {}\n',
+            [`${P}/b.ts`]: 'import { A } from "./a.js";\nexport class B { make() { return new A(); } }\n'
+        },
+        (root) => {
+            const r = analyze({ repoRoot: root });
+            assert.equal(r.cycles.length, 1);
+            assert.equal(r.cycles[0].dangerous, true);
+            assert.equal(exitCode(r), 1);
+            assert.ok(r.cycles[0].uses.some((u) => u.heritage), "the heritage clause must be reported as such");
+            assert.match(formatReport(r), /extends\/implements/);
+        }
+    );
+});
+
+test("flags a module-scope initializer, the _constructors_map shape", () => {
+    withTree(
+        {
+            [`${P}/a.ts`]: 'import { B } from "./b.js";\nexport const map = { b: B };\nexport class A {}\n',
+            [`${P}/b.ts`]: 'import type { A } from "./a.js";\nimport { helper } from "./a.js";\nexport class B { go(): void { helper(); } }\n',
+        },
+        (root) => {
+            const r = analyze({ repoRoot: root });
+            assert.equal(r.cycles.length, 1);
+            assert.equal(r.cycles[0].dangerous, true);
+        }
+    );
+});
+
+test("flags a module-scope loop, the generated-status-codes shape", () => {
+    withTree(
+        {
+            [`${P}/a.ts`]: 'export class Base {}\nimport { table } from "./b.js";\nfor (const k of Object.keys(table)) { void k; }\n',
+            [`${P}/b.ts`]: 'import { Base } from "./a.js";\nexport const table = { good: new Base() };\n'
+        },
+        (root) => {
+            const r = analyze({ repoRoot: root });
+            assert.equal(r.cycles.length, 1);
+            assert.equal(r.cycles[0].dangerous, true);
+        }
+    );
+});
+
+// --- benign: only used inside functions ----------------------------------------------
+
+test("does not flag a cycle whose bindings are only used inside functions", () => {
+    withTree(
+        {
+            [`${P}/a.ts`]: 'import { b } from "./b.js";\nexport function a(): number { return b(); }\n',
+            [`${P}/b.ts`]: 'import { a } from "./a.js";\nexport function b(): number { return a(); }\n'
+        },
+        (root) => {
+            const r = analyze({ repoRoot: root });
+            assert.equal(r.cycles.length, 1, "the cycle is still reported");
+            assert.equal(r.cycles[0].dangerous, false, "but it is not dangerous");
+            assert.equal(exitCode(r), 0);
+            assert.match(formatReport(r), /none that ESM would reject/);
+        }
+    );
+});
+
+test("does not flag a use inside a class method, only a heritage clause", () => {
+    withTree(
+        {
+            [`${P}/a.ts`]: 'import { B } from "./b.js";\nexport class A { make(): B { return new B(); } }\n',
+            [`${P}/b.ts`]: 'import { A } from "./a.js";\nexport class B { make(): A { return new A(); } }\n'
+        },
+        (root) => {
+            const r = analyze({ repoRoot: root });
+            assert.equal(r.cycles[0].dangerous, false);
+        }
+    );
+});
+
+test("import type creates no edge at all", () => {
+    withTree(
+        {
+            [`${P}/a.ts`]: 'import type { B } from "./b.js";\nexport class A { b?: B; }\n',
+            [`${P}/b.ts`]: 'import { A } from "./a.js";\nexport class B extends A {}\n'
+        },
+        (root) => {
+            const r = analyze({ repoRoot: root });
+            assert.equal(r.cycles.length, 0, "a type-only import is erased, so there is no cycle");
+        }
+    );
+});
+
+test("a named type-only specifier is erased too", () => {
+    withTree(
+        {
+            [`${P}/a.ts`]: 'import { type B } from "./b.js";\nexport class A { b?: B; }\n',
+            [`${P}/b.ts`]: 'import { A } from "./a.js";\nexport class B extends A {}\n'
+        },
+        (root) => {
+            assert.equal(analyze({ repoRoot: root }).cycles.length, 0);
+        }
+    );
+});
+
+test("a side-effect import is a runtime edge, even with no bindings", () => {
+    // `import "./x.js"` has no import clause at all, but it forces the target to
+    // evaluate, so it very much participates in a cycle
+    withTree(
+        {
+            [`${P}/a.ts`]: 'import "./b.js";\nexport class A {}\n',
+            [`${P}/b.ts`]: 'import { A } from "./a.js";\nexport class B extends A {}\n'
+        },
+        (root) => {
+            const r = analyze({ repoRoot: root });
+            assert.equal(r.cycles.length, 1, "the side-effect import closes the cycle");
+            assert.equal(r.cycles[0].dangerous, true, "and B extends A across it");
+        }
+    );
+});
+
+test("no cycle at all is reported clean", () => {
+    withTree(
+        {
+            [`${P}/a.ts`]: 'import { b } from "./b.js";\nexport const a = b;\n',
+            [`${P}/b.ts`]: "export const b = 1;\n"
+        },
+        (root) => {
+            const r = analyze({ repoRoot: root });
+            assert.equal(r.cycles.length, 0);
+            assert.equal(exitCode(r), 0);
+        }
+    );
+});
+
+// --- escape hatch and plumbing --------------------------------------------------------
+
+test("an ignore marker on any member downgrades the cycle", () => {
+    withTree(
+        {
+            [`${P}/a.ts`]: `// ${IGNORE_MARKER} - deliberate\nimport { B } from "./b.js";\nexport class A extends B {}\n`,
+            [`${P}/b.ts`]: 'import { A } from "./a.js";\nexport class B { make() { return new A(); } }\n'
+        },
+        (root) => {
+            const r = analyze({ repoRoot: root });
+            assert.equal(r.cycles[0].dangerous, false);
+            assert.equal(r.cycles[0].ignored, true);
+            assert.equal(exitCode(r), 0);
+        }
+    );
+});
+
+test("export * from participates in the graph", () => {
+    withTree(
+        {
+            [`${P}/a.ts`]: 'export * from "./b.js";\nexport class A {}\n',
+            [`${P}/b.ts`]: 'import { A } from "./a.js";\nexport class B extends A {}\n'
+        },
+        (root) => {
+            const r = analyze({ repoRoot: root });
+            assert.equal(r.cycles.length, 1);
+            assert.equal(r.cycles[0].dangerous, true);
+        }
+    );
+});
+
+test("a directory import resolves to index.ts", () => {
+    withTree(
+        {
+            [`${P}/a.ts`]: 'import { B } from "./sub/index.js";\nexport class A extends B {}\n',
+            [`${P}/sub/index.ts`]: 'import { A } from "../a.js";\nexport class B { make() { return new A(); } }\n'
+        },
+        (root) => {
+            assert.equal(analyze({ repoRoot: root }).cycles.length, 1);
+        }
+    );
+});
+
+test("--package narrows the scan", () => {
+    withTree(
+        {
+            "packages/p/source/a.ts": 'import { B } from "./b.js";\nexport class A extends B {}\n',
+            "packages/p/source/b.ts": 'import { A } from "./a.js";\nexport class B { m() { return new A(); } }\n',
+            "packages/q/source/a.ts": 'import { B } from "./b.js";\nexport class A extends B {}\n',
+            "packages/q/source/b.ts": 'import { A } from "./a.js";\nexport class B { m() { return new A(); } }\n'
+        },
+        (root) => {
+            assert.equal(analyze({ repoRoot: root }).cycles.length, 2);
+            assert.equal(analyze({ repoRoot: root, packageFilter: "p" }).cycles.length, 1);
+        }
+    );
+});


### PR DESCRIPTION
First piece of **FEAT-6** on the ESM migration backlog: https://github.com/orgs/node-opcua/projects/2

**2.x, non-breaking, tooling only.** No shipped source changes.

## Why

The three import cycles fixed in https://github.com/node-opcua/node-opcua/pull/1592 were invisible until someone went looking for them, and each would have thrown on the first `import "node-opcua"` after FEAT-2. FEAT-2 is also precisely when a *new* one would be most expensive to find, because it would surface as a runtime failure in the middle of flipping 116 packages.

## It classifies rather than counts

This is the whole design, and the reason the gate is usable.

A cycle is not a defect on its own. Under ESM the bindings are hoisted and live; the failure is a TDZ `ReferenceError`, and that only happens when a module **uses** a binding from a cyclic partner *while its own body is still evaluating*. If every use is inside a function that runs later, the cycle behaves exactly as it does under CommonJS.

This repo had **14 cycles and only 3 could break**. A gate that failed on all 14 would have been noise, and noise gets switched off. So it reports every cycle, fails only on the dangerous ones, and names the exact line that would throw:

```
check-import-cycles: 1 cycle(s) would throw under ESM, of 1 in 2 files

  2 files:
      packages/p/source/a.ts
      packages/p/source/b.ts
    used while the module body is still evaluating:
      packages/p/source/a.ts:2  B   (extends/implements)
```

Dangerous means a **class heritage clause** or a **module-scope initializer** — which are exactly the three shapes this repo actually had:

| shape | where it was |
|---|---|
| `class X extends Y` across a cycle | `node-opcua-address-space`, 8 files |
| a module-scope map of constructors | `namespace_impl._constructors_map` |
| a module-scope loop over an imported table | `opcua_status_code` + the generated codes |

All three are in the unit tests as fixtures.

## Edges, and two easy mistakes

- `import "./m.js"` — **an edge**. No bindings at all, but it forces the target to evaluate. My first implementation missed this; the tests caught it.
- `import { type X } from "./m.js"` — **not an edge**. TypeScript elides the whole statement when nothing in the clause survives, so there is no runtime import. My first implementation got this wrong in the other direction, counting an edge that does not exist, which would have produced a phantom cycle.

Both are now pinned by tests.

## Implementation notes

**Tarjan is iterative.** The recursive form overflows the default stack on a graph this size — my throwaway analysis needed `--stack-size=8000` — and a CI step should not depend on that flag. There is a test with a 20 000-node chain.

**Parser-based**, like `check-no-tla` and `check-import-extension`, because deciding whether a use is at module scope is a scope question, and telling `import type` from `import` cannot be done with text.

**Escape hatch**: `// check-import-cycles: ok - <reason>` on any member file downgrades a cycle, for the case where one is genuinely intended.

## Verification

| check | result |
|---|---|
| unit tests | **16/16** |
| against master | 2300 files, **13 cycles, none that ESM would reject** |
| matches the throwaway analysis that found the original 3 | yes, same 13 |
| deliberately broken fixture tree | exits 1, names the heritage clause |
| `pnpm run lint` | clean |

Wired into the `lint` job, alongside the other gates.

## Rest of FEAT-6

Still to come, all 2.x and non-breaking: **126 `.js` test files** to port to TypeScript (they carry 410 of the 534 `require()` calls in test trees), **599** extensionless specifiers in test trees, and **229** `__dirname` uses to concentrate. Those are what currently block FEAT-2, since a `.js` file inside a `"type": "module"` package is an ES module and its suite stops loading the moment its package flips.
