### PR TITLE
refactor(tests): replace the last require() calls in the test trees

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -99,6 +99,7 @@ jobs:
       # (a class heritage clause, a module-scope initializer). Of the 14 cycles this repo
       # had, 11 were harmless and flagging those would have made the gate noise.
       - run: pnpm run check:cycles
+      - run: pnpm run check:identity
       - name: Unit tests for the cycle rule
         run: node tools/check-import-cycles/test/test_rule.js
       # Raw private-key access is being migrated to the opaque key-operations

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "check:importext:fix": "node tools/check-import-extension.mjs --fix",
     "check:pack": "node tools/check-pack.mjs",
     "check:cycles": "node tools/check-import-cycles.mjs",
+    "check:identity": "node tools/check-module-identity.mjs",
     "check:cycles:all": "node tools/check-import-cycles.mjs --all",
     "check:consumers": "node fixtures/consumer-cjs/index.cjs && node fixtures/consumer-esm/index.mjs",
     "preinstall": "node prevent_npm_install.js",

--- a/packages/node-opcua-address-space/test/test_address_space_add_two_state_variable.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_add_two_state_variable.ts
@@ -5,8 +5,8 @@ import { StatusCodes } from "node-opcua-status-code";
 import should from "should";
 import sinon from "sinon";
 import { AddressSpace, type BaseNode, type Namespace } from "..";
+import { UATwoStateVariableImpl } from "../dist/src/state_machine/ua_two_state_variable.js";
 import { generateAddressSpace } from "../nodeJS.js";
-import { UATwoStateVariableImpl } from "../src/state_machine/ua_two_state_variable.js";
 
 let clock: sinon.SinonFakeTimers | null = null;
 

--- a/packages/node-opcua-address-space/test/test_address_space_dispose.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_dispose.ts
@@ -2,13 +2,13 @@ import fs from "node:fs";
 import path from "node:path";
 import "should";
 
