### PR TITLE
perf(address-space): one inflate per image replay, initial values at creation

### DIFF
--- a/packages/node-opcua-address-space/CHANGELOG.md
+++ b/packages/node-opcua-address-space/CHANGELOG.md
@@ -155,6 +155,18 @@ gives the same records, and the two address spaces digest the same; so does a na
   element is still rendered from the node, and `node.dumpXML(writer)` runs that walk from the node. Its output is
   byte-identical to before on every catalog namespace, pinned by a golden test.
 
+#### Replaying an image inflates it once, and initial values are set as the variables are created
+
+The default path inflated a catalog image three times (the sibling check, the header pre-pass and the replay) and
+parsed it through a streaming reader with one turn of the microtask queue per record. An image given whole is now
+inflated once, kept as lines for as long as its bytes live, and replayed through a synchronous iterator; the XML
+path applies the records a chunk completes together, one turn per chunk. A variable whose data type is already in
+the address space gets its initial value (or its default) when it is created instead of through a post-load task;
+an extension object still waits for the data types to be extracted, and a refused value is logged and skipped as
+the task did. Standard nodeset, best of 7 alternating: from its image 82 ms against 149 ms from the XML (45%, was
+29%); the Node.js `generateAddressSpace` default path 98 ms against 144 ms (32%, was 13%); a six-file chain 42% and
+33%.
+
 ### Security
 
 #### Per-node `RolePermissions` and `AccessRestrictions` are no longer dropped when loading a NodeSet2 file

