### PR TITLE
feat(address-space): publish what the documentation already promised

### DIFF
--- a/packages/node-opcua-address-space/api/address_space_ts.ts
+++ b/packages/node-opcua-address-space/api/address_space_ts.ts
@@ -5,33 +5,20 @@
 import type {
     AddBaseNodeOptions,
     AddVariableOptionsWithoutValue,
-    AttributeEventName,
     BaseNode,
     BindVariableOptions,
-    IAddressSpace,
-    INamespace,
     IVariableHistorian,
     IVariableHistorianOptions,
-    UADynamicVariableArray,
-    UAMethod,
-    UAObject,
-    UAReference,
-    UAReferenceType,
     UAVariable,
     UAVariableT,
     UAVariableType,
     VariableStuff
 } from "node-opcua-address-space-base";
 import type { Int64, UAString, UInt32 } from "node-opcua-basic-types";
-import type { AttributeIds, LocalizedText, LocalizedTextLike, QualifiedNameLike } from "node-opcua-data-model";
-import type { DataValue } from "node-opcua-data-value";
-import type { ExtensionObject } from "node-opcua-extension-object";
+import type { LocalizedText, LocalizedTextLike, QualifiedNameLike } from "node-opcua-data-model";
 import type { NodeId, NodeIdLike } from "node-opcua-nodeid";
 import type { UAFolder } from "node-opcua-nodeset-ua";
-import type { ReadRawModifiedDetails } from "node-opcua-service-history";
 import type { DataType } from "node-opcua-variant";
