### PR TITLE
perf(address-space): the default image path costs what the image path costs (FEAT-16)

### DIFF
--- a/packages/node-opcua-address-space/CHANGELOG.md
+++ b/packages/node-opcua-address-space/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Changed
 
+#### The default image path costs what the image path costs
+
+The Node.js `generateAddressSpace` replays the image next to a NodeSet2 file after checking it against the XML.
+That check used to read the XML whole and hash it on the main thread before anything else, and the image was
+inflated through `DecompressionStream` and scanned line by line twice for its header and trailer.
+
+- The XML's size is compared with the length the image header records first: a different length rejects the
+  image with no read. On a match the XML is hashed with web crypto while the image inflates; the digest still
+  decides, so an edit that keeps the byte count is caught as before. The file's timestamp is not a signal.
+- An image given whole inflates through zlib in Node.js (`setImageInflater`, a third of the cost, off the main
+  thread) and its header and trailer are read from its two ends whatever its size.
+- Measured on the standard nodeset: sibling path 98 to 94 ms, six-file chain 134 to 117 ms, against 151 and
+  194 ms from the XML; the explicit image path gains the same inflate and reader (93 to 89 ms, 125 to 110 ms).
+
 #### Loader and exporter cleanup
 
 One helper each for the nodeset dependency chain of the tests, the SHA-256 hex digest, the NodeId order of the

