### PR TITLE
fix(address-space,xml2json): cache and map hygiene from the 2026-09-03 review (FEAT-14)

### DIFF
--- a/packages/node-opcua-address-space/CHANGELOG.md
+++ b/packages/node-opcua-address-space/CHANGELOG.md
@@ -251,6 +251,29 @@ can be set to `"deny"` by products that drive access entirely from declared poli
 
 ### Fixed
 
+#### The caches behind the load-time speedups are bounded, invalidated and shared correctly
+
+A review of the memos and registries added with the loading performance work found eight places where
+retained memory or a stale answer could outlive what it described. All are fixed, each with a regression test.
+
+- A memoized `findReferencesEx` scan resolves a target created after the scan: `instantiate` and `deleteNode`
+  read `ref.node` of a target that existed and found `null`.
+- The scan memo and the child index follow a reference type that gains a `HasSubtype` link at runtime (a
+  companion nodeset loaded on a live server, or the namespace API): a node with many references was blind to
+  the new subtype while a small one saw it.
+- `findReferencesEx` and `findReferences` return frozen arrays on a memo hit: a caller that changed one used to
+  change what every later caller saw.
+- The accessor-name registries hold the vocabulary of the loaded nodesets only: a server creating and deleting
+  uniquely named nodes at runtime grew them by one entry per name, for ever.
+- The inflated lines of a nodeset image are released once its replay is done: a `MemoryNodesetImageStore` at
+  its 64 MiB cap could pin twelve times that in text.
+- The `isSubtypeOf` memo is keyed by NodeId, not by the node asked about: a type created and deleted at runtime
+  stayed reachable through the memos of the types it was compared with.
+- An own child accessor (a runtime name) that later gets a shared getter answers through the child index and
+  goes with its child; it used to keep returning the deleted node and hide its replacement.
+- A nodeset loaded into an address space already in use no longer throws "reference exists already in
+  _back_references" from the end-of-load sweep.
+
 #### The `UserAccessLevel` attribute of a `UAVariable` is no longer lost by the NodeSet2 serialisation layer ([#1552](https://github.com/node-opcua/node-opcua/issues/1552))
 
 Sibling of [#1550](https://github.com/node-opcua/node-opcua/issues/1550), in the same two files.

--- a/packages/node-opcua-address-space/api/loader/generateAddressSpaceRaw.ts
+++ b/packages/node-opcua-address-space/api/loader/generateAddressSpaceRaw.ts
@@ -12,7 +12,8 @@ import {
     inflatedImageLines,
     NodesetImageError,
     NodesetImageWriter,
-    readNodesetImageInfo
+    readNodesetImageInfo,
+    releaseInflatedImageLines
 } from "./nodeset_image.js";
 import { decodeHeader } from "./nodeset_image_codec.js";
 import { type NodesetImageStore, nodesetImageKey, sharedMemoryNodesetImageStore } from "./nodeset_image_store.js";
@@ -240,7 +241,11 @@ async function loadXmlSource(
         if (image && (await isReplayable(image, digest, reader.name))) {
             // a replay that fails half-way would leave nodes behind that the XML would then
             // collide with; the check above is what makes it safe to commit to the image here
-            await nodesetLoader.addRecords(imageLinesToRecords(await inflatedImageLines(image), { expectedDigest: digest }));
+            try {
+                await nodesetLoader.addRecords(imageLinesToRecords(await inflatedImageLines(image), { expectedDigest: digest }));
+            } finally {
+                releaseInflatedImageLines(image);
+            }
             doDebug && debugLog("loaded", reader.name, "from its image", key);
             return;
         }
@@ -398,7 +403,11 @@ export async function generateAddressSpaceRaw(
         doDebug && debugLog(" loading ", nodesetIndex, nodeset.reader.name);
         try {
             if (nodeset.image) {
-                await nodesetLoader.addRecords(imageLinesToRecords(await inflatedImageLines(nodeset.image)));
+                try {
+                    await nodesetLoader.addRecords(imageLinesToRecords(await inflatedImageLines(nodeset.image)));
+                } finally {
+                    releaseInflatedImageLines(nodeset.image);
+                }
             } else {
                 await loadXmlSource(nodesetLoader, nodeset.reader, store);
             }

--- a/packages/node-opcua-address-space/api/loader/nodeset_image.ts
+++ b/packages/node-opcua-address-space/api/loader/nodeset_image.ts
@@ -66,11 +66,23 @@ async function gzip(text: string): Promise<Uint8Array> {
 }
 
 /**
- * the lines of an image given whole, inflated once and kept as long as the image bytes live: the
- * sibling check, the header pre-pass and the replay all read the same buffer, and one inflate with
- * a native split is half the cost of the streaming reader on a 3.5 MB text
+ * the lines of an image given whole, inflated once and kept for the load: the sibling check, the
+ * header pre-pass and the replay all read the same buffer, and one inflate with a native split is
+ * half the cost of the streaming reader on a 3.5 MB text. The replay releases them (see
+ * {@link releaseInflatedImageLines}): the bytes may live on in an image store, which is sized by
+ * what it holds compressed, and the lines are twelve times as large
  */
 const imageLines = new WeakMap<Uint8Array, Promise<string[]>>();
+
+/** forget the inflated lines of `image`; the next reader inflates again */
+export function releaseInflatedImageLines(image: Uint8Array): void {
+    imageLines.delete(image);
+}
+
+/** whether the inflated lines of `image` are being kept, for the tests */
+export function hasInflatedImageLines(image: Uint8Array): boolean {
+    return imageLines.has(image);
+}
 const NEWLINE = String.fromCharCode(10);
 
 export function inflatedImageLines(image: Uint8Array): Promise<string[]> {
@@ -241,7 +253,11 @@ export async function* imageNodesetRecords(
     options: ReadNodesetImageOptions = {}
 ): AsyncGenerator<NodesetRecord> {
     if (image instanceof Uint8Array) {
-        yield* imageLinesToRecords(await inflatedImageLines(image), options);
+        try {
+            yield* imageLinesToRecords(await inflatedImageLines(image), options);
+        } finally {
+            releaseInflatedImageLines(image);
+        }
         return;
     }
     const reader = new ImageLineReader(options);

--- a/packages/node-opcua-address-space/api/loader/nodeset_image_store.ts
+++ b/packages/node-opcua-address-space/api/loader/nodeset_image_store.ts
@@ -21,7 +21,11 @@ export function nodesetImageKey(sourceDigest: string): string {
     return `${NODESET_RECORD_SCHEMA}-${sourceDigest}`;
 }
 
-/** an in-memory store: for browsers, tests, and a process that loads the same files repeatedly */
+/**
+ * an in-memory store: for browsers, tests, and a process that loads the same files repeatedly.
+ * The size cap counts the compressed bytes, which is all the store retains per entry: the loader
+ * inflates an image for one load and lets the lines go afterwards
+ */
 export class MemoryNodesetImageStore implements NodesetImageStore {
     private readonly images = new Map<string, Uint8Array>();
 

--- a/packages/node-opcua-address-space/api/loader/nodeset_record_applier.ts
+++ b/packages/node-opcua-address-space/api/loader/nodeset_record_applier.ts
@@ -211,8 +211,6 @@ function isMassivelyUsedReferenceType(referenceType: NodeId): boolean {
 }
 
 export class NodesetRecordApplier implements NodesetRecordConsumer {
-    /** what references() found about the record being applied, consumed by createNode */
-    private lastReferences: { pending: UAReference[]; unknown: boolean } | undefined;
     /** the back references the load owes, and the nodes it owes nothing else for; see takePendingBackReferences */
     private pending: PendingBackReferences = { settled: new Set(), references: [] };
 
@@ -516,31 +514,40 @@ export class NodesetRecordApplier implements NodesetRecordConsumer {
         };
     }
 
-    /**
-     * the node's references as the node will hold them, and what the end of the load must do about
-     * their inverses: a reference the document marks as not declared from the other end is kept for
-     * one propagation, and the node is settled; a node whose references carry no such information
-     * is left to the end-of-load sweep, which propagates it whole
-     */
+    /** the node's references as the node will hold them, one per reference of the record, in its order */
     private references(record: NodesetNodeRecord): UAReference[] {
-        const references: UAReference[] = [];
+        return record.references.map(
+            (r) =>
+                new ReferenceImpl({
+                    isForward: r.isForward,
+                    nodeId: this.translate(r.nodeId),
+                    referenceType: this.translate(r.referenceType)
+                })
+        );
+    }
+
+    /**
+     * what the end of the load must do about the inverses of a node's references: a reference the
+     * document marks as not declared from the other end is kept for one propagation, and the node
+     * is settled; a node whose references carry no such information is left to the end-of-load
+     * sweep, which propagates it whole. `references` are those built by {@link references} from
+     * the same record, in the same order.
+     */
+    private settle(node: BaseNode, record: NodesetNodeRecord, references: UAReference[]): void {
         const pending: UAReference[] = [];
-        let unknown = false;
-        for (const r of record.references) {
-            const reference = new ReferenceImpl({
-                isForward: r.isForward,
-                nodeId: this.translate(r.nodeId),
-                referenceType: this.translate(r.referenceType)
-            });
-            references.push(reference);
-            if (r.inverseDeclared === undefined) {
-                unknown = true;
-            } else if (!r.inverseDeclared && !isMassivelyUsedReferenceType(reference.referenceType)) {
-                pending.push(reference);
+        for (let i = 0; i < references.length; i++) {
+            const declared = record.references[i].inverseDeclared;
+            if (declared === undefined) {
+                return;
+            }
+            if (!declared && !isMassivelyUsedReferenceType(references[i].referenceType)) {
+                pending.push(references[i]);
             }
         }
-        this.lastReferences = { pending, unknown };
-        return references;
+        this.pending.settled.add(node);
+        for (const reference of pending) {
+            this.pending.references.push([node, reference]);
+        }
     }
 
     /**
@@ -555,25 +562,14 @@ export class NodesetRecordApplier implements NodesetRecordConsumer {
         return pending;
     }
 
-    private createNode(params: CreateNodeOptions): BaseNode {
+    private createNode(params: CreateNodeOptions, record: NodesetNodeRecord): BaseNode {
         // c8 ignore next
         if (!(params.nodeId instanceof NodeId)) {
             throw new Error("invalid param expecting a valid nodeId");
         } // already translated
         const namespace = this.addressSpace.getNamespace(params.nodeId.namespace);
         const node = namespace.internalCreateNode(params) as BaseNode;
-        const last = this.lastReferences;
-        // c8 ignore next
-        if (!last) {
-            throw new Error("internal error: createNode without the record's references");
-        }
-        this.lastReferences = undefined;
-        if (!last.unknown) {
-            this.pending.settled.add(node);
-            for (const reference of last.pending) {
-                this.pending.references.push([node, reference]);
-            }
-        }
+        this.settle(node, record, params.references as UAReference[]);
         return node;
     }
 
@@ -583,23 +579,29 @@ export class NodesetRecordApplier implements NodesetRecordConsumer {
         }
         switch (record.nodeClass) {
             case NodeClass.Object:
-                this.createNode({
-                    ...this.common(record),
-                    isAbstract: record.isAbstract,
-                    eventNotifier: record.eventNotifier,
-                    symbolicName: record.symbolicName ?? null,
-                    displayName: record.displayName,
-                    description: record.description
-                } as CreateNodeOptions);
+                this.createNode(
+                    {
+                        ...this.common(record),
+                        isAbstract: record.isAbstract,
+                        eventNotifier: record.eventNotifier,
+                        symbolicName: record.symbolicName ?? null,
+                        displayName: record.displayName,
+                        description: record.description
+                    } as CreateNodeOptions,
+                    record
+                );
                 return;
             case NodeClass.ObjectType:
-                this.createNode({
-                    ...this.common(record),
-                    isAbstract: record.isAbstract,
-                    eventNotifier: record.eventNotifier,
-                    displayName: record.displayName,
-                    description: record.description
-                } as CreateNodeOptions);
+                this.createNode(
+                    {
+                        ...this.common(record),
+                        isAbstract: record.isAbstract,
+                        eventNotifier: record.eventNotifier,
+                        displayName: record.displayName,
+                        description: record.description
+                    } as CreateNodeOptions,
+                    record
+                );
                 return;
             case NodeClass.ReferenceType: {
                 const params = {
@@ -613,7 +615,8 @@ export class NodesetRecordApplier implements NodesetRecordConsumer {
                 if (!(params.nodeId instanceof NodeId)) {
                     throw new Error("invalid param");
                 } // already translated
-                this.addressSpace.getNamespace(params.nodeId.namespace).addReferenceType(params);
+                const node = this.addressSpace.getNamespace(params.nodeId.namespace).addReferenceType(params);
+                this.settle(node, record, params.references as UAReference[]);
                 return;
             }
             case NodeClass.DataType:
@@ -626,21 +629,27 @@ export class NodesetRecordApplier implements NodesetRecordConsumer {
                 this.applyVariableType(record);
                 return;
             case NodeClass.Method:
-                this.createNode({
-                    ...this.common(record),
-                    parentNodeId: this.translateOrNull(record.parentNodeId),
-                    methodDeclarationId: this.translateOrNull(record.methodDeclarationId),
-                    displayName: record.displayName
-                } as CreateNodeOptions);
+                this.createNode(
+                    {
+                        ...this.common(record),
+                        parentNodeId: this.translateOrNull(record.parentNodeId),
+                        methodDeclarationId: this.translateOrNull(record.methodDeclarationId),
+                        displayName: record.displayName
+                    } as CreateNodeOptions,
+                    record
+                );
                 return;
             case NodeClass.View:
-                this.createNode({
-                    ...this.common(record),
-                    containsNoLoops: record.containsNoLoops,
-                    eventNotifier: record.eventNotifier,
-                    displayName: record.displayName,
-                    description: record.description
-                } as CreateNodeOptions);
+                this.createNode(
+                    {
+                        ...this.common(record),
+                        containsNoLoops: record.containsNoLoops,
+                        eventNotifier: record.eventNotifier,
+                        displayName: record.displayName,
+                        description: record.description
+                    } as CreateNodeOptions,
+                    record
+                );
                 return;
             default:
                 throw new Error(`NodesetRecordApplier: unexpected node class ${record.nodeClass}`);
@@ -662,7 +671,7 @@ export class NodesetRecordApplier implements NodesetRecordConsumer {
             partialDefinition: fields
         } as unknown as CreateNodeOptions;
 
-        let capturedDataTypeNode: UADataType | undefined = this.createNode(params) as UADataType;
+        let capturedDataTypeNode: UADataType | undefined = this.createNode(params, record) as UADataType;
         const queues = this.queues;
         const processBasicDataType = async (_addressSpace2: IAddressSpace) => {
             if (!capturedDataTypeNode) return;
@@ -782,7 +791,7 @@ export class NodesetRecordApplier implements NodesetRecordConsumer {
         const dataType = this.translateOrNull(record.dataType);
         const dataTypeReady = dataType !== null && value?.dataType !== DataType.ExtensionObject && this.isDataTypeReady(dataType);
         if (dataTypeReady) {
-            const variable = this.createNode(params) as UAVariable;
+            const variable = this.createNode(params, record) as UAVariable;
             this.setInitialValueNow(variable, value);
             return;
         }
@@ -822,7 +831,7 @@ export class NodesetRecordApplier implements NodesetRecordConsumer {
             };
             this.queues.postTasks0_InitializeVariable.push(task);
         }
-        capturedVariable = this.createNode(params) as UAVariable;
+        capturedVariable = this.createNode(params, record) as UAVariable;
     }
 
     /** a data type node whose basic type resolves: what an initial value needs to be checked against */
@@ -883,7 +892,7 @@ export class NodesetRecordApplier implements NodesetRecordConsumer {
                 record.description !== undefined ? (coerceLocalizedText(record.description || "") ?? undefined) : undefined,
             value
         } as unknown as CreateNodeOptions;
-        this.createNode(params);
+        this.createNode(params, record);
     }
     // #endregion
 }

--- a/packages/node-opcua-address-space/impl/base_node_impl.ts
+++ b/packages/node-opcua-address-space/impl/base_node_impl.ts
@@ -2112,6 +2112,10 @@ export function defineSharedChildAccessors(browseNames: string[]): void {
  *
  * This is the runtime fallback of child_accessors.ts, for names no loaded nodeset declared.
  */
+/** the child an own accessor was installed for, kept on the getter itself */
+const installedFor = Symbol("installedFor");
+type OwnChildAccessor = { [installedFor]?: BaseNode };
+
 function install_child_as_object_property(parentObj: BaseNode | null, child: BaseNode | null): void {
     // the parent may be unresolvable while a nodeset is still loading
     if (!parentObj || !child) {
@@ -2122,24 +2126,29 @@ function install_child_as_object_property(parentObj: BaseNode | null, child: Bas
         return;
     }
     doDebug && debugLog(`Installing property ${name}`, " on ", parentObj.browseName.toString());
+    const get: (() => BaseNode | undefined) & OwnChildAccessor = () =>
+        // an own property wins over the prototype: should the name get a shared getter later
+        // (a nodeset loaded afterwards declares it), this accessor answers what the getter
+        // would, through the child index, rather than the child it was installed for
+        hasSharedChildAccessor(name) ? resolveChildAccessor(parentObj, name) : child;
+    get[installedFor] = child;
     Object.defineProperty(parentObj, name, {
         configurable: true, // so that uninstall_child_object_property can remove it
         enumerable: true,
-        get() {
-            return child;
-        }
+        get
     });
 }
 
 function uninstall_child_object_property(parentObj: BaseNode, child: BaseNode): void {
     const name = BaseNode_getPrivate(child)?._accessorName;
-    if (!name || hasSharedChildAccessor(name)) {
-        return; // the child index already reflects the removal
+    if (!name) {
+        return;
     }
-    // only an accessor installed above goes; a field or a method of the same name stays, and so
-    // does an accessor designating another child of the same name
+    // only an accessor installed above goes, whether or not the name has a shared getter by now;
+    // a field or a method of the same name stays, and so does an accessor for another child of
+    // the same name. The getter is asked for the child it was installed for, not what it resolves
     const descriptor = Object.getOwnPropertyDescriptor(parentObj, name);
-    if (!descriptor?.get || !descriptor.configurable || descriptor.get.call(parentObj) !== child) {
+    if (!descriptor?.get || !descriptor.configurable || (descriptor.get as OwnChildAccessor)[installedFor] !== child) {
         return;
     }
     delete (parentObj as unknown as Record<string, unknown>)[name];

--- a/packages/node-opcua-address-space/impl/base_node_impl.ts
+++ b/packages/node-opcua-address-space/impl/base_node_impl.ts
@@ -77,6 +77,7 @@ import {
     BaseNode_removePrivate,
     BaseNode_toString,
     type HierarchicalIndexMap,
+    type ReferenceScanMemo,
     ToStringBuilder
 } from "./base_node_private.js";
 import {
@@ -467,7 +468,7 @@ export abstract class BaseNodeImpl<T extends BaseNodeEvents & ListenerSignature<
         // The memo goes with the rest of _cache whenever a reference is added or removed, and when
         // a reference type was created since it was built.
         const memoize = _private._referenceIdx.size + _private._back_referenceIdx.size > referenceScanMemoThreshold;
-        let entry: [UAReference[] | undefined, UAReference[] | undefined] | undefined;
+        let entry: ReferenceScanMemo | undefined;
         const slot = isForward ? 0 : 1;
         if (memoize) {
             const _cache = BaseNode_getCache(this);
@@ -480,24 +481,30 @@ export abstract class BaseNodeImpl<T extends BaseNodeEvents & ListenerSignature<
             }
             entry = _cache._refEx.get(referenceTypeNode);
             if (!entry) {
-                entry = [undefined, undefined];
+                entry = [undefined, undefined, false, false];
                 _cache._refEx.set(referenceTypeNode, entry);
             }
             const memoized = entry[slot];
             if (memoized) {
+                if (entry[slot + 2]) {
+                    // a reference was scanned before its target existed: the same answer as a
+                    // fresh scan, which resolves every target it can
+                    entry[slot + 2] = resolveScannedReferences(this.addressSpace, memoized);
+                }
                 return memoized;
             }
         }
 
         const results: UAReference[] = [];
         const addressSpace = this.addressSpace;
+        let unresolved = false;
         const process = (referenceIdx: Map<ReferenceKey, UAReference>) => {
             for (const ref of referenceIdx.values()) {
                 if (ref.isForward === isForward && referenceTypeNode.checkHasSubtype(ref.referenceType)) {
                     // callers read ref.node: resolved here, once per reference, for the references a
                     // load left unresolved (the end-of-load sweep no longer visits every one)
-                    if (!(ref as ReferenceImpl).node) {
-                        resolveReferenceNode(addressSpace, ref);
+                    if (!(ref as ReferenceImpl).node && !resolveReferenceNode(addressSpace, ref)) {
+                        unresolved = true;
                     }
                     results.push(ref);
                 }
@@ -506,8 +513,8 @@ export abstract class BaseNodeImpl<T extends BaseNodeEvents & ListenerSignature<
         process(_private._referenceIdx);
         process(_private._back_referenceIdx);
         if (entry) {
-            // callers iterate the result, they never change it; make a regression loud when debugging
-            entry[slot] = doDebug ? (Object.freeze(results) as UAReference[]) : results;
+            entry[slot] = results;
+            entry[slot + 2] = unresolved;
         }
         return results;
     }
@@ -1829,13 +1836,16 @@ function _propagate_ref(
         // holds the inverse as a forward reference of its own already: nothing to add, and no
         // ReferenceImpl to build for BaseNode_add_backward_reference to throw away. A node
         // created at runtime rarely is, and BaseNode_add_backward_reference copes when it is.
-        if (
-            sourceNodeKey !== undefined &&
-            BaseNode_getPrivate(related_node)._referenceIdx.has(
+        if (sourceNodeKey !== undefined) {
+            const inverse = BaseNode_getPrivate(related_node)._referenceIdx.get(
                 (reference as ReferenceImpl).inverseKey(addressSpace as AddressSpacePrivate, sourceNodeKey)
-            )
-        ) {
-            return;
+            ) as ReferenceImpl | undefined;
+            if (inverse) {
+                if (!inverse.node) {
+                    inverse.node = this;
+                }
+                return;
+            }
         }
         (related_node as BaseNodeImpl)._add_backward_reference(
             new ReferenceImpl({
@@ -1847,6 +1857,17 @@ function _propagate_ref(
             })
         );
     } // else addressSpace may be incomplete and under construction (while loading a nodeset.xml file for instance)
+}
+
+/** resolve what can be; true when a reference still has no target */
+function resolveScannedReferences(addressSpace: IAddressSpace, references: UAReference[]): boolean {
+    let unresolved = false;
+    for (const ref of references) {
+        if (!(ref as ReferenceImpl).node && !resolveReferenceNode(addressSpace, ref)) {
+            unresolved = true;
+        }
+    }
+    return unresolved;
 }
 
 function nodeid_is_nothing(nodeid: NodeId): boolean {

--- a/packages/node-opcua-address-space/impl/base_node_impl.ts
+++ b/packages/node-opcua-address-space/impl/base_node_impl.ts
@@ -77,6 +77,7 @@ import {
     BaseNode_removePrivate,
     BaseNode_toString,
     type HierarchicalIndexMap,
+    noteReferenceTypeChange,
     type ReferenceScanMemo,
     ToStringBuilder
 } from "./base_node_private.js";
@@ -1114,6 +1115,7 @@ export abstract class BaseNodeImpl<T extends BaseNodeEvents & ListenerSignature<
             _remove_HierarchicalReference(this, reference);
             this.uninstall_extra_properties(reference);
             this._clear_caches();
+            noteReferenceTypeChange(this);
         } else if (_private._back_referenceIdx.has(h)) {
             relatedNode.removeReference(backwardReference);
         } else {
@@ -1514,6 +1516,7 @@ export abstract class BaseNodeImpl<T extends BaseNodeEvents & ListenerSignature<
         _handle_HierarchicalReference(this, reference);
         if (clearCaches) {
             this._clear_caches();
+            noteReferenceTypeChange(this);
         }
         return reference;
     }

--- a/packages/node-opcua-address-space/impl/base_node_impl.ts
+++ b/packages/node-opcua-address-space/impl/base_node_impl.ts
@@ -514,7 +514,9 @@ export abstract class BaseNodeImpl<T extends BaseNodeEvents & ListenerSignature<
         process(_private._referenceIdx);
         process(_private._back_referenceIdx);
         if (entry) {
-            entry[slot] = results;
+            // the array is handed out again on every hit: frozen, so that a caller changing it
+            // fails loudly rather than changing what every later caller sees
+            entry[slot] = Object.freeze(results) as UAReference[];
             entry[slot + 2] = unresolved;
         }
         return results;
@@ -561,7 +563,7 @@ export abstract class BaseNodeImpl<T extends BaseNodeEvents & ListenerSignature<
         if (doDebug && !this.addressSpace.findReferenceType(referenceTypeNode.nodeId)) {
             throw new Error(`expecting valid reference name ${referenceType}`);
         }
-        const result = this.findReferences_no_cache(referenceTypeNode, isForward);
+        const result = Object.freeze(this.findReferences_no_cache(referenceTypeNode, isForward)) as UAReference[];
         _cache._ref.set(hash, result);
         return result;
     }

--- a/packages/node-opcua-address-space/impl/base_node_private.ts
+++ b/packages/node-opcua-address-space/impl/base_node_private.ts
@@ -40,6 +40,7 @@ import type { AddressSpacePrivate } from "./address_space_private.js";
 import { BaseNodeImpl, getReferenceType } from "./base_node_impl.js";
 import { UANamespace_process_modelling_rule } from "./namespace_private.js";
 import { ReferenceImpl, type ReferenceKey } from "./reference_impl.js";
+import { referenceTypeVersion } from "./reference_type_version.js";
 import { wipeMemorizedStuff } from "./tool_isSubtypeOf.js";
 
 const errorLog = make_errorLog("address-space:BaseNode");
@@ -94,6 +95,11 @@ interface BaseNodeCache {
      * address space yet): the index is rebuilt on the next lookup instead of missing a child
      */
     _childByNameMapIncomplete?: boolean;
+    /**
+     * the reference-type hierarchy the index was built against (referenceTypeVersion.count): a
+     * reference of a type that became hierarchical since is not in it, so it is rebuilt
+     */
+    _childByNameMapVersion?: number;
     __address_space: IAddressSpace | null;
     _browseFilter?: (this: BaseNode, context?: ISessionContext) => boolean;
     /** created on first use: a node that is never looked at pays nothing here */
@@ -1248,7 +1254,11 @@ export function _handle_HierarchicalReference(node: BaseNode, reference: UARefer
  */
 export function _get_HierarchicalReference(node: BaseNode): HierarchicalIndexMap {
     const _private = BaseNode_getPrivate(node);
-    if (_private._childByNameMap && !_private._childByNameMapIncomplete) {
+    if (
+        _private._childByNameMap &&
+        !_private._childByNameMapIncomplete &&
+        _private._childByNameMapVersion === referenceTypeVersion.count
+    ) {
         return _private._childByNameMap;
     }
     const addressSpace = node.addressSpace as AddressSpacePrivate;
@@ -1266,6 +1276,7 @@ export function _get_HierarchicalReference(node: BaseNode): HierarchicalIndexMap
     }
     if (complete && !addressSpace.suspendBackReference) {
         _private._childByNameMap = map;
+        _private._childByNameMapVersion = referenceTypeVersion.count;
     } else {
         _private._childByNameMap = undefined;
     }
@@ -1350,8 +1361,19 @@ export function BaseNode_remove_backward_reference(this: BaseNodeImpl, reference
         _private._back_referenceIdx.delete(h);
         // the memoized reference scans of this node listed the reference just removed
         BaseNode_clearCache(this);
+        noteReferenceTypeChange(this);
     }
     (<ReferenceImpl>reference).dispose();
+}
+
+/**
+ * a reference added to or removed from a reference type may move it in the hierarchy (a
+ * HasSubtype link made at runtime): every memo built against the hierarchy is then stale
+ */
+export function noteReferenceTypeChange(node: BaseNode): void {
+    if (node.nodeClass === NodeClass.ReferenceType) {
+        referenceTypeVersion.count += 1;
+    }
 }
 
 export function BaseNode_add_backward_reference(this: BaseNodeImpl, reference: UAReference): void {
@@ -1368,15 +1390,15 @@ export function BaseNode_add_backward_reference(this: BaseNodeImpl, reference: U
         }
         return;
     }
-    // c8 ignore next
-    if (_private._back_referenceIdx.has(h)) {
-        const opts = { addressSpace: this.addressSpace };
-        warningLog(" Warning !", this.browseName.toString());
-        warningLog("    ", reference.toString(opts));
-        warningLog(" already found in ===>");
-        warningLog([..._private._back_referenceIdx.values()].map((c: UAReference) => c.toString(opts)).join("\n"));
-        warningLog("===>");
-        throw new Error("reference exists already in _back_references");
+    const backward = _private._back_referenceIdx.get(h) as ReferenceImpl | undefined;
+    if (backward) {
+        // installed by an earlier propagation: the end-of-load sweep visits every namespace, so a
+        // nodeset loaded into an address space already in use meets the back references of the
+        // first load. The same back reference twice is nothing to add
+        if (!backward.node) {
+            backward.node = (reference as ReferenceImpl).node || (this.addressSpace.findNode(reference.nodeId) as BaseNode);
+        }
+        return;
     }
 
     if (!getReferenceType(reference)) {
@@ -1387,6 +1409,7 @@ export function BaseNode_add_backward_reference(this: BaseNodeImpl, reference: U
         _private._back_referenceIdx = new Map();
     }
     _private._back_referenceIdx.set(h, reference);
+    noteReferenceTypeChange(this);
     _handle_HierarchicalReference(this, reference);
     BaseNode_clearCache(this);
 }

--- a/packages/node-opcua-address-space/impl/base_node_private.ts
+++ b/packages/node-opcua-address-space/impl/base_node_private.ts
@@ -67,7 +67,7 @@ interface BaseNodeCacheInner {
      * dropped with the rest of the cache on every reference added or removed, and when the
      * reference-type hierarchy moved (`_refExVersion`)
      */
-    _refEx?: Map<UAReferenceType, [UAReference[] | undefined, UAReference[] | undefined]>;
+    _refEx?: Map<UAReferenceType, ReferenceScanMemo>;
     _refExVersion?: number;
     _encoding?: Map<string, UAObject | null>;
     _subtype_idx?: Map<number | string, UAReferenceType> | null;
@@ -79,6 +79,13 @@ interface BaseNodeCacheInner {
 
 export type UAReferenceWithNodeRef = UAReference & { node: BaseNode };
 export type HierarchicalIndexMap = Map<string, UAReferenceWithNodeRef | UAReferenceWithNodeRef[]>;
+
+/**
+ * the memoized scans of one node for one reference type: forward, inverse, and for each whether
+ * a reference in it still waits for its target (the target may be created after the scan; the
+ * memo then resolves it on the next hit rather than hand out a reference without a node)
+ */
+export type ReferenceScanMemo = [UAReference[] | undefined, UAReference[] | undefined, boolean, boolean];
 
 interface BaseNodeCache {
     _childByNameMap?: HierarchicalIndexMap;
@@ -1351,10 +1358,14 @@ export function BaseNode_add_backward_reference(this: BaseNodeImpl, reference: U
     const _private = BaseNode_getPrivate(this);
     const h = (<ReferenceImpl>reference).key(this.addressSpace as AddressSpacePrivate);
     // c8 ignore next
-    if (_private._referenceIdx.has(h)) {
-        //  the reference exists already in the forward references
-        //  this append for instance when the XML NotSetFile has redundant <UAReference>
-        //  in this case there is nothing to do
+    const forward = _private._referenceIdx.get(h) as ReferenceImpl | undefined;
+    if (forward) {
+        // the reference exists already among the forward references: a NodeSet2 file declares
+        // most references from both ends. Nothing to add, but the forward reference may have
+        // been added before its target existed (and memoized as such): the target is here now
+        if (!forward.node) {
+            forward.node = (reference as ReferenceImpl).node || (this.addressSpace.findNode(reference.nodeId) as BaseNode);
+        }
         return;
     }
     // c8 ignore next

--- a/packages/node-opcua-address-space/impl/child_accessors.ts
+++ b/packages/node-opcua-address-space/impl/child_accessors.ts
@@ -30,8 +30,10 @@ const forbiddenNames = new Set(["then", "catch", "finally", "toJSON", "length", 
 /**
  * accessor name -> the browse names mapping to it that cannot be derived back from it.
  * `enabledState` needs no entry (`EnabledState` is the accessor name capitalised, and a name that
- * is already lower case maps to itself), so a model with a hundred thousand runtime names costs
- * nothing here; `euRange` does (`EURange`), and so does a name with an underscore.
+ * is already lower case maps to itself); `euRange` does (`EURange`), and so does a name with an
+ * underscore. Only the shared getters read this map, so it holds the names a nodeset declared
+ * and the runtime names those getters resolve: a model with a hundred thousand runtime names
+ * costs nothing here.
  */
 const irregularBrowseNames = new Map<string, string[]>();
 
@@ -90,7 +92,11 @@ export function isReservedChildAccessorName(accessorName: string): boolean {
  * name back to it; with `requestShared`, also queue a shared getter for it, to be defined by the
  * next {@link defineSharedChildAccessors}.
  */
-/** browse name to accessor name, computed once: a nodeset repeats a few hundred names over thousands of nodes */
+/**
+ * browse name to accessor name, computed once for the names a nodeset declares: a nodeset repeats
+ * a few hundred names over thousands of nodes. A name first seen at runtime is computed and not
+ * remembered: it is seen once, and a server naming its nodes per job must leave no trace here.
+ */
 const accessorNameOf = new Map<string, string>();
 
 export function registerChildName(browseName: string | null | undefined, requestShared: boolean): string | undefined {
@@ -98,22 +104,43 @@ export function registerChildName(browseName: string | null | undefined, request
         return undefined;
     }
     let accessorName = accessorNameOf.get(browseName);
-    if (accessorName === undefined) {
-        accessorName = childAccessorName(browseName);
-        if (browseName !== accessorName && browseName !== upperFirstLetter(accessorName)) {
-            const known = irregularBrowseNames.get(accessorName);
-            if (!known) {
-                irregularBrowseNames.set(accessorName, [browseName]);
-            } else if (!known.includes(browseName)) {
-                known.push(browseName);
-            }
-        }
-        accessorNameOf.set(browseName, accessorName);
+    if (accessorName !== undefined) {
+        return accessorName;
     }
-    if (requestShared && !sharedAccessors.has(accessorName)) {
-        pendingSharedAccessors.add(accessorName);
+    accessorName = childAccessorName(browseName);
+    // a shared getter resolves the child by browse name through the index: it must know the
+    // irregular spellings of the names it serves, whether a nodeset or the runtime brought them.
+    // A runtime name with no shared getter is served by an own accessor that holds its child
+    const shared = requestShared || sharedAccessors.has(accessorName);
+    if (shared && browseName !== accessorName && browseName !== upperFirstLetter(accessorName)) {
+        const known = irregularBrowseNames.get(accessorName);
+        if (!known) {
+            irregularBrowseNames.set(accessorName, [browseName]);
+        } else if (!known.includes(browseName)) {
+            known.push(browseName);
+        }
+    }
+    if (requestShared) {
+        accessorNameOf.set(browseName, accessorName);
+        if (!sharedAccessors.has(accessorName)) {
+            pendingSharedAccessors.add(accessorName);
+        }
     }
     return accessorName;
+}
+
+/** how much the registries hold, for the tests that check they stay bounded by the nodeset vocabulary */
+export function childAccessorRegistrySizes(): { accessorNames: number; irregularNames: number; shared: number; pending: number } {
+    let irregularNames = 0;
+    for (const names of irregularBrowseNames.values()) {
+        irregularNames += names.length;
+    }
+    return {
+        accessorNames: accessorNameOf.size,
+        irregularNames,
+        shared: sharedAccessors.size,
+        pending: pendingSharedAccessors.size
+    };
 }
 
 /**

--- a/packages/node-opcua-address-space/impl/tool_isSubtypeOf.ts
+++ b/packages/node-opcua-address-space/impl/tool_isSubtypeOf.ts
@@ -15,7 +15,7 @@ import { NodeClass } from "node-opcua-data-model";
 import { type NodeId, type NodeIdLike, resolveNodeId, sameNodeId } from "node-opcua-nodeid";
 import type { BaseNodeImpl } from "./base_node_impl.js";
 import { BaseNode_getCache } from "./base_node_private.js";
-import { ReferenceImpl } from "./reference_impl.js";
+import { nodeIdKey, ReferenceImpl } from "./reference_impl.js";
 
 const HasSubTypeNodeId = resolveNodeId("HasSubtype");
 
@@ -65,9 +65,10 @@ function _slow_isSubtypeOf<T extends UAType>(this: T, Class: typeof BaseNodeImpl
 
 export type MemberFuncValue<T, P, R> = (this: T, param: P) => R;
 
-// per node, the memo of its isSubtypeOf answers: a node argument keys by identity, a NodeIdLike
-// argument by its string, so that the common call builds no string at all
-const g_WeakMap = new WeakMap<object, Map<string | object, unknown>>();
+// per node, the memo of its isSubtypeOf answers, keyed by the argument's NodeId (a number for a
+// numeric id, so that the common call builds no string): a memo keyed by the node itself would
+// keep every type ever asked about alive, deleted or not
+const g_WeakMap = new WeakMap<object, Map<string | number, unknown>>();
 
 export function wipeMemorizedStuff(node: object) {
     if (g_WeakMap.has(node)) {
@@ -79,18 +80,18 @@ export function wipeMemorizedStuff(node: object) {
 //  http://addyosmani.com/blog/faster-javascript-memoization/
 function wrap_memoize<T extends object, P, R>(
     func: MemberFuncValue<T, P, R>,
-    hashFunc?: (this: T, param: P) => string | object
+    hashFunc?: (this: T, param: P) => string | number
 ): MemberFuncValue<T, P, R> {
-    const effectiveHashFunc: (this: T, param: P) => string | object =
+    const effectiveHashFunc: (this: T, param: P) => string | number =
         hashFunc ??
         function (this: T, param: P) {
             return (param as unknown as object).toString();
         };
     return function memoize(this: T, param: P): R {
-        let memoMap = g_WeakMap.get(this) as Map<string | object, R> | undefined;
+        let memoMap = g_WeakMap.get(this) as Map<string | number, R> | undefined;
         if (!memoMap) {
-            memoMap = new Map<string | object, R>();
-            g_WeakMap.set(this, memoMap as Map<string | object, unknown>);
+            memoMap = new Map<string | number, R>();
+            g_WeakMap.set(this, memoMap as Map<string | number, unknown>);
         }
 
         const hash = effectiveHashFunc.call(this, param);
@@ -103,11 +104,11 @@ function wrap_memoize<T extends object, P, R>(
     };
 }
 
-function hashBaseNode(e: BaseNode | NodeIdLike): string | object {
+function hashBaseNode(e: BaseNode | NodeIdLike): string | number {
     if (e && typeof e === "object" && "nodeId" in e) {
-        return e;
+        return nodeIdKey((e as BaseNode).nodeId);
     }
-    return resolveNodeId(e as NodeIdLike).toString();
+    return nodeIdKey(resolveNodeId(e as NodeIdLike));
 }
 
 export type IsSubtypeOfFunc<T extends UAType> = (this: T, baseType: T) => boolean;

--- a/packages/node-opcua-address-space/test/test_child_accessor_registries.ts
+++ b/packages/node-opcua-address-space/test/test_child_accessor_registries.ts
@@ -1,0 +1,56 @@
+/**
+ * The registries behind the shared child accessors (browse name to accessor name, and the
+ * irregular spellings a getter must know) hold the vocabulary of the loaded nodesets: a server
+ * that names its nodes per job creates and deletes them for months without growing them.
+ */
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { DataType } from "node-opcua-variant";
+import should from "should";
+import type { AddressSpace, Namespace } from "../dist/api/index.js";
+import { childAccessorRegistrySizes, hasSharedChildAccessor } from "../dist/impl/child_accessors.js";
+import { getMiniAddressSpace } from "../test_helpers/get_mini_address_space.js";
+
+type Dotted = Record<string, unknown>;
+
+describe("the accessor-name registries", function (this: Mocha.Suite) {
+    this.timeout(120000);
+
+    let addressSpace: AddressSpace;
+    let namespace: Namespace;
+    before(async () => {
+        addressSpace = await getMiniAddressSpace();
+        namespace = addressSpace.getOwnNamespace();
+    });
+    after(() => {
+        addressSpace.dispose();
+    });
+
+    describe("the accessor-name registries", () => {
+        it("are bounded by the nodeset vocabulary, whatever the runtime creates and deletes", () => {
+            const folder = namespace.addFolder(addressSpace.rootFolder.objects, { browseName: "Churn" });
+            const before = childAccessorRegistrySizes();
+            for (let cycle = 0; cycle < 4; cycle++) {
+                const created = [];
+                for (let i = 0; i < 5000; i++) {
+                    // a regular name and an irregular one (an underscore, upper-case letters)
+                    const browseName = i % 2 === 0 ? `tag_${cycle}_${i}` : `EU_Range_${cycle}_${i}`;
+                    created.push(namespace.addVariable({ browseName, componentOf: folder, dataType: DataType.Double }));
+                }
+                should((folder as unknown as Dotted)[`tag_${cycle}_0`]).equal(created[0]);
+                for (const node of created) {
+                    namespace.deleteNode(node);
+                }
+                should(childAccessorRegistrySizes()).eql(before);
+            }
+            namespace.deleteNode(folder);
+        });
+
+        it("still map an irregular runtime name to the shared getter that serves it", () => {
+            addressSpace.registerChildAccessorNames(["EURange"]);
+            should(hasSharedChildAccessor("euRange")).eql(true);
+            const holder = namespace.addObject({ browseName: "Holder", organizedBy: addressSpace.rootFolder.objects });
+            const range = namespace.addVariable({ browseName: "EURange", propertyOf: holder, dataType: DataType.Double });
+            should((holder as unknown as Dotted).euRange).equal(range);
+        });
+    });
+});

--- a/packages/node-opcua-address-space/test/test_is_subtype_of_memo.ts
+++ b/packages/node-opcua-address-space/test/test_is_subtype_of_memo.ts
@@ -1,0 +1,55 @@
+/**
+ * The isSubtypeOf memo of a type is keyed by the NodeId of the type asked about, not by the node:
+ * a type created and deleted at runtime must not stay reachable through the memos of the types
+ * it was compared with.
+ */
+import v8 from "node:v8";
+import vm from "node:vm";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import should from "should";
+import type { AddressSpace, Namespace, UAObjectType } from "../dist/api/index.js";
+import { getMiniAddressSpace } from "../test_helpers/get_mini_address_space.js";
+
+/** a garbage collection, whether or not the process was started with --expose-gc */
+function collectGarbage(): () => void {
+    if (typeof globalThis.gc === "function") {
+        return globalThis.gc as () => void;
+    }
+    v8.setFlagsFromString("--expose-gc");
+    return vm.runInNewContext("gc") as () => void;
+}
+
+describe("the isSubtypeOf memo", function (this: Mocha.Suite) {
+    this.timeout(120000);
+
+    let addressSpace: AddressSpace;
+    let namespace: Namespace;
+    before(async () => {
+        addressSpace = await getMiniAddressSpace();
+        namespace = addressSpace.getOwnNamespace();
+    });
+    after(() => {
+        addressSpace.dispose();
+    });
+
+    describe("the isSubtypeOf memo", () => {
+        it("does not keep a deleted type alive, asked about in either direction", async () => {
+            const gc = collectGarbage();
+            const folderType = addressSpace.findObjectType("FolderType") as UAObjectType;
+            const baseObjectType = addressSpace.findObjectType("BaseObjectType") as UAObjectType;
+            const refs: WeakRef<UAObjectType>[] = [];
+            for (let i = 0; i < 2000; i++) {
+                const t = namespace.addObjectType({ browseName: `T${i}` });
+                should(folderType.isSubtypeOf(t)).eql(false);
+                should(t.isSubtypeOf(baseObjectType)).eql(true);
+                refs.push(new WeakRef(t));
+                namespace.deleteNode(t);
+            }
+            gc();
+            await new Promise((resolve) => setImmediate(resolve));
+            gc();
+            const alive = refs.filter((ref) => ref.deref() !== undefined).length;
+            should(alive).be.lessThan(10);
+        });
+    });
+});

--- a/packages/node-opcua-address-space/test/test_load_back_references.ts
+++ b/packages/node-opcua-address-space/test/test_load_back_references.ts
@@ -1,0 +1,63 @@
+/**
+ * The end of a load propagates the back references a document declares from one end only, for
+ * every node class the applier creates, reference types included: they go through addReferenceType
+ * rather than createNode, and used to be left to the whole-address-space sweep.
+ */
+import fs from "node:fs";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import should from "should";
+import { AddressSpace, generateAddressSpaceRaw, nodesetToImage, type UAReferenceType } from "../dist/api/index.js";
+import { NodesetRecordApplier } from "../dist/api/loader/nodeset_record_applier.js";
+import { get_mini_nodeset_filename } from "../test_helpers/get_mini_address_space.js";
+
+const uri = "urn:test:one-sided";
+const oneSided = `<?xml version="1.0" encoding="utf-8"?>
+<UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <NamespaceUris><Uri>${uri}</Uri></NamespaceUris>
+  <Models><Model ModelUri="${uri}" Version="1.0.0" PublicationDate="2026-01-01T00:00:00Z"/></Models>
+  <UAReferenceType NodeId="ns=1;i=1" BrowseName="1:HasParentSide">
+    <DisplayName>HasParentSide</DisplayName>
+    <References><Reference ReferenceType="HasSubtype" IsForward="false">i=33</Reference></References>
+    <InverseName>ParentSideOf</InverseName>
+  </UAReferenceType>
+  <UAReferenceType NodeId="ns=1;i=2" BrowseName="1:HasChildSide">
+    <DisplayName>HasChildSide</DisplayName>
+    <References><Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=1</Reference></References>
+    <InverseName>ChildSideOf</InverseName>
+  </UAReferenceType>
+</UANodeSet>`;
+
+describe("the back references of a loaded reference type", function (this: Mocha.Suite) {
+    this.timeout(60000);
+
+    it("are propagated, from the document's one-sided declaration", async () => {
+        const addressSpace = AddressSpace.create();
+        const settled: string[] = [];
+        const take = NodesetRecordApplier.prototype.takePendingBackReferences;
+        NodesetRecordApplier.prototype.takePendingBackReferences = function (this: NodesetRecordApplier) {
+            const pending = take.call(this);
+            for (const node of pending.settled) settled.push(node.browseName.name || "");
+            return pending;
+        };
+        // an image says of each reference whether the other end declares it; the XML reader does not
+        const image = await nodesetToImage(oneSided);
+        try {
+            await generateAddressSpaceRaw(addressSpace, [fs.readFileSync(get_mini_nodeset_filename(), "utf8"), image], {});
+        } finally {
+            NodesetRecordApplier.prototype.takePendingBackReferences = take;
+        }
+        try {
+            const ns = addressSpace.getNamespaceIndex(uri);
+            const parent = addressSpace.findNode(`ns=${ns};i=1`) as UAReferenceType;
+            const child = addressSpace.findNode(`ns=${ns};i=2`) as UAReferenceType;
+            should(parent.findReferencesEx("HasSubtype").map((ref) => ref.node)).containEql(child);
+            should(parent.getAllSubtypes()).containEql(child);
+            should(child.isSubtypeOf(parent)).eql(true);
+            // the reference types were settled by the applier, like every other node it created
+            should(settled).containEql("HasParentSide");
+            should(settled).containEql("HasChildSide");
+        } finally {
+            addressSpace.dispose();
+        }
+    });
+});

--- a/packages/node-opcua-address-space/test/test_nodeset_image_store.ts
+++ b/packages/node-opcua-address-space/test/test_nodeset_image_store.ts
@@ -21,6 +21,7 @@ import {
     nodesetToImage,
     readNodesetImageInfo
 } from "../dist/api/index.js";
+import { hasInflatedImageLines, imageNodesetRecords } from "../dist/api/loader/nodeset_image.js";
 import { FileNodesetImageStore, generateAddressSpace } from "../distNodeJS/index.js";
 import { type AddressSpaceDigest, digestAddressSpace } from "../test_helpers/address_space_digest.js";
 import { get_mini_nodeset_filename } from "../test_helpers/get_mini_address_space.js";
@@ -204,5 +205,31 @@ describe("Loading through an image store", function (this: Mocha.Suite) {
                 else process.env.NODE_OPCUA_NODESET_IMAGE_DIR = previous;
             }
         });
+    });
+});
+
+describe("what a memory image store retains", function (this: Mocha.Suite) {
+    this.timeout(60000);
+
+    it("is the compressed bytes only: the inflated lines go once the replay is done", async () => {
+        const store = new MemoryNodesetImageStore();
+        const file = get_mini_nodeset_filename();
+        for (let i = 0; i < 2; i++) {
+            const addressSpace = AddressSpace.create();
+            await generateAddressSpace(addressSpace, [file], { imageStore: store });
+            addressSpace.dispose();
+        }
+        should(store.size).eql(1);
+        const image = (await store.get(store.keys()[0])) as Uint8Array;
+        should(image).not.be.undefined();
+        should(hasInflatedImageLines(image)).eql(false);
+
+        // the record iterator over whole bytes releases them as well
+        let records = 0;
+        for await (const _record of imageNodesetRecords(image)) {
+            records += 1;
+        }
+        should(records).be.greaterThan(10);
+        should(hasInflatedImageLines(image)).eql(false);
     });
 });

--- a/packages/node-opcua-address-space/test/test_nodeset_source.ts
+++ b/packages/node-opcua-address-space/test/test_nodeset_source.ts
@@ -124,6 +124,24 @@ describe("Loading a nodeset from a source", function (this: Mocha.Suite) {
         should(await load([textPieces(`﻿${text}`, 7)])).eql(expected);
     });
 
+    it("keeps two loads that run at the same time apart", async () => {
+        // two servers in one process, each fed in chunks: the parsers must not share a reader state
+        const text = fs.readFileSync(nodesets.standard, "utf8");
+        const two = AddressSpace.create();
+        const one = AddressSpace.create();
+        try {
+            await Promise.all([
+                generateAddressSpaceRaw(one, [{ name: "one", source: () => textPieces(text, 1024) }], {}),
+                generateAddressSpaceRaw(two, [{ name: "two", source: () => textPieces(text, 1061) }], {})
+            ]);
+            should(digest(one)).eql(reference);
+            should(digest(two)).eql(reference);
+        } finally {
+            one.dispose();
+            two.dispose();
+        }
+    });
+
     it("orders the documents by their dependencies whatever the order given", async () => {
         const expected = await load(null, [nodesets.standard, nodesets.di]);
         should(await load([nodesetSourceFromFile(nodesets.di), nodesetSourceFromFile(nodesets.standard)])).eql(expected);

--- a/packages/node-opcua-address-space/test/test_own_child_accessor.ts
+++ b/packages/node-opcua-address-space/test/test_own_child_accessor.ts
@@ -1,0 +1,48 @@
+/**
+ * A child named at runtime gets an own accessor on its parent; a nodeset loaded afterwards may
+ * give the same name a shared getter. The own accessor then answers what the getter would, and
+ * goes with its child.
+ */
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { DataType } from "node-opcua-variant";
+import should from "should";
+import type { AddressSpace, Namespace, UAObject } from "../dist/api/index.js";
+import { hasSharedChildAccessor } from "../dist/impl/child_accessors.js";
+import { getMiniAddressSpace } from "../test_helpers/get_mini_address_space.js";
+
+type Dotted = Record<string, unknown>;
+
+describe("an own child accessor", function (this: Mocha.Suite) {
+    this.timeout(120000);
+
+    let addressSpace: AddressSpace;
+    let namespace: Namespace;
+    before(async () => {
+        addressSpace = await getMiniAddressSpace();
+        namespace = addressSpace.getOwnNamespace();
+    });
+    after(() => {
+        addressSpace.dispose();
+    });
+
+    describe("an own child accessor", () => {
+        it("does not outlive a shared getter of the same name", async () => {
+            const f = namespace.addObject({ browseName: "F8", organizedBy: addressSpace.rootFolder.objects }) as UAObject & Dotted;
+            const tag = namespace.addVariable({ browseName: "ZzTag", componentOf: f, dataType: DataType.Double });
+            should(f.zzTag).equal(tag);
+            should(Object.getOwnPropertyDescriptor(f, "zzTag")?.get).be.a.Function();
+
+            // a nodeset loaded later declares the name: it gets a shared getter
+            addressSpace.registerChildAccessorNames(["ZzTag"]);
+            should(hasSharedChildAccessor("zzTag")).eql(true);
+            should(f.zzTag).equal(tag);
+
+            namespace.deleteNode(tag);
+            should(f.zzTag).be.undefined();
+            should(Object.getOwnPropertyDescriptor(f, "zzTag")).be.undefined();
+
+            const again = namespace.addVariable({ browseName: "ZzTag", componentOf: f, dataType: DataType.Double });
+            should(f.zzTag).equal(again);
+        });
+    });
+});

--- a/packages/node-opcua-address-space/test/test_reference_memo_hygiene.ts
+++ b/packages/node-opcua-address-space/test/test_reference_memo_hygiene.ts
@@ -146,4 +146,27 @@ describe("the memoized reference scans", function (this: Mocha.Suite) {
         should(s.findReferencesEx("HasComponent").map((ref) => ref.node)).containEql(child);
         should(s.getComponentByName("Zz6", addressSpace.getNamespaceIndex(uri))).equal(child);
     });
+
+    it("hands out an array a caller cannot change", () => {
+        const objects = addressSpace.rootFolder.objects;
+        for (let i = 0; i < 15; i++) {
+            namespace.addObject({ browseName: `Pad${i}`, organizedBy: objects });
+        }
+        const elements = objects.getFolderElements().length;
+        const organizes = objects.findReferencesEx("Organizes");
+        should(organizes.length).be.greaterThan(8);
+        should(Object.isFrozen(organizes)).eql(true);
+        // in strict code the change throws; in sloppy code it is ignored: either way nothing moves
+        should(() => {
+            "use strict";
+            organizes.length = 0;
+        }).throw(TypeError);
+        should(() => {
+            "use strict";
+            (organizes as unknown[]).push(null);
+        }).throw(TypeError);
+        should(objects.findReferencesEx("Organizes").length).eql(organizes.length);
+        should(objects.getFolderElements().length).eql(elements);
+        should(Object.isFrozen(objects.findReferences("Organizes"))).eql(true);
+    });
 });

--- a/packages/node-opcua-address-space/test/test_reference_memo_hygiene.ts
+++ b/packages/node-opcua-address-space/test/test_reference_memo_hygiene.ts
@@ -8,7 +8,7 @@ import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { NodeId, resolveNodeId } from "node-opcua-nodeid";
 import { DataType } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, type Namespace, type UAObject, type UAObjectType, type UAReferenceType } from "../dist/api/index.js";
+import { AddressSpace, generateAddressSpaceRaw, type Namespace, type UAObject } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../test_helpers/get_mini_address_space.js";
 
 describe("the memoized reference scans", function (this: Mocha.Suite) {
@@ -99,5 +99,51 @@ describe("the memoized reference scans", function (this: Mocha.Suite) {
 
         namespace.deleteNode(x);
         should(y.findReferencesEx("HasCause", BrowseDirection.Inverse).length).eql(0);
+    });
+
+    it("follows a reference type that becomes a subtype of HasComponent at runtime", async () => {
+        const s = busyObject("S5");
+        const child = namespace.addObject({ browseName: "Zz5" });
+        const hasZz = namespace.addReferenceType({ browseName: "HasZz5", inverseName: "ZzOf5" });
+        s.addReference({ referenceType: hasZz, nodeId: child.nodeId });
+        should(s.findReferencesEx("HasComponent").map((ref) => ref.node)).not.containEql(child);
+        should(s.getComponentByName("Zz5")).be.null();
+        should(s.getComponents()).not.containEql(child);
+
+        hasZz.addReference({ referenceType: "HasSubtype", isForward: false, nodeId: resolveNodeId("HasComponent") });
+
+        should(s.findReferencesEx("HasComponent").map((ref) => ref.node)).containEql(child);
+        should(s.getComponents()).containEql(child);
+        should(s.getComponentByName("Zz5")).equal(child);
+    });
+
+    it("follows a reference type a companion nodeset loaded at runtime declares", async () => {
+        const s = busyObject("S6");
+        s.findReferencesEx("HasComponent");
+        should(s.getComponentByName("Zz6")).be.null();
+        const uri = "urn:test:zz6";
+        // the file's namespace table: 1 is the namespace S6 lives in, 2 the companion's own
+        const xml = `<?xml version="1.0" encoding="utf-8"?>
+<UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <NamespaceUris><Uri>${namespace.namespaceUri}</Uri><Uri>${uri}</Uri></NamespaceUris>
+  <Models><Model ModelUri="${uri}" Version="1.0.0" PublicationDate="2026-01-01T00:00:00Z"/></Models>
+  <UAReferenceType NodeId="ns=2;i=1" BrowseName="2:HasZz6">
+    <DisplayName>HasZz6</DisplayName>
+    <References><Reference ReferenceType="HasSubtype" IsForward="false">i=47</Reference></References>
+    <InverseName>ZzOf6</InverseName>
+  </UAReferenceType>
+  <UAObject NodeId="ns=2;i=2" BrowseName="2:Zz6">
+    <DisplayName>Zz6</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=58</Reference>
+      <Reference ReferenceType="ns=2;i=1" IsForward="false">ns=1;i=${s.nodeId.value}</Reference>
+    </References>
+  </UAObject>
+</UANodeSet>`;
+        await generateAddressSpaceRaw(addressSpace, [xml], {});
+        const child = addressSpace.findNode(`ns=${addressSpace.getNamespaceIndex(uri)};i=2`);
+        should(child).not.be.null();
+        should(s.findReferencesEx("HasComponent").map((ref) => ref.node)).containEql(child);
+        should(s.getComponentByName("Zz6", addressSpace.getNamespaceIndex(uri))).equal(child);
     });
 });

--- a/packages/node-opcua-address-space/test/test_reference_memo_hygiene.ts
+++ b/packages/node-opcua-address-space/test/test_reference_memo_hygiene.ts
@@ -1,0 +1,103 @@
+/**
+ * The memoized reference scans of a node (findReferencesEx on nodes with many references) must
+ * answer exactly what a fresh scan answers: with every target that exists resolved, following
+ * the reference-type hierarchy as it stands, and without being changed by a caller.
+ */
+import { BrowseDirection, NodeClass } from "node-opcua-data-model";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { NodeId, resolveNodeId } from "node-opcua-nodeid";
+import { DataType } from "node-opcua-variant";
+import should from "should";
+import { AddressSpace, type Namespace, type UAObject, type UAObjectType, type UAReferenceType } from "../dist/api/index.js";
+import { getMiniAddressSpace } from "../test_helpers/get_mini_address_space.js";
+
+describe("the memoized reference scans", function (this: Mocha.Suite) {
+    this.timeout(60000);
+
+    let addressSpace: AddressSpace;
+    let namespace: Namespace;
+    let counter = 0;
+    before(async () => {
+        addressSpace = await getMiniAddressSpace();
+        namespace = addressSpace.getOwnNamespace();
+    });
+    after(() => {
+        addressSpace.dispose();
+    });
+
+    /** an object with enough references for its scans to be memoized */
+    function busyObject(browseName: string, options: { organizedBy?: UAObject; componentOf?: UAObject } = {}): UAObject {
+        const node = namespace.addObject({ browseName, organizedBy: addressSpace.rootFolder.objects, ...options });
+        for (let i = 0; i < 12; i++) {
+            namespace.addVariable({ browseName: `V${i}`, componentOf: node, dataType: DataType.Double });
+        }
+        return node;
+    }
+    function lateNodeId(): NodeId {
+        counter += 1;
+        return new NodeId(NodeId.NodeIdType.STRING, `Late${counter}`, namespace.index);
+    }
+
+    it("resolves a target created after the scan that memoized the reference to it", () => {
+        const c = busyObject("C1");
+        const lateId = lateNodeId();
+        c.addReference({ referenceType: "HasComponent", nodeId: lateId });
+        const before = c.findReferencesEx("Aggregates");
+        const dangling = before.find((ref) => ref.nodeId.toString() === lateId.toString());
+        should(dangling).not.be.undefined();
+        should(dangling?.node).be.null();
+
+        // the target appears, under another parent, without a word about c: a fresh scan of c
+        // would resolve it, and so must the memoized one
+        const other = busyObject("Other1");
+        const late = namespace.addVariable({ browseName: "Late", nodeId: lateId, dataType: DataType.Double, componentOf: other });
+        const after = c.findReferencesEx("Aggregates");
+        should(after).equal(before);
+        should(after.find((ref) => ref.nodeId.toString() === lateId.toString())?.node).equal(late);
+    });
+
+    it("resolves a target that declares the inverse of the memoized reference", () => {
+        const c = busyObject("C2");
+        const lateId = lateNodeId();
+        c.addReference({ referenceType: "HasComponent", nodeId: lateId });
+        c.findReferencesEx("Aggregates");
+        const other = busyObject("Other2");
+        const late = namespace.addVariable({ browseName: "Late", nodeId: lateId, dataType: DataType.Double, componentOf: other });
+        late.addReference({ referenceType: "HasComponent", isForward: false, nodeId: c.nodeId });
+        const after = c.findReferencesEx("Aggregates").find((ref) => ref.nodeId.toString() === lateId.toString());
+        should(after?.node).equal(late);
+        should(c.getComponentByName("Late")).equal(late);
+    });
+
+    it("lets a type whose component holds such a reference be instantiated", () => {
+        const b = namespace.addObjectType({ browseName: "BType" });
+        const c = namespace.addObject({ browseName: "C", componentOf: b, modellingRule: "Mandatory" });
+        for (let i = 0; i < 12; i++) {
+            namespace.addVariable({ browseName: `V${i}`, componentOf: c, dataType: DataType.Double, modellingRule: "Mandatory" });
+        }
+        const lateId = lateNodeId();
+        c.addReference({ referenceType: "HasComponent", nodeId: lateId });
+        c.findReferencesEx("Aggregates");
+        namespace.addVariable({ browseName: "Late", nodeId: lateId, dataType: DataType.Double, modellingRule: "Mandatory" });
+
+        const t = namespace.addObjectType({ browseName: "TType", subtypeOf: b });
+        const instance = t.instantiate({ browseName: "T1", organizedBy: addressSpace.rootFolder.objects });
+        const clonedC = instance.getComponentByName("C") as UAObject;
+        should(clonedC).not.be.null();
+        should(clonedC.getComponentByName("Late")).not.be.null();
+    });
+
+    it("lets a deleted node take its non-hierarchical inverse references with it", () => {
+        const x = busyObject("X3");
+        const lateId = lateNodeId();
+        x.addReference({ referenceType: "HasCause", nodeId: lateId });
+        x.findReferencesEx("NonHierarchicalReferences", BrowseDirection.Forward);
+        const y = namespace.addObjectType({ browseName: "Y3", nodeId: lateId, subtypeOf: "BaseObjectType" });
+        y.addReference({ referenceType: "HasCause", isForward: false, nodeId: x.nodeId });
+        should(x.findReferencesEx("NonHierarchicalReferences", BrowseDirection.Forward).find((ref) => ref.nodeId.toString() === lateId.toString())?.node).equal(y);
+        should(y.findReferencesEx("HasCause", BrowseDirection.Inverse).length).eql(1);
+
+        namespace.deleteNode(x);
+        should(y.findReferencesEx("HasCause", BrowseDirection.Inverse).length).eql(0);
+    });
+});

--- a/packages/node-opcua-address-space/test/test_reference_memo_hygiene.ts
+++ b/packages/node-opcua-address-space/test/test_reference_memo_hygiene.ts
@@ -3,12 +3,12 @@
  * answer exactly what a fresh scan answers: with every target that exists resolved, following
  * the reference-type hierarchy as it stands, and without being changed by a caller.
  */
-import { BrowseDirection, NodeClass } from "node-opcua-data-model";
+import { BrowseDirection } from "node-opcua-data-model";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { NodeId, resolveNodeId } from "node-opcua-nodeid";
 import { DataType } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, generateAddressSpaceRaw, type Namespace, type UAObject } from "../dist/api/index.js";
+import { type AddressSpace, generateAddressSpaceRaw, type Namespace, type UAObject } from "../dist/api/index.js";
 import { getMiniAddressSpace } from "../test_helpers/get_mini_address_space.js";
 
 describe("the memoized reference scans", function (this: Mocha.Suite) {
@@ -94,7 +94,11 @@ describe("the memoized reference scans", function (this: Mocha.Suite) {
         x.findReferencesEx("NonHierarchicalReferences", BrowseDirection.Forward);
         const y = namespace.addObjectType({ browseName: "Y3", nodeId: lateId, subtypeOf: "BaseObjectType" });
         y.addReference({ referenceType: "HasCause", isForward: false, nodeId: x.nodeId });
-        should(x.findReferencesEx("NonHierarchicalReferences", BrowseDirection.Forward).find((ref) => ref.nodeId.toString() === lateId.toString())?.node).equal(y);
+        should(
+            x
+                .findReferencesEx("NonHierarchicalReferences", BrowseDirection.Forward)
+                .find((ref) => ref.nodeId.toString() === lateId.toString())?.node
+        ).equal(y);
         should(y.findReferencesEx("HasCause", BrowseDirection.Inverse).length).eql(1);
 
         namespace.deleteNode(x);
@@ -148,7 +152,7 @@ describe("the memoized reference scans", function (this: Mocha.Suite) {
     });
 
     it("hands out an array a caller cannot change", () => {
-        const objects = addressSpace.rootFolder.objects;
+        const objects = addressSpace.rootFolder.objects as unknown as UAObject & { getFolderElements(): unknown[] };
         for (let i = 0; i < 15; i++) {
             namespace.addObject({ browseName: `Pad${i}`, organizedBy: objects });
         }
@@ -158,11 +162,9 @@ describe("the memoized reference scans", function (this: Mocha.Suite) {
         should(Object.isFrozen(organizes)).eql(true);
         // in strict code the change throws; in sloppy code it is ignored: either way nothing moves
         should(() => {
-            "use strict";
             organizes.length = 0;
         }).throw(TypeError);
         should(() => {
-            "use strict";
             (organizes as unknown[]).push(null);
         }).throw(TypeError);
         should(objects.findReferencesEx("Organizes").length).eql(organizes.length);

--- a/packages/node-opcua-address-space/test/test_reference_memo_hygiene.ts
+++ b/packages/node-opcua-address-space/test/test_reference_memo_hygiene.ts
@@ -160,13 +160,23 @@ describe("the memoized reference scans", function (this: Mocha.Suite) {
         const organizes = objects.findReferencesEx("Organizes");
         should(organizes.length).be.greaterThan(8);
         should(Object.isFrozen(organizes)).eql(true);
-        // in strict code the change throws; in sloppy code it is ignored: either way nothing moves
-        should(() => {
+        // strict code sees a TypeError, sloppy code a silent no-op (the test files are compiled both
+        // ways): either way nothing moves
+        const attempt = (change: () => void) => {
+            try {
+                change();
+            } catch (err) {
+                should(err).be.instanceOf(TypeError);
+            }
+        };
+        const before = organizes.length;
+        attempt(() => {
             organizes.length = 0;
-        }).throw(TypeError);
-        should(() => {
+        });
+        attempt(() => {
             (organizes as unknown[]).push(null);
-        }).throw(TypeError);
+        });
+        should(organizes.length).eql(before);
         should(objects.findReferencesEx("Organizes").length).eql(organizes.length);
         should(objects.getFolderElements().length).eql(elements);
         should(Object.isFrozen(objects.findReferences("Organizes"))).eql(true);

--- a/packages/node-opcua-xml2json/CHANGELOG.md
+++ b/packages/node-opcua-xml2json/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- A parser definition handed to several `Xml2Json` instances (the nodeset loader's `Definition` reader is one) was
+  rewritten in place into reader states that every instance then shared; two documents parsed at the same time
+  mixed their elements. Each parser now builds its own reader states, and a definition stays a plain object.
+
 ### Changed
 
 #### `Xml2Json` parses a document delivered in pieces

--- a/packages/node-opcua-xml2json/source/xml2json.ts
+++ b/packages/node-opcua-xml2json/source/xml2json.ts
@@ -14,26 +14,37 @@ export interface Parser {
 }
 
 /**
- * @static
+ * the reader states of a definition, in a table of this engine's own. A definition is a plain
+ * object the caller may hand to any number of parsers (the shared Definition reader of the
+ * nodeset loader, for one), while a reader state carries the element being read: its parent, its
+ * attributes, its text so far. So the definition is never written to; each parser builds its
+ * states from it. A definition that refers to itself, directly or through a child, gets one state
+ * per engine for the cycle, the one being built when the cycle closes.
  * @private
-
- * @param parser {map<ReaderState|options>}
- * @return {map}
  */
-function _coerceParser(parser: ParserLike): Parser {
-    for (const name of Object.keys(parser)) {
-        if (parser[name] && !(parser[name] instanceof ReaderState)) {
-            // this is to prevent recursion
-            const tmp = parser[name];
-            delete parser[name];
-            parser[name] = new ReaderState(tmp);
-        }
+function _coerceParser(parser: ParserLike | undefined): Parser {
+    // no prototype: an element name is looked up in this table for every element of the document,
+    // one hash probe that cannot find an Object member by mistake
+    const table: Parser = Object.create(null);
+    if (!parser) {
+        return table;
     }
-    // an element name is looked up in this table for every element of the document; with no
-    // prototype behind it the lookup is one hash probe and cannot find an Object member by mistake
-    Object.setPrototypeOf(parser, null);
-    return parser as Parser;
+    for (const name of Object.keys(parser)) {
+        const entry = parser[name];
+        if (!entry) {
+            continue;
+        }
+        table[name] = entry instanceof ReaderState ? entry : (statesUnderConstruction.get(entry) ?? new ReaderState(entry));
+    }
+    return table;
 }
+
+/**
+ * the states being built from a definition, for the duration of one root construction: the way a
+ * definition that closes a cycle finds the state already under way instead of recursing for ever
+ */
+let statesUnderConstruction = new WeakMap<ReaderStateParserLike, ReaderState>();
+let constructionDepth = 0;
 
 export interface XmlAttributes {
     [key: string]: string;
@@ -119,17 +130,24 @@ export class ReaderState extends ReaderStateBase {
 
     constructor(options: ReaderStateParser | ReaderState) {
         super();
-        // ensure options object has only expected properties
-        options.parser = options.parser || {};
-
-        if (!(options instanceof ReaderStateBase)) {
-            this._init = options.init;
-            this._finish = options.finish;
-            this._startElement = options.startElement;
-            this._endElement = options.endElement;
+        if (options instanceof ReaderStateBase) {
+            this.parser = options.parser;
+            return;
         }
-
-        this.parser = _coerceParser(options.parser);
+        this._init = options.init;
+        this._finish = options.finish;
+        this._startElement = options.startElement;
+        this._endElement = options.endElement;
+        if (constructionDepth === 0) {
+            statesUnderConstruction = new WeakMap();
+        }
+        constructionDepth += 1;
+        try {
+            statesUnderConstruction.set(options, this);
+            this.parser = _coerceParser(options.parser);
+        } finally {
+            constructionDepth -= 1;
+        }
     }
 
     /**

--- a/packages/node-opcua-xml2json/test/test_parser_ownership.ts
+++ b/packages/node-opcua-xml2json/test/test_parser_ownership.ts
@@ -54,7 +54,6 @@ describe("Xml2Json owns its reader states", () => {
 
     it("builds one state per engine for a definition that refers to itself", () => {
         const node: ReaderStateParserLike = { parser: {} };
-        // biome-ignore lint/style/noNonNullAssertion: set two lines above
         node.parser!.Node = node;
         const a = new ReaderState({ parser: { Node: node } });
         const b = new ReaderState({ parser: { Node: node } });
@@ -65,7 +64,15 @@ describe("Xml2Json owns its reader states", () => {
     it("keeps two interleaved documents apart", () => {
         const seenA: Seen = { items: [] };
         const seenB: Seen = { items: [] };
-        const shared = { parser: { Item: { finish(this: { text: string; parent: { seen: Seen } }) { this.parent.seen.items.push(this.text); } } } };
+        const shared = {
+            parser: {
+                Item: {
+                    finish(this: { text: string; parent: { seen: Seen } }) {
+                        this.parent.seen.items.push(this.text);
+                    }
+                }
+            }
+        };
         const make = (seen: Seen) =>
             new Xml2Json({
                 parser: {

--- a/packages/node-opcua-xml2json/test/test_parser_ownership.ts
+++ b/packages/node-opcua-xml2json/test/test_parser_ownership.ts
@@ -1,0 +1,93 @@
+/**
+ * A parser definition is a plain object its author may hand to many parsers; each Xml2Json builds
+ * its own reader states from it. Two parsers reading at the same time therefore never share the
+ * element being read.
+ */
+import should from "should";
+import { ReaderState, type ReaderStateParserLike, Xml2Json } from "../dist/source/index.js";
+
+interface Seen {
+    items: string[];
+}
+function definition(seen: Seen): ReaderStateParserLike {
+    return {
+        parser: {
+            Item: {
+                finish(this: { text: string }) {
+                    seen.items.push(this.text);
+                }
+            }
+        }
+    };
+}
+
+describe("Xml2Json owns its reader states", () => {
+    it("leaves the definition it was built from a plain object", () => {
+        const seen: Seen = { items: [] };
+        const shared = definition(seen);
+        const root: ReaderStateParserLike = { parser: { Root: shared } };
+        new Xml2Json(root);
+        new Xml2Json(root);
+        should(Object.getPrototypeOf(root.parser)).equal(Object.prototype);
+        should(root.parser?.Root).equal(shared);
+        should(shared.parser?.Item instanceof ReaderState).eql(false);
+        should(Object.getPrototypeOf(shared.parser)).equal(Object.prototype);
+    });
+
+    it("gives two parsers built from one definition distinct states", () => {
+        const seen: Seen = { items: [] };
+        const root: ReaderStateParserLike = { parser: { Root: definition(seen) } };
+        const a = new ReaderState(root);
+        const b = new ReaderState(root);
+        should(a.parser.Root).not.equal(b.parser.Root);
+        should(a.parser.Root.parser.Item).not.equal(b.parser.Root.parser.Item);
+    });
+
+    it("keeps a reader state instance the definition names, as the author intended", () => {
+        const item = new ReaderState({});
+        const root: ReaderStateParserLike = { parser: { Root: { parser: { Item: item } } } };
+        const a = new ReaderState(root);
+        const b = new ReaderState(root);
+        should(a.parser.Root.parser.Item).equal(item);
+        should(b.parser.Root.parser.Item).equal(item);
+    });
+
+    it("builds one state per engine for a definition that refers to itself", () => {
+        const node: ReaderStateParserLike = { parser: {} };
+        // biome-ignore lint/style/noNonNullAssertion: set two lines above
+        node.parser!.Node = node;
+        const a = new ReaderState({ parser: { Node: node } });
+        const b = new ReaderState({ parser: { Node: node } });
+        should(a.parser.Node.parser.Node).equal(a.parser.Node);
+        should(b.parser.Node).not.equal(a.parser.Node);
+    });
+
+    it("keeps two interleaved documents apart", () => {
+        const seenA: Seen = { items: [] };
+        const seenB: Seen = { items: [] };
+        const shared = { parser: { Item: { finish(this: { text: string; parent: { seen: Seen } }) { this.parent.seen.items.push(this.text); } } } };
+        const make = (seen: Seen) =>
+            new Xml2Json({
+                parser: {
+                    Root: {
+                        init(this: { seen: Seen }) {
+                            this.seen = seen;
+                        },
+                        ...shared
+                    }
+                }
+            });
+        const a = make(seenA);
+        const b = make(seenB);
+        a.begin();
+        b.begin();
+        a.write("<Root><Item>a1</Item><Item>a");
+        b.write("<Root><Item>b1</Item><Item>b");
+        a.write("2</Item></Root>");
+        b.write("2</Item></Root>");
+        a.end();
+        b.end();
+        should(seenA.items).eql(["a1", "a2"]);
+        should(seenB.items).eql(["b1", "b2"]);
+    });
+});


### PR DESCRIPTION
FEAT-14 of the NodeSet2 loading performance board: the fixes for the eight findings of the 2026-09-03 review of PR 1609, 1611 and 1612, one commit per user story, each with a regression test that fails on master f0d1eac35 and passes here.

## What changed

| US | Finding | Fix | Test |
|---|---|---|---|
| 14.1 | `_coerceParser` rewrote a shared parser definition into reader states shared by every `Xml2Json`; two streamed loads at once mixed their values (105 wrong variables per address space in the repro) | each `ReaderState` copies the definition into a table of its own; a self-referential definition gets one state per engine | `test_parser_ownership.ts` (xml2json); `test_nodeset_source.ts` "keeps two loads that run at the same time apart" |
| 14.2 | a memoized `findReferencesEx` scan handed out references whose target was created after the scan, with `node` null (`instantiate` threw in `_clone_children_on_template`) | the memo remembers that a scan left a target unresolved and resolves it on the next hit; a back reference meeting its forward twin gives it its node | `test_reference_memo_hygiene.ts` (4 tests) |
| 14.3 | `referenceTypeVersion.count` moved only when a reference type was constructed: a `HasSubtype` link added at runtime left nodes with many references blind to the new subtype | adding or removing a reference on a reference type moves the stamp; the child index checks it too | same file, runtime API and companion-at-runtime variants |
| 14.4 | the memo array was returned unfrozen (`doDebug` is `const false`) | frozen on store, for `findReferencesEx` and `findReferences` | same file |
| 14.5 | `accessorNameOf` and `irregularBrowseNames` grew by one entry per runtime name, for ever (80 350 entries after four cycles of 20 000 names) | a runtime name is computed and forgotten; an irregular spelling is recorded only when a shared getter must resolve it | `test_child_accessor_registries.ts` |
| 14.6 | `inflatedImageLines` pinned the inflated text as long as the store kept the bytes (2.6 MiB per 212 KB image) | the replay releases the lines; the store documents that its cap counts compressed bytes only | `test_nodeset_image_store.ts` "what a memory image store retains" |
| 14.7 | the `isSubtypeOf` memo keyed a node argument by identity: 5000 deleted types stayed reachable | keyed by the argument's NodeId (a number for numeric ids) | `test_is_subtype_of_memo.ts` (both directions) |
| 14.8 | an own child accessor survived a later shared getter: the deleted child was still returned, its replacement unreachable | the own accessor defers to the child index once the name is shared, and is removed with its child in every case | `test_own_child_accessor.ts` |
| 14.9 | the applier carried the pending back references through a field one method armed and another consumed; the ReferenceType branch left it armed | `createNode(params, record)` settles the node from its record; reference types are settled too | `test_load_back_references.ts` |

Found on the way, fixed in the 14.3 commit: a second `generateAddressSpace` into an address space already in use threw `reference exists already in _back_references` from the end-of-load sweep, on master too. A back reference already installed is now left alone.

## Verification

- `node-opcua-address-space`: 1256 passing; `node-opcua-xml2json`: 28 passing; server 474, server-configuration 145, role-set-server 73, file-transfer 50, convert-nodeset-to-javascript 24, modeler 19, client-crawler 7, conformance-testing 6, alarm-condition 1, all passing; end2end: in progress, result added below when it completes.
- `pnpm run lint`, `check:entrypoints`, `check:cycles` clean.
- Benchmarks (idle machine, best of N), this branch against master f0d1eac35:

| scenario (best of 7) | master f0d1eac35 | this branch |
|---|---|---|
| standard, XML string | 0.246 s, 11.5 MB | 0.239 s, 11.5 MB |
| standard, XML stream | 0.241 s, 13.2 MB | 0.234 s, 13.2 MB |
| standard, image | 0.153 s, 11.5 MB | 0.139 s, 11.6 MB |
| chain (6 files), XML string | 0.298 s, 19.2 MB | 0.301 s, 20.4 MB |
| chain, XML stream | 0.317 s, 19.5 MB | 0.329 s, 20.4 MB |
| chain, image | 0.198 s, 14.8 MB | 0.189 s, 15.1 MB |
| FEAT-11 A/B standard: xml / image | 227 / 125 ms | 152 / 100 ms |
| FEAT-11 A/B chain: xml / image | 214 / 125 ms | 188 / 118 ms |

The chain heap column is measurement noise: a second pass over master and every commit of this branch gives 20.3 to 20.5 MB for all of them (chain, XML string) and 14.7 to 14.9 MB (image). Timings on the chain scenario differ by less than the run-to-run spread on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