--- a/packages/node-opcua-address-space/api/index.ts
+++ b/packages/node-opcua-address-space/api/index.ts
@@ -157,7 +157,9 @@ export * from "./interfaces/ua_subscription_diagnostics_variable_ex.js";
 export { ensureDatatypeExtracted, ensureDatatypeExtractedWithCallback } from "./loader/ensure_datatype_extracted.js";
 export * from "./loader/generateAddressSpaceRaw.js";
 export {
+    imageLinesToRecords,
     imageNodesetRecords,
+    inflatedImageLines,
     isNodesetImage,
     NodesetImageError,
     type NodesetImageHeader,

--- a/packages/node-opcua-address-space/api/loader/generateAddressSpaceRaw.ts
+++ b/packages/node-opcua-address-space/api/loader/generateAddressSpaceRaw.ts
@@ -7,7 +7,13 @@ import type { NamespacePrivate } from "../../impl/namespace_private.js";
 import { adjustNamespaceArray } from "../../impl/nodeset_tools/adjust_namespace_array.js";
 import type { NodeSetLoaderOptions } from "../interfaces/nodeset_loader_options.js";
 import { NodeSetLoader } from "./load_nodeset2.js";
-import { imageNodesetRecords, NodesetImageError, NodesetImageWriter, readNodesetImageInfo } from "./nodeset_image.js";
+import {
+    imageLinesToRecords,
+    inflatedImageLines,
+    NodesetImageError,
+    NodesetImageWriter,
+    readNodesetImageInfo
+} from "./nodeset_image.js";
 import { decodeHeader } from "./nodeset_image_codec.js";
 import { type NodesetImageStore, nodesetImageKey, sharedMemoryNodesetImageStore } from "./nodeset_image_store.js";
 import type { NodesetRecord, NodesetRecordConsumer } from "./nodeset_record.js";
@@ -234,7 +240,7 @@ async function loadXmlSource(
         if (image && (await isReplayable(image, digest, reader.name))) {
             // a replay that fails half-way would leave nodes behind that the XML would then
             // collide with; the check above is what makes it safe to commit to the image here
-            await nodesetLoader.addRecords(imageNodesetRecords(image, { expectedDigest: digest }));
+            await nodesetLoader.addRecords(imageLinesToRecords(await inflatedImageLines(image), { expectedDigest: digest }));
             doDebug && debugLog("loaded", reader.name, "from its image", key);
             return;
         }
@@ -392,7 +398,7 @@ export async function generateAddressSpaceRaw(
         doDebug && debugLog(" loading ", nodesetIndex, nodeset.reader.name);
         try {
             if (nodeset.image) {
-                await nodesetLoader.addRecords(imageNodesetRecords(nodeset.image));
+                await nodesetLoader.addRecords(imageLinesToRecords(await inflatedImageLines(nodeset.image)));
             } else {
                 await loadXmlSource(nodesetLoader, nodeset.reader, store);
             }

--- a/packages/node-opcua-address-space/api/loader/load_nodeset2.ts
+++ b/packages/node-opcua-address-space/api/loader/load_nodeset2.ts
@@ -15,9 +15,9 @@ import type { NamespacePrivate } from "../../impl/namespace_private.js";
 import type { NodeSetLoaderOptions } from "../interfaces/nodeset_loader_options.js";
 import { ensureDatatypeExtracted } from "./ensure_datatype_extracted.js";
 import { promoteObjectsAndVariables } from "./namespace_post_step.js";
-import { type NodesetRecordProducer, type NodesetRecordWithBytes, recordBytes } from "./nodeset_record.js";
+import { type NodesetRecord, type NodesetRecordProducer, type NodesetRecordWithBytes, recordBytes } from "./nodeset_record.js";
 import { type LoaderTaskQueues, makeLoaderTaskQueues, NodesetRecordApplier, type Task } from "./nodeset_record_applier.js";
-import { xmlNodesetRecords } from "./nodeset_xml_producer.js";
+import { makeXmlNodesetRecordReader } from "./nodeset_xml_producer.js";
 
 const doDebug = checkDebugFlag("load_nodeset2");
 const debugLog = make_debugLog("load_nodeset2");
@@ -80,30 +80,72 @@ export class NodeSetLoader {
         await this.addNodeSetStream([xmlData]);
     }
 
-    /** load a document delivered as text chunks; see {@link NodesetSource} */
+    /**
+     * load a document delivered as text chunks; see {@link NodesetSource}. The records a chunk
+     * completes are applied together: one turn of the microtask queue per chunk, not per record
+     */
     async addNodeSetStream(chunks: AsyncIterable<string> | Iterable<string>): Promise<void> {
-        await this.addRecords(xmlNodesetRecords(chunks));
+        const reader = makeXmlNodesetRecordReader();
+        try {
+            for await (const chunk of chunks) {
+                await this.applyAll(reader.write(chunk));
+            }
+            await this.applyAll(reader.end());
+        } catch (err) {
+            this.failed();
+            throw err;
+        }
     }
 
-    /** load a document from any producer of records: the XML reader, or a replayed image */
-    async addRecords(records: NodesetRecordProducer): Promise<void> {
-        const budget = this.yieldEveryBytes;
-        let sinceLastYield = 0;
+    /**
+     * load a document from any producer of records: the XML reader, or a replayed image. A
+     * synchronous iterable (an image given whole) is consumed without a microtask per record.
+     */
+    async addRecords(records: NodesetRecordProducer | Iterable<NodesetRecord>): Promise<void> {
         try {
-            for await (const record of records) {
-                this.applier.apply(record);
-                sinceLastYield += (record as NodesetRecordWithBytes)[recordBytes] ?? 0;
-                if (budget > 0 && sinceLastYield >= budget) {
-                    sinceLastYield = 0;
+            if (Symbol.iterator in records) {
+                await this.applyAll(records as Iterable<NodesetRecord>);
+                return;
+            }
+            for await (const record of records as NodesetRecordProducer) {
+                this.applyOne(record);
+                if (this.yieldDue()) {
                     await yieldToEventLoop();
                 }
             }
         } catch (err) {
-            // the address space holds what was loaded before the failure and must be disposed;
-            // it is not left in the middle of a load
-            this.addressSpace.suspendBackReference = false;
+            this.failed();
             throw err;
         }
+    }
+
+    private sinceLastYield = 0;
+
+    private applyOne(record: NodesetRecord): void {
+        this.applier.apply(record);
+        this.sinceLastYield += (record as NodesetRecordWithBytes)[recordBytes] ?? 0;
+    }
+
+    private yieldDue(): boolean {
+        if (this.yieldEveryBytes > 0 && this.sinceLastYield >= this.yieldEveryBytes) {
+            this.sinceLastYield = 0;
+            return true;
+        }
+        return false;
+    }
+
+    private async applyAll(records: Iterable<NodesetRecord>): Promise<void> {
+        for (const record of records) {
+            this.applyOne(record);
+            if (this.yieldDue()) {
+                await yieldToEventLoop();
+            }
+        }
+    }
+
+    /** the address space holds what was loaded before the failure and must be disposed; it is not left in the middle of a load */
+    private failed(): void {
+        this.addressSpace.suspendBackReference = false;
     }
 
     async terminate(): Promise<void> {

--- a/packages/node-opcua-address-space/api/loader/nodeset_image.ts
+++ b/packages/node-opcua-address-space/api/loader/nodeset_image.ts
@@ -64,8 +64,42 @@ async function gzip(text: string): Promise<Uint8Array> {
     return new Uint8Array(await new Response(compressed).arrayBuffer());
 }
 
+/**
+ * the lines of an image given whole, inflated once and kept as long as the image bytes live: the
+ * sibling check, the header pre-pass and the replay all read the same buffer, and one inflate with
+ * a native split is half the cost of the streaming reader on a 3.5 MB text
+ */
+const imageLines = new WeakMap<Uint8Array, Promise<string[]>>();
+const NEWLINE = String.fromCharCode(10);
+
+export function inflatedImageLines(image: Uint8Array): Promise<string[]> {
+    let lines = imageLines.get(image);
+    if (!lines) {
+        lines = (async () => {
+            let text: string;
+            try {
+                const inflated = new Blob([image as BlobPart])
+                    .stream()
+                    .pipeThrough(new DecompressionStream("gzip") as unknown as ReadableWritablePair<Uint8Array, Uint8Array>);
+                text = new TextDecoder("utf-8").decode(await new Response(inflated).arrayBuffer());
+            } catch (err) {
+                throw new NodesetImageError(`the image cannot be inflated: ${(err as Error).message}`);
+            }
+            return text.split(NEWLINE);
+        })();
+        imageLines.set(image, lines);
+        // a failed inflate is not worth remembering
+        lines.catch(() => imageLines.delete(image));
+    }
+    return lines;
+}
+
 /** the lines of a gzip-compressed text, as they inflate */
 async function* inflatedLines(source: Uint8Array | NodesetChunkStream): AsyncGenerator<string> {
+    if (source instanceof Uint8Array) {
+        yield* await inflatedImageLines(source);
+        return;
+    }
     const stream = (await toReadableStream(source)).pipeThrough(
         new DecompressionStream("gzip") as unknown as ReadableWritablePair<Uint8Array, Uint8Array>
     );
@@ -173,14 +207,34 @@ export async function* imageNodesetRecords(
     image: Uint8Array | NodesetChunkStream,
     options: ReadNodesetImageOptions = {}
 ): AsyncGenerator<NodesetRecord> {
-    let nodes = 0;
-    let trailer: NodesetImageTrailer | undefined;
-    let first = true;
+    if (image instanceof Uint8Array) {
+        yield* imageLinesToRecords(await inflatedImageLines(image), options);
+        return;
+    }
+    const reader = new ImageLineReader(options);
     for await (const line of inflatedLines(image)) {
-        if (line.length === 0) {
-            continue;
+        const record = reader.read(line);
+        if (record) {
+            yield record;
         }
-        if (trailer) {
+    }
+    reader.end();
+}
+
+/** one image line to a record, the trailer checked when it comes; shared by the two iterators */
+class ImageLineReader {
+    private nodes = 0;
+    private trailer: NodesetImageTrailer | undefined;
+    private first = true;
+
+    constructor(private readonly options: ReadNodesetImageOptions) {}
+
+    /** the record of a line, or undefined for a blank line or the trailer */
+    public read(line: string): NodesetRecord | undefined {
+        if (line.length === 0) {
+            return undefined;
+        }
+        if (this.trailer) {
             throw new NodesetImageError("an image carries nothing after its trailer");
         }
         let json: unknown;
@@ -189,34 +243,52 @@ export async function* imageNodesetRecords(
         } catch (err) {
             throw new NodesetImageError(`an image line is not JSON: ${(err as Error).message}`);
         }
-        if (first) {
-            first = false;
+        if (this.first) {
+            this.first = false;
             const record: NodesetRecordWithBytes = decodeHeader(json as NodesetImageHeader);
             record[recordBytes] = line.length;
-            yield record;
-            continue;
+            return record;
         }
         if ((json as { kind?: string }).kind === "trailer") {
-            trailer = json as NodesetImageTrailer;
-            if (trailer.nodes !== nodes) {
-                throw new NodesetImageError(`the image trailer announces ${trailer.nodes} nodes, ${nodes} were read`);
+            const trailer = json as NodesetImageTrailer;
+            if (trailer.nodes !== this.nodes) {
+                throw new NodesetImageError(`the image trailer announces ${trailer.nodes} nodes, ${this.nodes} were read`);
             }
-            if (options.expectedDigest !== undefined && trailer.sourceDigest !== options.expectedDigest) {
+            if (this.options.expectedDigest !== undefined && trailer.sourceDigest !== this.options.expectedDigest) {
                 throw new NodesetImageError("the image was built from another source (digest mismatch)");
             }
-            continue;
+            this.trailer = trailer;
+            return undefined;
         }
         const record: NodesetRecordWithBytes = decodeNode(json as NodesetImageNode);
         record[recordBytes] = line.length;
-        nodes += 1;
-        yield record;
+        this.nodes += 1;
+        return record;
     }
-    if (first) {
-        throw new NodesetImageError("the image is empty");
+
+    public end(): void {
+        if (this.first) {
+            throw new NodesetImageError("the image is empty");
+        }
+        if (!this.trailer) {
+            throw new NodesetImageError("the image is truncated: no trailer");
+        }
     }
-    if (!trailer) {
-        throw new NodesetImageError("the image is truncated: no trailer");
+}
+
+/**
+ * the records of an image given whole, as a synchronous iterator: what the loader consumes
+ * without a turn of the microtask queue per record. The lines come from {@link inflatedImageLines}.
+ */
+export function* imageLinesToRecords(lines: string[], options: ReadNodesetImageOptions = {}): Generator<NodesetRecord> {
+    const reader = new ImageLineReader(options);
+    for (const line of lines) {
+        const record = reader.read(line);
+        if (record) {
+            yield record;
+        }
     }
+    reader.end();
 }
 
 /** the header and the trailer of an image; the body lines are inflated but not parsed */

--- a/packages/node-opcua-address-space/api/loader/nodeset_record_applier.ts
+++ b/packages/node-opcua-address-space/api/loader/nodeset_record_applier.ts
@@ -703,6 +703,16 @@ export class NodesetRecordApplier implements NodesetRecordConsumer {
 
         const addressSpace = this.addressSpace;
         let capturedVariable: UAVariable | undefined;
+        // the value can be set now when its data type is already in the address space: nothing
+        // else in the post-load steps runs before it; only an extension object waits for the
+        // data types to be extracted
+        const dataType = this.translateOrNull(record.dataType);
+        const dataTypeReady = dataType !== null && value?.dataType !== DataType.ExtensionObject && this.isDataTypeReady(dataType);
+        if (dataTypeReady) {
+            const variable = this.createNode(params) as UAVariable;
+            this.setInitialValueNow(variable, value);
+            return;
+        }
         if (value && value.dataType !== DataType.Null) {
             let capturedValue: VariantOptions | undefined = value;
             const task = async (_addressSpace2: IAddressSpace) => {
@@ -740,6 +750,49 @@ export class NodesetRecordApplier implements NodesetRecordConsumer {
             this.queues.postTasks0_InitializeVariable.push(task);
         }
         capturedVariable = this.createNode(params) as UAVariable;
+    }
+
+    /** a data type node whose basic type resolves: what an initial value needs to be checked against */
+    private isDataTypeReady(dataType: NodeId): boolean {
+        const node = this.addressSpace.findNode(dataType) as UADataType | null;
+        if (!node || node.nodeClass !== NodeClass.DataType) {
+            return false;
+        }
+        try {
+            return node.basicDataType !== undefined;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * what the "initializing simple variables" post task does, done at creation; a value the
+     * variable refuses is logged and skipped, as the post task would
+     */
+    private setInitialValueNow(variable: UAVariable, value: VariantOptions | undefined): void {
+        try {
+            if (value && value.dataType !== DataType.Null) {
+                (variable as UAVariableImpl)._setInitialDataValue(value);
+                return;
+            }
+            const defaultValue = makeDefaultVariant(
+                this.addressSpace,
+                variable.dataType,
+                variable.valueRank,
+                variable.arrayDimensions
+            );
+            if (defaultValue) {
+                if (defaultValue.dataType === DataType.Null || isUninitializedMatrix(defaultValue)) {
+                    (variable as UAVariableImpl)._setInitialDataValue(defaultValue, StatusCodes.BadWaitingForInitialData);
+                } else {
+                    (variable as UAVariableImpl)._setInitialDataValue(defaultValue, StatusCodes.Good);
+                }
+            }
+        } catch (err) {
+            errorLog(
+                `[NODE-OPCUA-W36] generateAddressSpace: post-loading task failed during "initializing simple variables" and was skipped: ${(err as Error).message}`
+            );
+        }
     }
 
     private applyVariableType(record: NodesetNodeRecord): void {


### PR DESCRIPTION
Follow-up to #1609 (FEAT-11 and FEAT-12 of the NodeSet2 loading project), the two items ranked first after the idle-machine profile.

## What changes

- **One inflate per image.** The default `generateAddressSpace` path inflated a catalog image three times (sibling validation, header pre-pass, replay) and parsed it through the streaming reader with one microtask turn per record. An image given whole is now inflated once (`inflatedImageLines`, cached for as long as the image bytes live) and replayed through a synchronous iterator (`imageLinesToRecords`); the streaming reader stays for chunked sources.
- **Records applied per chunk on the XML path.** `addNodeSetStream` applies the records a chunk completes together: one microtask turn per chunk instead of per record.
- **Initial values at creation.** A variable whose data type is already in the address space gets its value, or its default, when it is created instead of through the "initializing simple variables" post-load task. An extension object still waits for the data types to be extracted; a refused value is logged and skipped exactly as the task did.

## Numbers (standard nodeset, best of 7 alternating, idle machine)

| | before | after |
|---|---|---|
| image replay vs XML | 107 ms vs 151 ms (29%) | 82 ms vs 149 ms (45%) |
| default `generateAddressSpace` (catalog image beside the XML) vs `imageStore: false` | 130 ms vs 150 ms (13%) | 98 ms vs 144 ms (32%) |
| six-file companion chain, image vs XML | 28% | 42% |
| six-file chain, default path | 24% | 33% |

Phase split of an image load: the records phase drops from 44 ms to 32 ms; the value work moves from the post-load phase into creation.

## Verification

address-space 1241, server 474, server-configuration 145, modeler, converter, crawler; the catalog digest fixture (31 chains through their images) unchanged; lint, test types, cycles and entry points clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)