### PR TITLE
feat: a nodeset loads after earlier calls; OPCUAServer nodesets option and source helpers

### DIFF
--- a/packages/node-opcua-address-space/CHANGELOG.md
+++ b/packages/node-opcua-address-space/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+### Added
+
+#### A nodeset loads after the models it requires, whatever call loaded them
+
+`generateAddressSpaceRaw` resolved each `RequiredModel` among the documents of the current call only, and failed
+with `Cannot find namespace for http://opcfoundation.org/UA/` when a companion nodeset was given in a second call,
+after `server.initialize()` had loaded `Opc.Ua.NodeSet2.xml`. A required model that the address space already
+holds now counts as loaded when its version is at least the required one; a lower version is an error naming both
+versions, and a model that neither the address space nor the call provides is still reported as missing.
+`findOrder` takes the predicate as an optional second argument (`loadedModelSatisfies(addressSpace)`).
+
+- The Node.js `generateAddressSpace` accepts `NodesetSource` values in its list next to file paths: a string is a
+  path, anything else is a source (a gzip stream, an HTTP response, a string of XML through `{ name, source }`).
+- `OPCUAServer` takes `nodesetSources?: NodesetSource[]`, loaded in the same call as `nodeset_filename` so a
+  dependency may cross from one list to the other, and `nodesetLoaderOptions?: NodeSetLoaderOptions`
+  (`yieldEveryBytes`, `imageStore`, `permissions`, `accessRestrictions`). The standard nodeset is still the
+  default when `nodeset_filename` is absent; `nodeset_filename: []` leaves it to the sources.
+
 ### Changed
 
 #### The default image path costs what the image path costs

--- a/packages/node-opcua-address-space/CHANGELOG.md
+++ b/packages/node-opcua-address-space/CHANGELOG.md
@@ -15,10 +15,18 @@ versions, and a model that neither the address space nor the call provides is st
 
 - The Node.js `generateAddressSpace` accepts `NodesetSource` values in its list next to file paths: a string is a
   path, anything else is a source (a gzip stream, an HTTP response, a string of XML through `{ name, source }`).
-- `OPCUAServer` takes `nodesetSources?: NodesetSource[]`, loaded in the same call as `nodeset_filename` so a
-  dependency may cross from one list to the other, and `nodesetLoaderOptions?: NodeSetLoaderOptions`
-  (`yieldEveryBytes`, `imageStore`, `permissions`, `accessRestrictions`). The standard nodeset is still the
-  default when `nodeset_filename` is absent; `nodeset_filename: []` leaves it to the sources.
+- `OPCUAServer` takes `nodesets?: string | Array<string | NodesetSource>`, the same mix, loaded in one call in
+  dependency order, and `nodesetLoaderOptions?: NodeSetLoaderOptions` (`yieldEveryBytes`, `imageStore`,
+  `permissions`, `accessRestrictions`). The standard nodeset is still loaded when nothing is given.
+- Helpers for the common sources, each lazy and reusable: `nodesetSourceFromGzipFile(path)` in the Node.js build;
+  `nodesetSourceFromUrl(url, { init?, gzip? })`, which rejects the load with the status on a response that is not
+  ok and inflates a `.gz` url, and `nodesetSourceFromStream(name, open)` in the core build, browser included.
+
+### Deprecated
+
+- `OPCUAServerOptions.nodeset_filename`, in favour of `nodesets`, which accepts the same paths and, in the same
+  list, `NodesetSource` values. Renaming the key is the whole migration; the old key keeps working, and when both
+  are given they load together, `nodeset_filename` entries first.
 
 ### Changed
 

--- a/packages/node-opcua-address-space/api/index.ts
+++ b/packages/node-opcua-address-space/api/index.ts
@@ -195,6 +195,7 @@ export {
 } from "./loader/nodeset_record.js";
 export type { NamedNodesetSource, NodesetChunk, NodesetChunkStream, NodesetSource } from "./loader/nodeset_source.js";
 export { sha256Hex } from "./loader/nodeset_source.js";
+export * from "./loader/nodeset_source_helpers.js";
 export { type NodesetToImageOptions, nodesetToImage } from "./loader/nodeset_to_image.js";
 export { makeXmlNodesetRecordReader, type XmlNodesetRecordReader, xmlNodesetRecords } from "./loader/nodeset_xml_producer.js";
 export * from "./loader/register_node_promoter.js";

--- a/packages/node-opcua-address-space/api/loader/generateAddressSpaceRaw.ts
+++ b/packages/node-opcua-address-space/api/loader/generateAddressSpaceRaw.ts
@@ -3,10 +3,12 @@ import { getMinOPCUADate } from "node-opcua-date-time";
 import { checkDebugFlag, make_debugLog, make_errorLog } from "node-opcua-debug";
 import type { CallbackT } from "node-opcua-status-code";
 import { type ReaderStateParser, type ReaderStateParserLike, Xml2Json, type XmlAttributes } from "node-opcua-xml2json";
+import semver from "semver";
 import type { NamespacePrivate } from "../../impl/namespace_private.js";
 import { adjustNamespaceArray } from "../../impl/nodeset_tools/adjust_namespace_array.js";
 import type { NodeSetLoaderOptions } from "../interfaces/nodeset_loader_options.js";
 import { NodeSetLoader } from "./load_nodeset2.js";
