### PR TITLE
fix(tools): scan what each package publishes; publish namespace iteration

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -77,6 +77,12 @@ jobs:
       # ERR_REQUIRE_ASYNC_MODULE, which is how every CommonJS consumer loads us. The test
       # suite would not notice: it loads packages with `import`, where top-level await is
       # legal. Only a consumer's application finds out. Checked here so it cannot happen.
+      # Which directories each gate looks at, derived from what each package publishes
+      # rather than a hardcoded source/src. That assumption had already cost coverage
+      # twice: source_nodejs was never scanned, and renaming a package's trees to api/impl
+      # dropped 151 files out of every gate at once, all of which kept reporting clean.
+      - name: Unit tests for shipped-directory discovery
+        run: node tools/shared/test/test_shipped_dirs.js
       - run: pnpm run check:tla
       - name: Unit tests for the top-level-await detector
         run: node tools/check-no-tla/test/test_detector.js

--- a/packages/node-opcua-address-space-base/source/index.ts
+++ b/packages/node-opcua-address-space-base/source/index.ts
@@ -8,6 +8,7 @@ export * from "./event_notifier_flags.js";
 export * from "./i_event_data.js";
 export * from "./modelling_rule_type.js";
 export * from "./namespace.js";
+export * from "./namespace_iteration.js";
 export * from "./session_context.js";
 export * from "./ua_data_type.js";
 export * from "./ua_dynamic_variable_array.js";

--- a/packages/node-opcua-address-space-base/source/namespace.ts
+++ b/packages/node-opcua-address-space-base/source/namespace.ts
@@ -19,6 +19,7 @@ import type { IAddressSpace } from "./address_space.js";
 import type { AddReferenceOpts, BaseNode, ConstructNodeIdOptions } from "./base_node.js";
 import type { BindVariableOptions } from "./bind_variable.js";
 import type { ModellingRuleType } from "./modelling_rule_type.js";
+import type { INamespaceIterable } from "./namespace_iteration.js";
 import type { UADataType } from "./ua_data_type.js";
 import type { UAEventType } from "./ua_event_type.js";
 import type { UAMethod } from "./ua_method.js";
@@ -286,7 +287,7 @@ export interface RequiredModel {
     publicationDate: Date;
 }
 
