### PR TITLE
refactor(address-space): name the entry point in the last 158 specifiers

### DIFF
--- a/packages/node-opcua-address-space/test/alarms_and_conditions/test_alarms_and_conditions.ts
+++ b/packages/node-opcua-address-space/test/alarms_and_conditions/test_alarms_and_conditions.ts
@@ -3,7 +3,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import "should";
 
-import { AddressSpace, type UAObject, type UAVariable } from "../..";
+import { AddressSpace, type UAObject, type UAVariable } from "../../dist/api/index.js";
 import { generateAddressSpace } from "../../distNodeJS/index.js";
 
 import { utest_acknowledgeable_condition } from "./utest_acknowledgeable_condition.js";

--- a/packages/node-opcua-address-space/test/alarms_and_conditions/test_certificate_alarm.ts
+++ b/packages/node-opcua-address-space/test/alarms_and_conditions/test_certificate_alarm.ts
@@ -7,7 +7,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { NodeId } from "node-opcua-nodeid";
 import { nodesets } from "node-opcua-nodesets";
 import { samplesCertificateFolder } from "node-opcua-test-helpers";
-import { AddressSpace, instantiateCertificateExpirationAlarm, type UACertificateExpirationAlarmEx } from "../..";
+import { AddressSpace, instantiateCertificateExpirationAlarm, type UACertificateExpirationAlarmEx } from "../../dist/api/index.js";
 import { generateAddressSpace } from "../../distNodeJS/index.js";
 
 export const OneDayDuration = 1000 * 60 * 60 * 24;

--- a/packages/node-opcua-address-space/test/alarms_and_conditions/test_reconstructed_alarm.ts
+++ b/packages/node-opcua-address-space/test/alarms_and_conditions/test_reconstructed_alarm.ts
@@ -7,7 +7,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { NodeId, resolveNodeId } from "node-opcua-nodeid";
 import { nodesets } from "node-opcua-nodesets";
 
-import { AddressSpace, instantiateCertificateExpirationAlarm } from "../..";
+import { AddressSpace, instantiateCertificateExpirationAlarm } from "../../dist/api/index.js";
 import { generateAddressSpace } from "../../nodeJS.js";
 
 const fakeCertificate = Buffer.from(

--- a/packages/node-opcua-address-space/test/alarms_and_conditions/utest_acknowledgeable_condition.ts
+++ b/packages/node-opcua-address-space/test/alarms_and_conditions/utest_acknowledgeable_condition.ts
@@ -4,7 +4,7 @@ import { StatusCodes } from "node-opcua-status-code";
 import { DataType } from "node-opcua-variant";
 import should from "should";
 
-import type { AddressSpace, UAObject } from "../..";
+import type { AddressSpace, UAObject } from "../../dist/api/index.js";
 import type { UAAcknowledgeableConditionEx } from "../../dist/api/interfaces/alarms_and_conditions/ua_acknowledgeable_condition_ex.js";
 import type { MochaSuiteEx } from "./test_alarms_and_conditions.js";
 

--- a/packages/node-opcua-address-space/test/alarms_and_conditions/utest_alarm_condition.ts
+++ b/packages/node-opcua-address-space/test/alarms_and_conditions/utest_alarm_condition.ts
@@ -7,7 +7,14 @@ import type { CallMethodResultOptions } from "node-opcua-types";
 import { DataType, Variant } from "node-opcua-variant";
 import should from "should";
 import sinon from "sinon";
-import { type AddressSpace, type BaseNode, SessionContext, type UAAlarmConditionEx, type UAObject, type UAVariable } from "../..";
+import {
+    type AddressSpace,
+    type BaseNode,
+    SessionContext,
+    type UAAlarmConditionEx,
+    type UAObject,
+    type UAVariable
+} from "../../dist/api/index.js";
 import type { MochaSuiteEx } from "./test_alarms_and_conditions.js";
 
 const debugLog = make_debugLog("TEST");

--- a/packages/node-opcua-address-space/test/alarms_and_conditions/utest_condition.ts
+++ b/packages/node-opcua-address-space/test/alarms_and_conditions/utest_condition.ts
@@ -12,7 +12,7 @@ import {
     type UAConditionEx,
     type UAEventType,
     type UAObject
-} from "../..";
+} from "../../dist/api/index.js";
 import { mockSession } from "../../testHelpers.js";
 import type { MochaSuiteEx } from "./test_alarms_and_conditions.js";
 

--- a/packages/node-opcua-address-space/test/alarms_and_conditions/utest_exclusive_deviation_alarm.ts
+++ b/packages/node-opcua-address-space/test/alarms_and_conditions/utest_exclusive_deviation_alarm.ts
@@ -1,7 +1,7 @@
 import { StatusCodes } from "node-opcua-status-code";
 import { type DataType, Variant } from "node-opcua-variant";
 import should from "should";