+import h from "humanize";
 import { AddressSpace } from "..";
 import { generateAddressSpace } from "../nodeJS.js";
 
 function dumpMemoryUse() {
     if (process.memoryUsage) {
         const m = process.memoryUsage();
-        const h = require("humanize");
         console.log(
             " memoryUsage = ",
             " rss =",

--- a/packages/node-opcua-address-space/test/test_isArgumentValid.ts
+++ b/packages/node-opcua-address-space/test/test_isArgumentValid.ts
@@ -5,8 +5,8 @@ import { Argument } from "node-opcua-types";
 import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
 import should from "should";
 import { AddressSpace, type Namespace } from "..";
+import { isArgumentValid } from "../dist/source/helpers/argument_list.js";
 import { generateAddressSpace } from "../nodeJS.js";
-import { isArgumentValid } from "../source/helpers/argument_list.js";
 
 const nodesetFilename = path.join(__dirname, "../nodesets/mini.Nodeset2.xml");
 

--- a/packages/node-opcua-address-space/test/test_issue_105.ts
+++ b/packages/node-opcua-address-space/test/test_issue_105.ts
@@ -2,7 +2,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import type { AddressSpace, Namespace } from "../";
 import { assertHasMatchingReference, getMiniAddressSpace } from "../testHelpers.js";
 
-const { createTemperatureSensorType } = require("./fixture_temperature_sensor_type");
+import { createTemperatureSensorType } from "./fixture_temperature_sensor_type.js";
 
 describe("testing github issue https://github.com/node-opcua/node-opcua/issues/105", () => {
     let addressSpace: AddressSpace;

--- a/packages/node-opcua-address-space/test/test_nodeset_to_xml.ts
+++ b/packages/node-opcua-address-space/test/test_nodeset_to_xml.ts
@@ -10,13 +10,12 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import { ThreeDCartesianCoordinates } from "node-opcua-types";
 import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
+import XMLWriter from "xml-writer";
 import { AddressSpace, type BaseNode, type Namespace, type UARootFolder, type UAVariable } from "..";
 import { generateAddressSpace } from "../nodeJS.js";
 import { createBoilerType, getMiniAddressSpace } from "../testHelpers.js";
-
-const XMLWriter = require("xml-writer");
-const { createTemperatureSensorType } = require("./fixture_temperature_sensor_type");
-const { createCameraType } = require("./fixture_camera_type");
+import { createCameraType } from "./fixture_camera_type.js";
+import { createTemperatureSensorType } from "./fixture_temperature_sensor_type.js";
 
 interface BaseNodeWithDumpXML {
     dumpXML(xw: unknown): void;

--- a/packages/node-opcua-address-space/test/test_xml_decode.ts
+++ b/packages/node-opcua-address-space/test/test_xml_decode.ts
@@ -7,8 +7,8 @@ import { DataType } from "node-opcua-variant";
 import { Xml2Json } from "node-opcua-xml2json";
 
 import { AddressSpace } from "..";
+import { makeXmlExtensionObjectReader } from "../dist/source/loader/make_xml_extension_object_parser.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
-import { makeXmlExtensionObjectReader } from "../source/loader/make_xml_extension_object_parser.js";
 
 describe("test xml decode", () => {
     let addressSpace: AddressSpace;

--- a/packages/node-opcua-chunkmanager/benchmark/bench_padding.ts
+++ b/packages/node-opcua-chunkmanager/benchmark/bench_padding.ts
@@ -1,4 +1,4 @@
-import { Benchmarker } from "../../node-opcua-benchmarker/source/benchmarker";
+import { Benchmarker } from "node-opcua-benchmarker";
 import { ChunkManager, Mode } from "../source/chunk_manager";
 
 const bench = new Benchmarker();

--- a/packages/node-opcua-client-dynamic-extension-object/test/test_lazy_loading.ts
+++ b/packages/node-opcua-client-dynamic-extension-object/test/test_lazy_loading.ts
@@ -5,9 +5,9 @@ import { DataTypeFactory, getStandardDataTypeFactory } from "node-opcua-factory"
 import { NodeId, resolveNodeId } from "node-opcua-nodeid";
 import type { IBasicSessionAsync2 } from "node-opcua-pseudo-session";
 import { type StatusCode, StatusCodes } from "node-opcua-status-code";
+import { StructureDefinition } from "node-opcua-types";
 import { ExtraDataTypeManager } from "../source/extra_data_type_manager.js";
-
-const { StructureDefinition } = require("node-opcua-types");
+import { serverImplementsDataTypeDefinition } from "../source/populate_data_type_manager.js";
 
 enum NodeClass {
     Object = 1,
@@ -340,7 +340,6 @@ describe("ExtraDataTypeManager Lazy Loading Robust", () => {
     });
 
     it("should optimize serverImplementsDataTypeDefinition", async () => {
-        const { serverImplementsDataTypeDefinition } = require("../source/populate_data_type_manager");
         const addressSpace = new MockAddressSpace();
 
         const structureRootId = resolveNodeId(DataTypeIds.Structure);

--- a/packages/node-opcua-client/test/test_issue_931.ts
+++ b/packages/node-opcua-client/test/test_issue_931.ts
@@ -4,7 +4,8 @@ import { MessageSecurityMode, OPCUAClient, type OPCUAClientOptions, SecurityPoli
 
 const debugLog = make_debugLog("TEST");
 
-const describe = require("node-opcua-leak-detector").describeWithLeakDetector;
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+
 async function wait(t: number) {
     return await new Promise((resolve) => setTimeout(resolve, t));
 }

--- a/packages/node-opcua-end2end-test/test/discovery/test_discovery.ts
+++ b/packages/node-opcua-end2end-test/test/discovery/test_discovery.ts
@@ -2,6 +2,11 @@ import path from "node:path";
 import { OPCUACertificateManager, OPCUAClientBase, OPCUAServer } from "node-opcua";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import type { TestHarness } from "./helpers/harness.js";
+import { t as tDiscoveryServer } from "./u_test_discovery_server.js";
+import { t as tFrequentServerRestart } from "./u_test_frequent_server_restart.js";
+import { t as tMultipleDiscoveryServersAndMdns } from "./u_test_multiple_discovery_servers_and_mdns.js";
+import { t as tOpcuaClientServerFindservers } from "./u_test_opcua_ClientServer_findservers.js";
+import { t as tRegistrationServerManager } from "./u_test_registration_server_manager.js";
 
 describe("testing DiscoveryServer - Umbrella ", function (this: Mocha.Runnable & TestHarness) {
     before(async () => {
@@ -35,9 +40,9 @@ describe("testing DiscoveryServer - Umbrella ", function (this: Mocha.Runnable &
     });
 
     // typescripts tests starts here...
-    require("./u_test_discovery_server").t(this);
-    require("./u_test_frequent_server_restart").t(this);
-    require("./u_test_multiple_discovery_servers_and_mdns").t(this);
-    require("./u_test_opcua_ClientServer_findservers").t(this);
-    require("./u_test_registration_server_manager").t(this);
+    tDiscoveryServer(this);
+    tFrequentServerRestart(this);
+    tMultipleDiscoveryServersAndMdns(this);
+    tOpcuaClientServerFindservers(this);
+    tRegistrationServerManager(this);
 });

--- a/packages/node-opcua-end2end-test/test/end_to_end/_helper_umbrella.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/_helper_umbrella.ts
@@ -24,6 +24,20 @@ import {
 } from "../../test_helpers/external_server_fixture.js";
 
 // Shape used by umbrella tests (they pass 'this' mocha context)
+/**
+ * The context once beforeTest() has populated it.
+ *
+ * The fields are optional on UmbrellaTestContext because they genuinely are absent until
+ * the before hook runs. Each u_test_* module, by contrast, declares only the fields its
+ * suite needs and declares them required - which is also correct, because no it() body runs
+ * before that hook. This names the boundary between the two once, instead of asserting it
+ * at every one of the ~90 call sites.
+ *
+ * require() used to hide this: the module was `any`, so t(test) accepted anything.
+ */
+export type ReadyUmbrellaTestContext = UmbrellaTestContext &
+    Required<Pick<UmbrellaTestContext, "endpointUrl" | "server" | "serverCertificate" | "temperatureVariableId">>;
+
 export interface UmbrellaTestContext extends Mocha.Context {
     port: number | string | undefined;
     endpointUrl?: string;

--- a/packages/node-opcua-end2end-test/test/end_to_end/alarms_and_conditions/u_test_e2e_alarm_client_side.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/alarms_and_conditions/u_test_e2e_alarm_client_side.ts
@@ -82,7 +82,10 @@ function displayAlarms(alarms: ClientAlarmList) {
     console.log("-----");
 }
 
-export function t(test: AlarmTestContext) {
+export function t(umbrellaTest: UmbrellaTestContext) {
+    // construct_demo_alarm_in_address_space attaches the IAlarmTestData fields, and it is
+    // this module that calls it, so the widening belongs here and not at the caller.
+    const test = umbrellaTest as AlarmTestContext;
     describe("A&C3 client side alarm monitoring", () => {
         let client: OPCUAClient;
         function resetConditions(test: AlarmTestContext) {

--- a/packages/node-opcua-end2end-test/test/end_to_end/alarms_and_conditions/u_test_e2e_conditions.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/alarms_and_conditions/u_test_e2e_conditions.ts
@@ -52,7 +52,12 @@ const stepInfo = (str: string) => {
         console.log(chalk.yellow("   --> ") + chalk.cyan(str));
     }
 };
-export function t(test: AlarmConditionsTestContext) {
+export function t(umbrellaTest: UmbrellaTestContext) {
+    // given_an_installed_event_monitored_item attaches monitoredItem1 and the spy, and the
+    // demo alarm fixture attaches the IAlarmTestData fields. Both belong to this module, so
+    // the widening happens here rather than at the caller: t() can only ask for what an
+    // umbrella is able to hand it.
+    const test = umbrellaTest as AlarmConditionsTestContext;
     describe("A&C monitoring conditions", () => {
         let client: OPCUAClient;
 

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_history_read_extension_object.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_history_read_extension_object.ts
@@ -34,7 +34,7 @@ interface RfidScanResultLike {
     scanData: { epc: { PC: number } };
 }
 
-const describe = require("node-opcua-leak-detector").describeWithLeakDetector;
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 
 const port = 2248;
 

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesA.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesA.ts
@@ -1,6 +1,11 @@
 import "should";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
-import { afterEachTest, afterTest, beforeEachTest, beforeTest, type UmbrellaTestContext } from "./_helper_umbrella.js";
+import { afterEachTest, afterTest, beforeEachTest, beforeTest, type ReadyUmbrellaTestContext } from "./_helper_umbrella.js";
+import { t as tE2eReadHistoryServerCapabilities } from "./u_test_e2e_ read_history_server_capabilities.js";
+import { t as tE2eClientSessionReadVariableValue } from "./u_test_e2e_ClientSession_readVariableValue.js";
+import { t as tE2eCallService } from "./u_test_e2e_call_service.js";
+import { t as tE2eClient } from "./u_test_e2e_client.js";
+import { t as tE2eClientNodeCrawler } from "./u_test_e2e_client_node_crawler.js";
 
 const port = 1311;
 
@@ -9,7 +14,7 @@ describe("testing Client - Umbrella-A ", function (this: Mocha.Context) {
     this.timeout(process.arch === "arm" ? 400000 : 30000);
     this.timeout(Math.max(200000, this.timeout()));
 
-    const test = this as UmbrellaTestContext;
+    const test = this as ReadyUmbrellaTestContext;
     test.port = port;
 
     before(async () => beforeTest(test));
@@ -18,9 +23,9 @@ describe("testing Client - Umbrella-A ", function (this: Mocha.Context) {
     after(async () => afterTest(test));
 
     // Load individual test modules (each exports function t(test))
-    require("./u_test_e2e_client").t(test);
-    require("./u_test_e2e_call_service").t(test);
-    require("./u_test_e2e_ClientSession_readVariableValue").t(test);
-    require("./u_test_e2e_client_node_crawler").t(test);
-    require("./u_test_e2e_ read_history_server_capabilities").t(test);
+    tE2eClient(test);
+    tE2eCallService(test);
+    tE2eClientSessionReadVariableValue(test);
+    tE2eClientNodeCrawler(test);
+    tE2eReadHistoryServerCapabilities(test);
 });

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesB.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesB.ts
@@ -1,6 +1,24 @@
 import "should";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
-import { afterEachTest, afterTest, beforeEachTest, beforeTest, type UmbrellaTestContext } from "./_helper_umbrella.js";
+import { afterEachTest, afterTest, beforeEachTest, beforeTest, type ReadyUmbrellaTestContext } from "./_helper_umbrella.js";
+import { t as tE2eAlarmClientSide } from "./alarms_and_conditions/u_test_e2e_alarm_client_side.js";
+import { t as tE2eConditions } from "./alarms_and_conditions/u_test_e2e_conditions.js";
+import { t as tE2eCreatesSessionEndpoints } from "./u_test_e2e_createsSession_endpoints.js";
+import { t as tE2eDeadbandFilter } from "./u_test_e2e_deadband_filter.js";
+import { t as tE2eEndpointShouldBeCaseInsensitive } from "./u_test_e2e_endpoint_should_be_case_insensitive.js";
+import { t as tE2eIssue610TimeoutHintOverflow } from "./u_test_e2e_issue_610_timeoutHint_overflow.js";
+import { t as tE2eIssueActivateAnExpiredSession } from "./u_test_e2e_issue_activate_an_expired_session.js";
+import { t as tE2eKeepAlive } from "./u_test_e2e_keepAlive.js";
+import { t as tE2eMonitoredItemClientTerminatedEvent } from "./u_test_e2e_monitoredItem_client_terminated_event.js";
+import { t as tE2eMonitoringLargerNumber2 } from "./u_test_e2e_monitoring_larger_number2.js";
+import { t as tE2eSubscriptionModifySubscription } from "./u_test_e2e_Subscription_modify_subscription.js";
+import { t as tE2eServerBehaviorOnWrongChannelId } from "./u_test_e2e_server_behavior_on_wrong_channel_id.js";
+import { t as tE2eSessionDiagnostics } from "./u_test_e2e_sessionDiagnostics.js";
+import { t as tE2eSessionDiagnostics2 } from "./u_test_e2e_sessionDiagnostics2.js";
+import { t as tE2eSessionSecurityDiagnostics } from "./u_test_e2e_sessionSecurityDiagnostics.js";
+import { t as tE2eSetTriggering } from "./u_test_e2e_set_triggering.js";
+import { t as tE2eTestAccessingServiceBeforeSessionIsActivated } from "./u_test_e2e_test_accessing_service_before_session_is_activated.js";
+import { t as tE2eWriteLargeArrayRange } from "./u_test_e2e_write_large_array_range.js";
 
 const port = 1999;
 
@@ -9,7 +27,7 @@ describe("testing Client - Umbrella-B ", function (this: Mocha.Context) {
     this.timeout(process.arch === "arm" ? 400000 : 30000);
     this.timeout(Math.max(200000, this.timeout()));
 
-    const test = this as UmbrellaTestContext;
+    const test = this as ReadyUmbrellaTestContext;
     test.port = port;
 
     before(async () => beforeTest(test));
@@ -18,22 +36,22 @@ describe("testing Client - Umbrella-B ", function (this: Mocha.Context) {
     after(async () => afterTest(test));
 
     // typescripts tests starts here...
-    require("./u_test_e2e_issue_610_timeoutHint_overflow").t(test);
-    require("./u_test_e2e_sessionDiagnostics").t(test);
-    require("./u_test_e2e_sessionDiagnostics2").t(test);
-    require("./u_test_e2e_sessionSecurityDiagnostics").t(test);
-    require("./u_test_e2e_issue_activate_an_expired_session").t(test);
-    require("./u_test_e2e_server_behavior_on_wrong_channel_id").t(test);
-    require("./u_test_e2e_test_accessing_service_before_session_is_activated").t(test);
-    require("./alarms_and_conditions/u_test_e2e_conditions").t(test);
-    require("./alarms_and_conditions/u_test_e2e_alarm_client_side").t(test);
-    require("./u_test_e2e_monitoredItem_client_terminated_event").t(test);
-    require("./u_test_e2e_endpoint_should_be_case_insensitive").t(test);
-    require("./u_test_e2e_keepAlive").t(test);
-    require("./u_test_e2e_createsSession_endpoints").t(test);
-    require("./u_test_e2e_deadband_filter").t(test);
-    require("./u_test_e2e_set_triggering").t(test);
-    require("./u_test_e2e_write_large_array_range").t(test);
-    require("./u_test_e2e_Subscription_modify_subscription").t(test);
-    require("./u_test_e2e_monitoring_larger_number2").t(test);
+    tE2eIssue610TimeoutHintOverflow(test);
+    tE2eSessionDiagnostics(test);
+    tE2eSessionDiagnostics2(test);
+    tE2eSessionSecurityDiagnostics(test);
+    tE2eIssueActivateAnExpiredSession(test);
+    tE2eServerBehaviorOnWrongChannelId(test);
+    tE2eTestAccessingServiceBeforeSessionIsActivated(test);
+    tE2eConditions(test);
+    tE2eAlarmClientSide(test);
+    tE2eMonitoredItemClientTerminatedEvent(test);
+    tE2eEndpointShouldBeCaseInsensitive(test);
+    tE2eKeepAlive(test);
+    tE2eCreatesSessionEndpoints(test);
+    tE2eDeadbandFilter(test);
+    tE2eSetTriggering(test);
+    tE2eWriteLargeArrayRange(test);
+    tE2eSubscriptionModifySubscription(test);
+    tE2eMonitoringLargerNumber2(test);
 });

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesC.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesC.ts
@@ -1,6 +1,25 @@
 import "should";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
-import { afterEachTest, afterTest, beforeEachTest, beforeTest, type UmbrellaTestContext } from "./_helper_umbrella.js";
+import { afterEachTest, afterTest, beforeEachTest, beforeTest, type ReadyUmbrellaTestContext } from "./_helper_umbrella.js";
+import { t as tE2eBrowseRequestIssue } from "./u_test_e2e_browse_request_issue.js";
+import { t as tE2eClosingUnactivatedSession } from "./u_test_e2e_closing_unactivated_session.js";
+import { t as tE2eIssue223DemonstrateClientCallService } from "./u_test_e2e_issue_223_demonstrate_client_call_service.js";
+import { t as tE2eIssue231ProtocolVersion } from "./u_test_e2e_issue_231_protocolVersion.js";
+import { t as tE2eIssue233 } from "./u_test_e2e_issue_233.js";
+import { t as tE2eIssue273 } from "./u_test_e2e_issue_273.js";
+import { t as tE2eIssue313 } from "./u_test_e2e_issue_313.js";
+import { t as tE2eIssue355 } from "./u_test_e2e_issue_355.js";
+import { t as tE2eIssue377 } from "./u_test_e2e_issue_377.js";
+import { t as tE2eIssue417 } from "./u_test_e2e_issue_417.js";
+import { t as tE2eIssue433 } from "./u_test_e2e_issue_433.js";
+import { t as tE2eIssue455 } from "./u_test_e2e_issue_455.js";
+import { t as tE2eIssue596 } from "./u_test_e2e_issue_596.js";
+import { t as tE2eMonitoredItemSemanticChanged } from "./u_test_e2e_monitored_item_semantic_changed.js";
+import { t as tE2eSubscriptionTransfer } from "./u_test_e2e_Subscription_Transfer.js";
+import { t as tE2eSubscriptionDiagnostics } from "./u_test_e2e_SubscriptionDiagnostics.js";
+import { t as tE2eServerConnectionWith500Sessions } from "./u_test_e2e_server_connection_with_500_sessions.js";
+import { t as tE2eSessionAuditEvents } from "./u_test_e2e_session_audit_events.js";
+import { t as tE2eTimeoutSession } from "./u_test_e2e_timeout_session.js";
 
 const port = 2522;
 
@@ -9,7 +28,7 @@ describe("testing Client - Umbrella-C", function (this: Mocha.Context) {
     this.timeout(process.arch === "arm" ? 400000 : 30000);
     this.timeout(Math.max(200000, this.timeout()));
 
-    const test = this as UmbrellaTestContext;
+    const test = this as ReadyUmbrellaTestContext;
     test.port = port;
 
     before(async () => beforeTest(test));
@@ -18,23 +37,23 @@ describe("testing Client - Umbrella-C", function (this: Mocha.Context) {
     after(async () => afterTest(test));
 
     // Register grouped end-to-end sub-tests
-    require("./u_test_e2e_server_connection_with_500_sessions").t(test);
-    require("./u_test_e2e_SubscriptionDiagnostics").t(test);
-    require("./u_test_e2e_browse_request_issue").t(test);
-    require("./u_test_e2e_timeout_session").t(test);
-    require("./u_test_e2e_session_audit_events").t(test);
-    require("./u_test_e2e_closing_unactivated_session").t(test);
-    require("./u_test_e2e_issue_223_demonstrate_client_call_service").t(test);
-    require("./u_test_e2e_Subscription_Transfer").t(test);
-    require("./u_test_e2e_issue_231_protocolVersion").t(test);
-    require("./u_test_e2e_monitored_item_semantic_changed").t(test);
-    require("./u_test_e2e_issue_233").t(test);
-    require("./u_test_e2e_issue_273").t(test);
-    require("./u_test_e2e_issue_313").t(test);
-    require("./u_test_e2e_issue_355").t(test);
-    require("./u_test_e2e_issue_377").t(test);
-    require("./u_test_e2e_issue_417").t(test);
-    require("./u_test_e2e_issue_433").t(test);
-    require("./u_test_e2e_issue_455").t(test);
-    require("./u_test_e2e_issue_596").t(test);
+    tE2eServerConnectionWith500Sessions(test);
+    tE2eSubscriptionDiagnostics(test);
+    tE2eBrowseRequestIssue(test);
+    tE2eTimeoutSession(test);
+    tE2eSessionAuditEvents(test);
+    tE2eClosingUnactivatedSession(test);
+    tE2eIssue223DemonstrateClientCallService(test);
+    tE2eSubscriptionTransfer(test);
+    tE2eIssue231ProtocolVersion(test);
+    tE2eMonitoredItemSemanticChanged(test);
+    tE2eIssue233(test);
+    tE2eIssue273(test);
+    tE2eIssue313(test);
+    tE2eIssue355(test);
+    tE2eIssue377(test);
+    tE2eIssue417(test);
+    tE2eIssue433(test);
+    tE2eIssue455(test);
+    tE2eIssue596(test);
 });

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesD.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesD.ts
@@ -1,6 +1,13 @@
 import "should";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
-import { afterEachTest, afterTest, beforeEachTest, beforeTest, type UmbrellaTestContext } from "./_helper_umbrella.js";
+import { afterEachTest, afterTest, beforeEachTest, beforeTest, type ReadyUmbrellaTestContext } from "./_helper_umbrella.js";
+import { t as tE2eClientMonitoredItemGroup } from "./u_test_e2e_ClientMonitoredItemGroup.js";
+import { t as tE2eCttModifyMonitoredItems010 } from "./u_test_e2e_ctt_modifyMonitoredItems010.js";
+import { t as tE2eMonitoredItemWithTimestampSourceIssue804 } from "./u_test_e2e_monitored_item_with_timestamp_source_issue#804.js";
+import { t as tE2eMonitoringLargeNumberOfNodes } from "./u_test_e2e_monitoring_large_number_of_nodes.js";
+import { t as tE2eRegisterNodes } from "./u_test_e2e_registerNodes.js";
+import { t as tE2eTransferSession } from "./u_test_e2e_transfer_session.js";
+import { t as tE2eWriteUseCase } from "./u_test_e2e_writeUseCase.js";
 
 const port = 1997;
 
@@ -9,7 +16,7 @@ describe("testing Client - Umbrella-D ", function (this: Mocha.Context) {
     this.timeout(process.arch === "arm" ? 400000 : 30000);
     this.timeout(Math.max(200000, this.timeout()));
 
-    const test = this as UmbrellaTestContext;
+    const test = this as ReadyUmbrellaTestContext;
     test.port = port;
 
     before(async () => beforeTest(test));
@@ -18,11 +25,11 @@ describe("testing Client - Umbrella-D ", function (this: Mocha.Context) {
     after(async () => afterTest(test));
 
     // Sub-test registrations
-    require("./u_test_e2e_monitoring_large_number_of_nodes").t(test);
-    require("./u_test_e2e_ClientMonitoredItemGroup").t(test);
-    require("./u_test_e2e_writeUseCase").t(test);
-    require("./u_test_e2e_transfer_session").t(test);
-    require("./u_test_e2e_registerNodes").t(test);
-    require("./u_test_e2e_ctt_modifyMonitoredItems010").t(test);
-    require("./u_test_e2e_monitored_item_with_timestamp_source_issue#804").t(test);
+    tE2eMonitoringLargeNumberOfNodes(test);
+    tE2eClientMonitoredItemGroup(test);
+    tE2eWriteUseCase(test);
+    tE2eTransferSession(test);
+    tE2eRegisterNodes(test);
+    tE2eCttModifyMonitoredItems010(test);
+    tE2eMonitoredItemWithTimestampSourceIssue804(test);
 });

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesE.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesE.ts
@@ -1,6 +1,7 @@
 import "should";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
-import { afterEachTest, afterTest, beforeEachTest, beforeTest, type UmbrellaTestContext } from "./_helper_umbrella.js";
+import { afterEachTest, afterTest, beforeEachTest, beforeTest, type ReadyUmbrellaTestContext } from "./_helper_umbrella.js";
+import { t as tE2eSubscriptionUseCase } from "./u_test_e2e_SubscriptionUseCase.js";
 
 const port = 1996;
 
@@ -9,7 +10,7 @@ describe("testing Client - Umbrella-E ", function (this: Mocha.Context) {
     this.timeout(process.arch === "arm" ? 400000 : 30000);
     this.timeout(Math.max(200000, this.timeout()));
 
-    const test = this as UmbrellaTestContext;
+    const test = this as ReadyUmbrellaTestContext;
     test.port = port;
 
     before(async () => beforeTest(test));
@@ -17,5 +18,5 @@ describe("testing Client - Umbrella-E ", function (this: Mocha.Context) {
     afterEach(async () => afterEachTest(test));
     after(async () => afterTest(test));
 
-    require("./u_test_e2e_SubscriptionUseCase").t(test);
+    tE2eSubscriptionUseCase(test);
 });

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesF.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesF.ts
@@ -1,6 +1,14 @@
 import "should";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
-import { afterEachTest, afterTest, beforeEachTest, beforeTest, type UmbrellaTestContext } from "./_helper_umbrella.js";
+import { afterEachTest, afterTest, beforeEachTest, beforeTest, type ReadyUmbrellaTestContext } from "./_helper_umbrella.js";
+import { t as tE2eIssue123 } from "./u_test_e2e_issue_123.js";
+import { t as tE2eIssue135CurrentMonitoredItemsCount } from "./u_test_e2e_issue_135_currentMonitoredItemsCount.js";
+import { t as tE2eIssue144 } from "./u_test_e2e_issue_144.js";
+import { t as tE2eIssue156 } from "./u_test_e2e_issue_156.js";
+import { t as tE2eIssue163 } from "./u_test_e2e_issue_163.js";
+import { t as tE2eIssue192 } from "./u_test_e2e_issue_192.js";
+import { t as tE2eIssue195 } from "./u_test_e2e_issue_195.js";
+import { t as tE2eIssue198 } from "./u_test_e2e_issue_198.js";
 
 const port = 1995;
 
@@ -9,7 +17,7 @@ describe("testing Client - Umbrella-F", function (this: Mocha.Context) {
     this.timeout(process.arch === "arm" ? 400_000 : 20_000);
     this.timeout(Math.max(200_000, this.timeout()));
 
-    const test = this as UmbrellaTestContext;
+    const test = this as ReadyUmbrellaTestContext;
     test.port = port;
 
     before(async () => beforeTest(test));
@@ -18,12 +26,12 @@ describe("testing Client - Umbrella-F", function (this: Mocha.Context) {
     after(async () => afterTest(test));
 
     // OPCUA Event Monitoring test cases
-    require("./u_test_e2e_issue_144").t(test);
-    require("./u_test_e2e_issue_156").t(test);
-    require("./u_test_e2e_issue_123").t(test);
-    require("./u_test_e2e_issue_163").t(test);
-    require("./u_test_e2e_issue_135_currentMonitoredItemsCount").t(test);
-    require("./u_test_e2e_issue_192").t(test);
-    require("./u_test_e2e_issue_195").t(test);
-    require("./u_test_e2e_issue_198").t(test);
+    tE2eIssue144(test);
+    tE2eIssue156(test);
+    tE2eIssue123(test);
+    tE2eIssue163(test);
+    tE2eIssue135CurrentMonitoredItemsCount(test);
+    tE2eIssue192(test);
+    tE2eIssue195(test);
+    tE2eIssue198(test);
 });

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesG.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesG.ts
@@ -1,6 +1,8 @@
 import "should";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
-import { afterEachTest, afterTest, beforeEachTest, beforeTest, type UmbrellaTestContext } from "./_helper_umbrella.js";
+import { afterEachTest, afterTest, beforeEachTest, beforeTest, type ReadyUmbrellaTestContext } from "./_helper_umbrella.js";
+import { t as tE2e1086 } from "./u_test_e2e_1086.js";
+import { t as tE2eIssue1018GetMonitoredItems } from "./u_test_e2e_issue1018_getMonitoredItems.js";
 
 const port = 1989;
 
@@ -9,7 +11,7 @@ describe("testing Client - Umbrella-G", function (this: Mocha.Context) {
     this.timeout(process.arch === "arm" ? 400_000 : 30_000);
     this.timeout(Math.max(200_000, this.timeout()));
 
-    const test = this as UmbrellaTestContext;
+    const test = this as ReadyUmbrellaTestContext;
     test.port = port;
 
     before(async () => beforeTest(test));
@@ -17,6 +19,6 @@ describe("testing Client - Umbrella-G", function (this: Mocha.Context) {
     afterEach(async () => afterEachTest(test));
     after(async () => afterTest(test));
 
-    require("./u_test_e2e_1086").t(test);
-    require("./u_test_e2e_issue1018_getMonitoredItems").t(test);
+    tE2e1086(test);
+    tE2eIssue1018GetMonitoredItems(test);
 });

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesH.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesH.ts
@@ -1,6 +1,10 @@
 import "should";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
-import { afterEachTest, afterTest, beforeEachTest, beforeTest, type UmbrellaTestContext } from "./_helper_umbrella.js";
+import { afterEachTest, afterTest, beforeEachTest, beforeTest, type ReadyUmbrellaTestContext } from "./_helper_umbrella.js";
+import { t as tE2eModifyMonitoredItemOnEvent } from "./u_test_e2e_modifyMonitoredItem_onEvent.js";
+import { t as tE2eMonitoredItemCtt018 } from "./u_test_e2e_monitored_item_ctt018.js";
+import { t as tE2eSubscriptionUseCaseMonitoringEvents } from "./u_test_e2e_SubscriptionUseCase_monitoring_events.js";
+import { t as tE2eServerWith500Clients } from "./u_test_e2e_server_with_500_clients.js";
 
 const port = 1994;
 
@@ -8,7 +12,7 @@ describe("testing Client - Umbrella-H", function (this: Mocha.Context) {
     this.timeout(process.arch === "arm" ? 400_000 : 30_000);
     this.timeout(Math.max(200_000, this.timeout()));
 
-    const test = this as UmbrellaTestContext;
+    const test = this as ReadyUmbrellaTestContext;
     test.port = port;
 
     before(async () => beforeTest(test));
@@ -16,8 +20,8 @@ describe("testing Client - Umbrella-H", function (this: Mocha.Context) {
     afterEach(async () => afterEachTest(test));
     after(async () => afterTest(test));
 
-    require("./u_test_e2e_SubscriptionUseCase_monitoring_events").t(test);
-    require("./u_test_e2e_monitored_item_ctt018").t(test);
-    require("./u_test_e2e_server_with_500_clients").t(test);
-    require("./u_test_e2e_modifyMonitoredItem_onEvent").t(test);
+    tE2eSubscriptionUseCaseMonitoringEvents(test);
+    tE2eMonitoredItemCtt018(test);
+    tE2eServerWith500Clients(test);
+    tE2eModifyMonitoredItemOnEvent(test);
 });

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesI.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesI.ts
@@ -1,6 +1,13 @@
 import "should";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
-import { afterEachTest, afterTest, beforeEachTest, beforeTest, type UmbrellaTestContext } from "./_helper_umbrella.js";
+import { afterEachTest, afterTest, beforeEachTest, beforeTest, type ReadyUmbrellaTestContext } from "./_helper_umbrella.js";
+import { t as tE2eBrowseRequest } from "./u_test_e2e_BrowseRequest.js";
+import { t as tE2eBrowseRead } from "./u_test_e2e_browse_read.js";
+import { t as tE2eCtt5102Test7 } from "./u_test_e2e_ctt_5.10.2_test7.js";
+import { t as tE2eCtt5105Test3 } from "./u_test_e2e_ctt_5.10.5_test3.js";
+import { t as tE2eCtt582022 } from "./u_test_e2e_ctt_582022.js";
+import { t as tE2eIssue445CurrentSessionCount } from "./u_test_e2e_issue_445_currentSessionCount.js";
+import { t as tE2eSecurityUsernamePassword } from "./u_test_e2e_security_username_password.js";
 
 const port = 1978;
 
@@ -8,7 +15,7 @@ describe("testing Client - Umbrella-I", function (this: Mocha.Context) {
     this.timeout(process.arch === "arm" ? 400_000 : 30_000);
     this.timeout(Math.max(30_000, this.timeout()));
 
-    const test = this as UmbrellaTestContext;
+    const test = this as ReadyUmbrellaTestContext;
     test.port = port;
 
     before(async () => beforeTest(test));
@@ -16,11 +23,11 @@ describe("testing Client - Umbrella-I", function (this: Mocha.Context) {
     afterEach(async () => afterEachTest(test));
     after(async () => afterTest(test));
 
-    require("./u_test_e2e_issue_445_currentSessionCount").t(test);
-    require("./u_test_e2e_browse_read").t(test);
-    require("./u_test_e2e_ctt_582022").t(test);
-    require("./u_test_e2e_ctt_5.10.5_test3").t(test);
-    require("./u_test_e2e_ctt_5.10.2_test7").t(test);
-    require("./u_test_e2e_BrowseRequest").t(test);
-    require("./u_test_e2e_security_username_password").t(test);
+    tE2eIssue445CurrentSessionCount(test);
+    tE2eBrowseRead(test);
+    tE2eCtt582022(test);
+    tE2eCtt5105Test3(test);
+    tE2eCtt5102Test7(test);
+    tE2eBrowseRequest(test);
+    tE2eSecurityUsernamePassword(test);
 });

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesJ.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesJ.ts
@@ -1,6 +1,16 @@
 import "should";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
-import { afterEachTest, afterTest, beforeEachTest, beforeTest, type UmbrellaTestContext } from "./_helper_umbrella.js";
+import { afterEachTest, afterTest, beforeEachTest, beforeTest, type ReadyUmbrellaTestContext } from "./_helper_umbrella.js";
+import { t as tE2eIssue73 } from "./u_test_e2e_issue_73.js";
+import { t as tE2eIssue119 } from "./u_test_e2e_issue_119.js";
+import { t as tE2eIssue141 } from "./u_test_e2e_issue_141.js";
+import { t as tE2eIssue146 } from "./u_test_e2e_issue_146.js";
+import { t as tE2eIssue205BetterSessionNames } from "./u_test_e2e_issue_205_betterSessionNames.js";
+import { t as tE2eIssue214StatusValueTimestamp } from "./u_test_e2e_issue_214_StatusValueTimestamp.js";
+import { t as tE2eIssue957 } from "./u_test_e2e_issue_957.js";
+import { t as tE2eMultipleDisconnection } from "./u_test_e2e_multiple_disconnection.js";
+import { t as tE2eReadWrite } from "./u_test_e2e_read_write.js";
+import { t as tE2eTranslateBrowsePath } from "./u_test_e2e_translateBrowsePath.js";
 
 const port = 1981;
 
@@ -8,7 +18,7 @@ describe("testing Client - Umbrella-J", function (this: Mocha.Context) {
     this.timeout(process.arch === "arm" ? 400_000 : 20_000);
     this.timeout(Math.max(200_000, this.timeout()));
 
-    const test = this as UmbrellaTestContext;
+    const test = this as ReadyUmbrellaTestContext;
     test.port = port;
 
     before(async () => beforeTest(test));
@@ -16,14 +26,14 @@ describe("testing Client - Umbrella-J", function (this: Mocha.Context) {
     afterEach(async () => afterEachTest(test));
     after(async () => afterTest(test));
 
-    require("./u_test_e2e_issue_205_betterSessionNames").t(test);
-    require("./u_test_e2e_issue_214_StatusValueTimestamp").t(test);
-    require("./u_test_e2e_translateBrowsePath").t(test);
-    require("./u_test_e2e_issue_73").t(test);
-    require("./u_test_e2e_issue_119").t(test);
-    require("./u_test_e2e_issue_141").t(test); // rather slow
-    require("./u_test_e2e_issue_146").t(test);
-    require("./u_test_e2e_read_write").t(test);
-    require("./u_test_e2e_issue_957").t(test);
-    require("./u_test_e2e_multiple_disconnection").t(test);
+    tE2eIssue205BetterSessionNames(test);
+    tE2eIssue214StatusValueTimestamp(test);
+    tE2eTranslateBrowsePath(test);
+    tE2eIssue73(test);
+    tE2eIssue119(test);
+    tE2eIssue141(test); // rather slow
+    tE2eIssue146(test);
+    tE2eReadWrite(test);
+    tE2eIssue957(test);
+    tE2eMultipleDisconnection(test);
 });

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesK.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_umbrella_e2e_seriesK.ts
@@ -1,6 +1,9 @@
 import "should";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
-import { afterEachTest, afterTest, beforeEachTest, beforeTest, type UmbrellaTestContext } from "./_helper_umbrella.js";
+import { afterEachTest, afterTest, beforeEachTest, beforeTest, type ReadyUmbrellaTestContext } from "./_helper_umbrella.js";
+import { t as tE2eIssue1375 } from "./u_test_e2e_issue_1375.js";
+import { t as tE2eMonitoredItemLongProcessing } from "./u_test_e2e_monitored_item_long_processing.js";
+import { t as tE2eSubscriptionUseCaseResendData } from "./u_test_e2e_SubscriptionUseCase_ResendData.js";
 
 const port = 1982;
 
@@ -8,7 +11,7 @@ describe("testing Client - Umbrella-K", function (this: Mocha.Context) {
     this.timeout(process.arch === "arm" ? 400_000 : 20_000);
     this.timeout(Math.max(200_000, this.timeout()));
 
-    const test = this as UmbrellaTestContext;
+    const test = this as ReadyUmbrellaTestContext;
     test.port = port;
 
     before(async () => beforeTest(test));
@@ -16,7 +19,7 @@ describe("testing Client - Umbrella-K", function (this: Mocha.Context) {
     afterEach(async () => afterEachTest(test));
     after(async () => afterTest(test));
 
-    require("./u_test_e2e_SubscriptionUseCase_ResendData").t(test);
-    require("./u_test_e2e_monitored_item_long_processing").t(test);
-    require("./u_test_e2e_issue_1375").t(test);
+    tE2eSubscriptionUseCaseResendData(test);
+    tE2eMonitoredItemLongProcessing(test);
+    tE2eIssue1375(test);
 });

--- a/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_createsSession_endpoints.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_createsSession_endpoints.ts
@@ -51,7 +51,8 @@ async function testCreateSessionResponse(
     // console.log("c", createSessionResponse.toString());
     return { createSessionResponse };
 }
-const describe = require("node-opcua-leak-detector").describeWithLeakDetector;
+
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 
 export function t(test: { endpointUrl: string }) {
     describe("PP1 CreateSessionResponse endpoints", () => {

--- a/packages/node-opcua-end2end-test/test_helpers/hvac_system.ts
+++ b/packages/node-opcua-end2end-test/test_helpers/hvac_system.ts
@@ -9,8 +9,8 @@ import type {
     UAObject,
     UAVariableT
 } from "node-opcua-address-space";
-import { adjustDataValueStatusCode } from "node-opcua-address-space/src/data_access/adjust_datavalue_status_code";
-import type { UAVariableImpl } from "node-opcua-address-space/src/ua_variable_impl";
+import { adjustDataValueStatusCode } from "node-opcua-address-space/dist/src/data_access/adjust_datavalue_status_code.js";
+import type { UAVariableImpl } from "node-opcua-address-space/dist/src/ua_variable_impl.js";
 import { assert } from "node-opcua-assert";
 
 const doDebug = false;

--- a/packages/node-opcua-factory/test/test_basic_type.ts
+++ b/packages/node-opcua-factory/test/test_basic_type.ts
@@ -1,5 +1,5 @@
-const { getBuiltInType, hasBuiltInType, findBuiltInType } = require("..");
-require("should");
+import { findBuiltInType, getBuiltInType, hasBuiltInType } from "..";
+import "should";
 
 describe("basic types: hasBuiltInType", () => {
     it("hasBuiltInType ", () => {

--- a/packages/node-opcua-leak-detector/test/fixtures/fixture_tsx.ts
+++ b/packages/node-opcua-leak-detector/test/fixtures/fixture_tsx.ts
@@ -1,7 +1,7 @@
 // Fixture: TypeScript test — requires tsx to load
 import assert from "node:assert";
 
-const { describeWithLeakDetector } = require("../../src/resource_leak_detector");
+import { describeWithLeakDetector } from "../../index.js";
 
 describeWithLeakDetector("fixture-tsx", () => {
     it("runs TypeScript syntax", () => {

--- a/packages/node-opcua-leak-detector/test/fixtures/fixture_tsx_leaked.ts
+++ b/packages/node-opcua-leak-detector/test/fixtures/fixture_tsx_leaked.ts
@@ -1,7 +1,7 @@
 // Fixture: TypeScript with leaked timer — proves tsx + leak combo exits
 import assert from "node:assert";
 
-const { describeWithLeakDetector } = require("../../src/resource_leak_detector");
+import { describeWithLeakDetector } from "../../index.js";
 
 describeWithLeakDetector("fixture-tsx-leaked", () => {
     it("TypeScript test with leaked timer", () => {

--- a/packages/node-opcua-leak-detector/test/test_leak_detector_tsx.ts
+++ b/packages/node-opcua-leak-detector/test/test_leak_detector_tsx.ts
@@ -15,7 +15,7 @@
 
 import assert from "node:assert";
 
-const { describeWithLeakDetector: _describeWithLeakDetector } = require("../src/resource_leak_detector");
+import { describeWithLeakDetector as _describeWithLeakDetector } from "../index.js";
 
 // These tests intentionally leak timers that only the detector
 // cleans up. Without it the process hangs — skip entirely.

--- a/packages/node-opcua-modeler/test/test_issue_889.ts
+++ b/packages/node-opcua-modeler/test/test_issue_889.ts
@@ -1,8 +1,8 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { AddressSpace, adjustNamespaceArray, PseudoSession, type UADataType } from "node-opcua-address-space";
 import { generateAddressSpace } from "node-opcua-address-space/nodeJS";
-
 import { assert } from "node-opcua-assert";
 import { DataTypeExtractStrategy, ExtraDataTypeManager, populateDataTypeManager } from "node-opcua-client-dynamic-extension-object";
 import type { EnumerationDefinitionSchema, StructureInfo } from "node-opcua-factory";
@@ -10,7 +10,6 @@ import { nodesets } from "node-opcua-nodesets";
 import { BrowseDescription } from "node-opcua-types";
 import should from "should";
 import { spy } from "sinon";
-
 import {
     addExtensionObjectDataType,
     BrowseDirection,
@@ -103,7 +102,6 @@ describe("loading very large DataType Definitions ", function (this: Mocha.Suite
         }
 
         const xml = namespace.toNodeset2XML();
-        const fs = require("node:fs");
         const tmpFile = path.join(os.tmpdir(), "tmp_1.xml");
         await fs.promises.writeFile(tmpFile, xml, "utf-8");
         /* to be completed */

--- a/packages/node-opcua-secure-channel/test_helpers/signature_helpers.ts
+++ b/packages/node-opcua-secure-channel/test_helpers/signature_helpers.ts
@@ -3,8 +3,7 @@ import "should";
 import { assert } from "node-opcua-assert";
 import { readPrivateKey } from "node-opcua-crypto";
 import { makeMessageChunkSignature, verifyChunkSignature } from "node-opcua-crypto/web";
-
-const { getFixture } = require("node-opcua-test-fixtures");
+import { getFixture } from "node-opcua-test-fixtures";
 
 function construct_makeMessageChunkSignatureForTest() {
     const privateKey = readPrivateKey(getFixture("certs/server_key_1024.pem"));

--- a/packages/node-opcua-secure-channel/tsconfig.json
+++ b/packages/node-opcua-secure-channel/tsconfig.json
@@ -57,6 +57,9 @@
             "path": "../node-opcua-status-code"
         },
         {
+            "path": "../node-opcua-test-fixtures"
+        },
+        {
             "path": "../node-opcua-transport"
         },
         {

--- a/packages/node-opcua-server/test/test_advertised_endpoints.ts
+++ b/packages/node-opcua-server/test/test_advertised_endpoints.ts
@@ -5,6 +5,7 @@ import { MessageSecurityMode, SecurityPolicy } from "node-opcua-secure-channel";
 import { UserTokenType } from "node-opcua-service-endpoints";
 import "should";
 
+import { getIpAddresses } from "node-opcua-hostname";
 import { OPCUAServer } from "../source/index.js";
 import { type AdvertisedEndpointConfig, normalizeAdvertisedEndpoints, parseOpcTcpUrl } from "../source/server_end_point.js";
 import { createServerCertificateManager } from "./create_server_certificate_manager.js";
@@ -610,7 +611,6 @@ describe("US-AE-18: IP/hostname segregation in cert SAN", () => {
 
 describe("getIpAddresses", () => {
     it("should return valid non-internal IPv4 addresses (if any)", () => {
-        const { getIpAddresses } = require("node-opcua-hostname");
         const ips: string[] = getIpAddresses();
         // In CI/container environments there may be no non-loopback interfaces
         for (const ip of ips) {

--- a/packages/node-opcua-server/test/test_extract_event_fields.ts
+++ b/packages/node-opcua-server/test/test_extract_event_fields.ts
@@ -18,7 +18,7 @@ import { NodeId, resolveNodeId } from "node-opcua-nodeid";
 import { nodesets } from "node-opcua-nodesets";
 import { checkFilter, ofType } from "node-opcua-service-filter";
 
-import { extractEventFields, FilterContextOnAddressSpace } from "node-opcua-service-filter/source/on_address_space/index";
+import { extractEventFields, FilterContextOnAddressSpace } from "node-opcua-service-filter/dist/on_address_space/index.js";
 import {
     ContentFilter,
     ElementOperand,

--- a/packages/node-opcua-server/test/test_server_publish_engine.ts
+++ b/packages/node-opcua-server/test/test_server_publish_engine.ts
@@ -40,13 +40,12 @@ import { StatusCodes } from "node-opcua-status-code";
 import should from "should";
 import sinon from "sinon";
 import { ServerSidePublishEngine, Subscription, type SubscriptionOptions, SubscriptionState } from "../source/index.js";
+import { add_mock_monitored_item } from "./helper.js";
 
 const property =
     <K extends string>(key: K) =>
     <T extends { [P in K]: unknown }>(obj: T): T[K] =>
         obj[key];
-
-const { add_mock_monitored_item } = require("./helper");
 
 function makeSubscription(options: SubscriptionOptions) {
     const subscription1 = new Subscription(options);

--- a/packages/node-opcua-server/test/test_set_triggering.ts
+++ b/packages/node-opcua-server/test/test_set_triggering.ts
@@ -24,6 +24,7 @@ import {
     type SubscriptionOptions,
     SubscriptionState
 } from "../source/index.js";
+import { getFakePublishEngine } from "./helper_fake_publish_engine.js";
 
 function makeSubscription(options: SubscriptionOptions) {
     const subscription1 = new Subscription(options);
@@ -33,7 +34,6 @@ function makeSubscription(options: SubscriptionOptions) {
     return subscription1;
 }
 
-const { getFakePublishEngine } = require("./helper_fake_publish_engine");
 const mini_nodeset_filename = get_mini_nodeset_filename();
 
 const doDebug = false;

--- a/packages/node-opcua-server/test/test_subscription_with_monitored_items_boolean_string_bytestring.ts
+++ b/packages/node-opcua-server/test/test_subscription_with_monitored_items_boolean_string_bytestring.ts
@@ -17,13 +17,12 @@ import { StatusCodes } from "node-opcua-status-code";
 import { DataType } from "node-opcua-variant";
 import sinon from "sinon";
 
-import { ServerEngine, Subscription, type SubscriptionOptions } from "..";
+import { ServerEngine, Subscription, type SubscriptionOptions } from "../source/index.js";
+import { getFakePublishEngine } from "./helper_fake_publish_engine.js";
 
 const mini_nodeset_filename = get_mini_nodeset_filename();
 
 const _context = SessionContext.defaultContext;
-
-const { getFakePublishEngine } = require("./helper_fake_publish_engine");
 
 const fake_publish_engine = getFakePublishEngine();
 

--- a/packages/node-opcua-server/test/test_subscription_with_monitored_items_limits.ts
+++ b/packages/node-opcua-server/test/test_subscription_with_monitored_items_limits.ts
@@ -12,8 +12,7 @@ import { DataType } from "node-opcua-variant";
 import sinon from "sinon";
 import { ServerEngine } from "../source/server_engine.js";
 import { Subscription } from "../source/server_subscription.js";
-
-const { getFakePublishEngine } = require("./helper_fake_publish_engine");
+import { getFakePublishEngine } from "./helper_fake_publish_engine.js";
 
 const fake_publish_engine = getFakePublishEngine();
 

--- a/packages/node-opcua-service-filter/test/test_make_where_clause.ts
+++ b/packages/node-opcua-service-filter/test/test_make_where_clause.ts
@@ -12,7 +12,7 @@ import {
     ofType,
     or,
     s
-} from "../source/make_content_filter.js";
+} from "../dist/make_content_filter.js";
 
 describe("make where clause", () => {
     it("should createa  simple OfType clause", () => {

--- a/packages/node-opcua-service-translate-browse-path/test/test_make_relative_path.ts
+++ b/packages/node-opcua-service-translate-browse-path/test/test_make_relative_path.ts
@@ -1,12 +1,12 @@
 import "should";
 import { QualifiedName } from "node-opcua-data-model";
 import { makeNodeId, resolveNodeId } from "node-opcua-nodeid";
+import sinon from "sinon";
 import { makeRelativePath, RelativePathElement } from "..";
 
 describe("makeRelativePath", () => {
     const hierarchicalReferenceTypeNodeId = resolveNodeId("HierarchicalReferences");
     const aggregatesReferenceTypeNodeId = resolveNodeId("Aggregates");
-    const sinon = require("sinon");
 
     it("MRP-01 should construct simple RelativePath for '/' ", () => {
         const relativePath = makeRelativePath("/");
@@ -153,7 +153,6 @@ describe("makeRelativePath", () => {
     //  finds targets with BrowseName = ‘1:Boiler’. From there follows any hierarchical
     // Reference and find targets with BrowseName = ‘1:HeatSensor’.
     it("MRP-11 should construct simple RelativePath for '<1:ConnectedTo>1:Boiler/1:HeatSensor'", () => {
-        const sinon = require("sinon");
         const addressSpace = {
             findReferenceType: sinon.stub().returns(makeNodeId(555, 1))
         };
@@ -182,7 +181,6 @@ describe("makeRelativePath", () => {
     //  Follows any forward Reference with a BrowseName = ‘1:ConnectedTo’ and finds targets
     // with BrowseName = ‘1:Boiler’. From there it finds all targets of hierarchical References.
     it("MRP-12 should construct simple RelativePath for '<1:ConnectedTo>1:Boiler/'", () => {
-        const sinon = require("sinon");
         const addressSpace = {
             findReferenceType: sinon.stub().returns(makeNodeId(555, 1))
         };

--- a/packages/node-opcua-transport/benchmark/bench_message_builder_base.ts
+++ b/packages/node-opcua-transport/benchmark/bench_message_builder_base.ts
@@ -1,4 +1,4 @@
-import { Benchmarker } from "../../node-opcua-benchmarker/source/benchmarker";
+import { Benchmarker } from "node-opcua-benchmarker";
 import { MessageBuilderBase } from "../source/message_builder_base";
 
 const bench = new Benchmarker();

--- a/packages/node-opcua-xml2json/test/test_xml2json.ts
+++ b/packages/node-opcua-xml2json/test/test_xml2json.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { make_debugLog } from "node-opcua-debug";
 import should from "should";
 import { type ParserLike, type ReaderStateParserLike, Xml2Json, type XmlAttributes } from "..";
-import { Xml2JsonFs } from "../source/nodejs/xml2json_fs.js";
+import { Xml2JsonFs } from "../dist/source/nodejs/xml2json_fs.js";
 
 const debugLog = make_debugLog("TEST");
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4244,6 +4244,8 @@ importers:
 
   tools/check-mocharc: {}
 
+  tools/check-module-identity: {}
+
   tools/check-no-tla:
     devDependencies:
       typescript:

--- a/tools/README.md
+++ b/tools/README.md
@@ -79,6 +79,15 @@ For more details, see [check-mocharc/README.md](check-mocharc/README.md).
 
 ### Other Tools
 
+Each has its own README with the reasoning behind the rule.
+
+- `check-no-tla/`: module-scope `await`, which breaks `require(esm)` for CJS consumers
+- `check-import-extension/`: relative specifiers must carry the extension ESM needs
+- `check-import-cycles/`: circular imports that would throw under ESM
+- `check-module-identity/`: a file must reach any one package by a single route
+- `check-pack/`: declared entry points must actually be published
+- `check-test-types/`: ratchet on test-suite type-checking
+- `check-test-ports/`: no hard-coded ports in tests
 - `clean/`: Cleanup utilities
 - `fix-tsconfigs/`: TypeScript configuration fixes
 
@@ -86,13 +95,23 @@ For more details, see [check-mocharc/README.md](check-mocharc/README.md).
 
 ```
 tools/
-├── scan-dependencies/     # Dependency scanning tool
-├── check-debug-log/       # Unguarded debug-log finder / fixer
-├── check-mocharc/         # Mocha config shape checker / fixer
-├── clean/                # Cleanup utilities
-├── fix-tsconfigs/        # TypeScript config fixes
-├── scan-deps.js          # Launcher for scan-dependencies
-├── check-debug-log.js    # Launcher for check-debug-log
-├── check-mocharc.js      # Launcher for check-mocharc
-└── README.md            # This file
+├── scan-dependencies/       # Dependency scanning tool
+├── check-debug-log/         # Unguarded debug-log finder / fixer
+├── check-mocharc/           # Mocha config shape checker / fixer
+├── check-no-tla/            # Module-scope await finder
+├── check-import-extension/  # Extension on relative specifiers
+├── check-import-cycles/     # Cycles that would throw under ESM
+├── check-module-identity/   # One route per package
+├── check-pack/              # Declared entry points are published
+├── check-test-types/        # Test-suite type-check ratchet
+├── clean/                   # Cleanup utilities
+├── fix-tsconfigs/           # TypeScript config fixes
+├── scan-deps.js             # Launcher for scan-dependencies
+├── check-debug-log.js       # Launcher for check-debug-log
+├── check-mocharc.js         # Launcher for check-mocharc
+├── check-no-tla.mjs         # Launcher for check-no-tla
+├── check-import-extension.mjs
+├── check-import-cycles.mjs
+├── check-module-identity.mjs
+└── README.md                # This file
 ``` 

--- a/tools/check-module-identity.mjs
+++ b/tools/check-module-identity.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+/** launcher for tools/check-module-identity - see tools/README.md */
+import "./check-module-identity/src/index.js";

--- a/tools/check-module-identity/README.md
+++ b/tools/check-module-identity/README.md
@@ -1,0 +1,85 @@
+# check-module-identity
+
+A file must reach any one package by a **single route**.
+
+```bash
+node tools/check-module-identity.mjs        # report, exit 1 on a violation
+pnpm run check:identity                     # same, via the root script
+```
+
+## Why
+
+A package can be reached several ways, and they are not the same module instance:
+
+| specifier | resolves to |
+|---|---|
+| `"node-opcua-foo"` | its `package.json` main, i.e. `dist/index.js` |
+| `"node-opcua-foo/dist/x.js"` | the **same** dist tree, same instances |
+| `"node-opcua-foo/source/x.js"` | a **second compilation** of the same code |
+| `".."` from inside the package | its own dist |
+| `"../source/x.js"` from inside it | a second compilation |
+
+Where two routes to one package meet in a running process there are two copies of every
+class and every module-scope registry. `instanceof` across the boundary is `false`, and a
+resource registered through one copy and disposed through the other is reported as a leak.
+
+## Why it needs a gate rather than review
+
+Neither of the usual checks sees it:
+
+- **`tsc` passes.** The two copies are structurally identical, so assignments type-check.
+  It only complains when a *nominal* difference leaks out, and then the error names two
+  paths that look the same — which invites "fixing" it by pointing one import at the other
+  tree, creating the mix rather than removing it.
+- **A single-package test run passes.** One process loading a package twice is usually fine
+  in isolation. It surfaces when something else runs alongside it and the timing shifts.
+
+It was found the hard way: a server test imported `Subscription` from `../source` while
+`ServerEngine` came from `..`. `tsc` was clean, the package's own suite was clean, and it
+failed only when two packages' suites ran concurrently — 35 to 42 leak-detector failures
+with no obvious connection to the change.
+
+## What is deliberately not flagged
+
+- **Deep imports into `dist/`** — same tree, same instances.
+- **`distNodeJS/` and `distHelpers/`** — sibling entry points that re-export `dist` rather
+  than recompiling it (`distNodeJS/generate_address_space.js` does `require("..")`).
+- **`import type`**, and a clause of only inline `type` specifiers — erased before anything
+  runs, so they cannot duplicate a module.
+
+  They are still worth keeping on the same route, for a different reason: two declarations
+  of one class are two *types*, and `tsc` says so. Moving a value import to `dist` while
+  leaving a sibling `import type` on `src` produces
+
+  ```
+  Types have separate declarations of a private property '_basicDataType'.
+  ```
+
+  which is the compiler catching the half-done version of this fix. That failure is loud, so
+  it does not need a gate — this rule covers the silent half.
+- **Subpath exports** such as `node-opcua-address-space/testHelpers` — they resolve into the
+  built tree.
+
+## Fixing a violation
+
+Point the source import at its `dist` equivalent, or import the package by name. Which one
+depends on the package's `rootDir`:
+
+| rootDir | `../source/x.js` becomes |
+|---|---|
+| `""` | `../dist/source/x.js` |
+| `"source"` | `../dist/x.js` |
+
+To opt out on one line, with a reason:
+
+```ts
+import { thing } from "../source/thing.js"; // check-module-identity: ok - why
+```
+
+## Tests
+
+`src/rule.js` is pure and takes source text plus a path, so the tests hand it strings.
+
+```bash
+node tools/check-module-identity/test/test_rule.js
+```

--- a/tools/check-module-identity/package.json
+++ b/tools/check-module-identity/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "@sterfive/check-module-identity",
+    "version": "1.0.0",
+    "private": true,
+    "description": "fail the build when a file reaches one package by two routes",
+    "bin": {
+        "check-module-identity": "src/index.js"
+    },
+    "type": "module",
+    "scripts": {
+        "check": "node src/index.js",
+        "test": "node test/test_rule.js"
+    }
+}

--- a/tools/check-module-identity/src/index.js
+++ b/tools/check-module-identity/src/index.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+/**
+ * check-module-identity - command line around src/rule.js.
+ *
+ * Usage:
+ *     node tools/check-module-identity.mjs              # report, exit 1 on a violation
+ *     node tools/check-module-identity.mjs --root ../x
+ */
+
+import process from "node:process";
+import { analyze, exitCode, formatReport } from "./rule.js";
+
+function valueOf(argv, flag) {
+    const i = argv.indexOf(flag);
+    return i === -1 ? undefined : argv[i + 1];
+}
+
+function main() {
+    const argv = process.argv.slice(2);
+    const result = analyze({ repoRoot: valueOf(argv, "--root") ?? "." });
+    console.log(formatReport(result));
+    return exitCode(result);
+}
+
+process.exit(main());

--- a/tools/check-module-identity/src/rule.js
+++ b/tools/check-module-identity/src/rule.js
@@ -1,0 +1,170 @@
+/**
+ * rule - a file must reach any one package by a single route.
+ *
+ * A package can be reached several ways, and they are not the same module instance:
+ *
+ *     "node-opcua-foo"                 -> its package.json main, i.e. dist/index.js
+ *     "node-opcua-foo/dist/x.js"       -> the SAME dist tree, same instances
+ *     "node-opcua-foo/source/x.js"     -> a SECOND compilation of the same code
+ *     ".." from inside the package     -> its own dist
+ *     "../source/x.js" from inside it  -> a second compilation
+ *
+ * Where two routes to one package meet in a running process there are two copies of every
+ * class and every module-scope registry. `instanceof` across the boundary is false, and a
+ * resource registered through one copy and disposed through the other is reported as a
+ * leak. Neither `tsc` nor a single-package test run detects it: the types are structurally
+ * identical and one process loading the package twice still passes in isolation. It shows
+ * up as an unrelated-looking failure somewhere else, which is why it needs a gate.
+ *
+ * Only VALUE imports count. `import type` is erased before anything runs and cannot
+ * duplicate a module.
+ *
+ * Deep imports into dist/ are fine - same tree, same instances - and so are the sibling
+ * entry points distNodeJS/ and distHelpers/, which re-export dist rather than recompiling
+ * (distNodeJS/generate_address_space.js does `require("..")`).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+/** opt out on one line, with a reason: `// check-module-identity: ok - why` */
+export const IGNORE_MARKER = "check-module-identity: ok";
+
+export const SOURCE_ROOTS = ["packages", "packages_extra"];
+
+const SKIP_DIRS = new Set(["node_modules", "dist", "dist-esm", "distNodeJS", "distHelpers", "coverage", "build"]);
+
+/** a compiled output tree: reaching into one of these is the same instance as the entry */
+const BUILT_DIR = /^dist/;
+
+/** a TypeScript source tree: reaching into one of these compiles the code a second time */
+const SOURCE_DIR = /^(source|src|source_nodejs)$/;
+
+/**
+ * The value-import specifiers of one file.
+ *
+ * `import type ...` and `import { type A, type B } ...` are both fully erased, so neither
+ * can bring a second copy of anything into the process.
+ */
+export function valueSpecifiers(text) {
+    const clean = text.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+    const out = [];
+    for (const m of clean.matchAll(/^[^\S\n]*import\s+(type\s+)?([\s\S]*?)\bfrom\s+["']([^"']+)["']/gm)) {
+        if (m[1]) continue;
+        const names = (m[2] ?? "")
+            .replace(/[{}]/g, "")
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean);
+        if (names.length > 0 && names.every((n) => n.startsWith("type "))) continue;
+        out.push(m[3]);
+    }
+    for (const m of clean.matchAll(/^[^\S\n]*import\s+["']([^"']+)["']/gm)) out.push(m[1]);
+    return out;
+}
+
+/**
+ * Which package a specifier reaches, and by which route.
+ * Returns { pkg, route } with route "built" or "source", or null when it reaches no
+ * package in a way that could duplicate one.
+ */
+export function classify(specifier, fileRelativeToPackage, packageName) {
+    // another package, by name: "node-opcua-foo", "node-opcua-foo/dist/x.js", ...
+    const byName = /^(@[\w.-]+\/[\w.-]+|[\w.-]+)(?:\/(.*))?$/.exec(specifier);
+    if (byName && !specifier.startsWith(".")) {
+        const [, pkg, rest] = byName;
+        if (!rest) return { pkg, route: "built" };
+        const head = rest.split("/")[0];
+        if (SOURCE_DIR.test(head)) return { pkg, route: "source" };
+        if (BUILT_DIR.test(head)) return { pkg, route: "built" };
+        // any other subpath is an export map entry, which resolves into the built tree
+        return { pkg, route: "built" };
+    }
+
+    // a relative specifier inside the package: how far up does it go?
+    const depth = fileRelativeToPackage.split("/").length - 1;
+    const up = "../".repeat(depth);
+    if (!specifier.startsWith("..")) return null;
+    const root = up.replace(/\/$/, "");
+    if (specifier === root) return { pkg: packageName, route: "built" };
+    if (!specifier.startsWith(up)) return null; // does not reach the package root
+    const rest = specifier.slice(up.length);
+    const head = rest.split("/")[0];
+    if (SOURCE_DIR.test(head)) return { pkg: packageName, route: "source" };
+    if (BUILT_DIR.test(head)) return { pkg: packageName, route: "built" };
+    return null;
+}
+
+/** findings for one file: [{ pkg, built: [...], source: [...] }] */
+export function findViolations(text, fileRelativeToPackage, packageName) {
+    const lines = text.split("\n");
+    const byPackage = new Map();
+    for (const spec of valueSpecifiers(text)) {
+        const c = classify(spec, fileRelativeToPackage, packageName);
+        if (!c) continue;
+        const line = lines.findIndex((l) => l.includes(`"${spec}"`) || l.includes(`'${spec}'`));
+        if (line >= 0 && lines[line].includes(IGNORE_MARKER)) continue;
+        if (!byPackage.has(c.pkg)) byPackage.set(c.pkg, { pkg: c.pkg, built: [], source: [] });
+        byPackage.get(c.pkg)[c.route].push(spec);
+    }
+    return [...byPackage.values()].filter((v) => v.built.length > 0 && v.source.length > 0);
+}
+
+export function findFiles(repoRoot = ".") {
+    const out = [];
+    const walk = (dir, pkgDir, pkgName) => {
+        if (!fs.existsSync(dir)) return;
+        for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+            const full = path.join(dir, e.name).replace(/\\/g, "/");
+            if (e.isDirectory()) {
+                if (!SKIP_DIRS.has(e.name)) walk(full, pkgDir, pkgName);
+            } else if (/\.(ts|mts|cts)$/.test(e.name) && !e.name.endsWith(".d.ts")) {
+                out.push({ file: full, relative: path.posix.relative(pkgDir, full), packageName: pkgName });
+            }
+        }
+    };
+    for (const root of SOURCE_ROOTS) {
+        const full = path.join(repoRoot, root);
+        if (!fs.existsSync(full)) continue;
+        for (const pkg of fs.readdirSync(full, { withFileTypes: true })) {
+            if (!pkg.isDirectory() || SKIP_DIRS.has(pkg.name)) continue;
+            const pkgDir = path.join(full, pkg.name).replace(/\\/g, "/");
+            walk(pkgDir, pkgDir, pkg.name);
+        }
+    }
+    return out;
+}
+
+export function analyze({ repoRoot = "." } = {}) {
+    const files = findFiles(repoRoot);
+    const findings = [];
+    for (const { file, relative, packageName } of files) {
+        for (const v of findViolations(fs.readFileSync(file, "utf8"), relative, packageName)) {
+            findings.push({ file, ...v });
+        }
+    }
+    return { scanned: files.length, findings };
+}
+
+export function exitCode(result) {
+    return result.findings.length > 0 ? 1 : 0;
+}
+
+export function formatReport(result) {
+    if (result.findings.length === 0) {
+        return `check-module-identity: ${result.scanned} files scanned, every package is reached by a single route.`;
+    }
+    const lines = [`check-module-identity: ${result.findings.length} file(s) reach a package by two routes, in ${result.scanned} scanned`, ""];
+    for (const f of result.findings) {
+        lines.push(`  ${f.file}  reaches ${f.pkg} twice:`);
+        for (const s of f.built) lines.push(`      built  "${s}"`);
+        for (const s of f.source) lines.push(`      source "${s}"`);
+    }
+    lines.push("");
+    lines.push("Those are two module instances: two copies of every class, two module-scope");
+    lines.push("registries. instanceof across the boundary is false, and a resource registered");
+    lines.push("through one copy and disposed through the other is reported as a leak.");
+    lines.push("");
+    lines.push("Point the source import at its dist equivalent, or import the package by name.");
+    return lines.join("\n");
+}

--- a/tools/check-module-identity/test/test_rule.js
+++ b/tools/check-module-identity/test/test_rule.js
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for the module-identity rule.
+ *
+ * The cases that matter are the ones where a naive rule gets it wrong: a deep import into
+ * dist is the SAME instance and must not be flagged, `import type` is erased and cannot
+ * duplicate anything, and the sibling build outputs (distNodeJS, distHelpers) re-export
+ * dist rather than recompiling it.
+ *
+ * Run: node test/test_rule.js
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { analyze, classify, exitCode, findViolations, formatReport, IGNORE_MARKER, valueSpecifiers } from "../src/rule.js";
+
+function withTree(files, fn) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "check-module-identity-"));
+    try {
+        for (const [rel, content] of Object.entries(files)) {
+            const full = path.join(root, rel);
+            fs.mkdirSync(path.dirname(full), { recursive: true });
+            fs.writeFileSync(full, content);
+        }
+        return fn(root.replace(/\\/g, "/"));
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+}
+
+// ── the hazard ──────────────────────────────────────────────────────────────────
+
+test("own package reached as both built output and source is a violation", () => {
+    const text = 'import { A } from "..";\nimport { B } from "../source/b.js";\n';
+    const found = findViolations(text, "test/x.ts", "node-opcua-foo");
+    assert.equal(found.length, 1);
+    assert.equal(found[0].pkg, "node-opcua-foo");
+    assert.deepEqual(found[0].built, [".."]);
+    assert.deepEqual(found[0].source, ["../source/b.js"]);
+});
+
+test("src/ and source_nodejs/ count as source too", () => {
+    for (const dir of ["src", "source_nodejs"]) {
+        const text = `import { A } from "..";\nimport { B } from "../${dir}/b.js";\n`;
+        assert.equal(findViolations(text, "test/x.ts", "p").length, 1, dir);
+    }
+});
+
+test("another package reached by name and through its source tree", () => {
+    const text = 'import { A } from "node-opcua-foo";\nimport { B } from "node-opcua-foo/source/b.js";\n';
+    const found = findViolations(text, "test/x.ts", "node-opcua-bar");
+    assert.equal(found.length, 1);
+    assert.equal(found[0].pkg, "node-opcua-foo");
+});
+
+test("a nested test file resolves its package root correctly", () => {
+    const text = 'import { A } from "../..";\nimport { B } from "../../source/b.js";\n';
+    assert.equal(findViolations(text, "test/deep/x.ts", "p").length, 1);
+});
+
+// ── what must NOT be flagged ────────────────────────────────────────────────────
+
+test("a deep import into dist is the same instance", () => {
+    const text = 'import { A } from "..";\nimport { B } from "../dist/private/b.js";\n';
+    assert.equal(findViolations(text, "test/x.ts", "p").length, 0);
+});
+
+test("distNodeJS and distHelpers re-export dist and are not a second copy", () => {
+    for (const dir of ["distNodeJS", "distHelpers"]) {
+        const text = `import { A } from "..";\nimport { B } from "../${dir}/index.js";\n`;
+        assert.equal(findViolations(text, "test/x.ts", "p").length, 0, dir);
+    }
+});
+
+test("import type is erased and cannot duplicate a module", () => {
+    const text = 'import { A } from "..";\nimport type { B } from "../source/b.js";\n';
+    assert.equal(findViolations(text, "test/x.ts", "p").length, 0);
+});
+
+test("a clause of only inline type specifiers is erased as well", () => {
+    const text = 'import { A } from "..";\nimport { type B, type C } from "../source/b.js";\n';
+    assert.equal(findViolations(text, "test/x.ts", "p").length, 0);
+});
+
+test("one route alone is fine, whichever it is", () => {
+    assert.equal(findViolations('import { B } from "../source/b.js";\n', "test/x.ts", "p").length, 0);
+    assert.equal(findViolations('import { A } from "..";\n', "test/x.ts", "p").length, 0);
+});
+
+test("two different packages do not combine into a violation", () => {
+    const text = 'import { A } from "node-opcua-foo";\nimport { B } from "node-opcua-bar/source/b.js";\n';
+    assert.equal(findViolations(text, "test/x.ts", "p").length, 0);
+});
+
+test("a subpath export resolves into the built tree", () => {
+    const text = 'import { A } from "node-opcua-foo";\nimport { B } from "node-opcua-foo/testHelpers";\n';
+    assert.equal(findViolations(text, "test/x.ts", "p").length, 0);
+});
+
+test("the ignore marker opts a line out", () => {
+    const text = `import { A } from "..";\nimport { B } from "../source/b.js"; // ${IGNORE_MARKER} - deliberate\n`;
+    assert.equal(findViolations(text, "test/x.ts", "p").length, 0);
+});
+
+// ── helpers ─────────────────────────────────────────────────────────────────────
+
+test("valueSpecifiers skips type-only imports and keeps side-effect ones", () => {
+    const text = ['import type { A } from "a";', 'import { B } from "b";', 'import "c";', 'import D from "d";'].join("\n");
+    assert.deepEqual(valueSpecifiers(text).sort(), ["b", "c", "d"]);
+});
+
+test("classify tells the two routes apart", () => {
+    assert.deepEqual(classify("..", "test/x.ts", "p"), { pkg: "p", route: "built" });
+    assert.deepEqual(classify("../source/a.js", "test/x.ts", "p"), { pkg: "p", route: "source" });
+    assert.deepEqual(classify("../dist/a.js", "test/x.ts", "p"), { pkg: "p", route: "built" });
+    assert.deepEqual(classify("node-opcua-foo", "test/x.ts", "p"), { pkg: "node-opcua-foo", route: "built" });
+    assert.deepEqual(classify("node-opcua-foo/src/a.js", "test/x.ts", "p"), { pkg: "node-opcua-foo", route: "source" });
+    assert.equal(classify("./sibling.js", "test/x.ts", "p"), null);
+});
+
+// ── end to end ──────────────────────────────────────────────────────────────────
+
+test("analyze walks the packages and the report explains the consequence", () => {
+    withTree(
+        {
+            "packages/p/test/bad.ts": 'import { A } from "..";\nimport { B } from "../source/b.js";\n',
+            "packages/p/test/good.ts": 'import { A } from "..";\nimport { B } from "../dist/b.js";\n',
+            "packages/p/source/b.ts": ""
+        },
+        (root) => {
+            const result = analyze({ repoRoot: root });
+            assert.equal(result.findings.length, 1);
+            assert.match(result.findings[0].file, /bad\.ts$/);
+            assert.equal(exitCode(result), 1);
+            const report = formatReport(result);
+            assert.match(report, /reaches p twice/);
+            assert.match(report, /instanceof across the boundary is false/);
+        }
+    );
+});
+
+test("a clean tree reports the count it scanned", () => {
+    withTree({ "packages/p/test/ok.ts": 'import { A } from "..";\n' }, (root) => {
+        const result = analyze({ repoRoot: root });
+        assert.equal(exitCode(result), 0);
+        assert.match(formatReport(result), /1 files scanned, every package is reached by a single route/);
+    });
+});


### PR DESCRIPTION
FEAT-6 US-6.2, plus a module-identity problem it uncovered. **Stacked on #1599** — review
that first; this branch contains its commit.

Four commits:

| | |
|---|---|
| `refactor(tests)` | the last `require()` calls become imports |
| `fix(secure-channel)` | a missing project reference that broke the build |
| `feat(tools)` | one route per package, and a gate for it |

---

## 1. The last require() calls

113 of the 114 in `.ts` test trees become imports; the one left is prose in a doc comment.
88 are the end2end umbrella pattern:

```js
require("./u_test_e2e_client").t(test);
```

rewritten by script to a hoisted import plus a call. Hoisting is safe and the script checks
it per target: every `u_test_*` module is imports plus `export function t()`, with nothing
at module scope. All 88 resolved. `mocha --dry-run` over end2end confirms **737 tests still
register** — the check that matters when imports start hoisting.

### What require() was hiding

The module was `any`, so `t(test)` accepted anything. Typing it produced 17 errors, all real:

**The umbrella context.** `UmbrellaTestContext` declares `endpointUrl`, `server` and
`serverCertificate` optional — correct, they are absent until `beforeTest()` runs. Each
`u_test_*` declares only the fields its suite needs, required — also correct, because no
`it()` runs before that hook. `ReadyUmbrellaTestContext` names that boundary once instead of
asserting it at ~90 call sites.

**The two alarm suites** asked for fields their *own* fixture attaches, so no caller could
satisfy them. They now take the base context and widen inside the module that owns them.

## 2. A missing project reference

`signature_helpers.ts` moving to a real import meant `tsc -b` had to *resolve*
`node-opcua-test-fixtures`. It was a declared devDependency but not a project reference, so
the composite build had no `.d.ts` for it.

`require()` never needed resolving, which is why it only appeared once the call became an
import. `check:testtypes` does not cover `test_helpers/` either — only `tsc -b packages`
does, and that had not been re-run after the conversion. It broke the pipeline; this fixes
it.

## 3. One route per package, and a gate

A package can be reached several ways, and they are not the same instance:

| specifier | resolves to |
|---|---|
| `"node-opcua-foo"` | its main, `dist/index.js` |
| `"node-opcua-foo/dist/x.js"` | the **same** dist tree |
| `"node-opcua-foo/source/x.js"` | a **second compilation** |
| `".."` inside the package | its own dist |
| `"../source/x.js"` inside it | a second compilation |

Two routes meeting in one process means two copies of every class and every module-scope
registry: `instanceof` across the boundary is false, and a resource registered through one
copy and disposed through the other is reported as a leak.

### How it was found

Fixing a type error in `test_subscription_with_monitored_items_boolean_string_bytestring.ts`,
I pointed one import at `../source` — which left the file importing `Subscription` from
source and `ServerEngine` from dist. `tsc` passed. That package's suite passed. It failed
only when two packages' suites ran concurrently: 35 to 42 leak-detector failures with no
visible connection to the change. Running the same pair on master gave **474 passing, zero
failing**, which ruled out machine load.

### The audit

Nine files reached a package by two routes. Type-only imports were excluded (erased before
anything runs) and each candidate's transitive runtime closure computed:

- **4 genuinely duplicated it.** `test_address_space_add_two_state_variable` pulled in **21**
  address-space modules a second time, including `ua_variable_impl` and `session_context`.
- **3 were leaves** whose runtime imports are all external, duplicating nothing *yet* — the
  fragile kind, one value import away from the silent failure.
- **2 were benchmarks.**

All nine now use one route. Fixing all of them rather than only the broken four means no
allowlist to maintain.

30 further files that a naive scan flags are **not** violations, each checked rather than
assumed: deep `dist/` imports are the same tree, and `distNodeJS`/`distHelpers` re-export
dist rather than recompiling (`distNodeJS/generate_address_space.js` does `require("..")`).

### The gate

`check-module-identity`, wired into `check:identity` and the CI lint job. **3760 files
scanned, clean.** 16 unit tests covering the hazard, the four things that must not be
flagged, and the ignore marker.

It needs to be a gate because neither usual check sees it: `tsc` passes on structurally
identical copies, and a single-package run passes because one process loading a package
twice is fine in isolation.

**My first fix was half-done and the compiler caught it** — moving a value import to `dist`
while leaving a sibling `import type` on `src` gives two declarations of one class
(`Types have separate declarations of a private property '_basicDataType'`). That half is
loud and needs no gate; the rule covers the silent half. Both are documented in the tool's
README, since it is the obvious way to get this wrong.

Also brought `tools/README.md` up to date: it listed none of the five `check-*` tools added
since it was written.

## Verification

`tsc -b packages`, `check:testtypes` 72/0, `check:identity` clean over 3760 files,
`check:importext` clean over 3029, `biome check .` clean over 1525, and
`test:per-package:dry-run` exit 0.

Suites: address-space **1096**, server **474**, secure-channel **269**, leak-detector **71**,
service-filter **66**, translate-browse-path **43**, modeler **19**, xml2json **14**, factory
**13**, client-dynamic-extension-object **4**, plus end2end dry-run at **737** registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