-export declare interface INamespace {
+export declare interface INamespace extends INamespaceIterable {
     version: string;
     publicationDate: Date;
     namespaceUri: string;

--- a/packages/node-opcua-address-space-base/source/namespace_iteration.ts
+++ b/packages/node-opcua-address-space-base/source/namespace_iteration.ts
@@ -1,0 +1,76 @@
+/**
+ * Reading what a namespace contains.
+ *
+ * A namespace has always been able to enumerate its own nodes - documentation generators,
+ * schema dumpers and model exporters all need it - but the methods carried a leading
+ * underscore and were absent from the published type, so every caller reached them through
+ * a cast to a hand-written interface. Three such copies existed in this repository alone,
+ * and each one had to be kept in step with an implementation it could not see.
+ *
+ * They are published here under their plain names. The underscore-prefixed spellings still
+ * work and are deprecated.
+ */
+import type { BaseNode } from "./base_node.js";
+import type { UADataType } from "./ua_data_type.js";
+import type { UAObjectType } from "./ua_object_type.js";
+import type { UAReferenceType } from "./ua_reference_type.js";
+import type { UAVariableType } from "./ua_variable_type.js";
+
+/**
+ * Enumerating the nodes a namespace holds.
+ *
+ * The iterators walk the namespace's own index, so they yield only nodes belonging to this
+ * namespace, in insertion order, and they do not follow references into any other. A count
+ * is a plain size lookup rather than a walk, so preferring it to `[...iterator()].length`
+ * is worth doing on a large model.
+ *
+ * None of these iterators tolerate the namespace being modified while one is open, for the
+ * same reason a Map iterator does not: adding or removing a node invalidates it. Collect
+ * into an array first when the loop body adds nodes.
+ */
+export interface INamespaceIterable {
+    /** every node in this namespace, whatever its node class */
+    nodeIterator(): IterableIterator<BaseNode>;
+
+    /** the object types defined in this namespace */
+    objectTypeIterator(): IterableIterator<UAObjectType>;
+    /** how many object types this namespace defines */
+    objectTypeCount(): number;
+
+    /** the variable types defined in this namespace */
+    variableTypeIterator(): IterableIterator<UAVariableType>;
+    /** how many variable types this namespace defines */
+    variableTypeCount(): number;
+
+    /** the data types defined in this namespace */
+    dataTypeIterator(): IterableIterator<UADataType>;
+    /** how many data types this namespace defines */
+    dataTypeCount(): number;
+
+    /** the reference types defined in this namespace */
+    referenceTypeIterator(): IterableIterator<UAReferenceType>;
+    /** how many reference types this namespace defines */
+    referenceTypeCount(): number;
+
+    /** how many aliases this namespace declares */
+    aliasCount(): number;
+
+    /** @deprecated use {@link INamespaceIterable.objectTypeIterator} */
+    _objectTypeIterator(): IterableIterator<UAObjectType>;
+    /** @deprecated use {@link INamespaceIterable.objectTypeCount} */
+    _objectTypeCount(): number;
+    /** @deprecated use {@link INamespaceIterable.variableTypeIterator} */
+    _variableTypeIterator(): IterableIterator<UAVariableType>;
+    /** @deprecated use {@link INamespaceIterable.variableTypeCount} */
+    _variableTypeCount(): number;
+    /** @deprecated use {@link INamespaceIterable.dataTypeIterator} */
+    _dataTypeIterator(): IterableIterator<UADataType>;
+    /** @deprecated use {@link INamespaceIterable.dataTypeCount} */
+    _dataTypeCount(): number;
+    /** @deprecated use {@link INamespaceIterable.referenceTypeIterator} */
+    _referenceTypeIterator(): IterableIterator<UAReferenceType>;
+    /** @deprecated use {@link INamespaceIterable.referenceTypeCount} */
+    _referenceTypeCount(): number;
+    /** @deprecated use {@link INamespaceIterable.aliasCount} */
+    _aliasCount(): number;
+}

--- a/packages/node-opcua-address-space/impl/data_access/ua_multistate_discrete_impl.ts
+++ b/packages/node-opcua-address-space/impl/data_access/ua_multistate_discrete_impl.ts
@@ -8,52 +8,54 @@ import type {
     CloneFilter,
     CloneOptions,
     INamespace,
+    UAProperty,
     UAVariable
 } from "node-opcua-address-space-base";
 import { assert } from "node-opcua-assert";
 import { VariableTypeIds } from "node-opcua-constants";
 import { coerceLocalizedText, type LocalizedText } from "node-opcua-data-model";
-import type { UAMultiStateDiscrete_Base } from "node-opcua-nodeset-ua";
 import { type StatusCode, StatusCodes } from "node-opcua-status-code";
 import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
 import type { AddMultiStateDiscreteOptions } from "../../api/address_space_ts.js";
 import type { ISetStateOptions } from "../../api/interfaces/i_set_state_options.js";
 import { registerNodePromoter } from "../../api/loader/register_node_promoter.js";
-import { UAVariableImpl } from "../ua_variable_impl.js";
+import { UAVariableImpl, UAVariableImplT } from "../ua_variable_impl.js";
 import { add_dataItem_stuff } from "./add_dataItem_stuff.js";
 
 export { UAMultiStateDiscrete } from "node-opcua-nodeset-ua";
 
-export interface UAMultiStateDiscreteEx<T, DT extends DataType> extends UAMultiStateDiscrete_Base<T, DT> {
-    //------------ helpers ------------------
-    getValue(): number;
-    getValueAsString(): string;
-    getIndex(value: string): number;
-    setValue(value: string | number, options?: ISetStateOptions): void;
-    checkVariantCompatibility(value: Variant): StatusCode;
-}
+// One declaration, in the api tree, rather than a lesser copy here: this file used to
+// declare its own UAMultiStateDiscreteEx without the UAVariableT half, so the two drifted
+// on what readValue returns.
+import type { UAMultiStateDiscreteEx } from "../../api/interfaces/data_access/ua_multistate_discrete_ex.js";
+
+export type { UAMultiStateDiscreteEx };
 
 /**
  * @class UAMultiStateDiscrete
  * @internal
  */
-export class UAMultiStateDiscreteImplBase<T, DT extends DataType> extends UAVariableImpl {
-    private get $7(): UAMultiStateDiscreteEx<T, DT> {
-        return this as unknown as UAMultiStateDiscreteEx<T, DT>;
-    }
+export class UAMultiStateDiscreteImplBase<T, DT extends DataType> extends UAVariableImplT<T, DT> {
+    /**
+     * The EnumStrings property, installed as a child node by the address space rather than
+     * assigned by this constructor - hence `declare`, which emits nothing.
+     */
+    public declare readonly enumStrings: UAProperty<LocalizedText[], DataType.LocalizedText>;
+
     public getValue(): number {
-        return this.readValue().value.value;
+        // MultiStateDiscrete fixes its value to UInt32 (OPC 10000-8), whatever T says
+        return this.readValue().value.value as number;
     }
 
     public getValueAsString(): string {
         const index = this.getValue();
-        const arr = this.$7.enumStrings.readValue().value.value;
+        const arr = this.enumStrings.readValue().value.value;
         assert(Array.isArray(arr));
         return arr[index].text ? arr[index].text?.toString() : "????";
     }
 
     public getIndex(value: string): number {
-        const arr = this.$7.enumStrings.readValue().value.value;
+        const arr = this.enumStrings.readValue().value.value;
         assert(Array.isArray(arr));
         const index = arr.findIndex((a: LocalizedText) => a.text === value);
         return index;
@@ -68,7 +70,7 @@ export class UAMultiStateDiscreteImplBase<T, DT extends DataType> extends UAVari
             this.setValue(index, options);
             return;
         }
-        const arrayEnumStrings = this.$7.enumStrings.readValue().value.value;
+        const arrayEnumStrings = this.enumStrings.readValue().value.value;
         if (value >= arrayEnumStrings.length) {
             throw new Error(`UAMultiStateDiscrete#setValue BadOutOfRange ${value}`);
         }
@@ -80,8 +82,8 @@ export class UAMultiStateDiscreteImplBase<T, DT extends DataType> extends UAVari
         if (!this._validate_DataType(value.dataType)) {
             return StatusCodes.BadTypeMismatch;
         }
-        if (this.$7.enumStrings) {
-            const arrayEnumStrings = this.$7.enumStrings.readValue().value.value;
+        if (this.enumStrings) {
+            const arrayEnumStrings = this.enumStrings.readValue().value.value;
             // MultiStateDiscreteType
             assert(value.dataType === DataType.UInt32);
             if (value.value >= arrayEnumStrings.length) {

--- a/packages/node-opcua-address-space/impl/data_access/ua_multistate_value_discrete_impl.ts
+++ b/packages/node-opcua-address-space/impl/data_access/ua_multistate_value_discrete_impl.ts
@@ -4,6 +4,7 @@ import type {
     CloneFilter,
     CloneOptions,
     INamespace,
+    UAProperty,
     UAVariable
 } from "node-opcua-address-space-base";
 import { assert } from "node-opcua-assert";
@@ -19,7 +20,7 @@ import {
     type UInt64
 } from "node-opcua-basic-types";
 import { VariableTypeIds } from "node-opcua-constants";
-import { coerceLocalizedText } from "node-opcua-data-model";
+import { coerceLocalizedText, type LocalizedText } from "node-opcua-data-model";
 import type { DataValue } from "node-opcua-data-value";
 import type { DTEnumValue } from "node-opcua-nodeset-ua";
 import { type StatusCode, StatusCodes } from "node-opcua-status-code";
@@ -89,12 +90,15 @@ function install_synchronization<T extends Number, DT extends DataType>(
 
 /** @internal */
 export class UAMultiStateValueDiscreteImplBase<T extends Number, DT extends DataType> extends UAVariableImpl {
-    private get $6(): UAMultiStateValueDiscreteEx<T, DT> {
-        return this as unknown as UAMultiStateValueDiscreteEx<T, DT>;
-    }
+    /**
+     * Properties installed as child nodes by the address space rather than assigned by this
+     * constructor - hence `declare`, which emits nothing.
+     */
+    public declare readonly enumValues: UAProperty<DTEnumValue[], DataType.ExtensionObject>;
+    public declare readonly valueAsText: UAProperty<LocalizedText, DataType.LocalizedText>;
     public setValue(value: string | number | Int64, options?: ISetStateOptions): void {
         if (typeof value === "string") {
-            const enumValues = this.$6.enumValues.readValue().value.value;
+            const enumValues = this.enumValues.readValue().value.value;
             const selected = enumValues.filter((a) => a.displayName.text === value)[0];
             if (selected) {
                 this._setValue(selected.value);
@@ -107,7 +111,7 @@ export class UAMultiStateValueDiscreteImplBase<T extends Number, DT extends Data
     }
 
     public getValueAsString(): string | string[] {
-        const v = this.$6.valueAsText.readValue().value.value;
+        const v = this.valueAsText.readValue().value.value;
         if (Array.isArray(v)) {
             return v.map((a) => a.text);
         }
@@ -119,7 +123,7 @@ export class UAMultiStateValueDiscreteImplBase<T extends Number, DT extends Data
     }
 
     public checkVariantCompatibility(value: Variant): StatusCode {
-        if (this.$6.enumValues) {
+        if (this.enumValues) {
             if (!this._isValueInRange(coerceInt32(value.value))) {
                 return StatusCodes.BadOutOfRange;
             }
@@ -141,7 +145,7 @@ export class UAMultiStateValueDiscreteImplBase<T extends Number, DT extends Data
      */
     public _isValueInRange(value: number): boolean {
         // MultiStateValueDiscreteType
-        const enumValues = this.$6.enumValues.readValue().value.value as DTEnumValue[];
+        const enumValues = this.enumValues.readValue().value.value as DTEnumValue[];
         const e = enumValues.findIndex((x: DTEnumValue) => coerceInt64toInt32(x.value) === value);
         return !(e === -1);
     }
@@ -151,7 +155,7 @@ export class UAMultiStateValueDiscreteImplBase<T extends Number, DT extends Data
      */
     public _enumValueIndex(): Record<Int32, DTEnumValue> {
         // construct an index to quickly find a EnumValue from a value
-        const enumValues: DTEnumValue[] = this.$6.enumValues.readValue().value.value;
+        const enumValues: DTEnumValue[] = this.enumValues.readValue().value.value;
         const enumValueIndex: Record<Int32, DTEnumValue> = Object.create(null);
         if (!enumValues?.forEach) {
             return enumValueIndex;

--- a/packages/node-opcua-address-space/impl/data_access/ua_two_state_discrete_impl.ts
+++ b/packages/node-opcua-address-space/impl/data_access/ua_two_state_discrete_impl.ts
@@ -4,6 +4,7 @@ import type {
     CloneFilter,
     CloneOptions,
     INamespace,
+    UAProperty,
     UAVariable
 } from "node-opcua-address-space-base";
 import assert from "node-opcua-assert";
@@ -19,9 +20,12 @@ import { add_dataItem_stuff } from "./add_dataItem_stuff.js";
 
 /** @internal */
 export class UATwoStateDiscreteImplBase extends UAVariableImpl {
-    private get $5(): UATwoStateDiscreteEx {
-        return this as unknown as UATwoStateDiscreteEx;
-    }
+    /**
+     * Properties installed as child nodes by the address space rather than assigned by this
+     * constructor - hence `declare`, which emits nothing.
+     */
+    public declare readonly falseState: UAProperty<LocalizedText, DataType.LocalizedText>;
+    public declare readonly trueState: UAProperty<LocalizedText, DataType.LocalizedText>;
     /*
      * @private
      */
@@ -79,10 +83,10 @@ export class UATwoStateDiscreteImplBase extends UAVariableImpl {
         }
     }
     getTrueStateAsString(): string {
-        return (this.$5.trueState.readValue().value.value as LocalizedText).text || "";
+        return (this.trueState.readValue().value.value as LocalizedText).text || "";
     }
     getFalseStateAsString(): string {
-        return (this.$5.falseState.readValue().value.value as LocalizedText).text || "";
+        return (this.falseState.readValue().value.value as LocalizedText).text || "";
     }
 
     public clone(options1: CloneOptions, optionalFilter?: CloneFilter, extraInfo?: CloneExtraInfo): UAVariable {

--- a/packages/node-opcua-address-space/impl/namespace_impl.ts
+++ b/packages/node-opcua-address-space/impl/namespace_impl.ts
@@ -331,40 +331,81 @@ export class NamespaceImpl implements NamespacePrivate {
         return this._nodeid_index.values();
     }
 
-    public _objectTypeIterator(): IterableIterator<UAObjectType> {
+    public objectTypeIterator(): IterableIterator<UAObjectType> {
         return this._objectTypeMap.values();
     }
 
-    public _objectTypeCount(): number {
+    public objectTypeCount(): number {
         return this._objectTypeMap.size;
     }
 
-    public _variableTypeIterator(): IterableIterator<UAVariableType> {
+    public variableTypeIterator(): IterableIterator<UAVariableType> {
         return this._variableTypeMap.values();
     }
 
-    public _variableTypeCount(): number {
+    public variableTypeCount(): number {
         return this._variableTypeMap.size;
     }
 
-    public _dataTypeIterator(): IterableIterator<UADataType> {
+    public dataTypeIterator(): IterableIterator<UADataType> {
         return this._dataTypeMap.values();
     }
 
-    public _dataTypeCount(): number {
+    public dataTypeCount(): number {
         return this._dataTypeMap.size;
     }
 
-    public _referenceTypeIterator(): IterableIterator<UAReferenceType> {
+    public referenceTypeIterator(): IterableIterator<UAReferenceType> {
         return this._referenceTypeMap.values();
     }
 
-    public _referenceTypeCount(): number {
+    public referenceTypeCount(): number {
         return this._referenceTypeMap.size;
     }
 
-    public _aliasCount(): number {
+    public aliasCount(): number {
         return this._aliases.size;
+    }
+
+    // The underscore spellings these had before they were published. Callers reached them
+    // through a cast, so they cannot be removed without warning; they delegate and are
+    // deprecated.
+
+    /** @deprecated use `objectTypeIterator` */
+    public _objectTypeIterator(): IterableIterator<UAObjectType> {
+        return this.objectTypeIterator();
+    }
+    /** @deprecated use `objectTypeCount` */
+    public _objectTypeCount(): number {
+        return this.objectTypeCount();
+    }
+    /** @deprecated use `variableTypeIterator` */
+    public _variableTypeIterator(): IterableIterator<UAVariableType> {
+        return this.variableTypeIterator();
+    }
+    /** @deprecated use `variableTypeCount` */
+    public _variableTypeCount(): number {
+        return this.variableTypeCount();
+    }
+    /** @deprecated use `dataTypeIterator` */
+    public _dataTypeIterator(): IterableIterator<UADataType> {
+        return this.dataTypeIterator();
+    }
+    /** @deprecated use `dataTypeCount` */
+    public _dataTypeCount(): number {
+        return this.dataTypeCount();
+    }
+    /** @deprecated use `referenceTypeIterator` */
+    public _referenceTypeIterator(): IterableIterator<UAReferenceType> {
+        return this.referenceTypeIterator();
+    }
+    /** @deprecated use `referenceTypeCount` */
+    public _referenceTypeCount(): number {
+        return this.referenceTypeCount();
+    }
+    /** @deprecated use `aliasCount` */
+    public _aliasCount(): number {
+        return this.aliasCount();
     }
 
     public findNode2(nodeId: NodeId): BaseNode | null {

--- a/packages/node-opcua-address-space/impl/namespace_impl.ts
+++ b/packages/node-opcua-address-space/impl/namespace_impl.ts
@@ -86,6 +86,7 @@ import type { UAExclusiveLimitAlarmEx } from "../api/interfaces/alarms_and_condi
 import type { UALimitAlarmEx } from "../api/interfaces/alarms_and_conditions/ua_limit_alarm_ex.js";
 import type { UANonExclusiveDeviationAlarmEx } from "../api/interfaces/alarms_and_conditions/ua_non_exclusive_deviation_alarm_ex.js";
 import type { UANonExclusiveLimitAlarmEx } from "../api/interfaces/alarms_and_conditions/ua_non_exclusive_limit_alarm_ex.js";
+import type { UAMultiStateDiscreteEx } from "../api/interfaces/data_access/ua_multistate_discrete_ex.js";
 import type { UAMultiStateValueDiscreteEx } from "../api/interfaces/data_access/ua_multistate_value_discrete_ex.js";
 import type { UAStateMachineEx } from "../api/interfaces/state_machine/ua_state_machine_type.js";
 import type { UATransitionEx } from "../api/interfaces/state_machine/ua_transition_ex.js";
@@ -109,7 +110,7 @@ import { UANonExclusiveLimitAlarmImplBase } from "./alarms_and_conditions/ua_non
 import { type UAOffNormalAlarmEx, UAOffNormalAlarmImplBase } from "./alarms_and_conditions/ua_off_normal_alarm_impl.js";
 import { BaseNodeImpl } from "./base_node_impl.js";
 import { add_dataItem_stuff } from "./data_access/add_dataItem_stuff.js";
-import { _addMultiStateDiscrete, type UAMultiStateDiscreteImpl } from "./data_access/ua_multistate_discrete_impl.js";
+import { _addMultiStateDiscrete } from "./data_access/ua_multistate_discrete_impl.js";
 import { _addMultiStateValueDiscrete } from "./data_access/ua_multistate_value_discrete_impl.js";
 import { _addTwoStateDiscrete } from "./data_access/ua_two_state_discrete_impl.js";
 import { _coerce_parent, _handle_hierarchy_parent } from "./handle_hierarchy_parent.js";
@@ -666,7 +667,10 @@ export class NamespaceImpl implements NamespacePrivate {
 
     /**
      */
-    public addMultiStateDiscrete<T, DT extends DataType>(options: AddMultiStateDiscreteOptions): UAMultiStateDiscreteImpl<T, DT> {
+    // returns the published type, not UAMultiStateDiscreteImpl: two generic signatures are
+    // compared with their parameters erased to constraints, so declaring the narrower one
+    // here makes this method fail to satisfy the very interface it implements
+    public addMultiStateDiscrete<T, DT extends DataType>(options: AddMultiStateDiscreteOptions): UAMultiStateDiscreteEx<T, DT> {
         return _addMultiStateDiscrete<T, DT>(this, options);
     }
 

--- a/packages/node-opcua-address-space/impl/namespace_private.ts
+++ b/packages/node-opcua-address-space/impl/namespace_private.ts
@@ -8,8 +8,7 @@ import type {
     CreateNodeOptions,
     INamespace,
     ModellingRuleType,
-    RequiredModel,
-    UADataType
+    RequiredModel
 } from "node-opcua-address-space-base";
 import { assert } from "node-opcua-assert";
 import type { NodeId } from "node-opcua-nodeid";
@@ -20,8 +19,6 @@ export interface NamespacePrivate extends INamespace {
     addressSpace: AddressSpacePrivate;
 
     setRequiredModels(requiredModels: RequiredModel[]): void;
-
-    nodeIterator(): IterableIterator<BaseNode>;
 
     constructNodeId(options: ConstructNodeIdOptions): NodeId;
 
@@ -35,15 +32,9 @@ export interface NamespacePrivate extends INamespace {
 
     internalCreateNode(options: CreateNodeOptions): BaseNode;
 
-    _dataTypeIterator(): IterableIterator<UADataType>;
-
     registerSymbolicNames: boolean;
 
-    _aliasCount(): number;
-    _objectTypeCount(): number;
-    _variableTypeCount(): number;
-    _dataTypeCount(): number;
-    _referenceTypeCount(): number;
+    // the iteration members used to be redeclared here; INamespace publishes them now
 }
 
 export declare const NamespacePrivate: new (options: unknown) => NamespacePrivate;

--- a/packages/node-opcua-address-space/impl/namespace_private.ts
+++ b/packages/node-opcua-address-space/impl/namespace_private.ts
@@ -6,16 +6,16 @@ import type {
     BaseNode,
     ConstructNodeIdOptions,
     CreateNodeOptions,
-    INamespace,
     ModellingRuleType,
     RequiredModel
 } from "node-opcua-address-space-base";
 import { assert } from "node-opcua-assert";
 import type { NodeId } from "node-opcua-nodeid";
 
+import type { Namespace } from "../api/namespace.js";
 import type { AddressSpacePrivate } from "./address_space_private.js";
 
-export interface NamespacePrivate extends INamespace {
+export interface NamespacePrivate extends Namespace {
     addressSpace: AddressSpacePrivate;
 
     setRequiredModels(requiredModels: RequiredModel[]): void;

--- a/packages/node-opcua-address-space/impl/nodeset_tools/dump_to_bsd.ts
+++ b/packages/node-opcua-address-space/impl/nodeset_tools/dump_to_bsd.ts
@@ -155,33 +155,11 @@ function shortcut(namespace: INamespace) {
  *
  * This function is exported from the package entry, and NamespacePrivate is not: asking for
  * one made it impossible to call from outside, since there is no public way to obtain the
- * argument. It needs `_dataTypeIterator`, which only the implementation has, so the narrowing
- * happens here once rather than at every call site.
+ * argument. The data types it walks now come from the published iterator; the narrowing that
+ * remains is for constructNamespaceDependency, which is internal.
  */
-/**
- * The one service this file needs that a Namespace does not publish: walking the data types
- * the namespace holds.
- *
- * Everything else dumpToBSD reads - index, namespaceUri, addressSpace - is on the public
- * Namespace. Asking for the whole NamespacePrivate would have meant demanding thirteen
- * members to use one, and would have made the parameter a type no caller outside this package
- * can obtain.
- *
- * A namespace cannot be enumerated through the published API at all: both nodeIterator and
- * _dataTypeIterator are private. Everyone who needs to walk one therefore declares their own
- * copy of the internals and converts into it - node-opcua-modeler's generate_markdown_doc has
- * a ten-member `NamespacePriv2`, its tests have a `NamespaceWithInternals`, and this is the
- * third. Publishing the capability once, as a named interface in the contract package, is the
- * fix; it is tracked separately because it is an API addition, not a repair.
- *
- * @internal
- */
-export interface IDataTypeIterable {
-    _dataTypeIterator(): IterableIterator<UADataType>;
-}
-
 export function dumpToBSD(namespace: Namespace): string {
-    const _namespace = namespace as unknown as IDataTypeIterable & NamespacePrivate;
+    const _namespace = namespace as unknown as NamespacePrivate;
     const dependency: INamespace[] = constructNamespaceDependency(_namespace);
 
     const _addressSpace = _namespace.addressSpace;
@@ -222,7 +200,7 @@ export function dumpToBSD(namespace: Namespace): string {
         xw.startElement("opc:Import").writeAttribute("Namespace", dependantNamespace.namespaceUri).endElement();
     }
     //
-    for (const dataType of _namespace._dataTypeIterator()) {
+    for (const dataType of namespace.dataTypeIterator()) {
         dumpDataTypeToBSD(xw, dataType, map);
     }
     xw.endElement();

--- a/packages/node-opcua-address-space/impl/ua_reference_type_impl.ts
+++ b/packages/node-opcua-address-space/impl/ua_reference_type_impl.ts
@@ -9,8 +9,9 @@ import { DataValue, type DataValueLike } from "node-opcua-data-value";
 import type { NodeId } from "node-opcua-nodeid";
 import { StatusCodes } from "node-opcua-status-code";
 import { DataType } from "node-opcua-variant";
-
-import { SessionContext, type UAReferenceType as UAReferenceTypePublic } from "../api/index.js";
+// the module itself, not the api barrel: the barrel also publishes the AddressSpace value,
+// and reaching it from here closes a cycle that throws under ESM
+import { SessionContext } from "../api/session_context.js";
 import { BaseNodeImpl, type InternalBaseNodeOptions } from "./base_node_impl.js";
 import { BaseNode_getCache } from "./base_node_private.js";
 import { ReferenceImpl } from "./reference_impl.js";
@@ -18,7 +19,7 @@ import { construct_isSubtypeOf, construct_slow_isSubtypeOf, get_subtypeOf, get_s
 
 const ReferenceTypeCounter = { count: 0 };
 
-function _internal_getAllSubtypes(referenceType: UAReferenceType): UAReferenceTypePublic[] {
+function _internal_getAllSubtypes(referenceType: UAReferenceType): UAReferenceType[] {
     const addressSpace = referenceType.addressSpace;
     const possibleReferenceTypes: UAReferenceType[] = [];
 
@@ -30,7 +31,7 @@ function _internal_getAllSubtypes(referenceType: UAReferenceType): UAReferenceTy
         assert(referenceTypeInner.nodeClass === NodeClass.ReferenceType);
         const references = referenceTypeInner.findReferences(hasSubtypeReferenceType, true);
         for (const _r of references) {
-            const subType: UAReferenceTypePublic | null = addressSpace.findReferenceType(_r.nodeId);
+            const subType: UAReferenceType | null = addressSpace.findReferenceType(_r.nodeId);
             if (!subType) throw new Error("cannot find subtype reference type");
             _findAllSubType(subType);
         }
@@ -52,7 +53,7 @@ function _getAllSubtypes(ref: UAReferenceType) {
     return _cache._allSubTypes;
 }
 
-function _internal_getSubtypeIndex(referenceType: UAReferenceType): Map<string, UAReferenceTypePublic> {
+function _internal_getSubtypeIndex(referenceType: UAReferenceType): Map<string, UAReferenceType> {
     const possibleReferenceTypes = _getAllSubtypes(referenceType);
     // create a index of reference type with browseName as key for faster search
     const keys: Map<string, UAReferenceType> = new Map();
@@ -62,7 +63,7 @@ function _internal_getSubtypeIndex(referenceType: UAReferenceType): Map<string, 
     return keys;
 }
 
-function _getSubtypeIndex(referenceType: UAReferenceType): Map<string, UAReferenceTypePublic> {
+function _getSubtypeIndex(referenceType: UAReferenceType): Map<string, UAReferenceType> {
     const _cache = BaseNode_getCache(referenceType);
     if (!_cache._subtype_idx || (_cache._subtype_idxVersion && _cache._subtype_idxVersion < ReferenceTypeCounter.count)) {
         // the cache need to be invalidated
@@ -86,7 +87,7 @@ export class UAReferenceTypeImpl extends BaseNodeImpl<BaseNodeEvents> implements
     public readonly symmetric: boolean;
     public readonly inverseName: LocalizedText;
 
-    public get subtypeOfObj(): UAReferenceTypePublic | null {
+    public get subtypeOfObj(): UAReferenceType | null {
         return get_subtypeOfObj.call(this) as unknown as UAReferenceType;
     }
 

--- a/packages/node-opcua-address-space/impl/ua_variable_impl.ts
+++ b/packages/node-opcua-address-space/impl/ua_variable_impl.ts
@@ -2426,7 +2426,14 @@ export class UAVariableImplT<T, DT extends DataType> extends UAVariableImpl {
         context: ISessionContext | null,
         callback?: CallbackT<DataValueT<T, DT>>
     ): Promise<DataValueT<T, DT>> | undefined {
-        return super.readValueAsync(context, callback as CallbackT<DataValue>) as Promise<DataValueT<T, DT>> | undefined;
+        // forward the arguments we were actually given. The base method is thenified, and
+        // thenify decides between promise and callback form by argument count, so passing an
+        // explicit undefined callback makes it hand that undefined straight through.
+        if (callback === undefined) {
+            return super.readValueAsync(context) as Promise<DataValueT<T, DT>>;
+        }
+        super.readValueAsync(context, callback as CallbackT<DataValue>);
+        return undefined;
     }
 
     public writeValue(
@@ -2447,12 +2454,17 @@ export class UAVariableImplT<T, DT extends DataType> extends UAVariableImpl {
         indexRangeOrCallback?: NumericRange | null | StatusCodeCallback,
         callback?: StatusCodeCallback
     ): Promise<StatusCode> | undefined {
-        return (super.writeValue as (...args: unknown[]) => Promise<StatusCode> | undefined)(
-            context,
-            dataValue,
-            indexRangeOrCallback,
-            callback
-        );
+        // same reason as readValueAsync above: forward the arity we were called with, and
+        // keep the call on `super.writeValue` so it stays a method call - binding it to a
+        // local would drop `this`
+        type Write = (...args: unknown[]) => Promise<StatusCode> | undefined;
+        if (callback === undefined) {
+            if (indexRangeOrCallback === undefined) {
+                return (super.writeValue as Write)(context, dataValue);
+            }
+            return (super.writeValue as Write)(context, dataValue, indexRangeOrCallback);
+        }
+        return (super.writeValue as Write)(context, dataValue, indexRangeOrCallback, callback);
     }
 }
 

--- a/packages/node-opcua-address-space/source_nodejs/generate_address_space.ts
+++ b/packages/node-opcua-address-space/source_nodejs/generate_address_space.ts
@@ -1,11 +1,11 @@
 import fs from "node:fs";
 import type { IAddressSpace } from "node-opcua-address-space-base";
 import { checkDebugFlag, make_debugLog, make_errorLog } from "node-opcua-debug";
-import { generateAddressSpaceRaw, type NodeSetLoaderOptions } from "..";
+import { generateAddressSpaceRaw, type NodeSetLoaderOptions } from "../dist/api/index.js";
 
-const _doDebug = checkDebugFlag(__filename);
-const debugLog = make_debugLog(__filename);
-const errorLog = make_errorLog(__filename);
+const _doDebug = checkDebugFlag("generate_address_space");
+const debugLog = make_debugLog("generate_address_space");
+const errorLog = make_errorLog("generate_address_space");
 
 export async function readNodeSet2XmlFile(xmlFile: string): Promise<string> {
     // c8 ignore next
@@ -14,7 +14,9 @@ export async function readNodeSet2XmlFile(xmlFile: string): Promise<string> {
         errorLog(msg);
         throw new Error(msg);
     }
-    debugLog(" parsing ", xmlFile);
+    if (_doDebug) {
+        debugLog(" parsing ", xmlFile);
+    }
     const xmlData = await fs.promises.readFile(xmlFile, "utf-8");
     return xmlData;
 }

--- a/packages/node-opcua-address-space/source_nodejs/index.ts
+++ b/packages/node-opcua-address-space/source_nodejs/index.ts
@@ -1,1 +1,1 @@
-export * from "./generate_address_space";
+export * from "./generate_address_space.js";

--- a/packages/node-opcua-address-space/test/test_address_space_add_two_state_variable.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_add_two_state_variable.ts
@@ -1,10 +1,13 @@
 import fs from "node:fs";
+import { coerceLocalizedText } from "node-opcua-data-model";
+import { DataValue } from "node-opcua-data-value";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import { StatusCodes } from "node-opcua-status-code";
+import { DataType, Variant } from "node-opcua-variant";
 import should from "should";
 import sinon from "sinon";
-import { AddressSpace, type BaseNode, type Namespace } from "../dist/api/index.js";
+import { AddressSpace, type BaseNode, type Namespace, SessionContext } from "../dist/api/index.js";
 import { UATwoStateVariableImpl } from "../dist/impl/state_machine/ua_two_state_variable.js";
 import { generateAddressSpace } from "../nodeJS.js";
 
@@ -36,6 +39,24 @@ describe("testing add TwoStateVariable ", function (this: Mocha.Suite) {
     afterEach(function (this: Mocha.Context) {
         clock?.restore();
         clock = null;
+    });
+
+    it("should read and write a TwoStateVariable in promise form", async () => {
+        // UATwoStateVariableImpl extends UAVariableImplT, whose readValue/writeValue
+        // overrides forward to a thenified base. Passing that base an explicit undefined
+        // callback makes it take the callback path with no callback to call, so the promise
+        // form breaks on any class deriving from it.
+        const node = namespace.addTwoStateVariable({ browseName: "TwoStateVariablePromiseForm" });
+        node.setValue(true);
+
+        const dataValue = await node.readValueAsync(SessionContext.defaultContext);
+        should(dataValue.value.value.text).eql("TRUE");
+
+        const statusCode = await node.writeValue(
+            SessionContext.defaultContext,
+            new DataValue({ value: new Variant({ dataType: DataType.LocalizedText, value: coerceLocalizedText("FALSE") }) })
+        );
+        should.exist(statusCode);
     });
 
     it("should add a TwoStateVariableType", () => {

--- a/packages/node-opcua-address-space/test/test_address_space_add_two_state_variable.ts
+++ b/packages/node-opcua-address-space/test/test_address_space_add_two_state_variable.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
-import { coerceLocalizedText } from "node-opcua-data-model";
-import { DataValue } from "node-opcua-data-value";
+import { coerceLocalizedText, type LocalizedText } from "node-opcua-data-model";
+import { DataValueT } from "node-opcua-data-value";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import { StatusCodes } from "node-opcua-status-code";
@@ -54,7 +54,9 @@ describe("testing add TwoStateVariable ", function (this: Mocha.Suite) {
 
         const statusCode = await node.writeValue(
             SessionContext.defaultContext,
-            new DataValue({ value: new Variant({ dataType: DataType.LocalizedText, value: coerceLocalizedText("FALSE") }) })
+            new DataValueT<LocalizedText, DataType.LocalizedText>({
+                value: new Variant({ dataType: DataType.LocalizedText, value: coerceLocalizedText("FALSE") })
+            })
         );
         should.exist(statusCode);
     });

--- a/packages/node-opcua-address-space/test/test_namespace_iteration.ts
+++ b/packages/node-opcua-address-space/test/test_namespace_iteration.ts
@@ -1,0 +1,103 @@
+import should from "should";
+import type { AddressSpace, INamespace, Namespace } from "../dist/api/index.js";
+import { getMiniAddressSpace } from "../testHelpers.js";
+
+/**
+ * Enumerating a namespace through the published API.
+ *
+ * Everything here imports from the package entry and takes `INamespace`, with no cast: that
+ * is the whole point. These methods existed before, spelled with a leading underscore and
+ * absent from the published type, so three separate hand-written copies of the interface had
+ * grown up around them.
+ */
+describe("Namespace iteration", () => {
+    let addressSpace: AddressSpace;
+    let namespace: Namespace;
+
+    beforeEach(async () => {
+        addressSpace = await getMiniAddressSpace();
+        namespace = addressSpace.registerNamespace("urn:namespace-iteration-test");
+    });
+
+    afterEach(() => {
+        addressSpace.dispose();
+    });
+
+    // taking INamespace, not NamespaceImpl: a caller outside the package can only have this
+    const countTypes = (ns: INamespace) => ({
+        objectTypes: ns.objectTypeCount(),
+        variableTypes: ns.variableTypeCount(),
+        dataTypes: ns.dataTypeCount(),
+        referenceTypes: ns.referenceTypeCount(),
+        aliases: ns.aliasCount()
+    });
+
+    it("counts nothing in a namespace that holds nothing", () => {
+        countTypes(namespace).should.eql({
+            objectTypes: 0,
+            variableTypes: 0,
+            dataTypes: 0,
+            referenceTypes: 0,
+            aliases: 0
+        });
+        [...namespace.nodeIterator()].length.should.eql(0);
+    });
+
+    it("yields each kind of type from its own iterator", () => {
+        namespace.addObjectType({ browseName: "MyObjectType" });
+        namespace.addVariableType({ browseName: "MyVariableType" });
+        namespace.addReferenceType({ browseName: "MyReferenceType", inverseName: "MyInverseName", isAbstract: false });
+        namespace.addEnumerationType({ browseName: "MyEnumeration", enumeration: [{ displayName: "A", value: 1 }] });
+
+        [...namespace.objectTypeIterator()].map((n) => n.browseName.name).should.eql(["MyObjectType"]);
+        [...namespace.variableTypeIterator()].map((n) => n.browseName.name).should.eql(["MyVariableType"]);
+        [...namespace.referenceTypeIterator()].map((n) => n.browseName.name).should.eql(["MyReferenceType"]);
+        [...namespace.dataTypeIterator()].map((n) => n.browseName.name).should.eql(["MyEnumeration"]);
+    });
+
+    it("counts agree with what the iterators yield", () => {
+        namespace.addObjectType({ browseName: "A" });
+        namespace.addObjectType({ browseName: "B" });
+        namespace.addVariableType({ browseName: "V" });
+
+        const counts = countTypes(namespace);
+        counts.objectTypes.should.eql([...namespace.objectTypeIterator()].length);
+        counts.variableTypes.should.eql([...namespace.variableTypeIterator()].length);
+        counts.objectTypes.should.eql(2);
+        counts.variableTypes.should.eql(1);
+    });
+
+    it("nodeIterator yields every node whatever its class", () => {
+        const objectType = namespace.addObjectType({ browseName: "SomeType" });
+        namespace.addObject({ browseName: "SomeObject", typeDefinition: objectType, organizedBy: addressSpace.rootFolder.objects });
+
+        const names = [...namespace.nodeIterator()].map((n) => n.browseName.name);
+        names.should.containEql("SomeType");
+        names.should.containEql("SomeObject");
+    });
+
+    it("counts an alias", () => {
+        const objectType = namespace.addObjectType({ browseName: "Aliased" });
+        namespace.addAlias("AnAlias", objectType.nodeId);
+        should(namespace.aliasCount()).eql(1);
+    });
+
+    it("still answers to the deprecated underscore spellings", () => {
+        // callers reached these through a cast, so they keep working and delegate
+        namespace.addObjectType({ browseName: "MyObjectType" });
+
+        namespace._objectTypeCount().should.eql(namespace.objectTypeCount());
+        [...namespace._objectTypeIterator()].should.eql([...namespace.objectTypeIterator()]);
+        [...namespace._dataTypeIterator()].should.eql([...namespace.dataTypeIterator()]);
+        namespace._aliasCount().should.eql(namespace.aliasCount());
+    });
+
+    it("does not leak nodes between namespaces", () => {
+        const other = addressSpace.registerNamespace("urn:some-other-namespace");
+        namespace.addObjectType({ browseName: "Mine" });
+        other.addObjectType({ browseName: "Theirs" });
+
+        [...namespace.objectTypeIterator()].map((n) => n.browseName.name).should.eql(["Mine"]);
+        [...other.objectTypeIterator()].map((n) => n.browseName.name).should.eql(["Theirs"]);
+    });
+});

--- a/packages/node-opcua-debug/source_nodejs/get_temp_filename.ts
+++ b/packages/node-opcua-debug/source_nodejs/get_temp_filename.ts
@@ -4,10 +4,14 @@
 import fs from "node:fs";
 import path from "node:path";
 
+// The one place this module learns where it sits on disk. `import.meta.dirname`
+// cannot be used while this package emits CommonJS (TS1470), so the ESM migration
+// has this single line to change rather than several scattered uses.
+const here = __dirname;
+
 export function getTempFilename(tmpFilename: string | null): string {
     tmpFilename = tmpFilename || "";
-    const folderOfThisFile = __dirname;
-    const temporaryFolder = path.join(folderOfThisFile, "../../../tmp/");
+    const temporaryFolder = path.join(here, "../../../tmp/");
     if (!fs.existsSync(temporaryFolder)) {
         fs.mkdirSync(temporaryFolder);
     }

--- a/packages/node-opcua-debug/source_nodejs/index.ts
+++ b/packages/node-opcua-debug/source_nodejs/index.ts
@@ -1,2 +1,2 @@
-export { getTempFilename } from "./get_temp_filename";
-export { redirectToFile } from "./redirect_to_file";
+export { getTempFilename } from "./get_temp_filename.js";
+export { redirectToFile } from "./redirect_to_file.js";

--- a/packages/node-opcua-debug/source_nodejs/redirect_to_file.ts
+++ b/packages/node-opcua-debug/source_nodejs/redirect_to_file.ts
@@ -5,7 +5,7 @@ import fs from "node:fs";
 import { format } from "node:util";
 
 import { assert } from "node-opcua-assert";
-import { getTempFilename } from "./get_temp_filename";
+import { getTempFilename } from "./get_temp_filename.js";
 
 /**
 

--- a/packages/node-opcua-modeler/source/generate_markdown_doc.ts
+++ b/packages/node-opcua-modeler/source/generate_markdown_doc.ts
@@ -16,18 +16,6 @@ import { DataType } from "node-opcua-variant";
 import { displayNodeElement } from "./displayNodeElement.js";
 import { TableHelper } from "./tableHelper.js";
 
-interface NamespacePriv2 extends INamespace {
-    nodeIterator(): IterableIterator<BaseNode>;
-    _objectTypeIterator(): IterableIterator<UAObjectType>;
-    _objectTypeCount(): number;
-    _variableTypeIterator(): IterableIterator<UAVariableType>;
-    _variableTypeCount(): number;
-    _dataTypeIterator(): IterableIterator<UADataType>;
-    _dataTypeCount(): number;
-    _referenceTypeIterator(): IterableIterator<UAReferenceType>;
-    _referenceTypeCount(): number;
-    _aliasCount(): number;
-}
 export interface IWriter {
     writeLine(_str: string): void;
 }
@@ -213,12 +201,11 @@ function dumpReferenceType(referenceType: UAReferenceType): string {
 }
 
 export function extractTypes(namespace: INamespace, options?: BuildDocumentationOptions) {
-    const namespacePriv = namespace as unknown as NamespacePriv2;
     if (!options?.node) {
-        const dataTypes = [...namespacePriv._dataTypeIterator()];
-        const objectTypes = [...namespacePriv._objectTypeIterator()];
-        const variableTypes = [...namespacePriv._variableTypeIterator()];
-        const referenceTypes = [...namespacePriv._referenceTypeIterator()];
+        const dataTypes = [...namespace.dataTypeIterator()];
+        const objectTypes = [...namespace.objectTypeIterator()];
+        const variableTypes = [...namespace.variableTypeIterator()];
+        const referenceTypes = [...namespace.referenceTypeIterator()];
         return { dataTypes, variableTypes, objectTypes, referenceTypes };
     }
     const node = options.node;
@@ -252,10 +239,10 @@ export function extractTypes(namespace: INamespace, options?: BuildDocumentation
         return { dataTypes: [], variableTypes, objectTypes: [], dataTypeNode: [], referenceTypes: [] };
     }
 
-    const dataTypes = [...namespacePriv._dataTypeIterator()];
-    const objectTypes = [...namespacePriv._objectTypeIterator()];
-    const variableTypes = [...namespacePriv._variableTypeIterator()];
-    const referenceTypes = [...namespacePriv._referenceTypeIterator()];
+    const dataTypes = [...namespace.dataTypeIterator()];
+    const objectTypes = [...namespace.objectTypeIterator()];
+    const variableTypes = [...namespace.variableTypeIterator()];
+    const referenceTypes = [...namespace.referenceTypeIterator()];
     return { dataTypes, variableTypes, objectTypes, referenceTypes };
 }
 
@@ -265,8 +252,6 @@ export async function buildDocumentation(
     options?: BuildDocumentationOptions
 ): Promise<void> {
     options = options || {};
-
-    const namespacePriv = namespace as unknown as NamespacePriv2;
 
     const namespaceUri = namespace.namespaceUri;
     // -------- Documentation
@@ -278,11 +263,11 @@ export async function buildDocumentation(
     writer.writeLine("");
 
     // -------------- writeReferences
-    if (namespacePriv._referenceTypeCount() > 0) {
+    if (namespace.referenceTypeCount() > 0) {
         writer.writeLine("");
         writer.writeLine("##  References ");
         writer.writeLine("");
-        for (const referenceType of namespacePriv._referenceTypeIterator()) {
+        for (const referenceType of namespace.referenceTypeIterator()) {
             writer.writeLine(`\n\n###  reference ${referenceType.browseName.name ?? ""}`);
             dumpReferenceType(referenceType);
         }

--- a/packages/node-opcua-modeler/source_nodejs/build_documentation_to_file.ts
+++ b/packages/node-opcua-modeler/source_nodejs/build_documentation_to_file.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import type { Namespace } from "node-opcua-address-space";
-import { type BuildDocumentationOptions, buildDocumentationToString } from "..";
+import { type BuildDocumentationOptions, buildDocumentationToString } from "../dist/index.js";
 
 export async function buildDocumentationToFile(namespace: Namespace, _filename: string, options?: BuildDocumentationOptions) {
     const str = await buildDocumentationToString(namespace, options);

--- a/packages/node-opcua-modeler/source_nodejs/build_model.ts
+++ b/packages/node-opcua-modeler/source_nodejs/build_model.ts
@@ -1,6 +1,6 @@
 import { readNodeSet2XmlFile } from "node-opcua-address-space/nodeJS";
-import type { Symbols } from "..";
-import { type BuildModelOptionsBase, buildModelInner } from "..";
+import type { Symbols } from "../dist/index.js";
+import { type BuildModelOptionsBase, buildModelInner } from "../dist/index.js";
 
 export async function buildModel(data: BuildModelOptionsBase): Promise<{ markdown: string; xmlModel: string; symbols: Symbols }> {
     const option1 = {

--- a/packages/node-opcua-modeler/source_nodejs/index.ts
+++ b/packages/node-opcua-modeler/source_nodejs/index.ts
@@ -1,5 +1,5 @@
 export { generateAddressSpace } from "node-opcua-address-space/nodeJS";
-export * from "..";
-export * from "./build_documentation_to_file";
-export * from "./build_model";
-export * from "./symbol_cvs";
+export * from "../dist/index.js";
+export * from "./build_documentation_to_file.js";
+export * from "./build_model.js";
+export * from "./symbol_cvs.js";

--- a/packages/node-opcua-modeler/source_nodejs/symbol_cvs.ts
+++ b/packages/node-opcua-modeler/source_nodejs/symbol_cvs.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import { types } from "node:util";
 import { type Parser, parse } from "csv-parse";
 
-import type { Symbols } from "..";
-import { toCSV } from "..";
+import type { Symbols } from "../dist/index.js";
+import { toCSV } from "../dist/index.js";
 
 // node 14 onward : import { readFile, writeFile } from "fs/promises";
 const { readFile, writeFile } = fs.promises;

--- a/packages/node-opcua-modeler/test/test_addExtensionObjectDataType.ts
+++ b/packages/node-opcua-modeler/test/test_addExtensionObjectDataType.ts
@@ -28,7 +28,6 @@ const doDebug = false;
 
 // reaching into Namespace internals not exposed on the public type, for test diagnostics only
 interface NamespaceWithInternals {
-    nodeIterator(): IterableIterator<BaseNode>;
     _nodeIdManager: { getSymbolCSV(): string };
 }
 
@@ -86,7 +85,7 @@ describe("addExtensionObjectDataType", function (this: Mocha.Suite) {
 
         // c8 ignore next
         if (doDebug) {
-            for (const b of (ns as unknown as NamespaceWithInternals).nodeIterator()) {
+            for (const b of ns.nodeIterator()) {
                 const withTypeDefinition = b as BaseNode & {
                     typeDefinitionObj?: BaseNode;
                     typeDefinition?: { toString(): string };

--- a/tools/check-debug-log/src/index.js
+++ b/tools/check-debug-log/src/index.js
@@ -35,6 +35,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
+import { shippedDirsOf } from "../../shared/shipped_dirs.mjs";
 
 const IGNORE_COMMENT = "// c8 ignore next";
 
@@ -58,8 +59,9 @@ function findSourceFiles(repoRoot, packageFilter) {
             if (packageFilter && pkg !== packageFilter) {
                 continue;
             }
-            for (const sub of SOURCE_DIRS) {
-                collect(path.join(rootDir, pkg, sub), files);
+            const pkgDir = path.join(rootDir, pkg);
+            for (const sub of shippedDirsOf(pkgDir, SOURCE_DIRS)) {
+                collect(path.join(pkgDir, sub), files);
             }
         }
     }

--- a/tools/check-debug-name/src/rule.js
+++ b/tools/check-debug-name/src/rule.js
@@ -15,6 +15,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { SOURCE_ROOTS, shippedDirsOf } from "../../shared/shipped_dirs.mjs";
 
 /** every factory in node-opcua-debug that takes a module name */
 export const FACTORIES = ["make_debugLog", "checkDebugFlag", "make_errorLog", "make_warningLog", "make_traceLog", "setDebugFlag"];
@@ -22,7 +23,12 @@ export const FACTORIES = ["make_debugLog", "checkDebugFlag", "make_errorLog", "m
 /** opt out of the rule on one line, with a reason: `// check-debug-name: ok - why` */
 export const IGNORE_MARKER = "check-debug-name: ok";
 
-export const SOURCE_ROOTS = ["packages", "packages_extra"];
+export { SOURCE_ROOTS };
+
+/**
+ * The conventional layout, used only when a package does not say what it publishes.
+ * What is actually scanned comes from each package's own `files` - see shipped_dirs.mjs.
+ */
 export const SOURCE_DIRS = ["source", "src"];
 
 /**
@@ -32,10 +38,14 @@ export const SOURCE_DIRS = ["source", "src"];
  */
 export const TEST_DIRS = ["test", "test_helpers", "test_fixtures"];
 
+/**
+ * A scope says which directories to scan. `shipped` means "whatever this package publishes",
+ * resolved per package rather than assumed; `extra` is scanned on top of it.
+ */
 export const SCOPES = {
-    source: SOURCE_DIRS,
-    tests: TEST_DIRS,
-    all: [...SOURCE_DIRS, ...TEST_DIRS]
+    source: { shipped: true, extra: [] },
+    tests: { shipped: false, extra: TEST_DIRS },
+    all: { shipped: true, extra: TEST_DIRS }
 };
 
 const SKIP_DIRS = new Set(["node_modules", "dist", "dist-esm", "coverage", "build"]);
@@ -114,8 +124,12 @@ export function fixText(text, filePath) {
     return { text: out, fixed };
 }
 
-/** every shipped source file under the given roots */
-export function findSourceFiles(repoRoot = ".", packageFilter, dirs = SOURCE_DIRS) {
+/**
+ * Every shipped source file under the given roots. `scope` is a SCOPES descriptor, or a
+ * plain array of directory names to scan in every package.
+ */
+export function findSourceFiles(repoRoot = ".", packageFilter, scope = SCOPES.source) {
+    const descriptor = Array.isArray(scope) ? { shipped: false, extra: scope } : scope;
     const files = [];
     for (const root of SOURCE_ROOTS) {
         const full = path.join(repoRoot, root);
@@ -129,8 +143,13 @@ export function findSourceFiles(repoRoot = ".", packageFilter, dirs = SOURCE_DIR
             if (packageFilter && pkg.name !== packageFilter) {
                 continue;
             }
-            for (const dir of dirs) {
-                walk(path.join(full, pkg.name, dir), files);
+            const pkgDir = path.join(full, pkg.name);
+            const dirs = [
+                ...(descriptor.shipped ? shippedDirsOf(pkgDir, SOURCE_DIRS) : []),
+                ...(descriptor.extra ?? [])
+            ];
+            for (const dir of new Set(dirs)) {
+                walk(path.join(pkgDir, dir), files);
             }
         }
     }
@@ -155,7 +174,7 @@ function walk(dir, out) {
 
 /** scan; with { write: true } the fixable violations are rewritten in place */
 export function analyze({ repoRoot = ".", packageFilter, write = false, scope = "source" } = {}) {
-    const files = findSourceFiles(repoRoot, packageFilter, SCOPES[scope] ?? SOURCE_DIRS);
+    const files = findSourceFiles(repoRoot, packageFilter, SCOPES[scope] ?? SCOPES.source);
     const findings = [];
     let fixedCount = 0;
     let fixedFiles = 0;

--- a/tools/check-entry-points/src/rule.js
+++ b/tools/check-entry-points/src/rule.js
@@ -25,6 +25,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import ts from "typescript";
+import { shippedDirsOf } from "../../shared/shipped_dirs.mjs";
 
 /** opt out on one line, with a reason: `// check-entry-points: ok - why` */
 export const IGNORE_MARKER = "check-entry-points: ok";
@@ -191,7 +192,7 @@ export function findPackages(repoRoot = ".", packageFilter) {
             const dir = path.join(full, entry.name).replace(/\\/g, "/");
             const pjPath = path.join(dir, "package.json");
             if (!fs.existsSync(pjPath)) continue;
-            const files = ["source", "src"].flatMap((sub) => sourceFilesUnder(path.join(dir, sub)));
+            const files = shippedDirsOf(dir).flatMap((sub) => sourceFilesUnder(path.join(dir, sub)));
             packages.push({ name: entry.name, dir, pjPath, files });
         }
     }

--- a/tools/check-import-cycles/src/rule.js
+++ b/tools/check-import-cycles/src/rule.js
@@ -21,8 +21,14 @@
 import fs from "node:fs";
 import path from "node:path";
 import ts from "typescript";
+import { shippedDirsOf } from "../../shared/shipped_dirs.mjs";
 
 export const SOURCE_ROOTS = ["packages", "packages_extra"];
+
+/**
+ * The conventional layout, used only when a package does not say what it publishes.
+ * What is actually scanned comes from each package's own `files` - see shipped_dirs.mjs.
+ */
 export const SOURCE_DIRS = ["source", "src"];
 
 const SKIP_DIRS = new Set(["node_modules", "dist", "dist-esm", "coverage", "build"]);
@@ -271,8 +277,9 @@ export function findSourceFiles(repoRoot = ".", packageFilter) {
             if (packageFilter && pkg.name !== packageFilter) {
                 continue;
             }
-            for (const dir of SOURCE_DIRS) {
-                walk(path.join(full, pkg.name, dir), files);
+            const pkgDir = path.join(full, pkg.name);
+            for (const dir of shippedDirsOf(pkgDir, SOURCE_DIRS)) {
+                walk(path.join(pkgDir, dir), files);
             }
         }
     }

--- a/tools/check-import-extension/src/rule.js
+++ b/tools/check-import-extension/src/rule.js
@@ -20,11 +20,18 @@
 import fs from "node:fs";
 import path from "node:path";
 import ts from "typescript";
+import { SOURCE_ROOTS, shippedDirsOf } from "../../shared/shipped_dirs.mjs";
 
 /** opt out of the rule on one line, with a reason: `// check-import-extension: ok - why` */
 export const IGNORE_MARKER = "check-import-extension: ok";
 
-export const SOURCE_ROOTS = ["packages", "packages_extra"];
+export { SOURCE_ROOTS };
+
+/**
+ * The conventional layout, used only when a package does not say what it publishes.
+ * What is actually scanned comes from each package's own `files` - see shipped_dirs.mjs
+ * for why this is no longer a constant.
+ */
 export const SOURCE_DIRS = ["source", "src"];
 
 /**
@@ -34,10 +41,14 @@ export const SOURCE_DIRS = ["source", "src"];
  */
 export const TEST_DIRS = ["test", "test_helpers", "test_fixtures"];
 
+/**
+ * A scope says which directories to scan. `shipped` means "whatever this package publishes",
+ * resolved per package rather than assumed; `extra` is scanned on top of it.
+ */
 export const SCOPES = {
-    source: SOURCE_DIRS,
-    tests: TEST_DIRS,
-    all: [...SOURCE_DIRS, ...TEST_DIRS]
+    source: { shipped: true, extra: [] },
+    tests: { shipped: false, extra: TEST_DIRS },
+    all: { shipped: true, extra: TEST_DIRS }
 };
 
 const SKIP_DIRS = new Set(["node_modules", "dist", "dist-esm", "coverage", "build"]);
@@ -195,7 +206,12 @@ export function fixText(text, filePath) {
     return { text: out, fixed: edits.length };
 }
 
-export function findSourceFiles(repoRoot = ".", packageFilter, dirs = SOURCE_DIRS) {
+/**
+ * `scope` is a SCOPES descriptor, or a plain array of directory names to scan in every
+ * package (which is what the unit tests hand it).
+ */
+export function findSourceFiles(repoRoot = ".", packageFilter, scope = SCOPES.source) {
+    const descriptor = Array.isArray(scope) ? { shipped: false, extra: scope } : scope;
     const files = [];
     for (const root of SOURCE_ROOTS) {
         const full = path.join(repoRoot, root);
@@ -209,8 +225,13 @@ export function findSourceFiles(repoRoot = ".", packageFilter, dirs = SOURCE_DIR
             if (packageFilter && pkg.name !== packageFilter) {
                 continue;
             }
-            for (const dir of dirs) {
-                walk(path.join(full, pkg.name, dir), files);
+            const pkgDir = path.join(full, pkg.name);
+            const dirs = [
+                ...(descriptor.shipped ? shippedDirsOf(pkgDir, SOURCE_DIRS) : []),
+                ...(descriptor.extra ?? [])
+            ];
+            for (const dir of new Set(dirs)) {
+                walk(path.join(pkgDir, dir), files);
             }
         }
     }
@@ -236,8 +257,7 @@ function walk(dir, out) {
 export function analyze({ repoRoot = ".", packageFilter, write = false, scope = "source" } = {}) {
     // note: the CLI defaults to "all"; the library default stays "source" so existing callers
     // and the unit tests keep their narrow scope unless they ask for more.
-    const dirs = SCOPES[scope] ?? SOURCE_DIRS;
-    const files = findSourceFiles(repoRoot, packageFilter, dirs);
+    const files = findSourceFiles(repoRoot, packageFilter, SCOPES[scope] ?? SCOPES.source);
     const findings = [];
     let fixedCount = 0;
     let fixedFiles = 0;

--- a/tools/check-import-extension/test/test_rule.js
+++ b/tools/check-import-extension/test/test_rule.js
@@ -335,3 +335,64 @@ test("the report always names the scope it covered", () => {
         assert.match(formatReport(analyze({ repoRoot: root, scope: "tests" })), /test files scanned/);
     });
 });
+
+// ── the scanned set follows what a package publishes ────────────────────────────
+//
+// These pin the regression that motivated the change: the gate scanned a hardcoded
+// `source`/`src`, so a package shipping anything else left its coverage silently, and the
+// report still said "clean" because nothing had been looked at.
+
+test("scans a source directory a package names in `files`, whatever it is called", () => {
+    withTree(
+        {
+            "packages/p/package.json": JSON.stringify({ name: "p", files: ["api", "impl", "dist"] }),
+            "packages/p/api/a.ts": 'import x from "./b";\n',
+            "packages/p/api/b.ts": "",
+            "packages/p/impl/c.ts": 'import x from "./d";\n',
+            "packages/p/impl/d.ts": ""
+        },
+        (root) => {
+            const result = analyze({ repoRoot: root });
+            assert.equal(result.scanned, 4);
+            assert.equal(result.findings.length, 2, JSON.stringify(result.findings));
+        }
+    );
+});
+
+test("scans a shipped directory alongside the conventional ones", () => {
+    withTree(
+        {
+            "packages/p/package.json": JSON.stringify({ name: "p", files: ["source", "source_nodejs"] }),
+            "packages/p/source/a.ts": 'import x from "./b";\n',
+            "packages/p/source/b.ts": "",
+            "packages/p/source_nodejs/c.ts": 'import x from "./d";\n',
+            "packages/p/source_nodejs/d.ts": ""
+        },
+        (root) => {
+            assert.equal(analyze({ repoRoot: root }).findings.length, 2);
+        }
+    );
+});
+
+test("build output is never scanned, even when `files` names it", () => {
+    withTree(
+        {
+            "packages/p/package.json": JSON.stringify({ name: "p", files: ["dist", "source"] }),
+            "packages/p/dist/a.ts": 'import x from "./b";\n',
+            "packages/p/dist/b.ts": "",
+            "packages/p/source/c.ts": ""
+        },
+        (root) => {
+            const result = analyze({ repoRoot: root });
+            assert.equal(result.scanned, 1);
+            assert.equal(result.findings.length, 0);
+        }
+    );
+});
+
+test("a package with no manifest still gets its conventional layout scanned", () => {
+    withTree({ "packages/p/source/a.ts": 'import x from "./b";\n', "packages/p/source/b.ts": "" }, (root) => {
+        // guessing wide is recoverable; scanning nothing and reporting clean is not
+        assert.equal(analyze({ repoRoot: root }).findings.length, 1);
+    });
+});

--- a/tools/check-no-tla/src/detector.js
+++ b/tools/check-no-tla/src/detector.js
@@ -15,8 +15,14 @@
 import fs from "node:fs";
 import path from "node:path";
 import ts from "typescript";
+import { shippedDirsOf } from "../../shared/shipped_dirs.mjs";
 
-/** shipped source only: test trees may use whatever they like, they are never required by a consumer */
+/**
+ * Shipped source only: test trees may use whatever they like, they are never required by a
+ * consumer. The conventional layout below is a fallback - what is actually scanned comes
+ * from each package's own `files`, so a package that ships an unconventionally named tree
+ * cannot slip out of coverage unnoticed.
+ */
 export const SCAN_DIRS = ["source", "src"];
 
 /** directories that never contain shipped source */
@@ -92,8 +98,9 @@ export function findSourceFiles(root = "packages") {
         if (!pkg.isDirectory() || SKIP_DIRS.has(pkg.name)) {
             continue;
         }
-        for (const dir of SCAN_DIRS) {
-            walk(path.join(root, pkg.name, dir), files);
+        const pkgDir = path.join(root, pkg.name);
+        for (const dir of shippedDirsOf(pkgDir, SCAN_DIRS)) {
+            walk(path.join(pkgDir, dir), files);
         }
     }
     return files;

--- a/tools/shared/shipped_dirs.mjs
+++ b/tools/shared/shipped_dirs.mjs
@@ -1,0 +1,90 @@
+/**
+ * Which directories of a package hold the TypeScript it ships.
+ *
+ * Shared, and derived from data, because the alternative has now failed twice. The gates began
+ * with a hardcoded `["source", "src"]`, which missed `source_nodejs` in three packages - and
+ * then node-opcua-address-space renamed its trees to `api/` and `impl/` and silently left every
+ * gate's coverage, which none of them noticed because they all still reported "clean".
+ *
+ * A package's `files` array is the list of what it publishes, so it is the honest source for
+ * this. Build output is excluded: `dist` is emitted, not authored.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+/** roots holding the workspace's packages */
+export const SOURCE_ROOTS = ["packages", "packages_extra"];
+
+/** never authored source, whatever a package lists */
+const NOT_SOURCE = /^dist|^node_modules$|^nodesets$|^certificates$|^bin$/;
+
+const holdsTypeScript = (dir) => {
+    const stack = [dir];
+    while (stack.length) {
+        const d = stack.pop();
+        let entries;
+        try {
+            entries = fs.readdirSync(d, { withFileTypes: true });
+        } catch {
+            continue;
+        }
+        for (const e of entries) {
+            if (e.isDirectory()) {
+                if (e.name !== "node_modules") stack.push(path.join(d, e.name));
+            } else if (/\.ts$/.test(e.name) && !e.name.endsWith(".d.ts")) {
+                return true;
+            }
+        }
+    }
+    return false;
+};
+
+/**
+ * The source directories one package ships, from its `files` array.
+ *
+ * `fallback` is used when a package declares no `files`, which npm reads as "publish
+ * everything": the conventional layout is then the best available answer.
+ */
+export function shippedDirsOf(packageDir, fallback = ["source", "src"]) {
+    const onlyExisting = () => fallback.filter((f) => fs.existsSync(path.join(packageDir, f)));
+
+    // No manifest, or one we cannot read, means we do not know what ships. Scan the
+    // conventional layout rather than nothing: guessing wide is recoverable, and a gate that
+    // quietly scans less than it claims is the failure this whole module exists to prevent.
+    const pjPath = path.join(packageDir, "package.json");
+    if (!fs.existsSync(pjPath)) return onlyExisting();
+    let pj;
+    try {
+        pj = JSON.parse(fs.readFileSync(pjPath, "utf8"));
+    } catch {
+        return onlyExisting();
+    }
+    const listed = pj.files ?? null;
+    const candidates = listed
+        ? listed.map((f) => f.replace(/^\.\//, "").replace(/\/$/, "")).filter((f) => !NOT_SOURCE.test(f))
+        : fallback;
+
+    const dirs = [];
+    for (const c of candidates) {
+        if (c.includes("*") || c.includes(".")) continue; // a glob or a single file, not a tree
+        const full = path.join(packageDir, c);
+        if (!fs.existsSync(full) || !fs.statSync(full).isDirectory()) continue;
+        if (holdsTypeScript(full)) dirs.push(c);
+    }
+    // a package with `files` that names no source tree still has one to check
+    return dirs.length ? dirs : fallback.filter((f) => fs.existsSync(path.join(packageDir, f)));
+}
+
+/** every source directory shipped across the workspace, as a sorted set of names */
+export function allShippedDirNames(repoRoot = ".") {
+    const names = new Set();
+    for (const root of SOURCE_ROOTS) {
+        const full = path.join(repoRoot, root);
+        if (!fs.existsSync(full)) continue;
+        for (const e of fs.readdirSync(full, { withFileTypes: true })) {
+            if (!e.isDirectory()) continue;
+            for (const d of shippedDirsOf(path.join(full, e.name))) names.add(d);
+        }
+    }
+    return [...names].sort();
+}

--- a/tools/shared/test/test_shipped_dirs.js
+++ b/tools/shared/test/test_shipped_dirs.js
@@ -1,0 +1,163 @@
+/**
+ * Tests for shipped_dirs - the module every gate uses to decide what it looks at.
+ *
+ * Worth its own suite because a mistake here is silent in exactly the way the gates are
+ * meant to prevent: scan too narrow and every one of them reports "clean" on a tree it
+ * never opened.
+ */
+import assert from "node:assert";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { allShippedDirNames, shippedDirsOf } from "../shipped_dirs.mjs";
+
+/** build a throwaway package directory from a { relativePath: contents } map */
+function withPackage(files, fn) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "shipped-dirs-"));
+    try {
+        for (const [rel, contents] of Object.entries(files)) {
+            const full = path.join(root, rel);
+            fs.mkdirSync(path.dirname(full), { recursive: true });
+            fs.writeFileSync(full, contents);
+        }
+        fn(root);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+}
+
+const manifest = (files) => JSON.stringify({ name: "p", ...(files ? { files } : {}) });
+
+test("reads the directories a package says it publishes", () => {
+    withPackage(
+        {
+            "package.json": manifest(["api", "impl"]),
+            "api/a.ts": "",
+            "impl/b.ts": ""
+        },
+        (root) => assert.deepEqual(shippedDirsOf(root).sort(), ["api", "impl"])
+    );
+});
+
+test("ignores a listed directory that holds no TypeScript we author", () => {
+    withPackage(
+        {
+            "package.json": manifest(["source", "nodesets", "certificates"]),
+            "source/a.ts": "",
+            "nodesets/Opc.Ua.NodeSet2.xml": "<x/>",
+            "certificates/cert.pem": ""
+        },
+        (root) => assert.deepEqual(shippedDirsOf(root), ["source"])
+    );
+});
+
+test("a directory of declarations only is not source", () => {
+    withPackage(
+        {
+            "package.json": manifest(["source", "typings"]),
+            "source/a.ts": "",
+            "typings/global.d.ts": ""
+        },
+        (root) => assert.deepEqual(shippedDirsOf(root), ["source"])
+    );
+});
+
+test("build output is excluded however it is named", () => {
+    withPackage(
+        {
+            "package.json": manifest(["dist", "distNodeJS", "distHelpers", "source"]),
+            // .ts under dist happens: sourcemaps and stray copies. It is emitted, not authored.
+            "dist/a.ts": "",
+            "distNodeJS/b.ts": "",
+            "distHelpers/c.ts": "",
+            "source/d.ts": ""
+        },
+        (root) => assert.deepEqual(shippedDirsOf(root), ["source"])
+    );
+});
+
+test("a single file in `files` is not mistaken for a directory", () => {
+    withPackage(
+        {
+            "package.json": manifest(["nodeJS.js", "nodeJS.d.ts", "source"]),
+            "nodeJS.js": "",
+            "nodeJS.d.ts": "",
+            "source/a.ts": ""
+        },
+        (root) => assert.deepEqual(shippedDirsOf(root), ["source"])
+    );
+});
+
+test("a glob in `files` is skipped rather than guessed at", () => {
+    withPackage({ "package.json": manifest(["dist/**/*", "source"]), "source/a.ts": "" }, (root) =>
+        assert.deepEqual(shippedDirsOf(root), ["source"])
+    );
+});
+
+test("trailing slashes and leading ./ are tolerated", () => {
+    withPackage({ "package.json": manifest(["./source/"]), "source/a.ts": "" }, (root) =>
+        assert.deepEqual(shippedDirsOf(root), ["source"])
+    );
+});
+
+test("nested TypeScript counts: a tree is source even when its root holds none", () => {
+    withPackage({ "package.json": manifest(["api"]), "api/interfaces/deep/a.ts": "" }, (root) =>
+        assert.deepEqual(shippedDirsOf(root), ["api"])
+    );
+});
+
+// ── falling back, which must always widen and never narrow ──────────────────────
+
+test("no `files` at all means the conventional layout", () => {
+    withPackage({ "package.json": manifest(null), "source/a.ts": "", "src/b.ts": "" }, (root) =>
+        assert.deepEqual(shippedDirsOf(root).sort(), ["source", "src"])
+    );
+});
+
+test("no manifest at all still yields the conventional layout", () => {
+    withPackage({ "source/a.ts": "" }, (root) => assert.deepEqual(shippedDirsOf(root), ["source"]));
+});
+
+test("an unparseable manifest falls back rather than scanning nothing", () => {
+    withPackage({ "package.json": "{ not json", "source/a.ts": "" }, (root) =>
+        assert.deepEqual(shippedDirsOf(root), ["source"])
+    );
+});
+
+test("`files` naming only build output still gets the conventional layout scanned", () => {
+    // the shape that started this: publish `dist`, author `source`, and a gate keyed on
+    // `files` alone would have looked at nothing at all
+    withPackage({ "package.json": manifest(["dist"]), "dist/a.ts": "", "source/b.ts": "" }, (root) =>
+        assert.deepEqual(shippedDirsOf(root), ["source"])
+    );
+});
+
+test("the caller chooses the fallback", () => {
+    withPackage({ "package.json": manifest(null), "lib/a.ts": "" }, (root) =>
+        assert.deepEqual(shippedDirsOf(root, ["lib"]), ["lib"])
+    );
+});
+
+test("a fallback directory that does not exist is not returned", () => {
+    withPackage({ "package.json": manifest(null), "source/a.ts": "" }, (root) =>
+        assert.deepEqual(shippedDirsOf(root), ["source"])
+    );
+});
+
+// ── against the repository itself ───────────────────────────────────────────────
+
+test("every directory this repository ships is one the gates now scan", () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const names = allShippedDirNames(repoRoot);
+
+    // the pair the gates used to hardcode
+    assert.ok(names.includes("source"), names.join());
+    assert.ok(names.includes("src"), names.join());
+
+    // and the three they silently missed: source_nodejs in several packages, and the
+    // api/impl split, which left coverage the day the directories were renamed
+    for (const missed of ["source_nodejs", "api", "impl"]) {
+        assert.ok(names.includes(missed), `${missed} not discovered, found: ${names.join()}`);
+    }
+});


### PR DESCRIPTION
Three non-breaking features: FEAT-7, then FEAT-13 in both its parts.

## FEAT-7: the gates were scanning less than they claimed

The gates keyed on a hardcoded `["source", "src"]`. That assumption had already
cost coverage twice:

| | |
|---|---|
| `source_nodejs` | never scanned, in 3 packages |
| `api` / `impl` | left coverage the moment address-space renamed its trees |

The second one is the sharper lesson: that rename and the gates' silence shipped
in the same change, and every gate went on reporting "clean" on a tree it had
stopped opening. `check-import-extension` quietly dropped from 3044 files to
2902.

Six tools now take their directories from each package's `files` array
(`tools/shared/shipped_dirs.mjs`), with the conventional layout as a fallback
only when a package has no manifest to read. The fallback deliberately widens
rather than narrows: guessing too much is recoverable, reporting clean on
something unread is not.

What the widened scan then found, all fixed here:

- 7 relative specifiers ESM cannot resolve
- 7 imports of `".."`, now naming the entry that `package.json` names
- 3 loggers taking `__filename`
- 1 unguarded debug call
- 1 `__dirname`, converted to the single-anchor pattern used elsewhere
- **1 cycle ESM would reject** - introduced by the api/impl rename itself, and
  invisible for exactly the same reason

Coverage after: 3055 files for import-extension, 3077 for debug-name, 2312 for
cycles.

## FEAT-13 part 2: publish namespace iteration

A namespace could always walk its own nodes, but the methods carried a leading
underscore and were absent from `INamespace`. So every caller cast to a
hand-written copy of the internals - three of them in this repository, each kept
in step with an implementation it could not see.

`INamespace` now extends `INamespaceIterable`, which names them plainly:
`nodeIterator`, `objectTypeIterator`/`objectTypeCount`, and the same for
variable types, data types, reference types, plus `aliasCount`. The
underscore spellings delegate and are deprecated, so existing casts keep
working. All three local copies are gone.

7 tests, taking `INamespace` and importing only from the package entry, because
being usable without a cast is the point.

**One thing to weigh:** adding members to a published interface is breaking for
anyone who *implements* `INamespace` by hand. Nothing in the repo does, and it
has ~40 members already, so this seemed the right call over publishing a
separate interface that would still have required a cast. Say the word if you'd
rather it were separate.

## FEAT-13 part 1: type the child nodes instead of casting to reach them

Three data-access classes reached their own child nodes through private
`$5`/`$6`/`$7` getters that cast `this` to the published interface. They are
`declare` fields now - which is not cosmetic: with `target: es2022`,
`useDefineForClassFields` is on, so a plain field would define these as
`undefined` in the constructor and clobber the real nodes.

MultiStateDiscrete also declared a second, thinner `UAMultiStateDiscreteEx`
lacking the `UAVariableT` half; it uses the api one now. With
`addMultiStateDiscrete` returning the type its own interface promises - the
shape its sibling `addMultiStateValueDiscrete` already had - `NamespacePrivate`
can extend `Namespace` instead of `INamespace`. That widening is what blocked
this work before.

### A regression this uncovered

Re-basing `UAMultiStateDiscreteImplBase` on `UAVariableImplT` broke a test, and
the cause was a pre-existing bug in `UAVariableImplT` itself: its
`readValueAsync` and `writeValue` overrides always forwarded the callback slot,
so an absent callback reached the thenified base as an explicit `undefined`.
thenify chooses promise or callback form by argument count, so it took the
callback path with nothing to call.

`UATwoStateVariableImpl` already derived from that class, so its promise form
was broken too - nothing had exercised it. Fixed, with a test that fails
without the fix.

## Verification

- `tsc -b packages` clean
- address-space: **1106 passing, 1 pending, 0 failing**
- modeler: 19 passing; debug: 5 passing
- every gate green at its widened scope
- `biome check` clean