-import type { AddressSpace, UAExclusiveDeviationAlarmEx, UAObject, UAVariable, UAVariableT } from "../..";
+import type { AddressSpace, UAExclusiveDeviationAlarmEx, UAObject, UAVariable, UAVariableT } from "../../dist/api/index.js";
 import type { MochaSuiteEx } from "./test_alarms_and_conditions.js";
 
 export function utest_exclusive_deviation_alarm(test: MochaSuiteEx): void {

--- a/packages/node-opcua-address-space/test/alarms_and_conditions/utest_issue_316.ts
+++ b/packages/node-opcua-address-space/test/alarms_and_conditions/utest_issue_316.ts
@@ -1,6 +1,6 @@
 import { DataType } from "node-opcua-variant";
 import should from "should";
-import type { AddressSpace, UAObject } from "../..";
+import type { AddressSpace, UAObject } from "../../dist/api/index.js";
 import type { MochaSuiteEx } from "./test_alarms_and_conditions.js";
 
 export function utest_issue_316(test: MochaSuiteEx): void {

--- a/packages/node-opcua-address-space/test/alarms_and_conditions/utest_limit_alarm.ts
+++ b/packages/node-opcua-address-space/test/alarms_and_conditions/utest_limit_alarm.ts
@@ -6,7 +6,7 @@ import { DataType, type Variant } from "node-opcua-variant";
 import should from "should";
 import sinon from "sinon";
 
-import type { AddressSpace, UAObject, UAVariable } from "../..";
+import type { AddressSpace, UAObject, UAVariable } from "../../dist/api/index.js";
 import type { MochaSuiteEx } from "./test_alarms_and_conditions.js";
 
 const debugLog = make_debugLog("TEST");

--- a/packages/node-opcua-address-space/test/alarms_and_conditions/utest_non_exclusive_deviation_alarm.ts
+++ b/packages/node-opcua-address-space/test/alarms_and_conditions/utest_non_exclusive_deviation_alarm.ts
@@ -1,6 +1,6 @@
 import { type DataType, Variant } from "node-opcua-variant";
 import should from "should";
-import type { AddressSpace, UANonExclusiveDeviationAlarmEx, UAObject, UAVariableT } from "../..";
+import type { AddressSpace, UANonExclusiveDeviationAlarmEx, UAObject, UAVariableT } from "../../dist/api/index.js";
 import type { MochaSuiteEx } from "./test_alarms_and_conditions.js";
 
 export function utest_non_exclusive_deviation_alarm(test: MochaSuiteEx): void {

--- a/packages/node-opcua-address-space/test/alarms_and_conditions/utest_off_normal_alarm.ts
+++ b/packages/node-opcua-address-space/test/alarms_and_conditions/utest_off_normal_alarm.ts
@@ -1,7 +1,7 @@
 import { DataType } from "node-opcua-variant";
 import should from "should";
 import sinon from "sinon";
-import type { AddressSpace, Namespace, UAMultiStateDiscreteEx, UAObject, UAVariable, UAVariableT } from "../..";
+import type { AddressSpace, Namespace, UAMultiStateDiscreteEx, UAObject, UAVariable, UAVariableT } from "../../dist/api/index.js";
 import type { MochaSuiteEx } from "./test_alarms_and_conditions.js";
 
 export function utest_off_normal_alarm(test: MochaSuiteEx): void {

--- a/packages/node-opcua-address-space/test/data_access/subtest_Y_array_item_type.ts
+++ b/packages/node-opcua-address-space/test/data_access/subtest_Y_array_item_type.ts
@@ -4,7 +4,7 @@ import { resolveNodeId } from "node-opcua-nodeid";
 import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
 import should from "should";
 
-import type { AddressSpace, Namespace, UAFolder } from "../..";
+import type { AddressSpace, Namespace, UAFolder } from "../../dist/api/index.js";
 
 interface MainTest {
     addressSpace: AddressSpace;

--- a/packages/node-opcua-address-space/test/data_access/subtest_analog_item_semantic_changed.ts
+++ b/packages/node-opcua-address-space/test/data_access/subtest_analog_item_semantic_changed.ts
@@ -5,7 +5,7 @@ import { WriteValue } from "node-opcua-service-write";
 import { DataType, Variant } from "node-opcua-variant";
 import should from "should";
 import sinon from "sinon";
-import { type AddressSpace, SessionContext, type UAAnalogItem } from "../..";
+import { type AddressSpace, SessionContext, type UAAnalogItem } from "../../dist/api/index.js";
 
 const context = SessionContext.defaultContext;
 

--- a/packages/node-opcua-address-space/test/data_access/subtest_analog_item_type.ts
+++ b/packages/node-opcua-address-space/test/data_access/subtest_analog_item_type.ts
@@ -6,7 +6,7 @@ import { StatusCodes } from "node-opcua-status-code";
 import { DataType, Variant } from "node-opcua-variant";
 import should from "should";
 
-import { type AddressSpace, type Namespace, SessionContext } from "../..";
+import { type AddressSpace, type Namespace, SessionContext } from "../../dist/api/index.js";
 
 interface MainTest {
     addressSpace: AddressSpace;

--- a/packages/node-opcua-address-space/test/data_access/subtest_data_item_PercentDeadband.ts
+++ b/packages/node-opcua-address-space/test/data_access/subtest_data_item_PercentDeadband.ts
@@ -4,7 +4,7 @@ import { StatusCodes } from "node-opcua-status-code";
 import { DataType, Variant } from "node-opcua-variant";
 import should from "should";
 
-import { type AddressSpace, type Namespace, SessionContext } from "../..";
+import { type AddressSpace, type Namespace, SessionContext } from "../../dist/api/index.js";
 
 interface MainTest {
     addressSpace: AddressSpace;

--- a/packages/node-opcua-address-space/test/data_access/subtest_multi_state_discrete_type.ts
+++ b/packages/node-opcua-address-space/test/data_access/subtest_multi_state_discrete_type.ts
@@ -5,7 +5,7 @@ import { DataType, Variant } from "node-opcua-variant";
 import should from "should";
 import sinon from "sinon";
 
-import { type AddressSpace, SessionContext, type UAMultiStateDiscreteEx } from "../..";
+import { type AddressSpace, SessionContext, type UAMultiStateDiscreteEx } from "../../dist/api/index.js";
 
 export function subtest_multi_state_discrete_type(mainTest: { addressSpace: AddressSpace }): void {
     describe("MultiStateDiscreteType", () => {

--- a/packages/node-opcua-address-space/test/data_access/subtest_multi_state_value_discrete_type.ts
+++ b/packages/node-opcua-address-space/test/data_access/subtest_multi_state_value_discrete_type.ts
@@ -16,7 +16,7 @@ import {
     type UAMultiStateValueDiscreteEx,
     type UAObject,
     type UAObjectType
-} from "../..";
+} from "../../dist/api/index.js";
 
 const context = new SessionContext();
 

--- a/packages/node-opcua-address-space/test/data_access/subtest_two_state_discrete_type.ts
+++ b/packages/node-opcua-address-space/test/data_access/subtest_two_state_discrete_type.ts
@@ -10,7 +10,7 @@ import { DataType } from "node-opcua-variant";
 import should from "should";
 import sinon from "sinon";
 
-import { AddressSpace, SessionContext, type UAObject, type UAObjectType, type UATwoStateDiscreteEx } from "../..";
+import { AddressSpace, SessionContext, type UAObject, type UAObjectType, type UATwoStateDiscreteEx } from "../../dist/api/index.js";
 import { generateAddressSpace } from "../../distNodeJS/index.js";
 
 const doDebug = false;

--- a/packages/node-opcua-address-space/test/data_access/test_data_item.ts
+++ b/packages/node-opcua-address-space/test/data_access/test_data_item.ts
@@ -4,7 +4,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import { encode_decode_round_trip_test } from "node-opcua-packet-analyzer/dist/test_helpers";
 import should from "should";
-import { AddressSpace } from "../..";
+import { AddressSpace } from "../../dist/api/index.js";
 import { generateAddressSpace } from "../../nodeJS.js";
 import { subtest_analog_item_semantic_changed } from "./subtest_analog_item_semantic_changed.js";
 import { subtest_analog_item_type } from "./subtest_analog_item_type.js";

--- a/packages/node-opcua-address-space/test/data_access/test_multi_state_value_discrete_type_from_nodeset.ts
+++ b/packages/node-opcua-address-space/test/data_access/test_multi_state_value_discrete_type_from_nodeset.ts
@@ -10,7 +10,7 @@ import {
     type UAMultiStateValueDiscreteEx,
     type UAVariable,
     validateIsNumericDataType
-} from "../..";
+} from "../../dist/api/index.js";
 import { generateAddressSpace } from "../../nodeJS.js";
 import { getAddressSpaceFixture } from "../../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/dynamic_extension_objects/test_issue_1436.ts
+++ b/packages/node-opcua-address-space/test/dynamic_extension_objects/test_issue_1436.ts
@@ -7,7 +7,7 @@ import { OpaqueStructure } from "node-opcua-extension-object";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import should from "should";
-import { AddressSpace, type Namespace, PseudoSession } from "../..";
+import { AddressSpace, type Namespace, PseudoSession } from "../../dist/api/index.js";
 import { generateAddressSpace } from "../../distNodeJS/index.js";
 import { getAddressSpaceFixture } from "../../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/finite_state_machine/test_finite_state_machine.ts
+++ b/packages/node-opcua-address-space/test/finite_state_machine/test_finite_state_machine.ts
@@ -17,7 +17,7 @@ import {
     type UAStateMachineEx,
     type UAStateMachineType,
     type UAVariable
-} from "../..";
+} from "../../dist/api/index.js";
 import { generateAddressSpace } from "../../nodeJS.js";
 import { getAddressSpaceFixture } from "../../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/fixture_camera_type.ts
+++ b/packages/node-opcua-address-space/test/fixture_camera_type.ts
@@ -1,7 +1,7 @@
 import { QualifiedName } from "node-opcua-data-model";
 import { DataType } from "node-opcua-variant";
 import should from "should";
-import type { IAddressSpace, InstantiateObjectOptions, UAMethod, UAObject, UAObjectType, UAVariableT } from "..";
+import type { IAddressSpace, InstantiateObjectOptions, UAMethod, UAObject, UAObjectType, UAVariableT } from "../dist/api/index.js";
 
 export interface FakeCamera extends UAObject {
     trigger: UAMethod;

--- a/packages/node-opcua-address-space/test/fixture_temperature_sensor_type.ts
+++ b/packages/node-opcua-address-space/test/fixture_temperature_sensor_type.ts
@@ -2,7 +2,7 @@ import "should";
 
 import type { Double } from "node-opcua-basic-types";
 import { DataType, Variant } from "node-opcua-variant";
-import type { AddressSpace, InstantiateObjectOptions, UAObject, UAObjectType, UAVariableT } from "..";
+import type { AddressSpace, InstantiateObjectOptions, UAObject, UAObjectType, UAVariableT } from "../dist/api/index.js";
 
 export interface TemperatureSensor extends UAObject {
     temperature: UAVariableT<Double, DataType.Double>;

--- a/packages/node-opcua-address-space/test/historical_access/test_address_space_historical_data_node.ts
+++ b/packages/node-opcua-address-space/test/historical_access/test_address_space_historical_data_node.ts
@@ -17,7 +17,13 @@ import type { WriteValueOptions } from "node-opcua-service-write";
 import { StatusCodes } from "node-opcua-status-code";
 import { DataType } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, type ContinuationPoint, ContinuationPointManager, SessionContext, type UAVariable } from "../..";
+import {
+    AddressSpace,
+    type ContinuationPoint,
+    ContinuationPointManager,
+    SessionContext,
+    type UAVariable
+} from "../../dist/api/index.js";
 import { generateAddressSpace } from "../../nodeJS.js";
 import { date_add } from "../../testHelpers.js";
 

--- a/packages/node-opcua-address-space/test/historical_access/test_address_space_historical_data_node_enumeration.ts
+++ b/packages/node-opcua-address-space/test/historical_access/test_address_space_historical_data_node_enumeration.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
-import { AddressSpace } from "../..";
+import { AddressSpace } from "../../dist/api/index.js";
 import { generateAddressSpace } from "../../nodeJS.js";
 
 describe("Testing Historical Data Node Enumeration", () => {

--- a/packages/node-opcua-address-space/test/historical_access/test_address_space_historical_data_node_in_memory.ts
+++ b/packages/node-opcua-address-space/test/historical_access/test_address_space_historical_data_node_in_memory.ts
@@ -6,7 +6,7 @@ import { nodesets } from "node-opcua-nodesets";
 import { type HistoryData, ReadRawModifiedDetails } from "node-opcua-service-history";
 import { StatusCodes } from "node-opcua-status-code";
 import should from "should";
-import { AddressSpace, type ContinuationPoint, ContinuationPointManager, SessionContext } from "../..";
+import { AddressSpace, type ContinuationPoint, ContinuationPointManager, SessionContext } from "../../dist/api/index.js";
 import { generateAddressSpace } from "../../nodeJS.js";
 import { date_add } from "../../testHelpers.js";
 

--- a/packages/node-opcua-address-space/test/historical_access/test_address_space_historical_data_node_write_and_extension_object.ts
+++ b/packages/node-opcua-address-space/test/historical_access/test_address_space_historical_data_node_write_and_extension_object.ts
@@ -5,7 +5,13 @@ import { nodesets } from "node-opcua-nodesets";
 import { type HistoryData, ReadRawModifiedDetails } from "node-opcua-service-history";
 import { StatusCodes } from "node-opcua-status-code";
 import { DataType } from "node-opcua-variant";
-import { AddressSpace, type ContinuationPoint, ContinuationPointManager, SessionContext, type UAVariable } from "../..";
+import {
+    AddressSpace,
+    type ContinuationPoint,
+    ContinuationPointManager,
+    SessionContext,
+    type UAVariable
+} from "../../dist/api/index.js";
 import { generateAddressSpace } from "../../nodeJS.js";
 import { date_add } from "../../testHelpers.js";
 

--- a/packages/node-opcua-address-space/test/historical_access/test_historize_bound_extension_object_child.ts
+++ b/packages/node-opcua-address-space/test/historical_access/test_historize_bound_extension_object_child.ts
@@ -11,7 +11,7 @@ import {
     SessionContext,
     type UAObjectType,
     type UAVariable
-} from "../..";
+} from "../../dist/api/index.js";
 import { generateAddressSpace } from "../../nodeJS.js";
 import { date_add } from "../../testHelpers.js";
 

--- a/packages/node-opcua-address-space/test/porting_040_042_issue.ts
+++ b/packages/node-opcua-address-space/test/porting_040_042_issue.ts
@@ -1,6 +1,6 @@
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import should from "should";
-import type { AddressSpace, Namespace } from "..";
+import type { AddressSpace, Namespace } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 describe("#513 Testing issue porting from 0.4.0 0.4.2", () => {

--- a/packages/node-opcua-address-space/test/sanity_test.ts
+++ b/packages/node-opcua-address-space/test/sanity_test.ts
@@ -1,5 +1,5 @@
 import should from "should";
-import * as opcua from "..";
+import * as opcua from "../dist/api/index.js";
 
 describe("node-opcua-address-space module sanity test ", () => {
     it("module 'node-opcua-address-space' should not export any null properties", () => {

--- a/packages/node-opcua-address-space/test/test_UAVariable_changeDataType.ts
+++ b/packages/node-opcua-address-space/test/test_UAVariable_changeDataType.ts
@@ -2,7 +2,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { coerceNodeId } from "node-opcua-nodeid";
 import { DataType, type Variant, VariantArrayType } from "node-opcua-variant";
 import should from "should";
-import type { AddressSpace, Namespace } from "..";
+import type { AddressSpace, Namespace } from "../dist/api/index.js";
 import { _getBasicDataTypeFromDataTypeNodeId } from "../impl/get_basic_datatype.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 

--- a/packages/node-opcua-address-space/test/test_accessLevel_userAccessLevel_pullrequest.ts
+++ b/packages/node-opcua-address-space/test/test_accessLevel_userAccessLevel_pullrequest.ts
@@ -2,7 +2,7 @@ import "should";
 import { AccessLevelFlag } from "node-opcua-data-model";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import should from "should";
-import type { AddressSpace, Namespace } from "..";
+import type { AddressSpace, Namespace } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 describe("testing Variables ", () => {

--- a/packages/node-opcua-address-space/test/test_add_in.ts
+++ b/packages/node-opcua-address-space/test/test_add_in.ts
@@ -1,7 +1,7 @@
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import should from "should";
-import { AddressSpace, type UAObject, type UAReferenceType } from "..";
+import { AddressSpace, type UAObject, type UAReferenceType } from "../dist/api/index.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
 
 interface UAMachineToolWithIdentification extends UAObject {

--- a/packages/node-opcua-address-space/test/test_address_space.ts
+++ b/packages/node-opcua-address-space/test/test_address_space.ts
@@ -5,7 +5,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { makeNodeId, NodeId, resolveNodeId } from "node-opcua-nodeid";
 import { DataType } from "node-opcua-variant";
 import should from "should";
-import type { AddressSpace, Namespace, UAReference } from "..";
+import type { AddressSpace, Namespace, UAReference } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 function findReference(references: UAReference[], nodeId: NodeId): UAReference[] {

--- a/packages/node-opcua-address-space/test/test_address_space_add_enumeration_type.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_add_enumeration_type.ts
@@ -5,7 +5,7 @@ import { BrowseDescription } from "node-opcua-service-browse";
 import { StatusCodes } from "node-opcua-status-code";
 import { DataType } from "node-opcua-variant";
 import should from "should";
-import { type AddressSpace, type Namespace, SessionContext } from "..";
+import { type AddressSpace, type Namespace, SessionContext } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 describe("AddressSpace : testing add enumeration type", () => {

--- a/packages/node-opcua-address-space/test/test_address_space_add_event_type.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_add_event_type.ts
@@ -4,7 +4,7 @@ import { resolveNodeId } from "node-opcua-nodeid";
 import { checkSelectClause, constructEventFilter } from "node-opcua-service-filter";
 import { StatusCodes } from "node-opcua-status-code";
 import should from "should";
-import type { AddressSpace, InstantiateConditionOptions, Namespace } from "..";
+import type { AddressSpace, InstantiateConditionOptions, Namespace } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 describe("AddressSpace : add event type ", () => {

--- a/packages/node-opcua-address-space/test/test_address_space_add_object_type.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_add_object_type.ts
@@ -3,7 +3,7 @@ import { NodeClass } from "node-opcua-data-model";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { DataType } from "node-opcua-variant";
 import should from "should";
-import type { AddressSpace, InstantiateObjectOptions, Namespace, UAObject, UAObjectType, UAVariable } from "..";
+import type { AddressSpace, InstantiateObjectOptions, Namespace, UAObject, UAObjectType, UAVariable } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 import { createCameraType, type FakeCameraType } from "./fixture_camera_type.js";
 import {

--- a/packages/node-opcua-address-space/test/test_address_space_add_two_state_variable.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_add_two_state_variable.ts
@@ -4,7 +4,7 @@ import { nodesets } from "node-opcua-nodesets";
 import { StatusCodes } from "node-opcua-status-code";
 import should from "should";
 import sinon from "sinon";
-import { AddressSpace, type BaseNode, type Namespace } from "..";
+import { AddressSpace, type BaseNode, type Namespace } from "../dist/api/index.js";
 import { UATwoStateVariableImpl } from "../dist/impl/state_machine/ua_two_state_variable.js";
 import { generateAddressSpace } from "../nodeJS.js";
 

--- a/packages/node-opcua-address-space/test/test_address_space_add_variable_type.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_add_variable_type.ts
@@ -1,7 +1,7 @@
 import { NodeClass } from "node-opcua-data-model";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import should from "should";
-import type { AddressSpace, Namespace } from "..";
+import type { AddressSpace, Namespace } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 describe("testing add new ObjectType ", () => {

--- a/packages/node-opcua-address-space/test/test_address_space_browse_path.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_browse_path.ts
@@ -5,7 +5,7 @@ import { BrowsePath, makeBrowsePath } from "node-opcua-service-translate-browse-
 import { StatusCodes } from "node-opcua-status-code";
 import should from "should";
 
-import { AddressSpace, type Namespace } from "..";
+import { AddressSpace, type Namespace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { add_eventGeneratorObject, getMiniAddressSpace } from "../testHelpers.js";
 

--- a/packages/node-opcua-address-space/test/test_address_space_construct_extension_object.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_construct_extension_object.ts
@@ -24,7 +24,14 @@ import { ServerState } from "node-opcua-types";
 import { get_clock_tick } from "node-opcua-utils";
 import { DataType, Variant } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, type BaseNode, type DTServerStatus, type Namespace, type UAServerStatus, type UAVariable } from "..";
+import {
+    AddressSpace,
+    type BaseNode,
+    type DTServerStatus,
+    type Namespace,
+    type UAServerStatus,
+    type UAVariable
+} from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 const debugLog = make_debugLog("TEST");

--- a/packages/node-opcua-address-space/test/test_address_space_delete_node.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_delete_node.ts
@@ -11,7 +11,7 @@ import {
     type UAObject,
     type UAObjectType,
     type UAVariable
-} from "..";
+} from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 

--- a/packages/node-opcua-address-space/test/test_address_space_dispose.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_dispose.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import "should";
 
 import h from "humanize";
-import { AddressSpace } from "..";
+import { AddressSpace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_address_space_find_reference.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_find_reference.ts
@@ -1,6 +1,6 @@
 import { resolveNodeId } from "node-opcua-nodeid";
 import should from "should";
-import { AddressSpace } from "..";
+import { AddressSpace } from "../dist/api/index.js";
 import { create_minimalist_address_space_nodeset } from "../testHelpers.js";
 
 describe("testing AddressSpace#findReferenceType and findReferenceTypeFromInverseName", () => {

--- a/packages/node-opcua-address-space/test/test_address_space_model_change_event.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_model_change_event.ts
@@ -3,7 +3,14 @@ import { nodesets } from "node-opcua-nodesets";
 import type { DataType } from "node-opcua-variant";
 import should from "should";
 import sinon from "sinon";
-import { type AddObjectOptions, AddressSpace, type Namespace, type UAObject, type UAProperty, type UAVariable } from "..";
+import {
+    type AddObjectOptions,
+    AddressSpace,
+    type Namespace,
+    type UAObject,
+    type UAProperty,
+    type UAVariable
+} from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 interface UAObjectWithVersion extends UAObject {

--- a/packages/node-opcua-address-space/test/test_address_space_namespace.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_namespace.ts
@@ -3,7 +3,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import { getFixture } from "node-opcua-test-fixtures";
 import should from "should";
-import { AddressSpace } from "..";
+import { AddressSpace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_address_space_object_instantiation.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_object_instantiation.ts
@@ -2,7 +2,7 @@ import { BrowseDirection } from "node-opcua-data-model";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { sameNodeId } from "node-opcua-nodeid";
 import should from "should";
-import type { AddressSpace, UAObject, UAObjectType, UAReferenceType, UAVariable } from "..";
+import type { AddressSpace, UAObject, UAObjectType, UAReferenceType, UAVariable } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 describe("testing add new ObjectType ", () => {

--- a/packages/node-opcua-address-space/test/test_argument_list.ts
+++ b/packages/node-opcua-address-space/test/test_argument_list.ts
@@ -12,7 +12,7 @@ import {
     decode_ArgumentList,
     encode_ArgumentList,
     verifyArguments_ArgumentList
-} from "..";
+} from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 const debugLog = make_debugLog("TEST");

--- a/packages/node-opcua-address-space/test/test_attribute_access_restrictions.ts
+++ b/packages/node-opcua-address-space/test/test_attribute_access_restrictions.ts
@@ -4,7 +4,7 @@ import { AccessRestrictionsFlag, AttributeIds, makeAccessRestrictionsFlag } from
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { StatusCodes } from "node-opcua-status-code";
 import { DataType } from "node-opcua-variant";
-import type { AddressSpace, Namespace } from "..";
+import type { AddressSpace, Namespace } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 describe("testing AccessRestrictions ", () => {

--- a/packages/node-opcua-address-space/test/test_attribute_role_permissions.ts
+++ b/packages/node-opcua-address-space/test/test_attribute_role_permissions.ts
@@ -6,7 +6,7 @@ import { resolveNodeId } from "node-opcua-nodeid";
 import { StatusCodes } from "node-opcua-status-code";
 import { PermissionType, type RolePermissionType } from "node-opcua-types";
 import { DataType, VariantArrayType } from "node-opcua-variant";
-import { type AddressSpace, type Namespace, WellKnownRoles } from "..";
+import { type AddressSpace, type Namespace, WellKnownRoles } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 describe("testing RolePermission Attribute ", () => {

--- a/packages/node-opcua-address-space/test/test_automatic_generation_of_string_node_ids.ts
+++ b/packages/node-opcua-address-space/test/test_automatic_generation_of_string_node_ids.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import should from "should";
 
-import type { AddressSpace, DTServerStatus, UAObjectType, UAServerStatus } from "..";
+import type { AddressSpace, DTServerStatus, UAObjectType, UAServerStatus } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 import { createCameraType, type FakeCamera } from "./fixture_camera_type.js";
 

--- a/packages/node-opcua-address-space/test/test_base_node.ts
+++ b/packages/node-opcua-address-space/test/test_base_node.ts
@@ -3,7 +3,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { type NodeId, resolveNodeId } from "node-opcua-nodeid";
 import should from "should";
 import sinon from "sinon";
-import type { AddressSpace, Namespace, UAObject, UAObjectType, UAReferenceType, UARootFolder } from "..";
+import type { AddressSpace, Namespace, UAObject, UAObjectType, UAReferenceType, UARootFolder } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 interface UAObjectWithInternals extends UAObject {

--- a/packages/node-opcua-address-space/test/test_basic_interface.ts
+++ b/packages/node-opcua-address-space/test/test_basic_interface.ts
@@ -2,7 +2,7 @@ import { describe } from "mocha";
 import { checkDebugFlag, make_debugLog } from "node-opcua-debug";
 import { nodesets } from "node-opcua-nodesets";
 import should from "should";
-import { AddressSpace, implementInterface } from "..";
+import { AddressSpace, implementInterface } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 const debugLog = make_debugLog("TEST");

--- a/packages/node-opcua-address-space/test/test_bindExtensionObject.ts
+++ b/packages/node-opcua-address-space/test/test_bindExtensionObject.ts
@@ -27,7 +27,7 @@ import {
     type UAVariable,
     type UAVariableT,
     type UAVariableType
-} from "..";
+} from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 

--- a/packages/node-opcua-address-space/test/test_boiler.ts
+++ b/packages/node-opcua-address-space/test/test_boiler.ts
@@ -9,7 +9,7 @@ import {
     promoteToStateMachine,
     SessionContext,
     type UAProgramStateMachineEx
-} from "..";
+} from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { createBoilerType, makeBoiler } from "../testHelpers.js";
 

--- a/packages/node-opcua-address-space/test/test_browse_next.ts
+++ b/packages/node-opcua-address-space/test/test_browse_next.ts
@@ -6,7 +6,7 @@ import type { ReferenceDescription } from "node-opcua-service-browse";
 import { StatusCodes } from "node-opcua-status-code";
 import should from "should";
 
-import { AddressSpace, PseudoSession } from "..";
+import { AddressSpace, PseudoSession } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 describe("BrowseNext", function () {

--- a/packages/node-opcua-address-space/test/test_browse_node.ts
+++ b/packages/node-opcua-address-space/test/test_browse_node.ts
@@ -5,7 +5,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { resolveNodeId } from "node-opcua-nodeid";
 import type { BrowseDescriptionOptions } from "node-opcua-types";
 import should from "should";
-import { type AddressSpace, dumpBrowseDescription, dumpReferences } from "..";
+import { type AddressSpace, dumpBrowseDescription, dumpReferences } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 describe("testing address space", () => {

--- a/packages/node-opcua-address-space/test/test_bug_setValueFromSource_terminal_values.ts
+++ b/packages/node-opcua-address-space/test/test_bug_setValueFromSource_terminal_values.ts
@@ -5,7 +5,7 @@ import { nodesets } from "node-opcua-nodesets";
 import { DataType, Variant } from "node-opcua-variant";
 import should from "should";
 
-import { AddressSpace, SessionContext, type UAVariable } from "..";
+import { AddressSpace, SessionContext, type UAVariable } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_companions.ts
+++ b/packages/node-opcua-address-space/test/test_companions.ts
@@ -1,6 +1,6 @@
 import "should";
 import { nodesets } from "node-opcua-nodesets";
-import { AddressSpace } from "..";
+import { AddressSpace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 describe("Companion ", () => {

--- a/packages/node-opcua-address-space/test/test_construct_namespace_dependencies.ts
+++ b/packages/node-opcua-address-space/test/test_construct_namespace_dependencies.ts
@@ -11,7 +11,7 @@ import {
     constructNamespaceDependency,
     constructNamespacePriorityTable,
     type IAddressSpace
-} from "..";
+} from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 import { makeBoiler } from "../testHelpers.js";

--- a/packages/node-opcua-address-space/test/test_continuation_point_manager.ts
+++ b/packages/node-opcua-address-space/test/test_continuation_point_manager.ts
@@ -3,7 +3,7 @@ import { ReferenceDescription } from "node-opcua-service-browse";
 import { StatusCodes } from "node-opcua-status-code";
 import { DataType } from "node-opcua-variant";
 import should from "should";
-import { ContinuationPointManager } from "..";
+import { ContinuationPointManager } from "../dist/api/index.js";
 
 describe("ContinuationPointManager", () => {
     it("should create a ContinuationPointManager", () => {

--- a/packages/node-opcua-address-space/test/test_convert_data_type_definition_to_structuretype_schema.ts
+++ b/packages/node-opcua-address-space/test/test_convert_data_type_definition_to_structuretype_schema.ts
@@ -8,7 +8,7 @@ import { StatusCodes } from "node-opcua-status-code";
 import type { StructureDefinition } from "node-opcua-types";
 import should from "should";
 import { DataTypeIds } from "../../node-opcua-constants/dist/index.js";
-import { AddressSpace, PseudoSession } from "..";
+import { AddressSpace, PseudoSession } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_datatype.ts
+++ b/packages/node-opcua-address-space/test/test_datatype.ts
@@ -3,7 +3,7 @@ import type { DataValue } from "node-opcua-data-value";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { StatusCodes } from "node-opcua-status-code";
 import { DataType } from "node-opcua-variant";
-import { type AddressSpace, SessionContext, type UADataType } from "..";
+import { type AddressSpace, SessionContext, type UADataType } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 const context = SessionContext.defaultContext;

--- a/packages/node-opcua-address-space/test/test_datatype_StructureWithSubtypedValues.ts
+++ b/packages/node-opcua-address-space/test/test_datatype_StructureWithSubtypedValues.ts
@@ -11,7 +11,7 @@ import { nodesets } from "node-opcua-nodesets";
 import { type StructureDefinition, StructureType } from "node-opcua-types";
 import { Variant, VariantArrayType } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, PseudoSession } from "..";
+import { AddressSpace, PseudoSession } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_datatype_definition.ts
+++ b/packages/node-opcua-address-space/test/test_datatype_definition.ts
@@ -4,7 +4,7 @@ import { nodesets } from "node-opcua-nodesets";
 import { StatusCodes } from "node-opcua-status-code";
 import { StructureDefinition } from "node-opcua-types";
 import should from "should";
-import { AddressSpace, SessionContext } from "..";
+import { AddressSpace, SessionContext } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 const _context = SessionContext.defaultContext;

--- a/packages/node-opcua-address-space/test/test_dump_to_bsd.ts
+++ b/packages/node-opcua-address-space/test/test_dump_to_bsd.ts
@@ -1,7 +1,7 @@
 import { nodesets } from "node-opcua-nodesets";
 import { DataType } from "node-opcua-variant";
 
-import { AddressSpace, dumpToBSD } from "..";
+import { AddressSpace, dumpToBSD } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 describe("converting DataType to BSD schema files", () => {

--- a/packages/node-opcua-address-space/test/test_eurange_issue.ts
+++ b/packages/node-opcua-address-space/test/test_eurange_issue.ts
@@ -2,7 +2,7 @@ import { AttributeIds } from "node-opcua-basic-types";
 import { checkDebugFlag, make_debugLog } from "node-opcua-debug";
 import { nodesets } from "node-opcua-nodesets";
 import should from "should";
-import { AddressSpace } from "..";
+import { AddressSpace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_expand_ext_obj_variable.ts
+++ b/packages/node-opcua-address-space/test/test_expand_ext_obj_variable.ts
@@ -9,7 +9,7 @@ import { StatusCodes } from "node-opcua-status-code";
 import { ThreeDCartesianCoordinates } from "node-opcua-types";
 import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, type BaseNode, type INamespace, PseudoSession, type UAVariable } from "..";
+import { AddressSpace, type BaseNode, type INamespace, PseudoSession, type UAVariable } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 async function simulateExternalWriteEx(node: BaseNode, value: ExtensionObject, sourceTimestamp: DateTime) {

--- a/packages/node-opcua-address-space/test/test_extension_object_array_node.ts
+++ b/packages/node-opcua-address-space/test/test_extension_object_array_node.ts
@@ -10,7 +10,7 @@ import {
     type DTSubscriptionDiagnostics,
     removeElement,
     type UASubscriptionDiagnostics
-} from "..";
+} from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 describe("Extension Object Array Node (or Complex Variable)", () => {

--- a/packages/node-opcua-address-space/test/test_extension_object_binding.ts
+++ b/packages/node-opcua-address-space/test/test_extension_object_binding.ts
@@ -4,7 +4,7 @@ import { nodesets } from "node-opcua-nodesets";
 import { DataType } from "node-opcua-variant";
 import sinon from "sinon";
 
-import { AddressSpace, type UAVariable } from "..";
+import { AddressSpace, type UAVariable } from "../dist/api/index.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
 
 interface CncPositionExtensionObject extends ExtensionObject {

--- a/packages/node-opcua-address-space/test/test_extension_object_subportion_consistency.ts
+++ b/packages/node-opcua-address-space/test/test_extension_object_subportion_consistency.ts
@@ -3,7 +3,7 @@ import { DataValue } from "node-opcua-data-value";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import { DataType } from "node-opcua-variant";
-import { AddressSpace, SessionContext, type UAVariable } from "..";
+import { AddressSpace, SessionContext, type UAVariable } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_extension_object_with_dates.ts
+++ b/packages/node-opcua-address-space/test/test_extension_object_with_dates.ts
@@ -3,7 +3,14 @@ import { StatusCodes } from "node-opcua-status-code";
 import type { CallMethodResultOptions } from "node-opcua-types";
 import { DataType, Variant } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, type ISessionContext, SessionContext, type UAMethod, type UAObject, type UAVariable } from "..";
+import {
+    AddressSpace,
+    type ISessionContext,
+    SessionContext,
+    type UAMethod,
+    type UAObject,
+    type UAVariable
+} from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_extract_fields.ts
+++ b/packages/node-opcua-address-space/test/test_extract_fields.ts
@@ -4,7 +4,7 @@ import { resolveNodeId } from "node-opcua-nodeid";
 import { nodesets } from "node-opcua-nodesets";
 import { extractFields, simpleBrowsePathsToString } from "node-opcua-pseudo-session";
 import should from "should";
-import { AddressSpace, PseudoSession } from "..";
+import { AddressSpace, PseudoSession } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 const _debugLog = make_debugLog("TEST");

--- a/packages/node-opcua-address-space/test/test_findReferenceEx.ts
+++ b/packages/node-opcua-address-space/test/test_findReferenceEx.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
-import { AddressSpace, type UAReference } from "..";
+import { AddressSpace, type UAReference } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 describe("testing findReferencesEx", () => {

--- a/packages/node-opcua-address-space/test/test_get_xxx_by_name.ts
+++ b/packages/node-opcua-address-space/test/test_get_xxx_by_name.ts
@@ -1,5 +1,5 @@
 import should from "should";
-import type { AddressSpace, UAObject } from "..";
+import type { AddressSpace, UAObject } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 describe("test component/property/method and method accessors", () => {

--- a/packages/node-opcua-address-space/test/test_isArgumentValid.ts
+++ b/packages/node-opcua-address-space/test/test_isArgumentValid.ts
@@ -3,8 +3,8 @@ import { resolveNodeId } from "node-opcua-nodeid";
 import { Argument } from "node-opcua-types";
 import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, type Namespace } from "..";
 import { isArgumentValid } from "../dist/api/helpers/argument_list.js";
+import { AddressSpace, type Namespace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_issue_1038.ts
+++ b/packages/node-opcua-address-space/test/test_issue_1038.ts
@@ -6,7 +6,7 @@ import { coerceNodeId } from "node-opcua-nodeid";
 import { nodesets } from "node-opcua-nodesets";
 import { StatusCodes } from "node-opcua-status-code";
 import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
-import { AddressSpace, type Namespace, PseudoSession, type UAVariable } from "..";
+import { AddressSpace, type Namespace, PseudoSession, type UAVariable } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 describe("testing github issue #1038", () => {

--- a/packages/node-opcua-address-space/test/test_issue_104.ts
+++ b/packages/node-opcua-address-space/test/test_issue_104.ts
@@ -3,7 +3,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { NodeId, NodeIdType } from "node-opcua-nodeid";
 import { DataType } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, type Namespace } from "..";
+import { AddressSpace, type Namespace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 import { assertHasMatchingReference } from "../testHelpers.js";

--- a/packages/node-opcua-address-space/test/test_issue_105.ts
+++ b/packages/node-opcua-address-space/test/test_issue_105.ts
@@ -1,6 +1,6 @@
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import should from "should";
-import type { AddressSpace, Namespace } from "../";
+import type { AddressSpace, Namespace } from "../dist/api/index.js";
 import { assertHasMatchingReference, getMiniAddressSpace } from "../testHelpers.js";
 import { createTemperatureSensorType } from "./fixture_temperature_sensor_type.js";
 

--- a/packages/node-opcua-address-space/test/test_issue_108.ts
+++ b/packages/node-opcua-address-space/test/test_issue_108.ts
@@ -7,7 +7,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { constructNodesetFilename, nodesets } from "node-opcua-nodesets";
 import type { DataType } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, type UAAnalogItem, type UAObject, type UAObjectType, type UARootFolder } from "..";
+import { AddressSpace, type UAAnalogItem, type UAObject, type UAObjectType, type UARootFolder } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 interface MyCustomType extends UAObjectType {

--- a/packages/node-opcua-address-space/test/test_issue_1096.ts
+++ b/packages/node-opcua-address-space/test/test_issue_1096.ts
@@ -2,7 +2,7 @@ import "should";
 
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
-import { AddressSpace, type UAVariable } from "..";
+import { AddressSpace, type UAVariable } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_issue_1119.ts
+++ b/packages/node-opcua-address-space/test/test_issue_1119.ts
@@ -6,7 +6,14 @@ import { nodesets } from "node-opcua-nodesets";
 import { type StatusCode, StatusCodes } from "node-opcua-status-code";
 import { type HistoryData, type HistoryReadResult, ReadRawModifiedDetails } from "node-opcua-types";
 import { DataType, Variant } from "node-opcua-variant";
-import { AddressSpace, type BindVariableOptions, type ISessionBase, PseudoSession, SessionContext, type UAVariable } from "..";
+import {
+    AddressSpace,
+    type BindVariableOptions,
+    type ISessionBase,
+    PseudoSession,
+    SessionContext,
+    type UAVariable
+} from "../dist/api/index.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
 
 describe("historization and status code Bad #1119", function () {

--- a/packages/node-opcua-address-space/test/test_issue_1132.ts
+++ b/packages/node-opcua-address-space/test/test_issue_1132.ts
@@ -2,7 +2,7 @@ import "should";
 
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
-import { AddressSpace, type UAVariable } from "..";
+import { AddressSpace, type UAVariable } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_issue_1277.ts
+++ b/packages/node-opcua-address-space/test/test_issue_1277.ts
@@ -2,7 +2,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import { DataType } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace } from "..";
+import { AddressSpace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 function git1277(addressSpace: AddressSpace) {

--- a/packages/node-opcua-address-space/test/test_issue_1284.ts
+++ b/packages/node-opcua-address-space/test/test_issue_1284.ts
@@ -1,5 +1,5 @@
 import should from "should";
-import { AddressSpace } from "..";
+import { AddressSpace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
 import { get_mini_nodeset_filename } from "../testHelpers.js";
 

--- a/packages/node-opcua-address-space/test/test_issue_1320.ts
+++ b/packages/node-opcua-address-space/test/test_issue_1320.ts
@@ -1,7 +1,7 @@
 import { DataType } from "node-opcua-basic-types";
 import { nodesets } from "node-opcua-nodesets";
 import should from "should";
-import { AddressSpace, type Namespace } from "..";
+import { AddressSpace, type Namespace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
 
 describe("testing github issue https://github.com/node-opcua/node-opcua/issues/1320", () => {

--- a/packages/node-opcua-address-space/test/test_issue_1342.ts
+++ b/packages/node-opcua-address-space/test/test_issue_1342.ts
@@ -3,7 +3,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import { Variant } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, type Namespace } from "..";
+import { AddressSpace, type Namespace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
 
 describe("testing github issue https://github.com/node-opcua/node-opcua/issues/1342", function (this: Mocha.Suite) {

--- a/packages/node-opcua-address-space/test/test_issue_1550_historizing_attribute.ts
+++ b/packages/node-opcua-address-space/test/test_issue_1550_historizing_attribute.ts
@@ -7,7 +7,7 @@ import { getTempFilename } from "node-opcua-debug/nodeJS";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import { DataType } from "node-opcua-variant";
-import { AddressSpace, type Namespace, type UAVariable, type UAVariableType } from "..";
+import { AddressSpace, type Namespace, type UAVariable, type UAVariableType } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 

--- a/packages/node-opcua-address-space/test/test_issue_1552_user_access_level.ts
+++ b/packages/node-opcua-address-space/test/test_issue_1552_user_access_level.ts
@@ -5,7 +5,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import { DataType } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, generateAddressSpaceRaw, type Namespace, type UAVariable, type UAVariableType } from "..";
+import { AddressSpace, generateAddressSpaceRaw, type Namespace, type UAVariable, type UAVariableType } from "../dist/api/index.js";
 import { generateAddressSpace, readNodeSet2XmlFile } from "../nodeJS.js";
 
 // see https://github.com/node-opcua/node-opcua/issues/1552

--- a/packages/node-opcua-address-space/test/test_issue_162.ts
+++ b/packages/node-opcua-address-space/test/test_issue_162.ts
@@ -4,7 +4,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import { DataType, Variant } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, type UAObject, type UAVariable } from "..";
+import { AddressSpace, type UAObject, type UAVariable } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 interface MyCustomObject extends UAObject {

--- a/packages/node-opcua-address-space/test/test_issue_312.ts
+++ b/packages/node-opcua-address-space/test/test_issue_312.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { getFixture } from "node-opcua-test-fixtures";
-import { AddressSpace } from "..";
+import { AddressSpace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_issue_314.ts
+++ b/packages/node-opcua-address-space/test/test_issue_314.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import { DataType } from "node-opcua-variant";
-import { AddressSpace, type UAVariable } from "..";
+import { AddressSpace, type UAVariable } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_issue_337.ts
+++ b/packages/node-opcua-address-space/test/test_issue_337.ts
@@ -3,7 +3,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { NumericRange } from "node-opcua-numeric-range";
 import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
 import should from "should";
-import type { AddressSpace } from "..";
+import type { AddressSpace } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 describe("Testing bug found in #337", () => {

--- a/packages/node-opcua-address-space/test/test_issue_343.ts
+++ b/packages/node-opcua-address-space/test/test_issue_343.ts
@@ -1,7 +1,7 @@
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 
 import { nodesets } from "node-opcua-nodesets";
-import { AddressSpace, NamespaceOptions } from "..";
+import { AddressSpace, NamespaceOptions } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { type BoilerType, createBoilerType } from "../testHelpers.js";
 

--- a/packages/node-opcua-address-space/test/test_issue_410.ts
+++ b/packages/node-opcua-address-space/test/test_issue_410.ts
@@ -8,7 +8,7 @@ import { nodesets } from "node-opcua-nodesets";
 import { StatusCodes } from "node-opcua-status-code";
 import { DataType, Variant } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, SessionContext, type UAAnalogItem } from "..";
+import { AddressSpace, SessionContext, type UAAnalogItem } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 describe("AnalogDataItem ValuePrecision issue #410", () => {

--- a/packages/node-opcua-address-space/test/test_issue_411.ts
+++ b/packages/node-opcua-address-space/test/test_issue_411.ts
@@ -3,7 +3,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import { DataType, Variant } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, type Namespace } from "..";
+import { AddressSpace, type Namespace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 interface AddressSpaceWithPrivateNamespaceIndex {

--- a/packages/node-opcua-address-space/test/test_issue_432.ts
+++ b/packages/node-opcua-address-space/test/test_issue_432.ts
@@ -1,5 +1,5 @@
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
-import type { AddressSpace } from "..";
+import type { AddressSpace } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 describe("testing github issue https://github.com/node-opcua/node-opcua/issues/432", () => {

--- a/packages/node-opcua-address-space/test/test_issue_435_removeReference.ts
+++ b/packages/node-opcua-address-space/test/test_issue_435_removeReference.ts
@@ -1,7 +1,7 @@
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import should from "should";
-import { AddressSpace, type BaseNode } from "..";
+import { AddressSpace, type BaseNode } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { type BoilerType, createBoilerType } from "../testHelpers.js";
 

--- a/packages/node-opcua-address-space/test/test_issue_449.ts
+++ b/packages/node-opcua-address-space/test/test_issue_449.ts
@@ -9,7 +9,7 @@ import {
     type BindVariableOptionsVariation1,
     SessionContext,
     type UAVariable
-} from "..";
+} from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 describe("testing github issue https://github.com/node-opcua/node-opcua/issues/449", () => {

--- a/packages/node-opcua-address-space/test/test_issue_466_469.ts
+++ b/packages/node-opcua-address-space/test/test_issue_466_469.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { LocalizedText } from "node-opcua-data-model";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
-import { AddressSpace, type Namespace } from "..";
+import { AddressSpace, type Namespace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { get_mini_nodeset_filename } from "../testHelpers.js";
 

--- a/packages/node-opcua-address-space/test/test_issue_625.ts
+++ b/packages/node-opcua-address-space/test/test_issue_625.ts
@@ -1,6 +1,6 @@
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { coerceNodeId } from "node-opcua-nodeid";
-import { AddressSpace } from "..";
+import { AddressSpace } from "../dist/api/index.js";
 
 describe("#625 automatic string nodeid assignment", () => {
     let addressSpace: AddressSpace;

--- a/packages/node-opcua-address-space/test/test_issue_846.ts
+++ b/packages/node-opcua-address-space/test/test_issue_846.ts
@@ -7,7 +7,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import { EndpointConfiguration, ServerDiagnosticsSummaryDataType, ServiceCounterDataType } from "node-opcua-types";
 import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
-import { AddressSpace, SessionContext, type UAObject, type UAVariable } from "..";
+import { AddressSpace, SessionContext, type UAObject, type UAVariable } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_issue_937.ts
+++ b/packages/node-opcua-address-space/test/test_issue_937.ts
@@ -5,7 +5,7 @@ import { BinaryStream } from "node-opcua-binary-stream";
 import { DataValue } from "node-opcua-data-value";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
-import { AddressSpace, type UADataType, type UAVariable } from "..";
+import { AddressSpace, type UADataType, type UAVariable } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_issue_998.ts
+++ b/packages/node-opcua-address-space/test/test_issue_998.ts
@@ -5,7 +5,7 @@ import { coerceNodeId, resolveNodeId } from "node-opcua-nodeid";
 import { nodesets } from "node-opcua-nodesets";
 import { getBuiltInDataType } from "node-opcua-pseudo-session";
 import { DataType } from "node-opcua-variant";
-import { AddressSpace, type Namespace, PseudoSession } from "..";
+import { AddressSpace, type Namespace, PseudoSession } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 describe("testing github issue #998", () => {

--- a/packages/node-opcua-address-space/test/test_issue_custom_basic_type.ts
+++ b/packages/node-opcua-address-space/test/test_issue_custom_basic_type.ts
@@ -1,7 +1,7 @@
 import { StatusCodes } from "node-opcua-status-code";
 import "should";
 import { DataType, Variant } from "node-opcua-variant";
-import { AddressSpace } from "..";
+import { AddressSpace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
 import { get_mini_nodeset_filename } from "../testHelpers.js";
 

--- a/packages/node-opcua-address-space/test/test_issue_datype_with_recursive_structure.ts
+++ b/packages/node-opcua-address-space/test/test_issue_datype_with_recursive_structure.ts
@@ -2,7 +2,7 @@ import "should";
 
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
-import { AddressSpace } from "..";
+import { AddressSpace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_issue_nodeset2_with_special_characters.ts
+++ b/packages/node-opcua-address-space/test/test_issue_nodeset2_with_special_characters.ts
@@ -2,7 +2,7 @@ import "should";
 
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
-import { AddressSpace, type UAVariable } from "..";
+import { AddressSpace, type UAVariable } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_load_mixing_old_and_new.ts
+++ b/packages/node-opcua-address-space/test/test_load_mixing_old_and_new.ts
@@ -4,7 +4,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import { nodesetFile } from "node-opcua-test-helpers";
 import should from "should";
-import { AddressSpace, PseudoSession, type UADataType } from "..";
+import { AddressSpace, PseudoSession, type UADataType } from "../dist/api/index.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_load_nodeset2.ts
+++ b/packages/node-opcua-address-space/test/test_load_nodeset2.ts
@@ -21,7 +21,7 @@ import {
     type UADataType,
     type UAVariable,
     type UAVariableType
-} from "..";
+} from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_load_nodeset2_resilience.ts
+++ b/packages/node-opcua-address-space/test/test_load_nodeset2_resilience.ts
@@ -5,7 +5,7 @@ import { nodesets } from "node-opcua-nodesets";
 import { StatusCodes } from "node-opcua-status-code";
 import { DataType } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, type UAVariable } from "..";
+import { AddressSpace, type UAVariable } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_loadnodeset_autoid.ts
+++ b/packages/node-opcua-address-space/test/test_loadnodeset_autoid.ts
@@ -10,7 +10,13 @@ import { StatusCodes } from "node-opcua-status-code";
 import { CallMethodResult, type DataTypeDefinition, StructureDefinition } from "node-opcua-types";
 import { DataType, Variant } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, ensureDatatypeExtracted, PseudoSession, resolveOpaqueOnAddressSpace, type UAVariable } from "..";
+import {
+    AddressSpace,
+    ensureDatatypeExtracted,
+    PseudoSession,
+    resolveOpaqueOnAddressSpace,
+    type UAVariable
+} from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 const debugLog = make_debugLog("TEST");

--- a/packages/node-opcua-address-space/test/test_loadnodeset_edge_cases.ts
+++ b/packages/node-opcua-address-space/test/test_loadnodeset_edge_cases.ts
@@ -3,8 +3,8 @@ import { nodesets } from "node-opcua-nodesets";
 import { StatusCodes } from "node-opcua-status-code";
 import { decodeVariant, encodeVariant } from "node-opcua-variant";
 import should from "should";
-import type { UAVariable } from "..";
-import { AddressSpace } from "..";
+import type { UAVariable } from "../dist/api/index.js";
+import { AddressSpace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_loadnodeset_packml.ts
+++ b/packages/node-opcua-address-space/test/test_loadnodeset_packml.ts
@@ -4,7 +4,7 @@ import { nodesets } from "node-opcua-nodesets";
 import { DataType, Variant } from "node-opcua-variant";
 import should from "should";
 
-import { AddressSpace, ensureDatatypeExtracted, resolveOpaqueOnAddressSpace } from "..";
+import { AddressSpace, ensureDatatypeExtracted, resolveOpaqueOnAddressSpace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 const debugLog = make_debugLog("TEST");

--- a/packages/node-opcua-address-space/test/test_loadnodeset_qualified_name_in_datatype.ts
+++ b/packages/node-opcua-address-space/test/test_loadnodeset_qualified_name_in_datatype.ts
@@ -3,7 +3,7 @@ import { checkDebugFlag, make_debugLog } from "node-opcua-debug";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import should from "should";
-import { AddressSpace, type UAVariable } from "..";
+import { AddressSpace, type UAVariable } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_loadnodeset_role_permissions.ts
+++ b/packages/node-opcua-address-space/test/test_loadnodeset_role_permissions.ts
@@ -4,7 +4,14 @@ import { resolveNodeId } from "node-opcua-nodeid";
 import { nodesets } from "node-opcua-nodesets";
 import { PermissionType } from "node-opcua-types";
 import should from "should";
-import { AddressSpace, generateAddressSpaceRaw, type UAMethod, type UAObject, type UAObjectType, type UAVariable } from "..";
+import {
+    AddressSpace,
+    generateAddressSpaceRaw,
+    type UAMethod,
+    type UAObject,
+    type UAObjectType,
+    type UAVariable
+} from "../dist/api/index.js";
 import { generateAddressSpace, readNodeSet2XmlFile } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_loadnodeset_union_datatype_1.04.ts
+++ b/packages/node-opcua-address-space/test/test_loadnodeset_union_datatype_1.04.ts
@@ -5,7 +5,7 @@ import {
 } from "node-opcua-client-dynamic-extension-object";
 import { coerceNodeId } from "node-opcua-nodeid";
 import { nodesets } from "node-opcua-nodesets";
-import { AddressSpace, PseudoSession } from "..";
+import { AddressSpace, PseudoSession } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_loadnodeset_value.ts
+++ b/packages/node-opcua-address-space/test/test_loadnodeset_value.ts
@@ -15,7 +15,7 @@ import {
     SessionContext,
     type UAObject,
     type UAVariable
-} from "..";
+} from "../dist/api/index.js";
 import { create_minimalist_address_space_nodeset } from "../distHelpers/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";

--- a/packages/node-opcua-address-space/test/test_make_optionals_map.ts
+++ b/packages/node-opcua-address-space/test/test_make_optionals_map.ts
@@ -1,5 +1,5 @@
 import "should";
-import { makeOptionalsMap } from "..";
+import { makeOptionalsMap } from "../dist/api/index.js";
 
 const j = <T>(o: T) => JSON.parse(JSON.stringify(o));
 describe("Testing makeOptionalsMap", () => {

--- a/packages/node-opcua-address-space/test/test_make_roles.ts
+++ b/packages/node-opcua-address-space/test/test_make_roles.ts
@@ -3,7 +3,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { resolveNodeId } from "node-opcua-nodeid";
 import { nodesets } from "node-opcua-nodesets";
 import should from "should";
-import { AddressSpace, makeRoles, WellKnownRoles } from "..";
+import { AddressSpace, makeRoles, WellKnownRoles } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 const GDS_NAMESPACE_URI = "http://opcfoundation.org/UA/GDS/";

--- a/packages/node-opcua-address-space/test/test_method.ts
+++ b/packages/node-opcua-address-space/test/test_method.ts
@@ -15,7 +15,7 @@ import {
     type UAObject,
     type UAObjectType,
     type UARootFolder
-} from "..";
+} from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 const context = SessionContext.defaultContext;

--- a/packages/node-opcua-address-space/test/test_method_service.ts
+++ b/packages/node-opcua-address-space/test/test_method_service.ts
@@ -7,7 +7,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { makeNodeId } from "node-opcua-nodeid";
 import { CallRequest } from "node-opcua-service-call";
 import { DataType } from "node-opcua-variant";
-import { AddressSpace, type UAObject } from "..";
+import { AddressSpace, type UAObject } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_multi_dimensional_array.ts
+++ b/packages/node-opcua-address-space/test/test_multi_dimensional_array.ts
@@ -3,7 +3,7 @@ import { NumericRange } from "node-opcua-numeric-range";
 import { StatusCodes } from "node-opcua-status-code";
 import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
 import should from "should";
-import { type AddressSpace, SessionContext, type UAVariable } from "..";
+import { type AddressSpace, SessionContext, type UAVariable } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 describe("Multi-Dimensional Array", () => {

--- a/packages/node-opcua-address-space/test/test_namespace.ts
+++ b/packages/node-opcua-address-space/test/test_namespace.ts
@@ -1,7 +1,7 @@
 import { NodeClass } from "node-opcua-data-model";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import should from "should";
-import { AddressSpace } from "..";
+import { AddressSpace } from "../dist/api/index.js";
 
 const _should = should;
 

--- a/packages/node-opcua-address-space/test/test_namespace_export_variable_with_extension_object.ts
+++ b/packages/node-opcua-address-space/test/test_namespace_export_variable_with_extension_object.ts
@@ -6,7 +6,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { resolveNodeId } from "node-opcua-nodeid";
 import { nodesets } from "node-opcua-nodesets";
 import type { Variant } from "node-opcua-variant";
-import { AddressSpace } from "..";
+import { AddressSpace } from "../dist/api/index.js";
 import type { UAVariableImpl } from "../dist/impl/ua_variable_impl.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";

--- a/packages/node-opcua-address-space/test/test_new_extension_objects.ts
+++ b/packages/node-opcua-address-space/test/test_new_extension_objects.ts
@@ -7,7 +7,7 @@ import { DataType, Variant } from "node-opcua-variant";
 import should from "should";
 import { spy } from "sinon";
 //
-import { AddressSpace, adjustNamespaceArray, PseudoSession } from "..";
+import { AddressSpace, adjustNamespaceArray, PseudoSession } from "../dist/api/index.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_nodeid_manager.ts
+++ b/packages/node-opcua-address-space/test/test_nodeid_manager.ts
@@ -2,7 +2,7 @@ import "should";
 import { coerceQualifiedName, NodeClass } from "node-opcua-data-model";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { makeNodeId, type NodeId, resolveNodeId } from "node-opcua-nodeid";
-import { AddressSpace, type ConstructNodeIdOptions, getNodeIdManager, NodeIdManager, setSymbols } from "..";
+import { AddressSpace, type ConstructNodeIdOptions, getNodeIdManager, NodeIdManager, setSymbols } from "../dist/api/index.js";
 import { get_mini_nodeset_filename } from "../distHelpers/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 

--- a/packages/node-opcua-address-space/test/test_nodeset_ordering.ts
+++ b/packages/node-opcua-address-space/test/test_nodeset_ordering.ts
@@ -2,7 +2,7 @@ import { nodesets } from "node-opcua-nodesets";
 import { getFixture } from "node-opcua-test-fixtures";
 // import fs from "fs";
 import should from "should";
-import { AddressSpace, findOrder, generateAddressSpaceRaw, preLoad } from "..";
+import { AddressSpace, findOrder, generateAddressSpaceRaw, preLoad } from "../dist/api/index.js";
 import { readNodeSet2XmlFile } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 

--- a/packages/node-opcua-address-space/test/test_nodeset_to_xml.ts
+++ b/packages/node-opcua-address-space/test/test_nodeset_to_xml.ts
@@ -11,7 +11,7 @@ import { nodesets } from "node-opcua-nodesets";
 import { ThreeDCartesianCoordinates } from "node-opcua-types";
 import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
 import XMLWriter from "xml-writer";
-import { AddressSpace, type BaseNode, type Namespace, type UARootFolder, type UAVariable } from "..";
+import { AddressSpace, type BaseNode, type Namespace, type UARootFolder, type UAVariable } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { createBoilerType, getMiniAddressSpace } from "../testHelpers.js";
 import { createCameraType } from "./fixture_camera_type.js";

--- a/packages/node-opcua-address-space/test/test_object_instantiate_multi.ts
+++ b/packages/node-opcua-address-space/test/test_object_instantiate_multi.ts
@@ -2,7 +2,7 @@ import { checkDebugFlag, make_debugLog } from "node-opcua-debug";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import should from "should";
-import { AddressSpace, getSymbols, type IAddressSpace, SessionContext, setSymbols } from "..";
+import { AddressSpace, getSymbols, type IAddressSpace, SessionContext, setSymbols } from "../dist/api/index.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
 
 const _context = SessionContext.defaultContext;

--- a/packages/node-opcua-address-space/test/test_object_instantiate_nested.ts
+++ b/packages/node-opcua-address-space/test/test_object_instantiate_nested.ts
@@ -2,7 +2,7 @@ import { coerceQualifiedName } from "node-opcua-data-model";
 import { nodesets } from "node-opcua-nodesets";
 import should from "should";
 
-import { AddressSpace, type Namespace, type UAObjectType } from "..";
+import { AddressSpace, type Namespace, type UAObjectType } from "../dist/api/index.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
 
 describe("Object Instantiate with various nested properties defined at different subType level", () => {

--- a/packages/node-opcua-address-space/test/test_object_instantiate_with_addin.ts
+++ b/packages/node-opcua-address-space/test/test_object_instantiate_with_addin.ts
@@ -2,7 +2,14 @@ import { checkDebugFlag, make_debugLog } from "node-opcua-debug";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import should from "should";
-import { AddressSpace, addDefaultInstanceBrowseName, getSymbols, instantiateAddIn, setSymbols, type UAObject } from "..";
+import {
+    AddressSpace,
+    addDefaultInstanceBrowseName,
+    getSymbols,
+    instantiateAddIn,
+    setSymbols,
+    type UAObject
+} from "../dist/api/index.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
 
 const debugLog = make_debugLog("TEST");

--- a/packages/node-opcua-address-space/test/test_object_instantiate_with_interface.ts
+++ b/packages/node-opcua-address-space/test/test_object_instantiate_with_interface.ts
@@ -2,7 +2,7 @@ import { checkDebugFlag, make_debugLog } from "node-opcua-debug";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import should from "should";
-import { AddressSpace, implementInterface } from "..";
+import { AddressSpace, implementInterface } from "../dist/api/index.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
 
 const debugLog = make_debugLog("TEST");

--- a/packages/node-opcua-address-space/test/test_object_instantiate_with_organizes_reference.ts
+++ b/packages/node-opcua-address-space/test/test_object_instantiate_with_organizes_reference.ts
@@ -3,7 +3,7 @@ import { checkDebugFlag, make_debugLog } from "node-opcua-debug";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import should from "should";
-import { AddressSpace, SessionContext } from "..";
+import { AddressSpace, SessionContext } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 const _context = SessionContext.defaultContext;

--- a/packages/node-opcua-address-space/test/test_object_type.ts
+++ b/packages/node-opcua-address-space/test/test_object_type.ts
@@ -5,7 +5,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { NodeId } from "node-opcua-nodeid";
 import { StatusCodes } from "node-opcua-status-code";
 import { DataType } from "node-opcua-variant";
-import { AddressSpace, SessionContext } from "..";
+import { AddressSpace, SessionContext } from "../dist/api/index.js";
 import { create_minimalist_address_space_nodeset } from "../testHelpers.js";
 
 const context = SessionContext.defaultContext;

--- a/packages/node-opcua-address-space/test/test_pseudo_session.ts
+++ b/packages/node-opcua-address-space/test/test_pseudo_session.ts
@@ -4,7 +4,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { StatusCodes } from "node-opcua-status-code";
 import type { ReadValueIdOptions } from "node-opcua-types";
 import should from "should";
-import { type AddressSpace, PseudoSession } from "..";
+import { type AddressSpace, PseudoSession } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 describe("PseudoSession", () => {

--- a/packages/node-opcua-address-space/test/test_referencetype.ts
+++ b/packages/node-opcua-address-space/test/test_referencetype.ts
@@ -17,7 +17,7 @@ import {
     SessionContext,
     type UAReferenceType,
     type UARootFolder
-} from "..";
+} from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 const context = SessionContext.defaultContext;

--- a/packages/node-opcua-address-space/test/test_remove_reference.ts
+++ b/packages/node-opcua-address-space/test/test_remove_reference.ts
@@ -1,7 +1,7 @@
 import { BrowseDirection } from "node-opcua-data-model";
 import { sameNodeId } from "node-opcua-nodeid";
 import should from "should";
-import type { AddressSpace, BaseNode, UARootFolder } from "..";
+import type { AddressSpace, BaseNode, UARootFolder } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../distHelpers/index.js";
 
 describe("AddressSpace : removeReference", () => {

--- a/packages/node-opcua-address-space/test/test_session_context.ts
+++ b/packages/node-opcua-address-space/test/test_session_context.ts
@@ -9,7 +9,7 @@ import { DataType } from "node-opcua-variant";
 import "should";
 
 import { samplesCertificateFolder } from "node-opcua-test-helpers";
-import { type AddressSpace, makeRoles, SessionContext } from "..";
+import { type AddressSpace, makeRoles, SessionContext } from "../dist/api/index.js";
 import { getMiniAddressSpace, makeMockSessionContext } from "../testHelpers.js";
 
 const certificateFolder = samplesCertificateFolder;

--- a/packages/node-opcua-address-space/test/test_session_context_anonymous_baseline.ts
+++ b/packages/node-opcua-address-space/test/test_session_context_anonymous_baseline.ts
@@ -6,7 +6,7 @@ import { nodesets } from "node-opcua-nodesets";
 import { PermissionType } from "node-opcua-types";
 import { DataType } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, type IServerBase, makeRoles, type UAMethod, type UAVariable, WellKnownRoles } from "..";
+import { AddressSpace, type IServerBase, makeRoles, type UAMethod, type UAVariable, WellKnownRoles } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { makeMockSessionContext } from "../testHelpers.js";
 

--- a/packages/node-opcua-address-space/test/test_session_context_client_certificate.ts
+++ b/packages/node-opcua-address-space/test/test_session_context_client_certificate.ts
@@ -2,7 +2,7 @@ import { CertificatePurpose, convertPEMtoDER, createSelfSignedCertificate, gener
 import { MessageSecurityMode } from "node-opcua-types";
 import should from "should";
 
-import { SessionContext } from "..";
+import { SessionContext } from "../dist/api/index.js";
 import { makeMockSessionContext } from "../testHelpers.js";
 
 describe("US-035: ISessionContext.clientCertificate / clientApplicationUri", () => {

--- a/packages/node-opcua-address-space/test/test_session_context_namespace_default_permissions.ts
+++ b/packages/node-opcua-address-space/test/test_session_context_namespace_default_permissions.ts
@@ -3,7 +3,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { PermissionType } from "node-opcua-types";
 import { DataType } from "node-opcua-variant";
 import should from "should";
-import { type AddressSpace, makeRoles, type Namespace, type UAVariable, WellKnownRoles } from "..";
+import { type AddressSpace, makeRoles, type Namespace, type UAVariable, WellKnownRoles } from "../dist/api/index.js";
 import { getMiniAddressSpace, makeMockSessionContext } from "../testHelpers.js";
 
 /**

--- a/packages/node-opcua-address-space/test/test_session_context_role_policy_override.ts
+++ b/packages/node-opcua-address-space/test/test_session_context_role_policy_override.ts
@@ -3,7 +3,7 @@ import "should";
 import { resolveNodeId } from "node-opcua-nodeid";
 import { AnonymousIdentityToken, UserNameIdentityToken } from "node-opcua-types";
 
-import { type IRolePolicyOverride, type IServerBase, type IUserManager, WellKnownRoles } from "..";
+import { type IRolePolicyOverride, type IServerBase, type IUserManager, WellKnownRoles } from "../dist/api/index.js";
 import { makeMockSessionContext } from "../testHelpers.js";
 
 describe("US-028: IRolePolicyOverride", () => {

--- a/packages/node-opcua-address-space/test/test_session_context_unresolved_permissions.ts
+++ b/packages/node-opcua-address-space/test/test_session_context_unresolved_permissions.ts
@@ -12,7 +12,7 @@ import {
     type UAVariable,
     type UnresolvedPermissionPolicy,
     WellKnownRoles
-} from "..";
+} from "../dist/api/index.js";
 import { getMiniAddressSpace, makeMockSessionContext } from "../testHelpers.js";
 
 describe("SessionContext - unresolved permissions", () => {

--- a/packages/node-opcua-address-space/test/test_set_permissions.ts
+++ b/packages/node-opcua-address-space/test/test_set_permissions.ts
@@ -28,7 +28,7 @@ import {
     type UAMethod,
     type UAObject,
     WellKnownRoles
-} from "..";
+} from "../dist/api/index.js";
 
 // let's make sure should don't get removed by typescript optimizer
 const _keep_should = should;

--- a/packages/node-opcua-address-space/test/test_validate_data_type_correctness.ts
+++ b/packages/node-opcua-address-space/test/test_validate_data_type_correctness.ts
@@ -3,7 +3,7 @@ import { nodesets } from "node-opcua-nodesets";
 import { DataType } from "node-opcua-variant";
 import should from "should";
 
-import { AddressSpace, validateDataTypeCorrectness } from "..";
+import { AddressSpace, validateDataTypeCorrectness } from "../dist/api/index.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
 
 describe("testing validateDataTypeCorrectness", () => {

--- a/packages/node-opcua-address-space/test/test_variable.ts
+++ b/packages/node-opcua-address-space/test/test_variable.ts
@@ -20,7 +20,7 @@ import {
     SessionContext,
     type UARootFolder,
     type UAVariable
-} from "..";
+} from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 import { create_minimalist_address_space_nodeset } from "../testHelpers.js";

--- a/packages/node-opcua-address-space/test/test_variable_change_datatype.ts
+++ b/packages/node-opcua-address-space/test/test_variable_change_datatype.ts
@@ -3,7 +3,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { resolveNodeId } from "node-opcua-nodeid";
 import { DataType, Variant } from "node-opcua-variant";
 
-import { type AddressSpace, SessionContext } from "..";
+import { type AddressSpace, SessionContext } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../testHelpers.js";
 
 const doDebug = false;

--- a/packages/node-opcua-address-space/test/test_variable_type.ts
+++ b/packages/node-opcua-address-space/test/test_variable_type.ts
@@ -6,7 +6,7 @@ import { StatusCodes } from "node-opcua-status-code";
 import { DataType } from "node-opcua-variant";
 import should from "should";
 import sinon from "sinon";
-import { AddressSpace, SessionContext } from "..";
+import { AddressSpace, SessionContext } from "../dist/api/index.js";
 import { create_minimalist_address_space_nodeset } from "../testHelpers.js";
 
 const debugLog = make_debugLog("TEST");

--- a/packages/node-opcua-address-space/test/test_variables_with_permission.ts
+++ b/packages/node-opcua-address-space/test/test_variables_with_permission.ts
@@ -28,7 +28,7 @@ import {
     type UAObject,
     type UAVariable,
     WellKnownRoles
-} from "..";
+} from "../dist/api/index.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
 import { getMiniAddressSpace, makeMockSessionContext, mockSession } from "../testHelpers.js";
 

--- a/packages/node-opcua-address-space/test/test_xml_decode.ts
+++ b/packages/node-opcua-address-space/test/test_xml_decode.ts
@@ -6,7 +6,7 @@ import { DataType } from "node-opcua-variant";
 import { Xml2Json } from "node-opcua-xml2json";
 import should from "should";
 
-import { AddressSpace } from "..";
+import { AddressSpace } from "../dist/api/index.js";
 import { makeXmlExtensionObjectReader } from "../dist/api/loader/make_xml_extension_object_parser.js";
 import { generateAddressSpace } from "../distNodeJS/index.js";
 

--- a/packages/node-opcua-address-space/test_helpers/alarms_and_conditions_demo.ts
+++ b/packages/node-opcua-address-space/test_helpers/alarms_and_conditions_demo.ts
@@ -2,7 +2,7 @@
  * @module node-opcua-address-space
  */
 import { assert } from "node-opcua-assert";
-import type { AddressSpace, UAExclusiveLimitAlarmEx, UANonExclusiveLimitAlarmEx, UAObject, UAVariable } from "..";
+import type { AddressSpace, UAExclusiveLimitAlarmEx, UANonExclusiveLimitAlarmEx, UAObject, UAVariable } from "../dist/api/index.js";
 
 export interface IAlarmTestData {
     tankLevel: UAVariable;

--- a/packages/node-opcua-address-space/test_helpers/assertHasMatchingReference.ts
+++ b/packages/node-opcua-address-space/test_helpers/assertHasMatchingReference.ts
@@ -3,7 +3,7 @@
  */
 import { assert } from "node-opcua-assert";
 import { NodeId, sameNodeId } from "node-opcua-nodeid";
-import type { AddReferenceOpts, BaseNode, UAReference } from "..";
+import type { AddReferenceOpts, BaseNode, UAReference } from "../dist/api/index.js";
 
 /**
  * asserts that the provided reference exists in the node references

--- a/packages/node-opcua-address-space/test_helpers/boiler_system.ts
+++ b/packages/node-opcua-address-space/test_helpers/boiler_system.ts
@@ -24,7 +24,7 @@ import {
     type UAReferenceType,
     type UATransitionEventType,
     type UAVariable
-} from "..";
+} from "../dist/api/index.js";
 
 import type { UAStateMachineImpl } from "../impl/state_machine/finite_state_machine.js";
 

--- a/packages/node-opcua-address-space/test_helpers/create_minimalist_address_space_nodeset.ts
+++ b/packages/node-opcua-address-space/test_helpers/create_minimalist_address_space_nodeset.ts
@@ -8,7 +8,7 @@ import { DataTypeIds, ObjectIds, ObjectTypeIds, ReferenceTypeIds, VariableTypeId
 import { NodeClass } from "node-opcua-data-model";
 import { resolveNodeId } from "node-opcua-nodeid";
 
-import type { AddReferenceOpts, AddressSpace, UAObject, UAReferenceType, UAVariableType } from "..";
+import type { AddReferenceOpts, AddressSpace, UAObject, UAReferenceType, UAVariableType } from "../dist/api/index.js";
 
 const doDebug = false;
 

--- a/packages/node-opcua-address-space/test_helpers/get_mini_address_space.ts
+++ b/packages/node-opcua-address-space/test_helpers/get_mini_address_space.ts
@@ -3,7 +3,7 @@
  */
 import { assert } from "node-opcua-assert";
 
-import { AddressSpace } from "..";
+import { AddressSpace } from "../dist/api/index.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
 import { getAddressSpaceFixture } from "./get_address_space_fixture.js";

--- a/packages/node-opcua-address-space/test_helpers/mock_session.ts
+++ b/packages/node-opcua-address-space/test_helpers/mock_session.ts
@@ -12,7 +12,7 @@ import type { DataValue } from "node-opcua-data-value";
 import { NodeId } from "node-opcua-nodeid";
 import type { ReferenceDescription } from "node-opcua-service-browse";
 import { AnonymousIdentityToken, MessageSecurityMode, UserNameIdentityToken } from "node-opcua-types";
-import { type AnyUserIdentityToken, type IServerBase, SessionContext } from "..";
+import { type AnyUserIdentityToken, type IServerBase, SessionContext } from "../dist/api/index.js";
 
 export class MockContinuationPointManager implements IContinuationPointManager {
     public registerHistoryReadRaw(

--- a/tools/check-import-extension/README.md
+++ b/tools/check-import-extension/README.md
@@ -33,24 +33,26 @@ A specifier made only of traversal names a *directory* and carries no filename, 
 resolves only through that directory's `package.json` - a resolution NodeNext does not
 perform for a relative specifier. There is no extension to add.
 
-They fail the gate all the same. While 333 of them stood in the tree they were reported
-without failing, because a gate that can never go green is not a gate; now that they are
-gone, the gate holds the line.
+They fail the gate. While 333 of them stood in the tree they were reported without failing,
+because a gate that can never go green is not a gate; they are all gone now.
 
-`--fix` still leaves them alone, because the replacement is not derivable from the
-specifier: it is whatever entry point the target package already names. Take that from
-`types`, with the `.d.ts` swapped for `.js`, and fall back to `main`.
+`--fix` still leaves them alone, because the replacement is not derivable from the specifier:
+it is whatever entry point the target package already names. Take that from `types`, with the
+`.d.ts` swapped for `.js`, and fall back to `main`.
 
 `types` first, not `main`, because these callers are TypeScript and `types` is the surface
-they are type-checked against. Most packages point both fields at one file and the choice
-does not arise. `node-opcua-address-space` does not - `main` is `dist/src/index_current.js`
-and `types` is `dist/source/index.d.ts`, two facades over one compiled tree with different
-export surfaces. Its 158 call sites were written against the second, and naming the first
-retypes every one of them against an API they were never checked against.
+they are type-checked against. Most packages point both fields at one file and the choice does
+not arise. `node-opcua-address-space` did not, and its 158 call sites had to wait: `main` named
+`dist/src/index_current.js` and `types` named `dist/source/index.d.ts`, two modules exporting
+two different `AddressSpace` classes. Naming one type-checked and then failed at run time,
+naming the other kept the run time and produced 545 type errors.
 
-Either facade loads the same module instances, so this choice is about types only.
-Reaching instead for `../source/index.js` would not be: that is a second compilation of the
-package, and `check-module-identity` exists because of what happens next.
+That is fixed, the 158 are converted, and `PACKAGE_ROOT_BLOCKED` is empty. `check-entry-points`
+now fails any package whose `types` and `main` name different modules, so the situation that
+required the exemption cannot recur unnoticed.
+
+Reaching for `../source/index.js` instead would be a different mistake: that is a second
+compilation of the package, and `check-module-identity` exists because of what happens next.
 
 ## Why
 

--- a/tools/check-import-extension/src/rule.js
+++ b/tools/check-import-extension/src/rule.js
@@ -262,23 +262,15 @@ export function analyze({ repoRoot = ".", packageFilter, write = false, scope = 
 }
 
 /**
- * Packages whose package-root specifiers cannot be replaced yet, and why.
+ * Packages whose package-root specifiers cannot be replaced yet, and why. Empty.
  *
- * A specifier is replaced by the entry point its target package names. That works whenever
- * `main` and `types` describe the same thing. Where they do not, there is no single
- * specifier that is right for both the compiler and the runtime, and the fix belongs to the
- * package, not to this rule.
+ * A specifier is replaced by the entry point its target package names, which works whenever
+ * `main` and `types` describe the same thing. node-opcua-address-space was listed here
+ * because they did not: the two named different modules exporting different AddressSpace
+ * classes. That is fixed, and check-entry-points now fails any package that splits them, so
+ * this cannot fill up again without someone noticing.
  */
-export const PACKAGE_ROOT_BLOCKED = new Map([
-    [
-        "packages/node-opcua-address-space",
-        "main is dist/src/index_current.js and types is dist/source/index.d.ts, and the two " +
-            "export different AddressSpace classes rather than one behind two facades. Naming " +
-            "types type-checks and then fails at run time (AddressSpace.create() returns an " +
-            "object with no registerNamespace); naming main keeps the run time and produces 545 " +
-            "type errors. Blocked until the package points both fields at one implementation."
-    ]
-]);
+export const PACKAGE_ROOT_BLOCKED = new Map();
 
 const packageOf = (file) => file.split("/").slice(0, 2).join("/");
 

--- a/tools/check-import-extension/test/test_rule.js
+++ b/tools/check-import-extension/test/test_rule.js
@@ -294,19 +294,31 @@ test("a package-root specifier fails the gate, and the report says what to name 
     });
 });
 
-test("a blocked package's package-root specifiers are exempt, and only that package's", () => {
-    const [blockedPkg] = [...PACKAGE_ROOT_BLOCKED.keys()];
-    const rootFinding = (file) => ({ file, kind: "package-root", line: 1, specifier: "..", fixable: false });
+test("nothing is exempt", () => {
+    // node-opcua-address-space was, while its main and types named different modules. That is
+    // fixed, and check-entry-points now fails any package that splits them, so an entry here
+    // should stay an anomaly rather than a habit.
+    assert.equal(PACKAGE_ROOT_BLOCKED.size, 0);
+});
 
-    assert.equal(isGating(rootFinding(`${blockedPkg}/test/a.ts`)), false);
-    assert.equal(isGating(rootFinding("packages/node-opcua-other/test/a.ts")), true);
-    // the exemption is for package-root only; a missing extension there still fails
-    assert.equal(isGating({ file: `${blockedPkg}/test/a.ts`, kind: "file", fixable: true }), true);
+test("the exemption mechanism still works, for whenever it is needed again", () => {
+    const blockedPkg = "packages/node-opcua-hypothetical";
+    PACKAGE_ROOT_BLOCKED.set(blockedPkg, "a reason, which the report prints");
+    try {
+        const rootFinding = (file) => ({ file, kind: "package-root", line: 1, specifier: "..", fixable: false });
 
-    // an exempt package is still reported, or the gate reads as if it had covered it
-    const report = formatReport({ scanned: 1, findings: [rootFinding(`${blockedPkg}/test/a.ts`)], scope: "all" });
-    assert.match(report, new RegExp(`1 import\\(s\\) of "\\." or "\\.\\." remain in ${blockedPkg}`));
-    assert.match(report, /main is dist\/src\/index_current\.js/);
+        assert.equal(isGating(rootFinding(`${blockedPkg}/test/a.ts`)), false);
+        assert.equal(isGating(rootFinding("packages/node-opcua-other/test/a.ts")), true);
+        // the exemption is for package-root only; a missing extension there still fails
+        assert.equal(isGating({ file: `${blockedPkg}/test/a.ts`, kind: "file", fixable: true }), true);
+
+        // an exempt package is still reported, or the gate reads as if it had covered it
+        const report = formatReport({ scanned: 1, findings: [rootFinding(`${blockedPkg}/test/a.ts`)], scope: "all" });
+        assert.match(report, new RegExp(`1 import\\(s\\) of "\\." or "\\.\\." remain in ${blockedPkg}`));
+        assert.match(report, /a reason, which the report prints/);
+    } finally {
+        PACKAGE_ROOT_BLOCKED.delete(blockedPkg);
+    }
 });
 
 test("a package-root specifier is never rewritten", () => {


### PR DESCRIPTION
Closes out FEAT-8, and removes the last carve-out from `check:importext`.

FEAT-8 converted 175 of 333 package-root specifiers and exempted
`node-opcua-address-space`, because its `main` and `types` named different modules and no
single specifier suited both:

- naming `types` type-checked and then failed at run time, with
  `addressSpace.registerNamespace is not a function`
- naming `main` kept the run time and produced **545 type errors**

FEAT-11 (#1603) unified the two, so the exemption's reason no longer held. Leaving a gate
carve-out whose justification has expired is how they become permanent, so it goes now.

## What changed

The remaining **158** specifiers name `../dist/api/index.js`, which is what both `main` and
`types` point at. Same codemod as the first 175: the target comes from `types` with the
`.d.ts` swapped for `.js`, and specifiers come from the TypeScript AST rather than a regex,
because this repository has generators whose output contains import statements.

`PACKAGE_ROOT_BLOCKED` is now **empty**. `check-entry-points` fails any package that splits
`main` from `types`, so the situation that required the exemption cannot recur unnoticed.

The gate's test for the exemption mechanism is rewritten rather than deleted: it asserts the
map is empty, and separately exercises the mechanism against a synthetic entry, so the
machinery stays covered for whenever it is needed again.

## Verification

The two checks that made this impossible the first time both pass: `check:testtypes` at
**72 packages, 0 grandfathered**, and no `registerNamespace is not a function` at run time.

`tsc -b packages` clean. `check:importext` 2902 files with no exemptions, `check:entrypoints`
117 packages, biome clean over 1540. `node-opcua-address-space` **1099 passing**.

Ten test files are reformatted: the longer specifiers pushed their import lines past the
132-column width, so the lists wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