+import { makeSemverCompatible } from "./make_semver_compatible.js";
 import {
     imageLinesToRecords,
     inflatedImageLines,
@@ -278,7 +280,48 @@ export async function preLoad(xmlFiles: string[], xmlLoader: (nodeset2xmlUri: st
     }
     return namespaceDesc;
 }
-export function findOrder(nodesetDescs: Array<{ namespaceModel: NodesetInfo }>): number[] {
+/**
+ * whether a model required by a document of this call, and provided by none of them, is
+ * satisfied anyway: the predicate says so for a model the address space already holds
+ * (see {@link loadedModelSatisfies}); by default nothing outside the call counts
+ */
+export type RequiredModelPredicate = (requiredModel: RequiredModel, requiredBy: string) => boolean;
+
+/**
+ * a required model that the address space already holds, from an earlier call or from an
+ * earlier `registerNamespace`: satisfied when the namespace is registered with a version at
+ * least the required one. A lower version is an error naming both versions; an absent
+ * namespace is not satisfied, and left to the caller to report as missing.
+ */
+export function loadedModelSatisfies(addressSpace: IAddressSpace): RequiredModelPredicate {
+    return (requiredModel: RequiredModel, requiredBy: string): boolean => {
+        const namespace = addressSpace.getNamespace(requiredModel.modelUri);
+        if (!namespace) {
+            return false;
+        }
+        const loaded = makeSemverCompatible(namespace.version);
+        const required = makeSemverCompatible(requiredModel.version);
+        if (semver.lt(loaded, required)) {
+            throw new Error(
+                `Namespace ${requiredModel.modelUri} is loaded with version ${namespace.version || "unknown"}` +
+                    ` but ${requiredBy} requires version ${requiredModel.version} or later`
+            );
+        }
+        return true;
+    };
+}
+
+/**
+ * the order in which the documents of one call load, each after the documents it requires
+ *
+ * @param nodesetDescs the documents of the call, each with the models it defines and requires
+ * @param isSatisfied a required model that no document of the call defines is an error unless
+ *   this says it is satisfied, typically because the address space holds it already
+ */
+export function findOrder(
+    nodesetDescs: Array<{ namespaceModel: NodesetInfo }>,
+    isSatisfied: RequiredModelPredicate = () => false
+): number[] {
     // compute the order of loading of the namespaces
     const order: number[] = [];
     const visited: Set<string> = new Set<string>();
@@ -296,6 +339,9 @@ export function findOrder(nodesetDescs: Array<{ namespaceModel: NodesetInfo }>):
         for (const requiredModel of model.requiredModel) {
             const requiredModelIndex = findNodesetIndex(requiredModel.modelUri);
             if (requiredModelIndex === -1) {
+                if (isSatisfied(requiredModel, model.modelUri)) {
+                    continue;
+                }
                 throw new Error(`Cannot find namespace for ${requiredModel.modelUri}`);
             }
             const nd = nodesetDescs[requiredModelIndex];
@@ -319,7 +365,9 @@ export function findOrder(nodesetDescs: Array<{ namespaceModel: NodesetInfo }>):
     return order;
 }
 /**
- * populate an address space from NodeSet2 documents, in dependency order whatever the order given
+ * populate an address space from NodeSet2 documents, in dependency order whatever the order given.
+ * A model that a document requires may come from the same call or from an earlier one: what
+ * the address space already holds, with a sufficient version, counts as loaded.
  *
  * @param addressSpace the addressSpace to populate
  * @param sources the documents, each a {@link NodesetSource}: text, bytes, a stream of chunks or a
@@ -379,7 +427,7 @@ export async function generateAddressSpaceRaw(
     const nodesetLoader = new NodeSetLoader(addressSpace, options);
 
     const nodesetDesc = await preLoadSources(readers);
-    const order = findOrder(nodesetDesc);
+    const order = findOrder(nodesetDesc, loadedModelSatisfies(addressSpace));
 
     // register namespace in the same order as specified in the xmlFiles array
     for (let index = 0; index < order.length; index++) {

--- a/packages/node-opcua-address-space/api/loader/nodeset_source_helpers.ts
+++ b/packages/node-opcua-address-space/api/loader/nodeset_source_helpers.ts
@@ -1,0 +1,50 @@
+/**
+ * @module node-opcua-address-space
+ *
+ * Ready-made {@link NodesetSource} values for the common places a NodeSet2 document comes
+ * from. Each is lazy: nothing is opened or fetched until the loader reaches the document, and
+ * the same value can be given to a later load. The file helpers live in the Node.js build
+ * (`nodesetSourceFromFile`, `nodesetSourceFromGzipFile`); these two need nothing but the
+ * platform and serve the browser build too.
+ */
+import type { NamedNodesetSource, NodesetChunkStream } from "./nodeset_source.js";
+
+/** a document from anything that opens a stream of chunks, under a name for error messages */
+export function nodesetSourceFromStream(name: string, open: () => NodesetChunkStream): NamedNodesetSource {
+    return { name, source: open };
+}
+
+export interface NodesetSourceFromUrlOptions {
+    /** passed to `fetch`: headers, credentials, a signal */
+    init?: RequestInit;
+    /**
+     * whether the body is gzip and must be inflated here. `fetch` inflates a response that
+     * carries `Content-Encoding: gzip` on its own; this is for a `.gz` file served as is.
+     * @default true when the url path ends in `.gz`
+     */
+    gzip?: boolean;
+}
+
+/**
+ * a document fetched from a URL when the loader gets to it. A response that is not ok rejects
+ * the load with the status and the url; nothing is retried.
+ */
+export function nodesetSourceFromUrl(url: string, options: NodesetSourceFromUrlOptions = {}): NamedNodesetSource {
+    const gzip = options.gzip ?? /\.gz$/i.test(new URL(url, "http://localhost").pathname);
+    const init = options.init;
+    return {
+        name: url,
+        source: async function* (): AsyncGenerator<Uint8Array> {
+            const response = await fetch(url, init);
+            if (!response.ok || !response.body) {
+                throw new Error(`cannot fetch ${url}: ${response.status} ${response.statusText}`.trimEnd());
+            }
+            const body = gzip
+                ? response.body.pipeThrough(
+                      new DecompressionStream("gzip") as unknown as ReadableWritablePair<Uint8Array, Uint8Array>
+                  )
+                : response.body;
+            yield* body as unknown as AsyncIterable<Uint8Array>;
+        }
+    };
+}

--- a/packages/node-opcua-address-space/source_nodejs/generate_address_space.ts
+++ b/packages/node-opcua-address-space/source_nodejs/generate_address_space.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
-import { gunzip } from "node:zlib";
+import zlib, { gunzip } from "node:zlib";
 import type { IAddressSpace } from "node-opcua-address-space-base";
 import { checkDebugFlag, make_debugLog, make_errorLog } from "node-opcua-debug";
 import {
@@ -60,6 +60,20 @@ export function nodesetSourceFromFile(xmlFile: string): NamedNodesetSource {
                 debugLog(" parsing ", xmlFile);
             }
             return fs.createReadStream(xmlFile, { highWaterMark: FILE_CHUNK_SIZE });
+        }
+    };
+}
+
+/**
+ * a gzip-compressed NodeSet2 file (`<name>.xml.gz`), inflated on the way, opened when the loader
+ * gets to it
+ */
+export function nodesetSourceFromGzipFile(gzipFile: string): NamedNodesetSource {
+    return {
+        name: gzipFile,
+        source: () => {
+            checkNodeSet2XmlFileExists(gzipFile);
+            return fs.createReadStream(gzipFile, { highWaterMark: FILE_CHUNK_SIZE }).pipe(zlib.createGunzip());
         }
     };
 }

--- a/packages/node-opcua-address-space/source_nodejs/generate_address_space.ts
+++ b/packages/node-opcua-address-space/source_nodejs/generate_address_space.ts
@@ -136,23 +136,29 @@ export function addressSpacePackageVersion(): string {
 }
 
 /**
- * load NodeSet2 files into an address space. A file with a valid precompiled image next to it
- * (`<name>.ndjson.gz`, the catalog ships one for every nodeset) is replayed from the image, with
- * nothing to configure. With `imageStore`, a file without one is hashed and its image replayed
- * when the store has it, written otherwise; `true` selects the per-user file store
- * ({@link FileNodesetImageStore}). `imageStore: false` disables the sibling images too and
- * streams the XML, for tests and for bisecting.
+ * load NodeSet2 documents into an address space: file paths, and {@link NodesetSource} values
+ * for a document that is not a file (a gzip stream, an HTTP response, a string of XML). A
+ * string in the list is always a path here; content and streams go through a source.
+ *
+ * A file with a valid precompiled image next to it (`<name>.ndjson.gz`, the catalog ships one
+ * for every nodeset) is replayed from the image, with nothing to configure. With `imageStore`,
+ * a file without one is hashed and its image replayed when the store has it, written
+ * otherwise; `true` selects the per-user file store ({@link FileNodesetImageStore}).
+ * `imageStore: false` disables the sibling images too and streams the XML, for tests and for
+ * bisecting. The documents load in dependency order whatever the order given; a model one of
+ * them requires may also be one the address space holds already, from an earlier call.
  */
 export async function generateAddressSpace(
     addressSpace: IAddressSpace,
-    xmlFiles: string | string[],
+    xmlFiles: string | Array<string | NodesetSource>,
     options?: NodeSetLoaderOptions
 ): Promise<void> {
-    const files = Array.isArray(xmlFiles) ? xmlFiles : [xmlFiles];
+    const documents = Array.isArray(xmlFiles) ? xmlFiles : [xmlFiles];
     const loaderOptions: NodeSetLoaderOptions = { ...(options || {}) };
     if (loaderOptions.imageStore === false) {
         // no sibling images, no store: the XML files, streamed
-        await generateAddressSpaceRaw(addressSpace, files.map(nodesetSourceFromFile), { ...loaderOptions, imageStore: undefined });
+        const sources = documents.map((document) => (typeof document === "string" ? nodesetSourceFromFile(document) : document));
+        await generateAddressSpaceRaw(addressSpace, sources, { ...loaderOptions, imageStore: undefined });
         return;
     }
     if (loaderOptions.imageStore === true) {
@@ -161,9 +167,13 @@ export async function generateAddressSpace(
     // the sibling store first: a catalog image is replayed with nothing to configure; what has
     // no valid image next to it goes through the XML, and through the store when there is one
     const sources: NodesetSource[] = [];
-    for (const file of files) {
-        const { source, path: taken, reason } = await siblingOrXml(file);
-        debugLog(`generateAddressSpace: ${path.basename(file)} from ${taken}${reason ? ` (${reason})` : ""}`);
+    for (const document of documents) {
+        if (typeof document !== "string") {
+            sources.push(document);
+            continue;
+        }
+        const { source, path: taken, reason } = await siblingOrXml(document);
+        debugLog(`generateAddressSpace: ${path.basename(document)} from ${taken}${reason ? ` (${reason})` : ""}`);
         sources.push(source);
     }
     await generateAddressSpaceRaw(addressSpace, sources, loaderOptions);

--- a/packages/node-opcua-address-space/test/test_nodeset_ordering.ts
+++ b/packages/node-opcua-address-space/test/test_nodeset_ordering.ts
@@ -110,7 +110,7 @@ describe("Ordering NodeSet2 files", () => {
 
             const diNamespace = addressSpace.getNamespace(DI);
             should.exist(diNamespace);
-            diNamespace.findNode("i=5001")!.browseName.name!.should.eql("DeviceSet");
+            should(diNamespace.findNode("i=5001")?.browseName.name).eql("DeviceSet");
             const deviceSet = addressSpace.rootFolder.objects.getFolderElementByName("DeviceSet", diNamespace.index);
             should.exist(deviceSet, "DeviceSet is organized by Objects, across the two calls");
             should(diNamespace.getRequiredModels()!.map((m) => m.modelUri)).eql([UA]);

--- a/packages/node-opcua-address-space/test/test_nodeset_ordering.ts
+++ b/packages/node-opcua-address-space/test/test_nodeset_ordering.ts
@@ -1,8 +1,9 @@
+import fs from "node:fs";
+import zlib from "node:zlib";
 import { nodesets } from "node-opcua-nodesets";
 import { getFixture } from "node-opcua-test-fixtures";
-// import fs from "fs";
 import should from "should";
-import { AddressSpace, findOrder, generateAddressSpaceRaw, preLoad } from "../dist/api/index.js";
+import { AddressSpace, findOrder, generateAddressSpaceRaw, type NodesetSource, preLoad } from "../dist/api/index.js";
 import { readNodeSet2XmlFile } from "../nodeJS.js";
 import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
 
@@ -80,5 +81,75 @@ describe("Ordering NodeSet2 files", () => {
         }
         should(_err!).be.instanceOf(Error);
         should(_err?.message).match(/Cannot find namespace for http:\/\/opcfoundation.org\/UA\/DI\//);
+    });
+
+    const UA = "http://opcfoundation.org/UA/";
+    const DI = "http://opcfoundation.org/UA/DI/";
+
+    /** a nodeset file as a gzip stream, the way a compressed model reaches a server */
+    const gzipStreamOf = (file: string): NodesetSource => ({
+        name: `${file}.gz`,
+        source: () => fs.createReadStream(file).pipe(zlib.createGzip()).pipe(zlib.createGunzip())
+    });
+
+    it("NSO-6 should order a document whose required model is satisfied outside the call", async () => {
+        const [di] = await preLoad([nodesets.di], readNodeSet2XmlFile);
+        di.xmlData = "";
+        should(() => findOrder([di])).throw(/Cannot find namespace for http:\/\/opcfoundation.org\/UA\//);
+        findOrder([di], (requiredModel) => requiredModel.modelUri === UA).should.eql([0]);
+    });
+
+    it("NSO-7 should load a companion nodeset in a second call, after the standard nodeset", async () => {
+        // a server has loaded Opc.Ua.NodeSet2.xml in initialize(); a model arrives later, as a gzip stream
+        const addressSpace = AddressSpace.create();
+        try {
+            await generateAddressSpaceRaw(addressSpace, [nodesets.standard], readNodeSet2XmlFile, {});
+            should(addressSpace.getNamespaceIndex(DI)).eql(-1);
+
+            await generateAddressSpaceRaw(addressSpace, [gzipStreamOf(nodesets.di)], {});
+
+            const diNamespace = addressSpace.getNamespace(DI);
+            should.exist(diNamespace);
+            diNamespace.findNode("i=5001")!.browseName.name!.should.eql("DeviceSet");
+            const deviceSet = addressSpace.rootFolder.objects.getFolderElementByName("DeviceSet", diNamespace.index);
+            should.exist(deviceSet, "DeviceSet is organized by Objects, across the two calls");
+            should(diNamespace.getRequiredModels()!.map((m) => m.modelUri)).eql([UA]);
+        } finally {
+            addressSpace.dispose();
+        }
+    });
+
+    it("NSO-8 should still report a model that neither call provides", async () => {
+        const addressSpace = AddressSpace.create();
+        try {
+            await generateAddressSpaceRaw(addressSpace, [nodesets.standard], readNodeSet2XmlFile, {});
+            // ADI requires DI, which is neither loaded nor in this call
+            await generateAddressSpaceRaw(addressSpace, [gzipStreamOf(nodesets.adi)], {}).should.be.rejectedWith(
+                /Cannot find namespace for http:\/\/opcfoundation.org\/UA\/DI\//
+            );
+            should(addressSpace.getNamespaceIndex("http://opcfoundation.org/UA/ADI/")).eql(-1, "nothing of ADI was loaded");
+        } finally {
+            addressSpace.dispose();
+        }
+    });
+
+    it("NSO-9 should reject a loaded model whose version is lower than the one required", async () => {
+        const addressSpace = AddressSpace.create();
+        try {
+            await generateAddressSpaceRaw(addressSpace, [nodesets.standard], readNodeSet2XmlFile, {});
+            const ua = addressSpace.getNamespace(UA);
+            const loadedVersion = ua.version;
+            ua.version = "1.03";
+            await generateAddressSpaceRaw(addressSpace, [gzipStreamOf(nodesets.di)], {}).should.be.rejectedWith(
+                /Namespace http:\/\/opcfoundation.org\/UA\/ is loaded with version 1.03 but http:\/\/opcfoundation.org\/UA\/DI\/ requires version [0-9.]+ or later/
+            );
+            should(addressSpace.getNamespaceIndex(DI)).eql(-1);
+            // the version it has is enough
+            ua.version = loadedVersion;
+            await generateAddressSpaceRaw(addressSpace, [gzipStreamOf(nodesets.di)], {});
+            should(addressSpace.getNamespaceIndex(DI)).not.eql(-1);
+        } finally {
+            addressSpace.dispose();
+        }
     });
 });

--- a/packages/node-opcua-address-space/test/test_nodeset_source.ts
+++ b/packages/node-opcua-address-space/test/test_nodeset_source.ts
@@ -5,14 +5,29 @@
  */
 import { createHash } from "node:crypto";
 import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
 import { Readable } from "node:stream";
 import zlib from "node:zlib";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import should from "should";
-import { AddressSpace, generateAddressSpaceRaw, type NodesetSource, type UAVariable } from "../dist/api/index.js";
+import {
+    AddressSpace,
+    generateAddressSpaceRaw,
+    type NodesetSource,
+    nodesetSourceFromStream,
+    nodesetSourceFromUrl,
+    type UAVariable
+} from "../dist/api/index.js";
 import type { AddressSpacePrivate } from "../dist/impl/address_space_private.js";
-import { generateAddressSpace, nodesetSourceFromFile, readNodeSet2XmlFile } from "../distNodeJS/index.js";
+import {
+    generateAddressSpace,
+    nodesetSourceFromFile,
+    nodesetSourceFromGzipFile,
+    readNodeSet2XmlFile
+} from "../distNodeJS/index.js";
 import { get_mini_nodeset_filename } from "../test_helpers/get_mini_address_space.js";
 
 interface Digest {
@@ -190,6 +205,75 @@ describe("Loading a nodeset from a source", function (this: Mocha.Suite) {
         } finally {
             addressSpace.dispose();
         }
+    });
+
+    describe("the source helpers", () => {
+        let tmp: string;
+        let gzipFile: string;
+        let httpServer: http.Server;
+        let baseUrl: string;
+        before(async () => {
+            tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nodeset-helpers-"));
+            gzipFile = path.join(tmp, "Opc.Ua.NodeSet2.xml.gz");
+            fs.writeFileSync(gzipFile, zlib.gzipSync(fs.readFileSync(nodesets.standard)));
+            // /plain.xml: the XML; /packed.xml.gz: gzip served as is; /encoded.xml: gzip with Content-Encoding
+            httpServer = http.createServer((req, res) => {
+                if (req.url === "/plain.xml") {
+                    fs.createReadStream(nodesets.standard).pipe(res);
+                } else if (req.url === "/packed.xml.gz") {
+                    fs.createReadStream(gzipFile).pipe(res);
+                } else if (req.url === "/encoded.xml") {
+                    res.setHeader("content-encoding", "gzip");
+                    fs.createReadStream(gzipFile).pipe(res);
+                } else {
+                    res.statusCode = 404;
+                    res.end("no such model");
+                }
+            });
+            await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+            baseUrl = `http://127.0.0.1:${(httpServer.address() as { port: number }).port}`;
+        });
+        after(async () => {
+            await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+            fs.rmSync(tmp, { recursive: true, force: true });
+        });
+
+        it("nodesetSourceFromGzipFile inflates a .xml.gz file", async () => {
+            should(await load([nodesetSourceFromGzipFile(gzipFile)])).eql(reference);
+        });
+
+        it("nodesetSourceFromGzipFile names a file that does not exist when the loader opens it", async () => {
+            const source = nodesetSourceFromGzipFile(path.join(tmp, "missing.xml.gz"));
+            await load([source]).should.be.rejectedWith(/missing\.xml\.gz/);
+        });
+
+        it("nodesetSourceFromUrl fetches the XML", async () => {
+            should(await load([nodesetSourceFromUrl(`${baseUrl}/plain.xml`)])).eql(reference);
+        });
+
+        it("nodesetSourceFromUrl inflates a .gz url, and a body fetch inflates on its own", async () => {
+            should(await load([nodesetSourceFromUrl(`${baseUrl}/packed.xml.gz`)])).eql(reference);
+            should(await load([nodesetSourceFromUrl(`${baseUrl}/encoded.xml`)])).eql(reference);
+            should(await load([nodesetSourceFromUrl(`${baseUrl}/plain.xml`, { gzip: false })])).eql(reference);
+        });
+
+        it("nodesetSourceFromUrl rejects with the status and the url, when the loader gets to it", async () => {
+            const before = nodesetSourceFromUrl(`${baseUrl}/nowhere.xml`, { init: { headers: { "x-test": "1" } } });
+            await load([before]).should.be.rejectedWith(/cannot fetch http:\/\/127\.0\.0\.1:\d+\/nowhere\.xml: 404/);
+        });
+
+        it("nodesetSourceFromStream names a factory", async () => {
+            const bytes = fs.readFileSync(nodesets.standard);
+            let opened = 0;
+            const source = nodesetSourceFromStream("pieces", () => {
+                opened += 1;
+                return bytePieces(bytes, 65536);
+            });
+            should(opened).eql(0);
+            should(await load([source])).eql(reference);
+            should(await load([source])).eql(reference, "the same value can be loaded again");
+            should(opened).eql(2);
+        });
     });
 
     it("turns the event loop while a chunked nodeset loads, as often as the budget says", async () => {

--- a/packages/node-opcua-address-space/test/test_nodeset_source.ts
+++ b/packages/node-opcua-address-space/test/test_nodeset_source.ts
@@ -30,6 +30,9 @@ import {
 } from "../distNodeJS/index.js";
 import { get_mini_nodeset_filename } from "../test_helpers/get_mini_address_space.js";
 
+// the local HTTP server that stands in for a model repository, in the source-helpers tests
+const httpPort = 5813;
+
 interface Digest {
     nodes: number;
     references: number;
@@ -211,7 +214,6 @@ describe("Loading a nodeset from a source", function (this: Mocha.Suite) {
         let tmp: string;
         let gzipFile: string;
         let httpServer: http.Server;
-        const httpPort = 5797;
         const baseUrl = `http://127.0.0.1:${httpPort}`;
         before(async () => {
             tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nodeset-helpers-"));

--- a/packages/node-opcua-address-space/test/test_nodeset_source.ts
+++ b/packages/node-opcua-address-space/test/test_nodeset_source.ts
@@ -179,6 +179,19 @@ describe("Loading a nodeset from a source", function (this: Mocha.Suite) {
         addressSpace.dispose();
     });
 
+    it("through generateAddressSpace, a list mixing file paths and sources", async () => {
+        // a string is a path here; a source stands for what is not a file
+        const gunzip = () => fs.createReadStream(nodesets.di).pipe(zlib.createGzip()).pipe(zlib.createGunzip());
+        const expected = await load(null, [nodesets.standard, nodesets.di]);
+        const addressSpace = AddressSpace.create();
+        try {
+            await generateAddressSpace(addressSpace, [nodesets.standard, { name: "di.gz", source: gunzip }]);
+            should(digest(addressSpace)).eql(expected);
+        } finally {
+            addressSpace.dispose();
+        }
+    });
+
     it("turns the event loop while a chunked nodeset loads, as often as the budget says", async () => {
         const bytes = fs.readFileSync(nodesets.standard);
         const ticks = async (yieldEveryBytes: number) => {

--- a/packages/node-opcua-address-space/test/test_nodeset_source.ts
+++ b/packages/node-opcua-address-space/test/test_nodeset_source.ts
@@ -211,7 +211,8 @@ describe("Loading a nodeset from a source", function (this: Mocha.Suite) {
         let tmp: string;
         let gzipFile: string;
         let httpServer: http.Server;
-        let baseUrl: string;
+        const httpPort = 5797;
+        const baseUrl = `http://127.0.0.1:${httpPort}`;
         before(async () => {
             tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nodeset-helpers-"));
             gzipFile = path.join(tmp, "Opc.Ua.NodeSet2.xml.gz");
@@ -230,8 +231,7 @@ describe("Loading a nodeset from a source", function (this: Mocha.Suite) {
                     res.end("no such model");
                 }
             });
-            await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
-            baseUrl = `http://127.0.0.1:${(httpServer.address() as { port: number }).port}`;
+            await new Promise<void>((resolve) => httpServer.listen(httpPort, "127.0.0.1", resolve));
         });
         after(async () => {
             await new Promise<void>((resolve) => httpServer.close(() => resolve()));

--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -13,6 +13,8 @@ import {
     type ISessionContext,
     innerBrowse,
     innerBrowseNext,
+    type NodeSetLoaderOptions,
+    type NodesetSource,
     type PseudoVariant,
     type PseudoVariantBoolean,
     type PseudoVariantByteString,
@@ -892,6 +894,33 @@ export interface OPCUAServerOptions extends OPCUABaseServerOptions, OPCUAServerE
     nodeset_filename?: string[] | string;
 
     /**
+     * NodeSet2 documents that are not files: a gzip file decompressed on the way, an HTTP
+     * response, a string of XML. Each is a {@link NodesetSource}; they load in the same call as
+     * `nodeset_filename`, in dependency order, so a source may require a model given as a file
+     * and the other way round. The standard nodeset is still loaded by default when
+     * `nodeset_filename` is absent; pass `nodeset_filename: []` to provide it as a source.
+     *
+     * example:
+     *
+     * ```javascript
+     * const server = new OPCUAServer({
+     *     nodesetSources: [
+     *         { name: modelFile, source: () => fs.createReadStream(modelFile).pipe(zlib.createGunzip()) }
+     *     ],
+     *     nodesetLoaderOptions: { yieldEveryBytes: 1024 * 1024 }
+     * });
+     * ```
+     */
+    nodesetSources?: NodesetSource[];
+
+    /**
+     * how the nodesets load: `yieldEveryBytes` keeps the process responsive while a streamed
+     * model loads, `imageStore` replays precompiled images, `permissions` and
+     * `accessRestrictions` say what of the declared access policy is applied.
+     */
+    nodesetLoaderOptions?: NodeSetLoaderOptions;
+
+    /**
      * the server Info
      *
      * this object contains the value that will populate the
@@ -1598,7 +1627,11 @@ export class OPCUAServer extends OPCUABaseServer<OPCUAServerEvents> {
         this.performPreInitialization()
             .then(() => {
                 OPCUAServer.registry.register(this);
-                this.engine.initialize(this.options, () => {
+                this.engine.initialize(this.options, (err?: Error | null) => {
+                    if (err) {
+                        done(err);
+                        return;
+                    }
                     if (!this.engine.addressSpace) {
                         done(new Error("no addressSpace"));
                         return;

--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -873,45 +873,40 @@ export interface OPCUAServerOptions extends OPCUABaseServerOptions, OPCUAServerE
     maxConnectionsPerEndpoint?: number;
 
     /**
-     * the nodeset.xml file(s) to load
+     * the NodeSet2 documents to load: file paths, and {@link NodesetSource} values for a
+     * document that is not a file. A string is a path, as it was in `nodeset_filename`;
+     * anything else is a source: a gzip file inflated on the way, an HTTP response, a string of
+     * XML. They load in one call, in dependency order whatever the order given, so a source may
+     * require a model given as a path and the other way round.
      *
-     * node-opcua comes with pre-installed node-set files that can be used
+     * When neither `nodesets` nor `nodeset_filename` is given, the standard nodeset is loaded.
      *
      * example:
      *
      * ```javascript
-     * import { nodesets } from "node-opcua-nodesets";
+     * import { nodesets, nodesetSourceFromGzipFile, nodesetSourceFromUrl, OPCUAServer } from "node-opcua";
      * const server = new OPCUAServer({
-     *     nodeset_filename: [
+     *     nodesets: [
      *         nodesets.standard,
      *         nodesets.di,
-     *         nodesets.adi,
-     *         nodesets.machinery,
-     *     ],
-     * });
-     * ```
-     */
-    nodeset_filename?: string[] | string;
-
-    /**
-     * NodeSet2 documents that are not files: a gzip file decompressed on the way, an HTTP
-     * response, a string of XML. Each is a {@link NodesetSource}; they load in the same call as
-     * `nodeset_filename`, in dependency order, so a source may require a model given as a file
-     * and the other way round. The standard nodeset is still loaded by default when
-     * `nodeset_filename` is absent; pass `nodeset_filename: []` to provide it as a source.
-     *
-     * example:
-     *
-     * ```javascript
-     * const server = new OPCUAServer({
-     *     nodesetSources: [
-     *         { name: modelFile, source: () => fs.createReadStream(modelFile).pipe(zlib.createGunzip()) }
+     *         nodesetSourceFromGzipFile("plant_model.xml.gz"),
+     *         nodesetSourceFromUrl("https://models.example.com/plant.xml")
      *     ],
      *     nodesetLoaderOptions: { yieldEveryBytes: 1024 * 1024 }
      * });
      * ```
      */
-    nodesetSources?: NodesetSource[];
+    nodesets?: string | Array<string | NodesetSource>;
+
+    /**
+     * the nodeset.xml file(s) to load
+     *
+     * @deprecated use {@link OPCUAServerOptions.nodesets}: it takes the same file paths, plus
+     * {@link NodesetSource} values for a gzip stream, an HTTP response or a string of XML.
+     * Renaming the key is the whole migration. Still honoured; entries given here load
+     * before those of `nodesets`.
+     */
+    nodeset_filename?: string[] | string;
 
     /**
      * how the nodesets load: `yieldEveryBytes` keeps the process responsive while a streamed

--- a/packages/node-opcua-server/source/server_engine.ts
+++ b/packages/node-opcua-server/source/server_engine.ts
@@ -15,6 +15,7 @@ import {
     type IServerBase,
     type ISessionContext,
     type MethodFunctor,
+    type NodesetSource,
     removeElement,
     type SessionContext,
     type UADynamicVariableArray,
@@ -899,15 +900,19 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
         options = options || {};
         assert(typeof callback === "function");
 
-        options.nodeset_filename = options.nodeset_filename || nodesets.standard;
-        const nodesetFiles = Array.isArray(options.nodeset_filename) ? options.nodeset_filename : [options.nodeset_filename];
-        // files and sources load in one call, so that a dependency may cross from one list to the other
-        const nodesetDocuments = [...nodesetFiles, ...(options.nodesetSources || [])];
+        const asList = <T>(value: T | T[] | undefined): T[] => (value === undefined ? [] : Array.isArray(value) ? value : [value]);
+        // the deprecated `nodeset_filename` and `nodesets` load in one call, the former first, so
+        // that a dependency may cross from one list to the other; nothing given means the standard nodeset
+        const nodesetDocuments: Array<string | NodesetSource> = [...asList(options.nodeset_filename), ...asList(options.nodesets)];
+        if (nodesetDocuments.length === 0) {
+            nodesetDocuments.push(nodesets.standard);
+        }
+        const nodesetNames = nodesetDocuments.map((d) => (typeof d === "string" ? d : (d as { name?: string }).name || "(source)"));
 
         const startTime = new Date();
 
         // c8 ignore next
-        doDebug && debugLog("Loading ", options.nodeset_filename, "...");
+        doDebug && debugLog("Loading ", nodesetNames, "...");
 
         this.addressSpace = AddressSpace.create();
 
@@ -929,8 +934,7 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
 
                 const endTime = new Date();
                 // c8 ignore next
-                doDebug &&
-                    debugLog("Loading ", options.nodeset_filename, " done : ", endTime.getTime() - startTime.getTime(), " ms");
+                doDebug && debugLog("Loading ", nodesetNames, " done : ", endTime.getTime() - startTime.getTime(), " ms");
 
                 const bindVariableIfPresent = (nodeId: NodeId, opts?: BindVariableOptions) => {
                     assert(!nodeId.isEmpty());

--- a/packages/node-opcua-server/source/server_engine.ts
+++ b/packages/node-opcua-server/source/server_engine.ts
@@ -900,6 +900,9 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
         assert(typeof callback === "function");
 
         options.nodeset_filename = options.nodeset_filename || nodesets.standard;
+        const nodesetFiles = Array.isArray(options.nodeset_filename) ? options.nodeset_filename : [options.nodeset_filename];
+        // files and sources load in one call, so that a dependency may cross from one list to the other
+        const nodesetDocuments = [...nodesetFiles, ...(options.nodesetSources || [])];
 
         const startTime = new Date();
 
@@ -915,12 +918,9 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
             const serverNamespace = this.addressSpace.registerNamespace(this.serverNamespaceUrn);
             assert(serverNamespace.index === 1);
         }
-        generateAddressSpace(this.addressSpace, options.nodeset_filename)
-            .catch((err) => {
-                console.log(err.message);
-                callback(err);
-            })
-            .then(() => {
+        // a load that fails reports once, through the callback, and the setup below is skipped
+        generateAddressSpace(this.addressSpace, nodesetDocuments, options.nodesetLoaderOptions).then(
+            () => {
                 /* c8 ignore next */
                 if (!this.addressSpace) {
                     throw new Error("Internal error");
@@ -1584,7 +1584,12 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
                 this._internalState = "initialized";
                 this.setServerState(ServerState.Running);
                 setImmediate(() => callback());
-            });
+            },
+            (err: Error) => {
+                errorLog(err.message);
+                callback(err);
+            }
+        );
     }
 
     public async browseWithAutomaticExpansion(

--- a/packages/node-opcua-server/test/test_server_nodeset_sources.ts
+++ b/packages/node-opcua-server/test/test_server_nodeset_sources.ts
@@ -1,10 +1,14 @@
 /**
- * A server loads its models from files (`nodeset_filename`) and from sources (`nodesetSources`):
- * a gzip stream here, in one call with the files, so the standard nodeset given as a file
- * satisfies what the streamed companion model requires. `nodesetLoaderOptions` reaches the loader.
+ * A server loads its models through `nodesets`: file paths and sources in one list, loaded in
+ * one call, so the standard nodeset given as a path satisfies what a streamed companion model
+ * requires. The deprecated `nodeset_filename` still works and merges into the same load.
+ * `nodesetLoaderOptions` reaches the loader.
  */
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import zlib from "node:zlib";
+import { nodesetSourceFromGzipFile } from "node-opcua-address-space/nodeJS";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import should from "should";
@@ -16,35 +20,56 @@ const DI = "http://opcfoundation.org/UA/DI/";
 describe("OPCUAServer loading nodesets from sources", function (this: Mocha.Suite) {
     this.timeout(60000);
 
-    it("loads a companion model given as a gzip stream next to the standard nodeset file", async () => {
+    let diGzipFile: string;
+    before(() => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nodeset-gz-"));
+        diGzipFile = path.join(tmp, "Opc.Ua.Di.NodeSet2.xml.gz");
+        fs.writeFileSync(diGzipFile, zlib.gzipSync(fs.readFileSync(nodesets.di)));
+    });
+    after(() => {
+        fs.rmSync(path.dirname(diGzipFile), { recursive: true, force: true });
+    });
+
+    const expectDeviceSet = (server: OPCUAServer) => {
+        const addressSpace = server.engine.addressSpace!;
+        const diNamespace = addressSpace.getNamespace(DI);
+        should.exist(diNamespace, "the DI namespace comes from the stream");
+        diNamespace.findNode("i=5001")!.browseName.name!.should.eql("DeviceSet");
+        should(addressSpace.getNamespaceArray()[1].namespaceUri).match(/^urn:/, "the server's own namespace stays at index 1");
+    };
+
+    it("loads a companion model given as a gzip file next to the standard nodeset path", async () => {
         const server = new OPCUAServer({
             port,
-            nodeset_filename: [nodesets.standard],
-            nodesetSources: [
-                {
-                    name: "Opc.Ua.Di.NodeSet2.xml.gz",
-                    source: () => fs.createReadStream(nodesets.di).pipe(zlib.createGzip()).pipe(zlib.createGunzip())
-                }
-            ],
+            nodesets: [nodesets.standard, nodesetSourceFromGzipFile(diGzipFile)],
             nodesetLoaderOptions: { yieldEveryBytes: 64 * 1024 }
         });
         try {
             await server.initialize();
-            const addressSpace = server.engine.addressSpace!;
-            const diNamespace = addressSpace.getNamespace(DI);
-            should.exist(diNamespace, "the DI namespace comes from the stream");
-            diNamespace.findNode("i=5001")!.browseName.name!.should.eql("DeviceSet");
-            should(addressSpace.getNamespaceArray()[1].namespaceUri).match(/^urn:/, "the server's own namespace stays at index 1");
+            expectDeviceSet(server);
         } finally {
             await server.shutdown();
         }
     });
 
-    it("names the missing model when a source requires one that no file provides", async () => {
+    it("merges the deprecated nodeset_filename with nodesets", async () => {
         const server = new OPCUAServer({
             port,
             nodeset_filename: [nodesets.standard],
-            nodesetSources: [{ name: "adi.xml", source: () => fs.createReadStream(nodesets.adi) }]
+            nodesets: [nodesetSourceFromGzipFile(diGzipFile)]
+        });
+        try {
+            await server.initialize();
+            expectDeviceSet(server);
+        } finally {
+            await server.shutdown();
+        }
+    });
+
+    it("names the missing model when a source requires one that no path provides", async () => {
+        const server = new OPCUAServer({
+            port,
+            nodesets: [nodesets.standard, { name: "adi.xml", source: () => fs.createReadStream(nodesets.adi) }]
         });
         try {
             await server.initialize().should.be.rejectedWith(/Cannot find namespace for http:\/\/opcfoundation.org\/UA\/DI\//);

--- a/packages/node-opcua-server/test/test_server_nodeset_sources.ts
+++ b/packages/node-opcua-server/test/test_server_nodeset_sources.ts
@@ -34,7 +34,7 @@ describe("OPCUAServer loading nodesets from sources", function (this: Mocha.Suit
         const addressSpace = server.engine.addressSpace!;
         const diNamespace = addressSpace.getNamespace(DI);
         should.exist(diNamespace, "the DI namespace comes from the stream");
-        diNamespace.findNode("i=5001")!.browseName.name!.should.eql("DeviceSet");
+        should(diNamespace.findNode("i=5001")?.browseName.name).eql("DeviceSet");
         should(addressSpace.getNamespaceArray()[1].namespaceUri).match(/^urn:/, "the server's own namespace stays at index 1");
     };
 

--- a/packages/node-opcua-server/test/test_server_nodeset_sources.ts
+++ b/packages/node-opcua-server/test/test_server_nodeset_sources.ts
@@ -1,0 +1,57 @@
+/**
+ * A server loads its models from files (`nodeset_filename`) and from sources (`nodesetSources`):
+ * a gzip stream here, in one call with the files, so the standard nodeset given as a file
+ * satisfies what the streamed companion model requires. `nodesetLoaderOptions` reaches the loader.
+ */
+import fs from "node:fs";
+import zlib from "node:zlib";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { nodesets } from "node-opcua-nodesets";
+import should from "should";
+import { OPCUAServer } from "../source/index.js";
+
+const port = 2036;
+const DI = "http://opcfoundation.org/UA/DI/";
+
+describe("OPCUAServer loading nodesets from sources", function (this: Mocha.Suite) {
+    this.timeout(60000);
+
+    it("loads a companion model given as a gzip stream next to the standard nodeset file", async () => {
+        const server = new OPCUAServer({
+            port,
+            nodeset_filename: [nodesets.standard],
+            nodesetSources: [
+                {
+                    name: "Opc.Ua.Di.NodeSet2.xml.gz",
+                    source: () => fs.createReadStream(nodesets.di).pipe(zlib.createGzip()).pipe(zlib.createGunzip())
+                }
+            ],
+            nodesetLoaderOptions: { yieldEveryBytes: 64 * 1024 }
+        });
+        try {
+            await server.initialize();
+            const addressSpace = server.engine.addressSpace!;
+            const diNamespace = addressSpace.getNamespace(DI);
+            should.exist(diNamespace, "the DI namespace comes from the stream");
+            diNamespace.findNode("i=5001")!.browseName.name!.should.eql("DeviceSet");
+            should(addressSpace.getNamespaceArray()[1].namespaceUri).match(/^urn:/, "the server's own namespace stays at index 1");
+        } finally {
+            await server.shutdown();
+        }
+    });
+
+    it("names the missing model when a source requires one that no file provides", async () => {
+        const server = new OPCUAServer({
+            port,
+            nodeset_filename: [nodesets.standard],
+            nodesetSources: [{ name: "adi.xml", source: () => fs.createReadStream(nodesets.adi) }]
+        });
+        try {
+            await server.initialize().should.be.rejectedWith(/Cannot find namespace for http:\/\/opcfoundation.org\/UA\/DI\//);
+        } finally {
+            // a server that failed to initialize cannot be shut down; release what it had built
+            server.engine.addressSpace?.dispose();
+            server.dispose();
+        }
+    });
+});


### PR DESCRIPTION
## Problem

`findOrder()` in `generateAddressSpaceRaw.ts` resolved each `RequiredModel` among the documents of the current call only. After `server.initialize()` had loaded `Opc.Ua.NodeSet2.xml`, a second call such as `generateAddressSpaceRaw(server.engine.addressSpace, [diGzipStreamSource])` failed with `Cannot find namespace for http://opcfoundation.org/UA/`, although namespace 0 was in the address space.

## Loader (commit 1)

- `findOrder(nodesetDescs, isSatisfied?)`: a required model that no document of the call provides is an error unless the predicate says it is satisfied.
- `loadedModelSatisfies(addressSpace)`: satisfied when the namespace is registered with a version at least the required one (semver over `makeSemverCompatible`, as the record applier already does). A lower version throws naming both versions. An absent namespace stays `Cannot find namespace for …`.
- The record applier already reused an existing namespace, so nothing else changes on the load path.
- Found on the way: a failed nodeset load in `ServerEngine.initialize` went through `.catch().then()`, calling the callback twice, and `OPCUAServer.initialize()` ignored the error, so the promise resolved with a half-loaded address space. It now rejects with the loader's message.

## Server (commit 2)

```ts
const server = new OPCUAServer({
    nodesets: [
        nodesets.standard,                                   // a string is a path, as in nodeset_filename
        nodesetSourceFromGzipFile("plant_model.xml.gz"),     // Node.js build
        nodesetSourceFromUrl("https://models.example.com/plant.xml", { init: { headers } })
    ],
    nodesetLoaderOptions: { yieldEveryBytes: 1024 * 1024 }
});
```

| Option | Meaning |
|---|---|
| `nodesets?: string \| Array<string \| NodesetSource>` | paths and sources in one list, loaded in one call in dependency order |
| `nodesetLoaderOptions?: NodeSetLoaderOptions` | `yieldEveryBytes`, `imageStore`, `permissions`, `accessRestrictions` |
| `nodeset_filename` | **deprecated**, still honoured; when both are given they load together, its entries first |

Nothing given still loads the standard nodeset. Renaming the key is the whole migration. The Node.js `generateAddressSpace(addressSpace, documents, options)` accepts the same mix.

## Source helpers

Each is lazy (nothing opened or fetched before the loader reaches the document) and reusable across loads.

| Helper | Build | Behaviour |
|---|---|---|
| `nodesetSourceFromGzipFile(path)` | Node.js | `.xml.gz` inflated on the way; a missing file is reported when opened |
| `nodesetSourceFromUrl(url, { init?, gzip? })` | core, browser too | rejects the load with `cannot fetch <url>: <status>` when not ok; inflates a `.gz` url or `gzip: true`; a `Content-Encoding: gzip` body is left to `fetch` |
| `nodesetSourceFromStream(name, open)` | core | a name and a factory |

## Tests

- `test_nodeset_ordering.ts` NSO-6 to NSO-9: the predicate alone; DI as a gzip stream in a second call after the standard nodeset; ADI in a second call with DI nowhere still fails; a loaded UA version lower than DI requires fails, then loads once the version is enough.
- `test_nodeset_source.ts`: `generateAddressSpace` with a path and a source; each helper against a local HTTP server (plain, `.gz` as is, `Content-Encoding: gzip`, 404) and a temp gzip file.
- `test_server_nodeset_sources.ts`: `nodesets` with a path and a gzip file plus `yieldEveryBytes`; `nodeset_filename` merged with `nodesets`; a source requiring a missing model rejects `initialize()`.

| Suite | Result |
|---|---|
| node-opcua-address-space | 1265 passing, 1 pending |
| node-opcua-server | 485 passing |
| `test:check` both packages, biome | clean |

The advanced book chapter `150-address_space_loading/s10` is updated in the book repo: multi-call loading, `nodesets`, the deprecation note and the helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