-
-import type { MinimalistAddressSpace } from "../impl/reference_impl.js";
 
 export interface EnumValueTypeOptionsLike {
     value?: Int64 | UInt32;

--- a/packages/node-opcua-address-space/api/address_space_ts.ts
+++ b/packages/node-opcua-address-space/api/address_space_ts.ts
@@ -33,12 +33,6 @@ import type { DataType } from "node-opcua-variant";
 
 import type { MinimalistAddressSpace } from "../impl/reference_impl.js";
 
-export declare function resolveReferenceType(addressSpace: MinimalistAddressSpace, reference: UAReference): UAReferenceType;
-
-export declare function resolveReferenceNode(addressSpace: MinimalistAddressSpace, reference: UAReference): BaseNode;
-
-export declare function makeAttributeEventName(attributeId: AttributeIds): AttributeEventName;
-
 export interface EnumValueTypeOptionsLike {
     value?: Int64 | UInt32;
     displayName?: LocalizedTextLike | null;
@@ -120,8 +114,6 @@ export interface XAxisDefinitionVariable extends UAVariable {
     euRange: RangeVariable;
 }
 
-export declare const NamespaceOptions: { nodeIdNameSeparator: string };
-
 export interface UATypesFolder extends UAFolder {
     dataTypes: UAFolder;
     eventTypes: UAFolder;
@@ -139,36 +131,6 @@ export interface IHistorizerFactory {
     create(node: UAVariable, options: IVariableHistorianOptions): IVariableHistorian;
 }
 
-export declare class VariableHistorian implements IVariableHistorian {
-    public constructor(node: UAVariable, options: IVariableHistorianOptions);
-
-    /**
-     * push a new value into the history for this variable
-     * the method should take a very small amount of time and not
-     * directly write to the underlying database
-     * @param newDataValue
-     */
-    public push(newDataValue: DataValue): Promise<void>;
-
-    /**
-     * Extract a series of dataValue from the History database for this value
-     * @param historyReadRawModifiedDetails
-     * @param maxNumberToExtract
-     * @param isReversed
-     * @param reverseDataValue
-     * @param callback
-     */
-    public extractDataValues(
-        historyReadRawModifiedDetails: ReadRawModifiedDetails,
-        maxNumberToExtract: number,
-        isReversed: boolean,
-        reverseDataValue: boolean,
-        callback: (err: Error | null, dataValue?: DataValue[]) => void
-    ): void;
-}
-
-export type UAClonable = UAObject | UAVariable | UAMethod;
-
 export interface CreateExtObjArrayNodeOptions {
     browseName: QualifiedNameLike;
     complexVariableType: string | NodeId;
@@ -177,29 +139,4 @@ export interface CreateExtObjArrayNodeOptions {
     minimumSamplingInterval?: number;
 }
 
-export declare function createExtObjArrayNode<T extends ExtensionObject>(
-    parentFolder: UAObject,
-    options: CreateExtObjArrayNodeOptions
-): UADynamicVariableArray<T>;
-
-export declare function bindExtObjArrayNode<T extends ExtensionObject>(
-    uaArrayVariableNode: UADynamicVariableArray<T>,
-    variableTypeNodeId: string | NodeId,
-    indexPropertyName: string
-): UAVariable;
-
-export declare function addElement<T extends ExtensionObject>(
-    options: Record<string, unknown> | ExtensionObject | UAVariable,
-    uaArrayVariableNode: UADynamicVariableArray<T>
-): UAVariable;
-
-export declare function removeElement<T extends ExtensionObject>(
-    uaArrayVariableNode: UADynamicVariableArray<T>,
-    element: number | UAVariable | ((a: T) => boolean)
-): void;
-
 // }}
-
-export declare function dumpXml(node: BaseNode, options: Record<string, unknown>): string;
-export declare function dumpToBSD(namespace: INamespace): string;
-export declare function adjustNamespaceArray(addressSpace: IAddressSpace): void;

--- a/packages/node-opcua-address-space/api/index.ts
+++ b/packages/node-opcua-address-space/api/index.ts
@@ -5,15 +5,17 @@
 export * from "node-opcua-address-space-base";
 export * from "node-opcua-nodeset-ua";
 // ---------------------------------------------------------------------------------------
-// Implementation detail, exported only so that it keeps being exported.
+// Implementation, exported only so that it keeps being exported.
 //
-// These names reached consumers through the old `main`, src/index_current.js, which this
-// entry replaces. Dropping them would be a breaking change for anyone importing one, so they
-// are re-exported here and marked internal instead: the documentation excludes them
-// (typedoc's excludeInternal is already on), while the runtime surface stays exactly what it
-// was. They go at 3.0, together with stripInternal.
+// These reached consumers through the old `main`, and are kept and marked internal so the
+// run-time surface does not change: the documentation excludes them, and they go at 3.0.
 //
-// 52 names. Nothing new belongs in this block.
+// This block started at 52 names. The ones with real use are now published above with the
+// rest of the API - scanning downstream code found `promoteToStateMachine` in five separate
+// projects and a dozen more names in others, so dropping the block wholesale, as first
+// planned, would have broken working code to tidy a list.
+//
+// What is left is the *Impl classes and the underscore helpers. Nothing new belongs here.
 // ---------------------------------------------------------------------------------------
 /** @internal */
 export {
@@ -44,12 +46,13 @@ export {
     UANonExclusiveLimitAlarmImplBase
 } from "../impl/alarms_and_conditions/index.js";
 export { instantiateCertificateExpirationAlarm } from "../impl/alarms_and_conditions/ua_certificate_expiration_alarm_impl.js";
-/** @internal */
+/** The event name a node emits when one of its attributes changes. */
 export { makeAttributeEventName } from "../impl/base_node_impl.js";
 /** @internal */
 export { add_dataItem_stuff } from "../impl/data_access/add_dataItem_stuff.js";
 /** @internal */
 export { adjustDataValueStatusCode } from "../impl/data_access/adjust_datavalue_status_code.js";
+/** @see promoteToStateMachine */
 /** @internal */
 export {
     _addMultiStateDiscrete,
@@ -57,7 +60,8 @@ export {
     UAMultiStateDiscreteImpl,
     UAMultiStateDiscreteImplBase
 } from "../impl/data_access/ua_multistate_discrete_impl.js";
-// deprecated: validateDataType
+/** @see promoteToStateMachine */
+// validateDataType is deprecated
 /** @internal */
 export {
     _addMultiStateValueDiscrete,
@@ -67,6 +71,7 @@ export {
     validateDataType,
     validateIsNumericDataType
 } from "../impl/data_access/ua_multistate_value_discrete_impl.js";
+/** @see promoteToStateMachine */
 /** @internal */
 export {
     _addTwoStateDiscrete,
@@ -75,25 +80,30 @@ export {
     UATwoStateDiscreteImplBase
 } from "../impl/data_access/ua_two_state_discrete_impl.js";
 export * from "../impl/event_data.js";
-/** @internal */
+/** Building and maintaining a variable whose value is an array of extension objects. */
 export { addElement, bindExtObjArrayNode, createExtObjArrayNode, removeElement } from "../impl/extension_object_array_node.js";
-/** @internal */
+/** The default historian, installed through {@link AddressSpace.historizerFactory}. */
 export { VariableHistorian } from "../impl/historical_access/address_space_historical_data_node.js";
 /** @internal */
 export { isNonEmptyQualifiedName, NamespaceImpl } from "../impl/namespace_impl.js";
-/** @internal */
+/** How node ids are assigned within a namespace. */
 export { ConstructNodeIdOptions, NamespaceOptions, NodeIdManager } from "../impl/nodeid_manager.js";
-/** @internal */
+/** Rewrites the server's namespace array to match the namespaces actually loaded. */
 export { adjustNamespaceArray } from "../impl/nodeset_tools/adjust_namespace_array.js";
 export * from "../impl/nodeset_tools/construct_namespace_dependency.js";
-/** @internal */
+/** A namespace's data types as an OPC binary schema (BSD) document. */
 export { dumpToBSD } from "../impl/nodeset_tools/dump_to_bsd.js";
 /** @internal */
 export { sortByBrowseName } from "../impl/nodeset_tools/nodeset_to_xml.js";
 export * from "../impl/private_namespace.js";
-/** @internal */
+/** Following a reference to the node, or the reference type, it points at. */
 export { resolveReferenceNode, resolveReferenceType } from "../impl/reference_impl.js";
-/** @internal */
+/**
+ * Upgrading a node to the typed view of what it already is.
+ *
+ * Loading a nodeset gives plain nodes; promoting one returns the same node seen through the
+ * interface for its type, with the helpers that go with it.
+ */
 export { promoteToStateMachine, promoteToStateMachineType } from "../impl/state_machine/finite_state_machine.js";
 export { validateDataTypeCorrectness } from "../impl/validate_data_type_correctness.js";
 export * from "./address_space_public.js";

--- a/packages/node-opcua-address-space/api/interfaces/alarms_and_conditions/condition_info_i.ts
+++ b/packages/node-opcua-address-space/api/interfaces/alarms_and_conditions/condition_info_i.ts
@@ -4,6 +4,7 @@
 import type { UInt16 } from "node-opcua-basic-types";
 import type { LocalizedText, LocalizedTextLike } from "node-opcua-data-model";
 import type { StatusCode } from "node-opcua-status-code";
+import { ConditionInfoImpl } from "../../../impl/alarms_and_conditions/condition_info_impl.js";
 
 export interface ConditionInfoOptions {
     message?: string | LocalizedTextLike | null;
@@ -22,3 +23,38 @@ export interface ConditionInfo {
     retain: boolean | null;
     isDifferentFrom(otherConditionInfo: ConditionInfo): boolean;
 }
+
+/**
+ * The static side of {@link ConditionInfo}, so that `new ConditionInfo({...})` works.
+ *
+ * Naming the constructor separately keeps the published surface to what a caller needs: a way
+ * to build one. The class behind it carries nothing else, but stating the shape here means the
+ * implementation can change without the API following it.
+ */
+export interface ConditionInfoConstructor {
+    new (options: ConditionInfoOptions): ConditionInfo;
+}
+
+/**
+ * Builds the message, severity, quality and retain flag that a condition reports.
+ *
+ * ```ts
+ * alarm.calculateConditionInfo = (state, isActive, value, oldConditionInfo) =>
+ *     new ConditionInfo({
+ *         message: `Tank is almost ${Math.ceil(value * 100)}% full`,
+ *         severity: 100,
+ *         quality: StatusCodes.Good,
+ *         retain: true
+ *     });
+ * ```
+ *
+ * The interface of the same name above is the shape of the result; this is the constructor
+ * for it. A type and a value may share a name, which is what lets both live here - and one
+ * module has to own the name, or `export *` from two of them is ambiguous.
+ *
+ * The documentation for the alarm override point has called `new ConditionInfo({...})` for
+ * years while only the type was exported and the sole constructor was an internal class, so
+ * the example did not run as written and code following it had to reach into the
+ * implementation to find one.
+ */
+export const ConditionInfo: ConditionInfoConstructor = ConditionInfoImpl;

--- a/packages/node-opcua-address-space/api/interfaces/alarms_and_conditions/ua_alarm_condition_ex.ts
+++ b/packages/node-opcua-address-space/api/interfaces/alarms_and_conditions/ua_alarm_condition_ex.ts
@@ -22,6 +22,35 @@ export interface UAAlarmConditionHelper extends UAAcknowledgeableConditionHelper
     updateState(): void;
     getCurrentConditionInfo(): ConditionInfo;
     installInputNodeMonitoring(inputNode: BaseNode | NodeId): void;
+
+    /**
+     * What the alarm reports when its state changes. Assign to it to give an alarm a message
+     * and a severity of its own:
+     *
+     * ```ts
+     * alarm.calculateConditionInfo = (state, isActive, value, oldConditionInfo) =>
+     *     new ConditionInfo({
+     *         message: `Tank is almost ${Math.ceil(Number(value) * 100)}% full`,
+     *         severity: 100,
+     *         quality: StatusCodes.Good,
+     *         retain: true
+     *     });
+     * ```
+     *
+     * The default returns the previous ConditionInfo unchanged, so an alarm that does not
+     * assign one reports nothing new.
+     *
+     * This has been the documented way to give an alarm its own message for years, but under
+     * the name `_calculateConditionInfo` and only on the implementation class, so following
+     * the documentation meant importing from inside the package. That name still works and is
+     * deprecated.
+     */
+    calculateConditionInfo(
+        stateName: string | null,
+        isActive: boolean,
+        value: string,
+        oldConditionInfo: ConditionInfo
+    ): ConditionInfo;
 }
 
 export interface UALarmConditionEvents extends UAAcknowledgeableConditionEvents {}

--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_alarm_condition_impl.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_alarm_condition_impl.ts
@@ -378,26 +378,29 @@ export class UAAlarmConditionImplBase extends UAAcknowledgeableConditionImplBase
         return oldConditionInfo;
     }
 
-    /***
-     *
-     * this method need to be overridden by the instantiate to allow custom message and severity
-     * to be set based on specific context of the alarm.
+    /**
+     * What this alarm reports when its state changes. Assign to it to give an alarm a message
+     * and a severity of its own.
      *
      * @example
      *
+     * ```ts
+     * const myAlarm = namespace.instantiateExclusiveLimitAlarm({ ... });
+     * myAlarm.calculateConditionInfo = (stateName, isActive, value, oldConditionInfo) =>
+     *     new ConditionInfo({
+     *         message: `Tank is almost ${Math.ceil(Number(value) * 100)}% full`,
+     *         severity: 100,
+     *         quality: StatusCodes.Good,
+     *         retain: true
+     *     });
+     * ```
      *
-     *    var myAlarm = addressSpace.instantiateExclusiveLimitAlarm({...});
-     *    myAlarm._calculateConditionInfo = function(stateName,value,oldCondition) {
-     *       var percent = Math.ceil(value * 100);
-     *       return new ConditionInfo({
-     *            message: "Tank is almost " + percent + "% full",
-     *            severity: 100,
-     *            quality: StatusCodes.Good
-     *      });
-     *    };
-     *
+     * This example is now runnable. It was written against `_calculateConditionInfo` and
+     * `new ConditionInfo(...)`, while the method sat on this class only and ConditionInfo was
+     * exported as a type with no constructor - so following the documentation meant importing
+     * two names from inside the package.
      */
-    public _calculateConditionInfo(
+    public calculateConditionInfo(
         stateData: string | null,
         _isActive: boolean,
         value: string,
@@ -420,6 +423,18 @@ export class UAAlarmConditionImplBase extends UAAcknowledgeableConditionImplBase
         }
     }
 
+    /**
+     * @deprecated assign {@link calculateConditionInfo} instead; this delegates to it.
+     */
+    public _calculateConditionInfo(
+        stateData: string | null,
+        isActive: boolean,
+        value: string,
+        oldCondition: ConditionInfo
+    ): ConditionInfo {
+        return this.calculateConditionInfo(stateData, isActive, value, oldCondition);
+    }
+
     public _signalInitialCondition(): void {
         this.currentBranch().setActiveState(false);
         this.currentBranch().setAckedState(true);
@@ -435,6 +450,9 @@ export class UAAlarmConditionImplBase extends UAAcknowledgeableConditionImplBase
         // xx assert(isActive !== alarm.activeState.getValue());
 
         const oldConditionInfo = this.getCurrentConditionInfo();
+        // deliberately the deprecated name: code that overrode `_calculateConditionInfo`
+        // still takes effect through it, and code that assigns the published
+        // `calculateConditionInfo` is reached by the default below. Both work.
         const newConditionInfo = this._calculateConditionInfo(stateName, isActive, value, oldConditionInfo);
 
         // detect potential internal bugs due to misused of _signalNewCondition

--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_non_exclusive_limit_alarm_impl.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_non_exclusive_limit_alarm_impl.ts
@@ -111,7 +111,7 @@ export class UANonExclusiveLimitAlarmImplBase extends UALimitAlarmImpl implement
         return alarm;
     }
 
-    public _calculateConditionInfo(
+    public calculateConditionInfo(
         state: string | null,
         isActive: boolean,
         value: string,

--- a/packages/node-opcua-address-space/test/test_custom_alarm_condition_info.ts
+++ b/packages/node-opcua-address-space/test/test_custom_alarm_condition_info.ts
@@ -1,0 +1,115 @@
+/**
+ * Giving an alarm a message of its own, using only what the package publishes.
+ *
+ * This is the example from calculateConditionInfo's own documentation. It did not run as
+ * written: `ConditionInfo` was exported as a type with no constructor, and the override point
+ * was `_calculateConditionInfo` on an unpublished class - so following the documentation meant
+ * importing two names from inside the package.
+ *
+ * The imports below are the point of the test. If either name has to come from a deep path
+ * again, this stops compiling.
+ */
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { nodesets } from "node-opcua-nodesets";
+import { StatusCodes } from "node-opcua-status-code";
+import { DataType } from "node-opcua-variant";
+import should from "should";
+
+import {
+    AddressSpace,
+    ConditionInfo,
+    type Namespace,
+    type UAExclusiveLimitAlarmEx,
+    type UAObject,
+    type UAVariable
+} from "../dist/api/index.js";
+import { generateAddressSpace } from "../distNodeJS/index.js";
+
+describe("custom condition info on an alarm", function (this: Mocha.Suite) {
+    this.timeout(Math.max(this.timeout(), 30000));
+
+    let addressSpace: AddressSpace;
+    let namespace: Namespace;
+    let source: UAObject;
+    let inputNode: UAVariable;
+
+    before(async () => {
+        addressSpace = AddressSpace.create();
+        await generateAddressSpace(addressSpace, [nodesets.standard]);
+        namespace = addressSpace.registerNamespace("Private");
+        addressSpace.installAlarmsAndConditionsService();
+
+        const green = namespace.addObject({
+            browseName: "Green",
+            eventNotifier: 0x1,
+            notifierOf: addressSpace.rootFolder.objects.server,
+            organizedBy: addressSpace.rootFolder.objects
+        });
+        source = namespace.addObject({ browseName: "Tank", componentOf: green, eventSourceOf: green });
+        inputNode = namespace.addVariable({ browseName: "TankLevel", dataType: "Double", propertyOf: source });
+        inputNode.setValueFromSource({ dataType: DataType.Double, value: 0 });
+    });
+
+    after(() => addressSpace.dispose());
+
+    const makeAlarm = (browseName: string) =>
+        namespace.instantiateExclusiveLimitAlarm("ExclusiveLimitAlarmType", {
+            browseName,
+            conditionSource: source,
+            highHighLimit: 100.0,
+            highLimit: 10.0,
+            inputNode,
+            lowLimit: 1.0,
+            lowLowLimit: -10.0
+        }) as UAExclusiveLimitAlarmEx;
+
+    it("builds a ConditionInfo through the published constructor", () => {
+        const info = new ConditionInfo({
+            message: "Tank is almost 80% full",
+            severity: 100,
+            quality: StatusCodes.Good,
+            retain: true
+        });
+        should(info.message?.text).eql("Tank is almost 80% full");
+        should(info.severity).eql(100);
+        should(info.retain).eql(true);
+        // the shape the interface promises, not just a bag of fields
+        should(typeof info.isDifferentFrom).eql("function");
+    });
+
+    it("takes an assigned calculateConditionInfo when the alarm changes state", () => {
+        const alarm = makeAlarm("TankLevelAlarm");
+
+        let asked = 0;
+        alarm.calculateConditionInfo = (_stateName, _isActive, value, _old) => {
+            asked++;
+            return new ConditionInfo({
+                message: `Tank level reported as ${value}`,
+                severity: 100,
+                quality: StatusCodes.Good,
+                retain: true
+            });
+        };
+
+        inputNode.setValueFromSource({ dataType: DataType.Double, value: 50.0 });
+
+        should(asked).be.greaterThan(0, "expecting the assigned calculateConditionInfo to be consulted");
+        should(alarm.getCurrentConditionInfo().message?.text).match(/Tank level reported as/);
+    });
+
+    it("still honours the deprecated name, so code written against the old documentation keeps working", () => {
+        const alarm = makeAlarm("TankLevelAlarmLegacy");
+
+        let asked = 0;
+        // the shape the documentation carried for years, assigned on the instance
+        (alarm as unknown as { _calculateConditionInfo: () => ConditionInfo })._calculateConditionInfo = () => {
+            asked++;
+            return new ConditionInfo({ message: "legacy", severity: 1, quality: StatusCodes.Good, retain: true });
+        };
+
+        inputNode.setValueFromSource({ dataType: DataType.Double, value: 200.0 });
+
+        should(asked).be.greaterThan(0, "expecting an override of the deprecated name to still win");
+        should(alarm.getCurrentConditionInfo().message?.text).eql("legacy");
+    });
+});

--- a/tools/check-entry-points/src/rule.js
+++ b/tools/check-entry-points/src/rule.js
@@ -87,9 +87,17 @@ export function exportedSymbols(text, filePath) {
  * never reach the documentation, because typedoc only follows what the entry point exposes.
  * Flagging them would be a gate reporting on something it does not actually guard.
  */
-export function publishedNames(entryFile) {
+export function publishedDeclarations(entryFile) {
     const seen = new Set();
-    const names = new Set();
+    /** name -> { value: boolean, ambient: {file,line} | null } */
+    const decls = new Map();
+
+    const note = (name, kind, where) => {
+        const d = decls.get(name) ?? { value: false, ambient: null };
+        if (kind === "value") d.value = true;
+        if (kind === "ambient" && !d.ambient) d.ambient = where;
+        decls.set(name, d);
+    };
 
     const visit = (file) => {
         if (seen.has(file) || !fs.existsSync(file)) return;
@@ -101,7 +109,9 @@ export function publishedNames(entryFile) {
             if (ts.isExportDeclaration(st)) {
                 const spec = st.moduleSpecifier && ts.isStringLiteral(st.moduleSpecifier) ? st.moduleSpecifier.text : null;
                 if (st.exportClause && ts.isNamedExports(st.exportClause)) {
-                    for (const el of st.exportClause.elements) names.add(el.name.text);
+                    // a re-export carries whatever the other module has; `export type` does not
+                    const kind = st.isTypeOnly ? "type" : "value";
+                    for (const el of st.exportClause.elements) note(el.name.text, el.isTypeOnly ? "type" : kind, null);
                     continue; // an explicit list does not pull in the rest of that module
                 }
                 // `export * from "..."`: everything that module publishes, recursively
@@ -110,18 +120,35 @@ export function publishedNames(entryFile) {
             }
             const mods = ts.canHaveModifiers(st) ? (ts.getModifiers(st) ?? []) : [];
             if (!mods.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)) continue;
-            if (ts.isClassDeclaration(st) || ts.isFunctionDeclaration(st) || ts.isInterfaceDeclaration(st)) {
-                if (st.name) names.add(st.name.text);
-            } else if (ts.isTypeAliasDeclaration(st) || ts.isEnumDeclaration(st)) {
-                names.add(st.name.text);
+
+            // `declare` emits nothing: it promises a value that some other module must provide
+            const isAmbient = mods.some((m) => m.kind === ts.SyntaxKind.DeclareKeyword);
+            const { line } = ts.getLineAndCharacterOfPosition(sf, st.getStart(sf));
+            const where = { file, line: line + 1 };
+
+            if (ts.isInterfaceDeclaration(st) || ts.isTypeAliasDeclaration(st)) {
+                // type-only by construction, and legitimately so
+                note(st.name.text, "type", null);
+            } else if (ts.isClassDeclaration(st) || ts.isFunctionDeclaration(st)) {
+                if (st.name) note(st.name.text, isAmbient ? "ambient" : "value", where);
+            } else if (ts.isEnumDeclaration(st)) {
+                note(st.name.text, isAmbient ? "ambient" : "value", where);
             } else if (ts.isVariableStatement(st)) {
-                for (const d of st.declarationList.declarations) if (ts.isIdentifier(d.name)) names.add(d.name.text);
+                const ambient = isAmbient || st.declarationList.declarations.every((d) => !d.initializer);
+                for (const d of st.declarationList.declarations) {
+                    if (ts.isIdentifier(d.name)) note(d.name.text, ambient ? "ambient" : "value", where);
+                }
             }
         }
     };
 
     visit(entryFile);
-    return names;
+    return decls;
+}
+
+/** the names a package publishes, whatever kind of declaration each has */
+export function publishedNames(entryFile) {
+    return new Set(publishedDeclarations(entryFile).keys());
 }
 
 /** a relative specifier as written for ESM (".js") back to the .ts it is emitted from */
@@ -197,6 +224,7 @@ export function analyze({ repoRoot = ".", packageFilter } = {}) {
     const packages = findPackages(repoRoot, packageFilter);
     const entryFindings = [];
     const internalFindings = [];
+    const phantomFindings = [];
     let scanned = 0;
 
     for (const pkg of packages) {
@@ -209,7 +237,18 @@ export function analyze({ repoRoot = ".", packageFilter } = {}) {
         }
 
         const entrySource = entrySourceFor(pkg.dir, p);
-        const published = entrySource ? publishedNames(entrySource) : null;
+        const declarations = entrySource ? publishedDeclarations(entrySource) : null;
+        const published = declarations ? new Set(declarations.keys()) : null;
+
+        // a `declare` promises a value that some module has to provide. When none does, the
+        // name is in the .d.ts and undefined at run time - it compiles and gives you nothing.
+        for (const [name, d] of declarations ?? []) {
+            if (d.ambient && !d.value) {
+                // resolveTs walks with absolute paths; report where the reader can find it
+                const rel = path.relative(repoRoot, d.ambient.file).split(path.sep).join("/");
+                phantomFindings.push({ package: pkg.name, name, file: rel, line: d.ambient.line });
+            }
+        }
 
         for (const file of pkg.files) {
             scanned++;
@@ -223,7 +262,7 @@ export function analyze({ repoRoot = ".", packageFilter } = {}) {
             }
         }
     }
-    return { packages: packages.length, scanned, entryFindings, internalFindings };
+    return { packages: packages.length, scanned, entryFindings, internalFindings, phantomFindings };
 }
 
 /**
@@ -252,18 +291,34 @@ export function currentCounts(result) {
 }
 
 export function exitCode(result, baseline = {}) {
-    return result.entryFindings.length > 0 || overBaseline(result, baseline).length > 0 ? 1 : 0;
+    const phantoms = result.phantomFindings ?? [];
+    return result.entryFindings.length > 0 || phantoms.length > 0 || overBaseline(result, baseline).length > 0 ? 1 : 0;
 }
 
 export function formatReport(result, baseline = {}) {
     const lines = [];
     const over = overBaseline(result, baseline);
 
-    if (result.entryFindings.length === 0 && over.length === 0) {
+    const phantoms = result.phantomFindings ?? [];
+
+    if (phantoms.length) {
+        lines.push(`check-entry-points: ${phantoms.length} name(s) declared in the types and defined nowhere`, "");
+        for (const f of phantoms.slice(0, 20)) {
+            lines.push(`  ${f.file}:${f.line}  ${f.name}   (${f.package})`);
+        }
+        lines.push("");
+        lines.push("  A `declare` promises a value that some module has to provide. When none does, the");
+        lines.push("  name reaches the .d.ts and is undefined at run time: importing it compiles and gives");
+        lines.push("  you nothing. Either export the implementation, or delete the declaration.");
+        lines.push("");
+    }
+
+    if (result.entryFindings.length === 0 && over.length === 0 && phantoms.length === 0) {
         const tally = result.internalFindings.length;
         lines.push(
             `check-entry-points: ${result.packages} packages, ${result.scanned} files. Every types field describes ` +
-                `its own main${tally ? `, and no package exceeds its untagged-export baseline (${tally} total)` : ""}.`
+                `its own main, every declared name is defined` +
+                `${tally ? `, and no package exceeds its untagged-export baseline (${tally} total)` : ""}.`
         );
         return lines.join("\n");
     }

--- a/tools/check-entry-points/test/test_rule.js
+++ b/tools/check-entry-points/test/test_rule.js
@@ -14,7 +14,18 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { analyze, classifyEntry, currentCounts, exitCode, exportedSymbols, formatReport, overBaseline, publishedNames, IGNORE_MARKER } from "../src/rule.js";
+import {
+    analyze,
+    classifyEntry,
+    currentCounts,
+    exitCode,
+    exportedSymbols,
+    formatReport,
+    overBaseline,
+    publishedDeclarations,
+    publishedNames,
+    IGNORE_MARKER
+} from "../src/rule.js";
 
 function withTree(files, fn) {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "check-entry-"));
@@ -180,6 +191,74 @@ test("a clean tree reports what it covered", () => {
             const result = analyze({ repoRoot: root });
             assert.equal(exitCode(result, {}), 0);
             assert.match(formatReport(result, {}), /Every types field describes its own main/);
+        }
+    );
+});
+
+test("a declare with no implementation anywhere is a phantom", () => {
+    // the shape that shipped: declared in the type surface, exported by no module, so it
+    // reaches the .d.ts and is undefined at run time
+    withTree(
+        {
+            "packages/p/package.json": pkg(),
+            "packages/p/source/index.ts": 'export * from "./types.js";\n',
+            "packages/p/source/types.ts": "export declare function dumpXml(node: unknown): string;\n"
+        },
+        (root) => {
+            const result = analyze({ repoRoot: root });
+            assert.equal(result.phantomFindings.length, 1);
+            assert.equal(result.phantomFindings[0].name, "dumpXml");
+            assert.equal(exitCode(result, { p: 999 }), 1, "the baseline covers tags, never a phantom");
+            assert.match(formatReport(result, {}), /declared in the types and defined nowhere/);
+        }
+    );
+});
+
+test("a declare that some module does implement is not a phantom", () => {
+    withTree(
+        {
+            "packages/p/package.json": pkg(),
+            "packages/p/source/index.ts": 'export * from "./types.js";\nexport { dumpXml } from "./impl.js";\n',
+            "packages/p/source/types.ts": "export declare function dumpXml(node: unknown): string;\n",
+            "packages/p/source/impl.ts": "export function dumpXml(_node: unknown): string { return \"\"; }\n"
+        },
+        (root) => {
+            assert.equal(analyze({ repoRoot: root }).phantomFindings.length, 0);
+        }
+    );
+});
+
+test("an interface is type-only by construction and is never a phantom", () => {
+    withTree(
+        {
+            "packages/p/package.json": pkg(),
+            "packages/p/source/index.ts": 'export * from "./types.js";\n',
+            "packages/p/source/types.ts": "export interface Shape { a: number }\nexport type Other = Shape;\n"
+        },
+        (root) => {
+            assert.equal(analyze({ repoRoot: root }).phantomFindings.length, 0, "a type is supposed to have no value");
+        }
+    );
+});
+
+test("publishedDeclarations separates what has a value from what only has a type", () => {
+    withTree(
+        {
+            "packages/p/source/index.ts": 'export * from "./m.js";\n',
+            "packages/p/source/m.ts":
+                "export interface OnlyType { a: number }\n" +
+                "export declare function promised(): void;\n" +
+                "export function real(): void {}\n" +
+                "export const value = 1;\n"
+        },
+        (root) => {
+            const d = publishedDeclarations(path.join(root, "packages/p/source/index.ts"));
+            assert.equal(d.get("real").value, true);
+            assert.equal(d.get("value").value, true);
+            assert.equal(d.get("OnlyType").value, false);
+            assert.equal(d.get("OnlyType").ambient, null, "an interface is not an unkept promise");
+            assert.equal(d.get("promised").value, false);
+            assert.ok(d.get("promised").ambient, "a declare records where it was promised");
         }
     );
 });


### PR DESCRIPTION
FEAT-14, US-14.1. Follows #1603, which unified this package's entry points and marked the
implementation internal. That raised a question nobody had asked: **what does this package
publish?** The answer was "whatever `main` happened to export", and downstream code had built
on the parts the documentation never mentioned.

## The documented example did not run

The alarm override point carries this comment, in this repository:

> this method need to be overridden by the instantiate to allow custom message and severity to
> be set based on specific context of the alarm.

with an `@example` calling `new ConditionInfo({...})`. Following it was impossible:

- `ConditionInfo` was exported as a **type only**. `typeof ConditionInfo === "undefined"`.
  The only constructor was `ConditionInfoImpl`, which #1603 had just marked internal.
- the override point was `_calculateConditionInfo`, underscore-named, declared on the
  implementation class, which the package does not publish.

So code doing this was not reaching past the API. It was following the documentation, using
the only names that exist:

```ts
import { UAAlarmConditionImpl } from "node-opcua-address-space/dist/impl/alarms_and_conditions/ua_alarm_condition_impl.js";
import { ConditionInfoImpl } from "node-opcua-address-space/dist/impl/alarms_and_conditions/condition_info_impl.js";
```

**Now published:** `ConditionInfo` has a constructor, declared beside the interface it builds
so one module owns the name. `calculateConditionInfo` is on the published alarm interface, so
assigning it type-checks.

`_calculateConditionInfo` stays, deprecated, and the alarm still calls **it** internally: an
override of the old name wins exactly as before, and the default delegates to the new one, so
both forms work. The test asserting that is the one that protects existing code.

## The compatibility block was going to break people

#1603 parked 52 names in an internal block so the run-time surface would not shrink, with a
note saying they would be dropped at 3.0. Scanning downstream code found that plan was wrong:
`promoteToStateMachine` alone is used by **five separate projects**, and a dozen more names by
others.

They are API in practice; the entry simply never said so. They move out of the block, with doc
comments: the `promoteTo*` family, `dumpToBSD`, `VariableHistorian`, `NodeIdManager`,
`addElement`/`removeElement`/`bindExtObjArrayNode`/`createExtObjArrayNode`,
`resolveReferenceNode`/`resolveReferenceType`, `adjustNamespaceArray`, `makeAttributeEventName`.

The block keeps what it was meant for: the `*Impl` classes and the underscore helpers.

## Twelve hand-written declarations, and one that named nothing

The type surface carried twelve `export declare` entries. Eleven named something the entry
re-exports from the implementation, and an explicit re-export takes precedence over
`export *` - so they were shadowed, describing nothing while free to drift from what they
shadowed. That is how `dumpToBSD` came to be declared taking `INamespace` while the
implementation took `NamespacePrivate`.

The twelfth, **`dumpXml`, named nothing at all**: declared here, exported by no module,
`undefined` at run time, with no implementation anywhere in the repository.
`import { dumpXml } from "node-opcua"` compiled and gave you nothing. It can no longer be
imported.

## A third check in the gate

`check-entry-points` compared the `main` and `types` **fields**, so it could not have caught
`dumpXml`: both fields were correct, the contents were the lie. It now also fails when a name
the entry declares is defined by no module.

A `declare` promises a value and emits nothing, so an unbacked one is a broken promise.
Interfaces and type aliases are exempt by construction - they are meant to have no value, and
conflating the two would have made the check noise. Verified by reintroducing `dumpXml`.

## Verification

`tsc -b packages` clean. Ratchet **72 packages, 0 grandfathered**. `check:entrypoints` across
117 packages: entries coherent, every declared name defined, no package over its baseline.
Biome clean. Gate unit tests 16/16.

`node-opcua-address-space` **1099 passing**, including three new tests that import only from
the package entry - if either name has to come from a deep path again, they stop compiling.

Documentation regenerated and inspected rather than assumed: `ConditionInfo`,
`promoteToStateMachine`, `dumpToBSD`, `VariableHistorian`, `NodeIdManager`, `addElement`,
`resolveReferenceNode`, `adjustNamespaceArray`, `makeAttributeEventName` all appear;
`UAAlarmConditionImpl`, `ConditionInfoImpl`, `NamespaceImpl`, `AddressSpaceImpl` and
`_addTwoStateDiscrete` do not; **zero** names ending `Impl` or `ImplBase` remain.

## Not here

US-14.2 is the 3.0 half and deliberately later: `stripInternal`, dropping the remaining
`*Impl` re-exports, and a deep-import check. Doing `stripInternal` first would have hardened
exactly the boundary that was in the wrong place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
