### PR TITLE
feat(conformance-testing): CTT folder named after the UACTT settings

### DIFF
--- a/packages/node-opcua-address-space-for-conformance-testing/package.json
+++ b/packages/node-opcua-address-space-for-conformance-testing/package.json
@@ -45,5 +45,9 @@
         "data",
         "dist",
         "src"
-    ]
+    ],
+    "devDependencies": {
+        "node-opcua-nodesets": "2.179.0",
+        "should": "^13.2.3"
+    }
 }

--- a/packages/node-opcua-address-space-for-conformance-testing/src/address_space_for_conformance_testing.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/address_space_for_conformance_testing.ts
@@ -5,9 +5,9 @@
  */
 import type { AddressSpace, UAObject } from "node-opcua-address-space";
 import { add_eventGeneratorObject } from "node-opcua-address-space/testHelpers";
-
 import { addAccessRightVariables } from "./conformance_testing/access_right_variables.js";
 import { addAnalogDataItems } from "./conformance_testing/analog_data_items.js";
+import { addCttFolder } from "./conformance_testing/ctt_folder";
 import {
     addMultiStateDiscreteVariable,
     addMultiStateValueDiscreteVariables,
@@ -83,4 +83,7 @@ export async function build_address_space_for_conformance_testing(
     addMultiStateDiscreteVariable(namespace, simulationFolder);
 
     addTriggerNodes(namespace, simulationFolder);
+
+    // nodes named after the CTT settings the folders above do not serve
+    addCttFolder(namespace, objectsFolder);
 }

--- a/packages/node-opcua-address-space-for-conformance-testing/src/address_space_for_conformance_testing.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/address_space_for_conformance_testing.ts
@@ -7,7 +7,7 @@ import type { AddressSpace, UAObject } from "node-opcua-address-space";
 import { add_eventGeneratorObject } from "node-opcua-address-space/testHelpers";
 import { addAccessRightVariables } from "./conformance_testing/access_right_variables.js";
 import { addAnalogDataItems } from "./conformance_testing/analog_data_items.js";
-import { addCttFolder } from "./conformance_testing/ctt_folder";
+import { addCttFolder } from "./conformance_testing/ctt_folder.js";
 import {
     addMultiStateDiscreteVariable,
     addMultiStateValueDiscreteVariables,

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_folder.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_folder.ts
@@ -22,7 +22,7 @@ import { standardUnits } from "node-opcua-data-access";
 import { AccessLevelFlag, makeAccessLevelFlag } from "node-opcua-data-model";
 import { buildVariantArray, DataType, Variant, VariantArrayType } from "node-opcua-variant";
 
-import { typeAndDefaultValue } from "./type_defaults";
+import { typeAndDefaultValue } from "./type_defaults.js";
 
 const readWrite = makeAccessLevelFlag("CurrentRead | CurrentWrite");
 

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_folder.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_folder.ts
@@ -1,0 +1,467 @@
+/**
+ * The `CTT` folder: nodes named after the settings of the OPC Foundation
+ * Compliance Test Tool (UACTT) server project.
+ *
+ * The browse path below Objects/CTT mirrors the setting path below
+ * "Server Test/NodeIds", e.g. the setting
+ *   Server Test/NodeIds/Static/HA Profile/Arrays/Int162D
+ * is served by
+ *   Objects/CTT/Static/HA Profile/Arrays/Int162D   (NodeId s=CTT/Static/HA Profile/Arrays/Int162D)
+ * so a CTT project generator can fill the setting by browsing, without any
+ * hand-maintained map. Only settings the rest of this address space does not
+ * already serve are built here.
+ *
+ * Not covered (the server needs more than an address space for them):
+ * Decimal, the HA Aggregates nodes, NodeDoesNotSupportServerTimestamp,
+ * NodeManagement/RootNode, the alarm input nodes.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import type { AddressSpace, Namespace, UAObject, UAVariable } from "node-opcua-address-space";
+import { standardUnits } from "node-opcua-data-access";
+import { AccessLevelFlag, makeAccessLevelFlag } from "node-opcua-data-model";
+import { buildVariantArray, DataType, Variant, VariantArrayType } from "node-opcua-variant";
+
+import { typeAndDefaultValue } from "./type_defaults";
+
+const readWrite = makeAccessLevelFlag("CurrentRead | CurrentWrite");
+
+/** setting leaf -> OPC UA DataType name */
+const TYPE_ALIAS: Record<string, string> = { Bool: "Boolean" };
+
+function defaultValueOf(dataTypeName: string): unknown {
+    const e = typeAndDefaultValue.find((t) => t.type === dataTypeName);
+    if (!e) throw new Error(`no default value for ${dataTypeName}`);
+    return typeof e.defaultValue === "function" ? e.defaultValue() : e.defaultValue;
+}
+
+function variantFor(dataTypeName: string, valueRank: number): { variant: Variant; arrayDimensions: number[] | null } {
+    const dataType = DataType[dataTypeName as keyof typeof DataType];
+    const defaultValue = defaultValueOf(dataTypeName);
+    if (valueRank === -1) {
+        return {
+            variant: new Variant({ dataType, arrayType: VariantArrayType.Scalar, value: defaultValue }),
+            arrayDimensions: null
+        };
+    }
+    const dimensions = valueRank === 1 ? [5] : [2, 3];
+    const length = dimensions.reduce((a, b) => a * b, 1);
+    return {
+        variant: new Variant({
+            dataType,
+            arrayType: valueRank === 1 ? VariantArrayType.Array : VariantArrayType.Matrix,
+            dimensions: valueRank === 1 ? null : dimensions,
+            value: buildVariantArray(dataType, length, defaultValue)
+        }),
+        arrayDimensions: dimensions
+    };
+}
+
+class CttFolder {
+    private readonly folders = new Map<string, UAObject>();
+
+    constructor(
+        readonly namespace: Namespace,
+        root: UAObject
+    ) {
+        this.folders.set("", root);
+    }
+
+    get addressSpace(): AddressSpace {
+        return this.namespace.addressSpace as AddressSpace;
+    }
+
+    /** the folder for a setting group, created on demand, e.g. "Static/HA Profile/Arrays" */
+    folder(relPath: string): UAObject {
+        const existing = this.folders.get(relPath);
+        if (existing) return existing;
+        const i = relPath.lastIndexOf("/");
+        const parent = this.folder(i < 0 ? "" : relPath.slice(0, i));
+        const browseName = i < 0 ? relPath : relPath.slice(i + 1);
+        const f = this.namespace.addFolder(parent, { browseName, nodeId: `s=CTT/${relPath}` });
+        this.folders.set(relPath, f);
+        return f;
+    }
+
+    nodeId(relPath: string): string {
+        return `s=CTT/${relPath}`;
+    }
+
+    /** a plain read/write variable at the given setting path */
+    variable(relPath: string, dataType: string, valueRank: number, value: Variant, arrayDimensions: number[] | null): UAVariable {
+        const i = relPath.lastIndexOf("/");
+        return this.namespace.addVariable({
+            componentOf: this.folder(relPath.slice(0, i)),
+            browseName: relPath.slice(i + 1),
+            nodeId: this.nodeId(relPath),
+            description: `CTT setting ${relPath}`,
+            dataType,
+            valueRank,
+            arrayDimensions,
+            accessLevel: readWrite,
+            userAccessLevel: readWrite,
+            value
+        });
+    }
+
+    typedVariable(relPath: string, dataTypeName: string, valueRank: number): UAVariable {
+        const { variant, arrayDimensions } = variantFor(dataTypeName, valueRank);
+        return this.variable(relPath, dataTypeName, valueRank, variant, arrayDimensions);
+    }
+}
+
+// ─── Static / All Profiles ──────────────────────────────────────────────
+
+function addVariantVariables(ctt: CttFolder): void {
+    // "Variant" in CTT terms: a Variable whose DataType attribute is BaseDataType
+    const scalar = new Variant({ dataType: DataType.Double, value: 3.14 });
+    ctt.variable("Static/All Profiles/Scalar/Variant", "BaseDataType", -1, scalar, null);
+    ctt.variable(
+        "Static/All Profiles/Arrays/Variant",
+        "BaseDataType",
+        1,
+        new Variant({ dataType: DataType.Double, arrayType: VariantArrayType.Array, value: new Float64Array([1, 2, 3, 4, 5]) }),
+        [5]
+    );
+    ctt.variable(
+        "Static/All Profiles/Multi-Dimensional-Arrays/Variant",
+        "BaseDataType",
+        2,
+        new Variant({
+            dataType: DataType.Double,
+            arrayType: VariantArrayType.Matrix,
+            dimensions: [2, 3],
+            value: new Float64Array([1, 2, 3, 4, 5, 6])
+        }),
+        [2, 3]
+    );
+}
+
+function addImageVariable(ctt: CttFolder): void {
+    // the abstract Image data type (the concrete ImagePNG/GIF/JPG/BMP nodes live under Simulation)
+    let png: Buffer;
+    try {
+        png = fs.readFileSync(path.join(__dirname, "../../data", "tux.png"));
+    } catch (_err) {
+        png = Buffer.from("89504e470d0a1a0a", "hex");
+    }
+    ctt.variable("Static/All Profiles/Scalar/Image", "Image", -1, new Variant({ dataType: DataType.ByteString, value: png }), null);
+}
+
+function addStructureVariables(ctt: CttFolder): void {
+    const addressSpace = ctt.addressSpace;
+    const structures: { dataType: string; fields: Record<string, unknown> }[] = [
+        { dataType: "Range", fields: { low: -10, high: 10 } },
+        {
+            dataType: "EUInformation",
+            fields: {
+                namespaceUri: "http://www.opcfoundation.org/UA/units/un/cefact",
+                unitId: 4408652,
+                displayName: { text: "°C" },
+                description: { text: "degree Celsius" }
+            }
+        },
+        { dataType: "TimeZoneDataType", fields: { offset: 60, daylightSavingInOffset: false } },
+        {
+            dataType: "EnumValueType",
+            fields: { value: [1, 0], displayName: { text: "One" }, description: { text: "the value one" } }
+        },
+        {
+            dataType: "Argument",
+            fields: {
+                name: "arg",
+                dataType: "i=6",
+                valueRank: -1,
+                arrayDimensions: null,
+                description: { text: "an Int32 argument" }
+            }
+        }
+    ];
+    structures.forEach((s, i) => {
+        const dataTypeNode = addressSpace.findDataType(s.dataType);
+        if (!dataTypeNode) throw new Error(`DataType ${s.dataType} not found`);
+        const value = addressSpace.constructExtensionObject(dataTypeNode, s.fields);
+        ctt.variable(
+            `Static/All Profiles/Structures/Structure${String(i + 1).padStart(3, "0")}`,
+            s.dataType,
+            -1,
+            new Variant({ dataType: DataType.ExtensionObject, value }),
+            null
+        );
+    });
+}
+
+// ─── Static / DA Profile ────────────────────────────────────────────────
+
+function addAnalogItemArrays(ctt: CttFolder): void {
+    const folder = ctt.folder("Static/DA Profile/AnalogItemType Arrays");
+    for (const dataTypeName of ["Double", "Float", "Int16", "Int32", "UInt16", "UInt32"]) {
+        const dataType = DataType[dataTypeName as keyof typeof DataType];
+        ctt.namespace.addAnalogDataItem({
+            organizedBy: folder,
+            browseName: dataTypeName,
+            nodeId: ctt.nodeId(`Static/DA Profile/AnalogItemType Arrays/${dataTypeName}`),
+            dataType: dataTypeName,
+            valueRank: 1,
+            arrayDimensions: [5],
+            arrayType: VariantArrayType.Array,
+            engineeringUnitsRange: { low: -100, high: 100 },
+            instrumentRange: { low: -1000, high: 1000 },
+            engineeringUnits: standardUnits.degree_celsius,
+            value: new Variant({ dataType, arrayType: VariantArrayType.Array, value: buildVariantArray(dataType, 5, 0) }),
+            accessLevel: readWrite,
+            userAccessLevel: readWrite
+        });
+    }
+}
+
+function axis(addressSpace: AddressSpace, title: string, low: number, high: number) {
+    const axisInformation = addressSpace.findDataType("AxisInformation");
+    if (!axisInformation) throw new Error("AxisInformation not found");
+    return addressSpace.constructExtensionObject(axisInformation, {
+        engineeringUnits: standardUnits.second,
+        euRange: { low, high },
+        title: { text: title },
+        axisScaleType: 0, // Linear
+        axisSteps: null
+    });
+}
+
+/**
+ * The five ArrayItemType subtypes: plain variables of the right VariableType,
+ * given the mandatory ArrayItemType properties by hand. instantiate() refuses
+ * a ValueRank that differs from the type's (ImageItemType and CubeItemType
+ * need 2 and 3) and namespace.addYArrayItem() ignores nodeId and organizedBy.
+ */
+function addArrayItems(ctt: CttFolder): void {
+    const addressSpace = ctt.addressSpace;
+    const namespace = ctt.namespace;
+    const group = "Static/DA Profile/ArrayItemType";
+    const folder = ctt.folder(group);
+    const xAxis = axis(addressSpace, "x", 0, 10);
+    const yAxis = axis(addressSpace, "y", 0, 20);
+    const zAxis = axis(addressSpace, "z", 0, 30);
+    const rangeType = addressSpace.findDataType("Range");
+    const xvType = addressSpace.findDataType("XVType");
+    if (!rangeType || !xvType) throw new Error("Range or XVType not found");
+
+    const extensionObject = (value: unknown) => new Variant({ dataType: DataType.ExtensionObject, value });
+    const arrayItem = (
+        typeName: string,
+        options: { dataType: string; valueRank: number; arrayDimensions: number[]; value: Variant },
+        axes: Record<string, Variant>
+    ): UAVariable => {
+        const v = namespace.addVariable({
+            organizedBy: folder,
+            browseName: typeName,
+            nodeId: ctt.nodeId(`${group}/${typeName}`),
+            typeDefinition: typeName,
+            dataType: options.dataType,
+            valueRank: options.valueRank,
+            arrayDimensions: options.arrayDimensions,
+            accessLevel: readWrite,
+            userAccessLevel: readWrite,
+            value: options.value
+        });
+        const property = (browseName: string, dataType: string, value: Variant, valueRank = -1) =>
+            namespace.addVariable({ propertyOf: v, browseName, dataType, valueRank, value, modellingRule: "Mandatory" });
+        property("Title", "LocalizedText", new Variant({ dataType: DataType.LocalizedText, value: { text: typeName } }));
+        property("AxisScaleType", "AxisScaleEnumeration", new Variant({ dataType: DataType.Int32, value: 0 }));
+        property("EURange", "Range", extensionObject(addressSpace.constructExtensionObject(rangeType, { low: 0, high: 100 })));
+        property(
+            "InstrumentRange",
+            "Range",
+            extensionObject(addressSpace.constructExtensionObject(rangeType, { low: 0, high: 1000 }))
+        );
+        property("EngineeringUnits", "EUInformation", extensionObject(standardUnits.degree_celsius));
+        for (const [name, value] of Object.entries(axes)) {
+            property(name, "AxisInformation", value, value.arrayType === VariantArrayType.Array ? 1 : -1);
+        }
+        return v;
+    };
+
+    arrayItem(
+        "YArrayItemType",
+        {
+            dataType: "Double",
+            valueRank: 1,
+            arrayDimensions: [5],
+            value: new Variant({
+                dataType: DataType.Double,
+                arrayType: VariantArrayType.Array,
+                value: new Float64Array([1, 2, 3, 4, 5])
+            })
+        },
+        { XAxisDefinition: extensionObject(xAxis) }
+    );
+    arrayItem(
+        "XYArrayItemType",
+        {
+            dataType: "XVType",
+            valueRank: 1,
+            arrayDimensions: [3],
+            value: new Variant({
+                dataType: DataType.ExtensionObject,
+                arrayType: VariantArrayType.Array,
+                value: [0, 1, 2].map((i) => addressSpace.constructExtensionObject(xvType, { x: i, value: i * 2 }))
+            })
+        },
+        { XAxisDefinition: extensionObject(xAxis) }
+    );
+    arrayItem(
+        "ImageItemType",
+        {
+            dataType: "UInt16",
+            valueRank: 2,
+            arrayDimensions: [2, 3],
+            value: new Variant({
+                dataType: DataType.UInt16,
+                arrayType: VariantArrayType.Matrix,
+                dimensions: [2, 3],
+                value: new Uint16Array([1, 2, 3, 4, 5, 6])
+            })
+        },
+        { XAxisDefinition: extensionObject(xAxis), YAxisDefinition: extensionObject(yAxis) }
+    );
+    arrayItem(
+        "CubeItemType",
+        {
+            dataType: "Double",
+            valueRank: 3,
+            arrayDimensions: [2, 2, 2],
+            value: new Variant({
+                dataType: DataType.Double,
+                arrayType: VariantArrayType.Matrix,
+                dimensions: [2, 2, 2],
+                value: new Float64Array([1, 2, 3, 4, 5, 6, 7, 8])
+            })
+        },
+        {
+            XAxisDefinition: extensionObject(xAxis),
+            YAxisDefinition: extensionObject(yAxis),
+            ZAxisDefinition: extensionObject(zAxis)
+        }
+    );
+    arrayItem(
+        "NDimensionArrayItemType",
+        {
+            dataType: "Double",
+            valueRank: 2,
+            arrayDimensions: [2, 3],
+            value: new Variant({
+                dataType: DataType.Double,
+                arrayType: VariantArrayType.Matrix,
+                dimensions: [2, 3],
+                value: new Float64Array([1, 2, 3, 4, 5, 6])
+            })
+        },
+        {
+            AxisDefinition: new Variant({
+                dataType: DataType.ExtensionObject,
+                arrayType: VariantArrayType.Array,
+                value: [xAxis, yAxis]
+            })
+        }
+    );
+}
+
+// ─── Static / HA Profile ────────────────────────────────────────────────
+
+const HA_TYPES = [
+    "Bool",
+    "Byte",
+    "ByteString",
+    "DateTime",
+    "Double",
+    "Float",
+    "Int16",
+    "Int32",
+    "Int64",
+    "SByte",
+    "String",
+    "UInt16",
+    "UInt32",
+    "UInt64",
+    "XmlElement"
+];
+
+/** a variable with in-memory history and a first value, so reads are Good with timestamps */
+function historize(ctt: CttFolder, variable: UAVariable): UAVariable {
+    ctt.addressSpace.installHistoricalDataNode(variable);
+    const current = variable.readValue().value;
+    variable.setValueFromSource(current);
+    return variable;
+}
+
+function addHistorizingVariables(ctt: CttFolder): void {
+    for (const leaf of HA_TYPES) {
+        const dataTypeName = TYPE_ALIAS[leaf] ?? leaf;
+        historize(ctt, ctt.typedVariable(`Static/HA Profile/Scalar/${leaf}`, dataTypeName, -1));
+        historize(ctt, ctt.typedVariable(`Static/HA Profile/Arrays/${leaf}`, dataTypeName, 1));
+        historize(ctt, ctt.typedVariable(`Static/HA Profile/Arrays/${leaf}2D`, dataTypeName, 2));
+    }
+
+    const range = ctt.addressSpace.findDataType("Range");
+    if (!range) throw new Error("Range not found");
+    historize(
+        ctt,
+        ctt.variable(
+            "Static/HA Profile/StructureNodeSupportingHistory",
+            "Range",
+            -1,
+            new Variant({
+                dataType: DataType.ExtensionObject,
+                value: ctt.addressSpace.constructExtensionObject(range, { low: 0, high: 1 })
+            }),
+            null
+        )
+    );
+
+    // AccessLevel_* : the AccessLevel attribute; UserAccessLevel_* : the UserAccessLevel attribute
+    const history = AccessLevelFlag.HistoryRead;
+    const flags: Record<string, number> = {
+        ReadOnly: AccessLevelFlag.CurrentRead | history,
+        WriteOnly: AccessLevelFlag.CurrentWrite | history,
+        None: history
+    };
+    for (const attribute of ["AccessLevel", "UserAccessLevel"]) {
+        for (const [kind, flag] of Object.entries(flags)) {
+            const relPath = `Static/HA Profile/AccessRights/${attribute}_${kind}`;
+            const i = relPath.lastIndexOf("/");
+            const full = AccessLevelFlag.CurrentRead | AccessLevelFlag.CurrentWrite | history;
+            const v = ctt.namespace.addVariable({
+                componentOf: ctt.folder(relPath.slice(0, i)),
+                browseName: relPath.slice(i + 1),
+                nodeId: ctt.nodeId(relPath),
+                description: `CTT setting ${relPath}`,
+                dataType: "Int32",
+                valueRank: -1,
+                accessLevel: full,
+                userAccessLevel: full,
+                value: new Variant({ dataType: DataType.Int32, value: 36 })
+            });
+            historize(ctt, v);
+            // installHistoricalDataNode() adds CurrentRead to both attributes: set the flags after it
+            v.accessLevel = attribute === "AccessLevel" ? flag : full;
+            v.userAccessLevel = attribute === "UserAccessLevel" ? flag : full;
+        }
+    }
+}
+
+// ─── entry point ────────────────────────────────────────────────────────
+
+export function addCttFolder(namespace: Namespace, objectsFolder: UAObject): UAObject {
+    const root = namespace.addFolder(objectsFolder, {
+        browseName: "CTT",
+        nodeId: "s=CTT",
+        description: "Nodes named after the settings of the OPC Foundation Compliance Test Tool server project"
+    });
+    const ctt = new CttFolder(namespace, root);
+    addVariantVariables(ctt);
+    addImageVariable(ctt);
+    addStructureVariables(ctt);
+    addAnalogItemArrays(ctt);
+    addArrayItems(ctt);
+    addHistorizingVariables(ctt);
+    return root;
+}

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/discrete_variables.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/discrete_variables.ts
@@ -25,7 +25,7 @@ export function addTwoStateDiscreteVariables(namespace: Namespace, parentFolder:
     const DADiscreteTypeFolder = getDADiscreteTypeFolder(namespace, parentFolder);
 
     const twoStateDiscrete001 = namespace.addTwoStateDiscrete({
-        organizedBy: DADiscreteTypeFolder,
+        componentOf: DADiscreteTypeFolder,
         nodeId: "s=TwoStateDiscrete001",
         browseName: "TwoStateDiscrete001",
         trueState: "Enabled",
@@ -33,7 +33,7 @@ export function addTwoStateDiscreteVariables(namespace: Namespace, parentFolder:
     });
 
     const twoStateDiscrete002 = namespace.addTwoStateDiscrete({
-        organizedBy: DADiscreteTypeFolder,
+        componentOf: DADiscreteTypeFolder,
         nodeId: "s=TwoStateDiscrete002",
         browseName: "TwoStateDiscrete002",
         trueState: "On",
@@ -41,9 +41,9 @@ export function addTwoStateDiscreteVariables(namespace: Namespace, parentFolder:
         optionals: ["TransitionTime", "EffectiveDisplayName"]
     });
 
-    // HasTrueSubState is not hierarchical: the folder keeps it browsable
+    // HasTrueSubState is not hierarchical: the HasComponent reference keeps it browsable
     const twoStateDiscrete003 = namespace.addTwoStateDiscrete({
-        organizedBy: DADiscreteTypeFolder,
+        componentOf: DADiscreteTypeFolder,
         browseName: "twoStateDiscrete003",
         nodeId: "s=TwoStateDiscrete003",
         optionals: ["TransitionTime"],
@@ -51,7 +51,7 @@ export function addTwoStateDiscreteVariables(namespace: Namespace, parentFolder:
     });
 
     const twoStateDiscrete004 = namespace.addTwoStateDiscrete({
-        organizedBy: DADiscreteTypeFolder,
+        componentOf: DADiscreteTypeFolder,
         nodeId: "s=TwoStateDiscrete004",
         browseName: "TwoStateDiscrete004",
         trueState: "InProgress",
@@ -59,7 +59,7 @@ export function addTwoStateDiscreteVariables(namespace: Namespace, parentFolder:
     });
 
     const twoStateDiscrete005 = namespace.addTwoStateDiscrete({
-        organizedBy: DADiscreteTypeFolder,
+        componentOf: DADiscreteTypeFolder,
         nodeId: "s=TwoStateDiscrete005",
         browseName: "TwoStateDiscrete005",
         trueState: "InProgress",

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/discrete_variables.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/discrete_variables.ts
@@ -41,7 +41,9 @@ export function addTwoStateDiscreteVariables(namespace: Namespace, parentFolder:
         optionals: ["TransitionTime", "EffectiveDisplayName"]
     });
 
+    // HasTrueSubState is not hierarchical: the folder keeps it browsable
     const twoStateDiscrete003 = namespace.addTwoStateDiscrete({
+        organizedBy: DADiscreteTypeFolder,
         browseName: "twoStateDiscrete003",
         nodeId: "s=TwoStateDiscrete003",
         optionals: ["TransitionTime"],

--- a/packages/node-opcua-address-space-for-conformance-testing/test/test_ctt_folder.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/test/test_ctt_folder.ts
@@ -34,7 +34,7 @@ describe("the CTT folder", function () {
 
     it("mirrors the setting path in the browse path and the NodeId", () => {
         const v = byPath("Static/HA Profile/Arrays/Int162D");
-        v.browseName.name!.should.eql("Int162D");
+        should(v.browseName.name).eql("Int162D");
         // follow the hierarchical references from the CTT folder, segment by segment
         let n: UAObject | UAVariable = ctt;
         for (const segment of ["Static", "HA Profile", "Arrays", "Int162D"]) {
@@ -52,7 +52,11 @@ describe("the CTT folder", function () {
         for (let i = 1; i <= 5; i++) {
             const v = byPath(`Static/All Profiles/Structures/Structure00${i}`);
             v.readValue().value.dataType.should.eql(DataType.ExtensionObject);
-            addressSpace.findDataType(v.dataType)!.isSubtypeOf(addressSpace.findDataType("Structure")!).should.eql(true);
+            const dataType = addressSpace.findDataType(v.dataType);
+            const structure = addressSpace.findDataType("Structure");
+            should.exist(dataType);
+            should.exist(structure);
+            should(dataType?.isSubtypeOf(structure!)).eql(true);
         }
         byPath("Static/All Profiles/Arrays/Variant").valueRank.should.eql(1);
         byPath("Static/All Profiles/Multi-Dimensional-Arrays/Variant").valueRank.should.eql(2);
@@ -60,11 +64,11 @@ describe("the CTT folder", function () {
 
     it("serves the DA arrays and the five ArrayItemTypes with their axis properties", () => {
         const a = byPath("Static/DA Profile/AnalogItemType Arrays/Int16");
-        a.typeDefinitionObj.browseName.name!.should.eql("AnalogItemType");
+        should(a.typeDefinitionObj.browseName.name).eql("AnalogItemType");
         a.valueRank.should.eql(1);
         for (const t of ["YArrayItemType", "XYArrayItemType", "ImageItemType", "CubeItemType", "NDimensionArrayItemType"]) {
             const v = byPath(`Static/DA Profile/ArrayItemType/${t}`);
-            v.typeDefinitionObj.browseName.name!.should.eql(t);
+            should(v.typeDefinitionObj.browseName.name).eql(t);
             should.exist(v.getPropertyByName("Title"), `${t} Title`);
             v.readValue().statusCode.should.eql(StatusCodes.Good);
         }
@@ -92,7 +96,7 @@ describe("the CTT folder", function () {
         const ro = byPath("Static/HA Profile/AccessRights/AccessLevel_ReadOnly");
         (ro.accessLevel & 3).should.eql(1);
         const uw = byPath("Static/HA Profile/AccessRights/UserAccessLevel_WriteOnly");
-        (uw.userAccessLevel & 3).should.eql(2);
+        ((uw.userAccessLevel ?? 0) & 3).should.eql(2);
         (uw.accessLevel & 3).should.eql(3);
     });
 });

--- a/packages/node-opcua-address-space-for-conformance-testing/test/test_ctt_folder.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/test/test_ctt_folder.ts
@@ -1,0 +1,90 @@
+import { AddressSpace, type UAObject, type UAVariable } from "node-opcua-address-space";
+import { generateAddressSpace } from "node-opcua-address-space/nodeJS";
+import { nodesets } from "node-opcua-nodesets";
+import { StatusCodes } from "node-opcua-status-code";
+import { DataType } from "node-opcua-variant";
+import should from "should";
+
+import { build_address_space_for_conformance_testing } from "../dist/index.js";
+
+describe("the CTT folder", function () {
+    this.timeout(60_000);
+
+    let addressSpace: AddressSpace;
+    let ctt: UAObject;
+    const byPath = (relPath: string): UAVariable => {
+        const ns = addressSpace.getNamespaceIndex("urn://node-opcua-simulator");
+        const node = addressSpace.findNode(`ns=${ns};s=CTT/${relPath}`);
+        should.exist(node, `expected a node for CTT setting ${relPath}`);
+        return node as UAVariable;
+    };
+
+    before(async () => {
+        addressSpace = AddressSpace.create();
+        await generateAddressSpace(addressSpace, [nodesets.standard]);
+        addressSpace.registerNamespace("urn:test");
+        await build_address_space_for_conformance_testing(addressSpace, {});
+        ctt = addressSpace.rootFolder.objects.getFolderElementByName("CTT") as UAObject;
+        should.exist(ctt);
+    });
+    after(async () => {
+        await addressSpace.shutdown();
+        addressSpace.dispose();
+    });
+
+    it("mirrors the setting path in the browse path and the NodeId", () => {
+        const v = byPath("Static/HA Profile/Arrays/Int162D");
+        v.browseName.name!.should.eql("Int162D");
+        // follow the hierarchical references from the CTT folder, segment by segment
+        let n: UAObject | UAVariable = ctt;
+        for (const segment of ["Static", "HA Profile", "Arrays", "Int162D"]) {
+            const children = n.findReferencesExAsObject("HierarchicalReferences") as (UAObject | UAVariable)[];
+            const next = children.find((c) => c.browseName.name === segment);
+            should.exist(next, `${segment} below ${n.browseName.name}`);
+            n = next as UAObject | UAVariable;
+        }
+        n.nodeId.toString().should.eql(v.nodeId.toString());
+    });
+
+    it("serves Variant, Image and Structure scalars", () => {
+        byPath("Static/All Profiles/Scalar/Variant").dataType.toString().should.eql("ns=0;i=24");
+        byPath("Static/All Profiles/Scalar/Image").dataType.toString().should.eql("ns=0;i=30");
+        for (let i = 1; i <= 5; i++) {
+            const v = byPath(`Static/All Profiles/Structures/Structure00${i}`);
+            v.readValue().value.dataType.should.eql(DataType.ExtensionObject);
+            addressSpace.findDataType(v.dataType)!.isSubtypeOf(addressSpace.findDataType("Structure")!).should.eql(true);
+        }
+        byPath("Static/All Profiles/Arrays/Variant").valueRank.should.eql(1);
+        byPath("Static/All Profiles/Multi-Dimensional-Arrays/Variant").valueRank.should.eql(2);
+    });
+
+    it("serves the DA arrays and the five ArrayItemTypes with their axis properties", () => {
+        const a = byPath("Static/DA Profile/AnalogItemType Arrays/Int16");
+        a.typeDefinitionObj.browseName.name!.should.eql("AnalogItemType");
+        a.valueRank.should.eql(1);
+        for (const t of ["YArrayItemType", "XYArrayItemType", "ImageItemType", "CubeItemType", "NDimensionArrayItemType"]) {
+            const v = byPath(`Static/DA Profile/ArrayItemType/${t}`);
+            v.typeDefinitionObj.browseName.name!.should.eql(t);
+            should.exist(v.getPropertyByName("Title"), `${t} Title`);
+            v.readValue().statusCode.should.eql(StatusCodes.Good);
+        }
+        should.exist(byPath("Static/DA Profile/ArrayItemType/CubeItemType").getPropertyByName("ZAxisDefinition"));
+    });
+
+    it("serves historizing scalars, arrays and access-right variables", () => {
+        const v = byPath("Static/HA Profile/Scalar/Bool");
+        v.historizing.should.eql(true);
+        v.dataType.toString().should.eql("ns=0;i=1");
+        const dv = v.readValue();
+        dv.statusCode.should.eql(StatusCodes.Good);
+        should.exist(dv.sourceTimestamp);
+        byPath("Static/HA Profile/Arrays/Double").valueRank.should.eql(1);
+        byPath("Static/HA Profile/Arrays/Double2D").valueRank.should.eql(2);
+        byPath("Static/HA Profile/StructureNodeSupportingHistory").historizing.should.eql(true);
+        const ro = byPath("Static/HA Profile/AccessRights/AccessLevel_ReadOnly");
+        (ro.accessLevel & 3).should.eql(1);
+        const uw = byPath("Static/HA Profile/AccessRights/UserAccessLevel_WriteOnly");
+        (uw.userAccessLevel & 3).should.eql(2);
+        (uw.accessLevel & 3).should.eql(3);
+    });
+});

--- a/packages/node-opcua-address-space-for-conformance-testing/test/test_ctt_folder.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/test/test_ctt_folder.ts
@@ -71,11 +71,11 @@ describe("the CTT folder", function () {
         should.exist(byPath("Static/DA Profile/ArrayItemType/CubeItemType").getPropertyByName("ZAxisDefinition"));
     });
 
-    it("keeps the TwoStateDiscrete variables reachable from their folder", () => {
+    it("keeps the TwoStateDiscrete variables as components of their folder", () => {
         const ns = addressSpace.getNamespaceIndex("urn://node-opcua-simulator");
         const folder = addressSpace.findNode(`ns=${ns};s=Simulation_DA_DiscreteType`) as UAObject;
         should.exist(folder);
-        const names = folder.findReferencesExAsObject("Organizes").map((n) => n.browseName.name);
+        const names = folder.findReferencesExAsObject("HasComponent").map((n) => n.browseName.name);
         for (let i = 1; i <= 5; i++) names.should.containEql(i === 3 ? "twoStateDiscrete003" : `TwoStateDiscrete00${i}`);
     });
 

--- a/packages/node-opcua-address-space-for-conformance-testing/test/test_ctt_folder.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/test/test_ctt_folder.ts
@@ -71,6 +71,14 @@ describe("the CTT folder", function () {
         should.exist(byPath("Static/DA Profile/ArrayItemType/CubeItemType").getPropertyByName("ZAxisDefinition"));
     });
 
+    it("keeps the TwoStateDiscrete variables reachable from their folder", () => {
+        const ns = addressSpace.getNamespaceIndex("urn://node-opcua-simulator");
+        const folder = addressSpace.findNode(`ns=${ns};s=Simulation_DA_DiscreteType`) as UAObject;
+        should.exist(folder);
+        const names = folder.findReferencesExAsObject("Organizes").map((n) => n.browseName.name);
+        for (let i = 1; i <= 5; i++) names.should.containEql(i === 3 ? "twoStateDiscrete003" : `TwoStateDiscrete00${i}`);
+    });
+
     it("serves historizing scalars, arrays and access-right variables", () => {
         const v = byPath("Static/HA Profile/Scalar/Bool");
         v.historizing.should.eql(true);

--- a/packages/node-opcua-address-space/impl/data_access/ua_two_state_discrete_impl.ts
+++ b/packages/node-opcua-address-space/impl/data_access/ua_two_state_discrete_impl.ts
@@ -134,6 +134,7 @@ export function _addTwoStateDiscrete(namespace: INamespace, options: AddTwoState
         displayName: options.displayName,
         componentOf: options.componentOf,
         propertyOf: options.propertyOf,
+        organizedBy: options.organizedBy,
         dataType: DataType.Boolean,
         nodeId: options.nodeId,
         typeDefinition: twoStateDiscreteType.nodeId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -584,6 +584,13 @@ importers:
       node-opcua-variant:
         specifier: 2.180.0
         version: link:../node-opcua-variant
+    devDependencies:
+      node-opcua-nodesets:
+        specifier: 2.179.0
+        version: link:../node-opcua-nodesets
+      should:
+        specifier: ^13.2.3
+        version: 13.2.3
 
   packages/node-opcua-aggregates:
     dependencies:


### PR DESCRIPTION
## Why

The OPC Foundation Compliance Test Tool (UACTT) server project has ~230 NodeId settings. A generator can fill them by browsing the server instead of maintaining a map by hand, provided the address space exposes nodes named after the settings. This adds that convention to `node-opcua-address-space-for-conformance-testing`.

## What

**`Objects/CTT`** (new, `ctt_folder.ts`): the browse path below it mirrors the setting path below `Server Test/NodeIds`; NodeIds are `s=CTT/<setting path>`. Only settings the existing `Simulation` folder does not serve are built here:

| Group | Nodes |
|---|---|
| Static / All Profiles | `Scalar/Variant`, `Scalar/Image`, `Arrays/Variant`, `Multi-Dimensional-Arrays/Variant`, `Structures/Structure001..005` (Range, EUInformation, TimeZoneDataType, EnumValueType, Argument) |
| Static / DA Profile | `AnalogItemType Arrays/{Double,Float,Int16,Int32,UInt16,UInt32}`, `ArrayItemType/{YArrayItemType,XYArrayItemType,ImageItemType,CubeItemType,NDimensionArrayItemType}` with Title, AxisScaleType, EURange, InstrumentRange, EngineeringUnits and axis definitions |
| Static / HA Profile | `Scalar/<15 types>`, `Arrays/<15 types>`, `Arrays/<15 types>2D`, `StructureNodeSupportingHistory`, `AccessRights/{AccessLevel,UserAccessLevel}_{ReadOnly,WriteOnly,None}`, all with `installHistoricalDataNode()` and a first value |

Two fixes found on the way:

- `Namespace.addTwoStateDiscrete()` forwarded `componentOf` and `propertyOf` only, so `organizedBy` was silently dropped.
- The five `TwoStateDiscrete00x` variables of the conformance address space were therefore orphans (the third one hung only off `HasTrueSubState`, which is not hierarchical). They are now components of `Simulation_DA_DiscreteType`.

Not covered, since an address space alone cannot provide them: Decimal, the HA Aggregates nodes, NodeDoesNotSupportServerTimestamp, NodeManagement/RootNode, the alarm input nodes.

## Notes

- `ImageItemType` and `CubeItemType` need ValueRank 2 and 3, which `UAVariableType.instantiate()` refuses when it differs from the type's; `addYArrayItem()` ignores `nodeId`/`organizedBy`. The ArrayItems are therefore plain variables with the mandatory properties added by hand.
- `installHistoricalDataNode()` forces `CurrentRead` into both access-level attributes, so the HA access-right flags are set after it.
- Measured with the UACTT project generator of sterfive/certified-node-opcua against server-for-ctt-test: unresolved NodeId settings go from 107 to 35, 72 settings served by this folder.

## Tests

`packages/node-opcua-address-space-for-conformance-testing`: new `test/test_ctt_folder.ts` (builds the address space on the standard nodeset; checks browse paths, data types, type definitions, history, access flags, TwoStateDiscrete components). 6 passing. New devDependencies `node-opcua-nodesets` and `should` for that package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
