### PR TITLE
refactor(tests): anchor the last two path counters in the test trees

### DIFF
--- a/packages/node-opcua-convert-nodeset-to-javascript/test/paths.ts
+++ b/packages/node-opcua-convert-nodeset-to-javascript/test/paths.ts
@@ -23,6 +23,11 @@ export function scratch(...segments: string[]): string {
     return path.join(packageRoot, ...segments);
 }
 
+/** a fixture under test_fixtures/, where this package's sample nodesets live */
+export function testFixture(...segments: string[]): string {
+    return path.join(packageRoot, "test_fixtures", ...segments);
+}
+
 /** somewhere under test/, where a suite's inputs live */
 export function testPath(...segments: string[]): string {
     return path.join(packageRoot, "test", ...segments);

--- a/packages/node-opcua-convert-nodeset-to-javascript/test_fixtures/helper.ts
+++ b/packages/node-opcua-convert-nodeset-to-javascript/test_fixtures/helper.ts
@@ -1,9 +1,9 @@
 import fs from "node:fs";
-import path from "node:path";
 import should from "should";
+import { testFixture } from "../test/paths.js";
 
 export function getFixture(file: string): string {
-    const full = path.join(__dirname, "../test_fixtures", file);
-    should(fs.existsSync(full)).be.eql(true);
+    const full = testFixture(file);
+    should(fs.existsSync(full)).be.eql(true, `expecting a fixture at ${full}`);
     return full;
 }

--- a/packages/node-opcua-end2end-test/test/test_dos_attack_by_consuming_secure_channel_and_not_using_them.ts
+++ b/packages/node-opcua-end2end-test/test/test_dos_attack_by_consuming_secure_channel_and_not_using_them.ts
@@ -3,7 +3,6 @@
  */
 import "should";
 import { spawn } from "node:child_process";
-import path from "node:path";
 import chalk from "chalk";
 import {
     ClientSecureChannelLayer,
@@ -18,6 +17,7 @@ import { checkDebugFlag, make_debugLog } from "node-opcua-debug";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import sinon from "sinon";
 import { createServerCertificateManager } from "../test_helpers/createServerCertificateManager.js";
+import { compiledHelper } from "../test_helpers/paths.js";
 
 // _secureChannel (private impl field) and its transport's underlying raw socket (not part of
 // the public IClientTransport surface) are reached here only to simulate an abrupt connection
@@ -234,7 +234,7 @@ describe("testing Server resilience to DDOS attacks", function (this: Mocha.Cont
         let launches = 0;
         async function launchCrashingClient() {
             launches++;
-            const server_script = path.join(__dirname, "../dist/test_helpers/crashing_client");
+            const server_script = compiledHelper("crashing_client");
             await new Promise<void>((resolve) => {
                 const child = spawn("node", [server_script, String(port)], {});
                 child.on("close", () => resolve());

--- a/packages/node-opcua-end2end-test/test_helpers/paths.ts
+++ b/packages/node-opcua-end2end-test/test_helpers/paths.ts
@@ -73,3 +73,12 @@ export function tmpFolderFor(...segments: string[]): string {
 export function serverScript(name: string): string {
     return path.join(packageRoot, "test_helpers", "bin", name);
 }
+
+/**
+ * A helper spawned from its compiled form under dist/, rather than from source the way
+ * serverScript's targets are. Kept separate so the two are not confused: this one only
+ * exists after a build.
+ */
+export function compiledHelper(name: string): string {
+    return path.join(packageRoot, "dist", "test_helpers", name);
+}


### PR DESCRIPTION
Closing out FEAT-6 US-6.4.

The story reduced 229 `__dirname`/`__filename` uses in the test trees to one named anchor
per package, so that the FEAT-2 flip is a per-package one-liner. Auditing before closing the
item found **two counting uses it had missed**, which would have made those two packages
exceptions to exactly that promise.

| file | was |
|---|---|
| `convert-nodeset-to-javascript/test_fixtures/helper.ts` | `path.join(__dirname, "../test_fixtures", file)` |
| `end2end/test/test_dos_attack_...ts` | `path.join(__dirname, "../dist/test_helpers/crashing_client")` |

The first walked `../test_fixtures` from a file that already sits **inside**
`test_fixtures`, which happened to resolve. It now asks the package's `paths.ts`, which
gains a `testFixture()` accessor for that folder.

The second spawns a helper from its **compiled** form. That is a different place from
`serverScript()`'s `test_helpers/bin`, and it only exists after a build, so it gets its own
`compiledHelper()` rather than being folded into the existing accessor.

Every remaining `__dirname` in a test tree is now an anchor: 18 of them, one per package,
each a single line that becomes `import.meta.dirname` at the flip.

## Verification

`tsc -b packages` clean, ratchet **72 packages, 0 grandfathered**, biome clean,
`check:importext` 3042, `check:identity` 3773, `check:shortcircuit` 3773.

Suites: convert-nodeset-to-javascript **21**, and the end2end DoS test that actually spawns
the compiled helper **5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