--- a/packages/node-opcua-address-space/api/index.ts
+++ b/packages/node-opcua-address-space/api/index.ts
@@ -168,7 +168,8 @@ export {
     type NodesetImageWriterOptions,
     nodesetImageProblem,
     type ReadNodesetImageOptions,
-    readNodesetImageInfo
+    readNodesetImageInfo,
+    setImageInflater
 } from "./loader/nodeset_image.js";
 export { decodeValue, encodeValue, type JsonNodeId, type JsonQualifiedName, type JsonValue } from "./loader/nodeset_image_codec.js";
 export {
@@ -193,6 +194,7 @@ export {
     XmlExtensionObjectFragment
 } from "./loader/nodeset_record.js";
 export type { NamedNodesetSource, NodesetChunk, NodesetChunkStream, NodesetSource } from "./loader/nodeset_source.js";
+export { sha256Hex } from "./loader/nodeset_source.js";
 export { type NodesetToImageOptions, nodesetToImage } from "./loader/nodeset_to_image.js";
 export { makeXmlNodesetRecordReader, type XmlNodesetRecordReader, xmlNodesetRecords } from "./loader/nodeset_xml_producer.js";
 export * from "./loader/register_node_promoter.js";

--- a/packages/node-opcua-address-space/api/loader/nodeset_image.ts
+++ b/packages/node-opcua-address-space/api/loader/nodeset_image.ts
@@ -86,16 +86,36 @@ export function hasInflatedImageLines(image: Uint8Array): boolean {
 }
 const NEWLINE = String.fromCharCode(10);
 
+/** gzip bytes to text, the way the platform does it best; see {@link setImageInflater} */
+export type ImageInflater = (image: Uint8Array) => Promise<string>;
+
+const inflateWithDecompressionStream: ImageInflater = async (image) => {
+    const inflated = new Blob([image as BlobPart])
+        .stream()
+        .pipeThrough(new DecompressionStream("gzip") as unknown as ReadableWritablePair<Uint8Array, Uint8Array>);
+    return new TextDecoder("utf-8").decode(await new Response(inflated).arrayBuffer());
+};
+
+let inflateImage: ImageInflater = inflateWithDecompressionStream;
+
+/**
+ * how an image given whole is inflated: DecompressionStream everywhere by default; the Node.js
+ * entry point installs zlib, three times as fast on a 200 KB image and off the main thread.
+ * Returns the inflater that was installed before.
+ */
+export function setImageInflater(inflater: ImageInflater): ImageInflater {
+    const previous = inflateImage;
+    inflateImage = inflater;
+    return previous;
+}
+
 export function inflatedImageLines(image: Uint8Array): Promise<string[]> {
     let lines = imageLines.get(image);
     if (!lines) {
         lines = (async () => {
             let text: string;
             try {
-                const inflated = new Blob([image as BlobPart])
-                    .stream()
-                    .pipeThrough(new DecompressionStream("gzip") as unknown as ReadableWritablePair<Uint8Array, Uint8Array>);
-                text = new TextDecoder("utf-8").decode(await new Response(inflated).arrayBuffer());
+                text = await inflateImage(image);
             } catch (err) {
                 throw new NodesetImageError(`the image cannot be inflated: ${(err as Error).message}`);
             }
@@ -363,10 +383,25 @@ export function nodesetImageProblem(
     return null;
 }
 
-/** the header and the trailer of an image; the body lines are inflated but not parsed */
-export async function readNodesetImageInfo(
-    image: Uint8Array | NodesetChunkStream
-): Promise<{ header: NodesetImageHeader; trailer: NodesetImageTrailer | null; lines: number }> {
+/** the shape {@link readNodesetImageInfo} returns */
+export interface NodesetImageInfo {
+    header: NodesetImageHeader;
+    trailer: NodesetImageTrailer | null;
+    /** the node lines: every non-empty line but the header and the trailer */
+    lines: number;
+}
+
+const TRAILER_PREFIX = '{"kind":"trailer"';
+
+/**
+ * the header and the trailer of an image; the body lines are inflated but not parsed. An image
+ * given whole is read from its two ends, whatever its size: the header is its first line, the
+ * trailer its last non-empty one, and the node lines are counted, not read
+ */
+export async function readNodesetImageInfo(image: Uint8Array | NodesetChunkStream): Promise<NodesetImageInfo> {
+    if (image instanceof Uint8Array) {
+        return imageInfoFromLines(await inflatedImageLines(image));
+    }
     let header: NodesetImageHeader | undefined;
     let trailer: NodesetImageTrailer | null = null;
     let lines = 0;
@@ -389,4 +424,28 @@ export async function readNodesetImageInfo(
         throw new NodesetImageError("the image is empty");
     }
     return { header, trailer, lines };
+}
+
+function imageInfoFromLines(lines: string[]): NodesetImageInfo {
+    let first = 0;
+    while (first < lines.length && lines[first].length === 0) first++;
+    if (first === lines.length) {
+        throw new NodesetImageError("the image is empty");
+    }
+    const header = JSON.parse(lines[first]) as NodesetImageHeader;
+    if (header.kind !== "header") {
+        throw new NodesetImageError("the first line of an image must be its header");
+    }
+    let last = lines.length - 1;
+    while (last > first && lines[last].length === 0) last--;
+    let trailer: NodesetImageTrailer | null = null;
+    if (last > first && lines[last].startsWith(TRAILER_PREFIX)) {
+        trailer = JSON.parse(lines[last]) as NodesetImageTrailer;
+        last--;
+    }
+    let count = 0;
+    for (let i = first + 1; i <= last; i++) {
+        if (lines[i].length > 0) count++;
+    }
+    return { header, trailer, lines: count };
 }

--- a/packages/node-opcua-address-space/source_nodejs/generate_address_space.ts
+++ b/packages/node-opcua-address-space/source_nodejs/generate_address_space.ts
@@ -1,6 +1,7 @@
-import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { promisify } from "node:util";
+import { gunzip } from "node:zlib";
 import type { IAddressSpace } from "node-opcua-address-space-base";
 import { checkDebugFlag, make_debugLog, make_errorLog } from "node-opcua-debug";
 import {
@@ -11,9 +12,16 @@ import {
     type NodesetToImageOptions,
     nodesetImageProblem,
     nodesetToImage as nodesetToImageRaw,
-    readNodesetImageInfo
+    readNodesetImageInfo,
+    setImageInflater,
+    sha256Hex
 } from "../dist/api/index.js";
 import { FileNodesetImageStore } from "./nodeset_image_file_store.js";
+
+// an image given whole inflates through zlib here: a third of the cost of DecompressionStream on
+// a 200 KB image, and in the thread pool, so that the XML hash runs alongside
+const gunzipAsync = promisify(gunzip);
+setImageInflater(async (image) => (await gunzipAsync(image)).toString("utf8"));
 
 const _doDebug = checkDebugFlag("generate_address_space");
 const debugLog = make_debugLog("generate_address_space");
@@ -79,12 +87,17 @@ export function siblingImageFileOf(xmlFile: string): string {
  */
 async function siblingOrXml(xmlFile: string): Promise<{ source: NamedNodesetSource; path: "image" | "xml"; reason?: string }> {
     checkNodeSet2XmlFileExists(xmlFile);
-    const xml = new Uint8Array(fs.readFileSync(xmlFile));
-    const asXml = (reason?: string) => ({
-        source: { name: xmlFile, source: () => [xml] } as NamedNodesetSource,
-        path: "xml" as const,
-        reason
-    });
+    // the XML is read only when it is going to be parsed or hashed; the image decision starts
+    // with what costs nothing: its size
+    let xmlBytes: Promise<Uint8Array> | undefined;
+    const readXml = () => {
+        xmlBytes = xmlBytes || fs.promises.readFile(xmlFile).then((buffer) => new Uint8Array(buffer));
+        return xmlBytes;
+    };
+    const asXml = async (reason?: string) => {
+        const xml = await readXml();
+        return { source: { name: xmlFile, source: () => [xml] } as NamedNodesetSource, path: "xml" as const, reason };
+    };
     const imageFile = siblingImageFileOf(xmlFile);
     let image: Uint8Array;
     try {
@@ -92,10 +105,19 @@ async function siblingOrXml(xmlFile: string): Promise<{ source: NamedNodesetSour
     } catch {
         return asXml("no image next to it");
     }
-    const digest = createHash("sha256").update(xml).digest("hex");
     try {
+        // the inflate (zlib, off the main thread) and the hash of the XML (web crypto, off the
+        // main thread too) run alongside; the digest is what decides, the length only rejects early
+        const infoPending = readNodesetImageInfo(image);
+        const digestPending = readXml().then(sha256Hex);
+        digestPending.catch(() => undefined);
+        const info = await infoPending;
+        const sourceLength = info.header.sourceLength;
+        if (sourceLength !== undefined && sourceLength !== fs.statSync(xmlFile).size) {
+            return asXml(`the image is stale: it was built from ${sourceLength} bytes, the XML has ${fs.statSync(xmlFile).size}`);
+        }
         // a catalog package older or newer than this loader, a stale or truncated image: its XML is still right
-        const problem = nodesetImageProblem(await readNodesetImageInfo(image), digest);
+        const problem = nodesetImageProblem(info, await digestPending);
         if (problem) return asXml(problem);
     } catch (err) {
         return asXml(`the image cannot be read: ${(err as Error).message}`);

--- a/packages/node-opcua-address-space/test/test_nodeset_sibling_images.ts
+++ b/packages/node-opcua-address-space/test/test_nodeset_sibling_images.ts
@@ -26,10 +26,16 @@ async function load(file: string, imageStore?: false): Promise<AddressSpaceDiges
     }
 }
 
-/** an image whose trailer claims the digest of `xmlFile` while its content is `image`'s */
+/**
+ * an image whose header and trailer claim the length and the digest of `xmlFile` while its content
+ * is `image`'s: what only a replay of the sibling image can produce
+ */
 function imageClaiming(image: Uint8Array, xmlFile: string): Uint8Array {
     const digest = createHash("sha256").update(fs.readFileSync(xmlFile)).digest("hex");
     const lines = zlib.gunzipSync(image).toString("utf8").split("\n");
+    const header = JSON.parse(lines[0]);
+    header.sourceLength = fs.statSync(xmlFile).size;
+    lines[0] = JSON.stringify(header);
     const trailerIndex = lines.length - 2; // the text ends with a newline
     const trailer = JSON.parse(lines[trailerIndex]);
     trailer.sourceDigest = digest;
@@ -105,6 +111,50 @@ describe("Sibling images", function (this: Mocha.Suite) {
         const good = await nodesetFileToImage(xmlFile);
         fs.writeFileSync(siblingImageFileOf(xmlFile), good.subarray(0, good.length - 30));
         should(await load(xmlFile)).eql(reference);
+    });
+
+    it("falls back to the XML when the image was built from a document of another length, before hashing", async () => {
+        // the trailer digest is the XML's: only the length check can tell this image apart
+        const image = await nodesetFileToImage(editedXml);
+        const lines = zlib.gunzipSync(image).toString("utf8").split("\n");
+        const trailer = JSON.parse(lines[lines.length - 2]);
+        trailer.sourceDigest = createHash("sha256").update(fs.readFileSync(xmlFile)).digest("hex");
+        lines[lines.length - 2] = JSON.stringify(trailer);
+        fs.writeFileSync(siblingImageFileOf(xmlFile), zlib.gzipSync(lines.join("\n")));
+        should(await load(xmlFile)).eql(reference);
+    });
+
+    it("falls back to the XML when the document changed without changing length", async () => {
+        // an edit that keeps the byte count: the length check passes, the digest decides
+        const xml = fs.readFileSync(xmlFile, "utf8");
+        const sameLength = xml.replace('BrowseName="Objects"', 'BrowseName="ObjectZ"');
+        should(sameLength.length).eql(xml.length);
+        const sameLengthFile = path.join(directory, "sameLength.NodeSet2.xml");
+        fs.writeFileSync(sameLengthFile, sameLength);
+        fs.writeFileSync(siblingImageFileOf(sameLengthFile), await nodesetFileToImage(xmlFile));
+        const info = await readNodesetImageInfo(new Uint8Array(fs.readFileSync(siblingImageFileOf(sameLengthFile))));
+        should(info.header.sourceLength).eql(fs.statSync(sameLengthFile).size);
+        const loaded = await load(sameLengthFile);
+        should(loaded).eql(await load(sameLengthFile, false));
+        should(loaded).not.eql(reference);
+    });
+
+    it("reads the header and the trailer of a whole image from its ends, as the stream reader does", async () => {
+        const image = await nodesetFileToImage(xmlFile);
+        const whole = await readNodesetImageInfo(image);
+        const streamed = await readNodesetImageInfo(
+            (async function* () {
+                for (let i = 0; i < image.length; i += 1000) yield image.subarray(i, i + 1000);
+            })()
+        );
+        should(whole).eql(streamed);
+        should(whole.trailer?.nodes).eql(whole.lines);
+        // a truncated image: no trailer, the lines that are there are counted
+        const lines = zlib.gunzipSync(image).toString("utf8").split("\n");
+        const truncated = new Uint8Array(zlib.gzipSync(lines.slice(0, lines.length - 2).join("\n")));
+        const info = await readNodesetImageInfo(truncated);
+        should(info.trailer).be.null();
+        should(info.lines).eql(whole.lines);
     });
 
     describe("the catalog", () => {


### PR DESCRIPTION
FEAT-16 of the NodeSet2 loading performance board: the default (sibling image) path of the Node.js `generateAddressSpace` now costs what the explicit image path costs, and the explicit path gains the same two changes.

## What changed

- **US-16.1, the sibling decision.** `siblingOrXml` used to read the XML whole and hash it synchronously before anything else, even when the image was going to be taken. Now: the XML's size is compared with the `sourceLength` the image header records (one `stat`, a mismatch rejects with no read); on a match the XML is read and hashed with web crypto while the image inflates in the zlib thread pool; the digest decides as before. The file's timestamp and the model's publication date are deliberately not signals: `git checkout` and `pnpm install` rewrite identical bytes with a new mtime, copies and `touch -r` keep an old mtime over new bytes, hand edits and forgotten bumps keep the date, and an mtime in the image would tie it to one filesystem. Decided with the maintainer on 2026-09-03, recorded on the board item.
- **US-16.2, the whole-buffer reader.** `setImageInflater` lets a platform inflate an image its own way; the Node.js entry point installs `zlib.gunzip` (2.9 ms against 10.2 ms for `DecompressionStream` on the 212 KB standard image, and off the main thread). `readNodesetImageInfo` on a whole image reads the header from its first line and the trailer from its last, counting the node lines instead of iterating them (0.04 ms against about 4 ms), which the pre-load of every image source also benefits from.

## Measurements (best of 7, this machine)

| scenario | XML | sibling image, before | sibling image, after | explicit image, before | explicit image, after |
|---|---|---|---|---|---|
| standard | 151 ms | 98 ms | 94 ms | 93 ms | 89 ms |
| six-file chain | 194 ms | 134 ms | 117 ms | 125 ms | 110 ms |

Sibling path against XML: 37% and 40% under. Phase costs on the standard nodeset before the change, for the record: XML read 2.5 ms + hash 2.0 ms on the main thread, header/trailer scan 14 ms (inflate included), replay 112 ms.

## Tests

`test_nodeset_sibling_images.ts`: an image built from a document of another length is rejected before hashing even when its trailer claims the XML's digest; a document edited without changing its length still falls back to the XML (the digest decides); the whole-image reader gives what the stream reader gives, trailer or not. The forgery helper of the existing replay test now claims the length as well as the digest.

## Verification

- `node-opcua-address-space`: 1263 passing; `tools/check-nodeset-images.mjs` and `build-nodeset-images.mjs --check`: 33 images match, current.
- Dependents: server 482, convert-nodeset-to-javascript 24, modeler 19, client-crawler 7, conformance-testing 6, server-configuration 145, all passing. `pnpm run lint` (two pre-existing warnings in node-opcua-server), `check:entrypoints`, `check:cycles` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
