### PR TITLE
fix(generator): generate() writes into a buffer of its own

### DIFF
--- a/packages/node-opcua-generator/source/generate_extension_object_code.ts
+++ b/packages/node-opcua-generator/source/generate_extension_object_code.ts
@@ -27,16 +27,12 @@ import { type DataTypeAndEncodingId, type MapDataTypeAndEncodingIdProvider, pars
 
 import { writeStructuredType } from "./factory_code_generator.js";
 import { LineFile1 } from "./utils/line_file.js";
-import { makeWrite } from "./utils/write_func.js";
+import { makeWrite, type WriteFunc } from "./utils/write_func.js";
 
 const doDebug = checkDebugFlag("generate_extension_object_code");
 const debugLog = make_debugLog("generate_extension_object_code");
 
-const f = new LineFile1();
-
-const write = makeWrite(f);
-
-function writeEnumeratedType(enumerationSchema: EnumerationDefinitionSchema): void {
+function writeEnumeratedType(write: WriteFunc, enumerationSchema: EnumerationDefinitionSchema): void {
     const arrayValues = Object.keys(enumerationSchema.enumValues)
         .filter((a: string) => a.match("[0-9]+"))
         .map((a: string) => parseInt(a, 10))
@@ -113,7 +109,7 @@ function writeEnumeratedType(enumerationSchema: EnumerationDefinitionSchema): vo
     write(`assert(_enumeration${enumerationSchema.name}.isFlaggable ===  ${isFlaggable});`);
 }
 
-function writeStructuredTypeWithSchema(structuredType: IStructuredTypeSchema) {
+function writeStructuredTypeWithSchema(write: WriteFunc, structuredType: IStructuredTypeSchema) {
     write(`// --------------------------------------------------------------------------------------------`);
 
     write(`const schema${structuredType.name} = buildStructuredType({`);
@@ -139,6 +135,13 @@ function writeStructuredTypeWithSchema(structuredType: IStructuredTypeSchema) {
 }
 
 export async function generate(filename: string, generatedTypescriptFilename: string): Promise<void> {
+    // The output buffer belongs to this call. It used to be module scope, so a second
+    // generate() in the same process appended to the first one's output and emitted every
+    // type twice. node-opcua-types calls this once per process, which is why that never
+    // showed up.
+    const f = new LineFile1();
+    const write = makeWrite(f);
+
     const content = await readFile(filename, "utf-8");
 
     const idProvider: MapDataTypeAndEncodingIdProvider = {
@@ -298,7 +301,7 @@ import {
             return;
         }
         alreadyDone[enumerationSchema.name] = enumerationSchema;
-        writeEnumeratedType(enumerationSchema);
+        writeEnumeratedType(write, enumerationSchema);
     }
 
     function processStructuredType(structuredType: IStructuredTypeSchema): void {
@@ -324,7 +327,7 @@ import {
                 processEnumeratedType(fieldSchema);
             }
         }
-        writeStructuredTypeWithSchema(structuredType);
+        writeStructuredTypeWithSchema(write, structuredType);
     }
 
     //xx processStructuredType(dataTypeFactory.getStructuredTypeSchema("LocalizedText"));

--- a/packages/node-opcua-generator/source/index.ts
+++ b/packages/node-opcua-generator/source/index.ts
@@ -4,5 +4,21 @@
  */
 
 export { generate } from "./generate_extension_object_code.js";
+
+/**
+ * The schema-literal path, deprecated and going at 3.0.
+ *
+ * These three and `generateCode` behind them cannot work: `registerObject` builds
+ * `<name>_Schema` and `generateCode` then looks up `<name>_Schema_Schema`, and `generateCode`
+ * hands `produce_TScript_code` a raw schema literal where it wants a built
+ * `StructuredTypeSchema`. Both throw. They date from the 2018 TypeScript port and were only
+ * ever covered by the test files that port disabled.
+ *
+ * Nothing in this repository calls them - `node-opcua-types` uses `generate` - and they are
+ * not re-exported by the `node-opcua` umbrella, so reaching them means depending on this
+ * build-time package directly and calling something that throws.
+ *
+ * @deprecated cannot work; use `generate`, which is what builds node-opcua-types
+ */
 export { generateTypeScriptCodeFromSchema, registerObject, unregisterObject } from "./generator.js";
 /* c8 ignore stop */

--- a/packages/node-opcua-generator/test/test_generate_extension_object_code.ts
+++ b/packages/node-opcua-generator/test/test_generate_extension_object_code.ts
@@ -87,6 +87,31 @@ describe("generating TypeScript from a binary schema", () => {
         syntactic.should.eql([], `expecting the generated code to parse cleanly, got: ${syntactic.join("; ")}`);
     });
 
+    it("should produce the same code when called twice in one process", async () => {
+        // The output buffer used to be module scope, so the second call appended to the
+        // first one's output and every type came out twice. node-opcua-types calls generate
+        // once per process, which is why nothing caught it.
+        const secondFile = path.join(outputFolder, "_generated_sample_types_again.ts");
+        await generate(testFixture("SampleTypes.bsd"), secondFile);
+        const second = fs.readFileSync(secondFile, "utf8");
+
+        // the header carries a timestamp, so compare what follows it
+        const body = (text: string) => text.split("\n").slice(1).join("\n");
+        should(body(second)).eql(body(code));
+    });
+
+    it("should declare each generated type once", async () => {
+        const thirdFile = path.join(outputFolder, "_generated_sample_types_third.ts");
+        await generate(testFixture("SampleTypes.bsd"), thirdFile);
+        const third = fs.readFileSync(thirdFile, "utf8");
+
+        // one `const schemaX = buildStructuredType({` per structured type, however many
+        // times generate() has run before this one
+        const declared = [...third.matchAll(/^const schema(\w+) = buildStructuredType\(\{/gm)].map((m) => m[1]);
+        should(declared.length).be.greaterThan(0, "expecting the fixture to yield structured types");
+        should([...new Set(declared)].length).eql(declared.length, `each type once, got: ${declared.join(", ")}`);
+    });
+
     it("should reject a schema file that is not there", async () => {
         let caught: Error | undefined;
         try {


### PR DESCRIPTION
FEAT-12, the non-breaking half. The removal it sets up is a 3.0 change and is not here.

## US-12.2: generate() could not be called twice

`generate_extension_object_code.ts` held its output `LineFile1` at module scope, so a second
`generate()` in the same process appended to the first one's output and emitted every type
twice - 765 lines became 1526. `node-opcua-types` calls it once per process, which is why
nothing ever caught it.

The two helpers that wrote into that buffer now take the writer as a parameter, which
`writeStructuredType` already did. So there is no module state left to reset, rather than a
reset that would still interleave if two `generate()` calls overlapped. `alreadyDone`, the
other piece of state, was already function-scoped.

Two tests cover it, and I checked they fail against the code as it was rather than assuming
they would: without the fix, "should produce the same code when called twice in one process"
fails and mocha bails there (7 of 10 run). With it, 10 pass.

**The strongest check is that `pnpm run generate` produces byte-identical output** across the
whole monorepo - `git status` clean afterwards. That is the real consumer, exercised end to
end.

## US-12.1: what to do with the schema-literal path

**Decision: remove it at 3.0.** Deprecated here so the intent is published first.

`registerObject`, `unregisterObject`, `generateTypeScriptCodeFromSchema` and `generateCode`
behind them cannot work:

- `registerObject` builds ``` `${schema}_Schema` ``` and `generateCode` then looks up
  ``` module[`${schemaName}_Schema`] ```, so it asks for `SampleBase_Schema_Schema` and throws
- `generateCode` hands `produce_TScript_code` a raw schema literal where it wants a built
  `StructuredTypeSchema`: `TypeError: schema.getBaseSchema is not a function`

The argument for removing rather than repairing is that **code which always throws cannot
have working users.** I checked the blast radius rather than assuming it:

- nothing in this repository calls them - `node-opcua-types` imports `generate`, and that is
  the only import of this package anywhere in the monorepo
- they are not re-exported by the `node-opcua` umbrella, so reaching them means depending on
  this build-time package directly
- scanning the downstream projects found no callers; the apparent hits were an old vendored
  copy of node-opcua itself, and `_registerObjectType`, an unrelated method on NamespaceImpl

They carry `@deprecated` now, which reaches the emitted `.d.ts`, so anyone who does hold one
sees it in their editor before 3.0 takes it away.

Left for the 3.0 change: dropping the four exports and `opcua_code_generator.ts`, a scratch
file that nothing references, is not a `bin`, hardcodes its class name, logs `process.argv`
without reading it, does not await, and runs on import.

## Verification

- `tsc -b packages` clean
- node-opcua-generator: **10 passing** (was 8, and 1 of those failing without the fix)
- node-opcua-types: 42 passing
- `pnpm run generate`: **no drift**
- `check:testtypes` OK, `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
