### PR TITLE
fix(client): notify subscriptionId changes after a reconnection rebuild

### DIFF
--- a/documentation/creating_a_client_typescript.md
+++ b/documentation/creating_a_client_typescript.md
@@ -259,6 +259,11 @@ subscription
   })
   .on("terminated", function() {
     console.log("terminated");
+  })
+  .on("subscriptionId_changed", function(subscriptionId, previousSubscriptionId) {
+    // the client had to recreate the subscription on the server while repairing
+    // a broken connection; subscriptionId no longer matches the value seen in "started"
+    console.log("subscriptionId changed from", previousSubscriptionId, "to", subscriptionId);
   });
 
 // install monitored item

--- a/packages/node-opcua-client/source/client_subscription.ts
+++ b/packages/node-opcua-client/source/client_subscription.ts
@@ -255,6 +255,23 @@ export declare interface ClientSubscription {
     on(event: "terminated", eventHandler: () => void): this;
 
     /**
+     * notify the observers that the subscription has been recreated with a new subscriptionId.
+     *
+     * This happens when the client repairs a broken connection and the server could not
+     * transfer the original subscription (TransferSubscriptions not supported or refused,
+     * or the subscription had already timed out and been deleted on the server). In that
+     * case the client silently creates a new subscription on the server, and `subscriptionId`
+     * is updated to reflect it. Since `started` is only emitted once, applications that need
+     * to track the current subscriptionId (for logging, diagnostics, or correlating it with
+     * server-side state) should listen to this event as well.
+     * @event subscriptionId_changed
+     */
+    on(
+        event: "subscriptionId_changed",
+        eventHandler: (subscriptionId: SubscriptionId, previousSubscriptionId: SubscriptionId) => void
+    ): this;
+
+    /**
      * notify the observers that a new monitored item has been added to the subscription.
      * @event  item_added
      */

--- a/packages/node-opcua-client/source/private/reconnection/client_subscription_reconnection.ts
+++ b/packages/node-opcua-client/source/private/reconnection/client_subscription_reconnection.ts
@@ -65,6 +65,10 @@ export async function recreateSubscriptionAndMonitoredItem(_subscription: Client
         throw _err;
     }
 
+    if (subscription.subscriptionId !== oldSubscriptionId) {
+        subscription.emit("subscriptionId_changed", subscription.subscriptionId, oldSubscriptionId);
+    }
+
     const _test = subscription.publishEngine.getSubscription(subscription.subscriptionId);
 
     // c8 ignore next

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_subscription_survives_refused_transfer_on_reconnection.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_subscription_survives_refused_transfer_on_reconnection.ts
@@ -141,6 +141,7 @@ interface ScenarioResult {
     reconnected: boolean;
     lastValueBeforeBreak: number;
     valuesAfterRecovery: number[];
+    subscriptionIdChangedEvents: Array<{ subscriptionId: number; previousSubscriptionId: number }>;
 }
 
 /**
@@ -181,6 +182,11 @@ async function runReconnectionScenario(handle: ServerHandle): Promise<ScenarioRe
             TimestampsToReturn.Both
         );
 
+        const subscriptionIdChangedEvents: Array<{ subscriptionId: number; previousSubscriptionId: number }> = [];
+        subscription.on("subscriptionId_changed", (subscriptionId, previousSubscriptionId) => {
+            subscriptionIdChangedEvents.push({ subscriptionId, previousSubscriptionId });
+        });
+
         // 1) make sure the subscription is live and delivering notifications
         const valuesBefore = await collectValueChanges(
             monitoredItem,
@@ -208,7 +214,7 @@ async function runReconnectionScenario(handle: ServerHandle): Promise<ScenarioRe
         );
         const after = subscription.subscriptionId;
 
-        return { before, after, reconnected, lastValueBeforeBreak, valuesAfterRecovery };
+        return { before, after, reconnected, lastValueBeforeBreak, valuesAfterRecovery, subscriptionIdChangedEvents };
     } finally {
         await client.disconnect();
     }
@@ -247,6 +253,17 @@ describe("GHTR1 - transferred-vs-rebuilt subscription after reconnection (OPC UA
                 .some((s) => /BadUserAccessDenied/.test(s))
                 .should.eql(true, `server should have refused the transfer, got: ${handle.transferStatuses.join(", ")}`);
             result.after.should.not.eql(result.before, "subscription should have been rebuilt with a new subscriptionId");
+
+            // the application must be notified of the new subscriptionId (GITHUB ISSUE #1368): "started"
+            // is only emitted once, so a rebuild that happens later needs its own event.
+            result.subscriptionIdChangedEvents
+                .some((event) => event.subscriptionId === result.after && event.previousSubscriptionId === result.before)
+                .should.eql(
+                    true,
+                    `expected a subscriptionId_changed event from ${result.before} to ${result.after}, got: ${JSON.stringify(
+                        result.subscriptionIdChangedEvents
+                    )}`
+                );
         } finally {
             await handle.stop();
         }
@@ -266,6 +283,10 @@ describe("GHTR1 - transferred-vs-rebuilt subscription after reconnection (OPC UA
                 .some((s) => /^Good/.test(s))
                 .should.eql(true, `server should have accepted the transfer, got: ${handle.transferStatuses.join(", ")}`);
             result.after.should.eql(result.before, "subscription should have been transferred keeping its subscriptionId");
+            result.subscriptionIdChangedEvents.should.eql(
+                [],
+                "no subscriptionId_changed event should fire when the subscriptionId did not change"
+            );
         } finally {
             await handle.stop();
         }


### PR DESCRIPTION
## Summary
- When the server can't transfer a subscription during reconnection (transfer unsupported/refused, or a timed-out subscription discovered via Republish), the client silently recreates it with a new `subscriptionId` — `started` only fires once at creation, so the application had no supported way to observe the change.
- Emits a new `subscriptionId_changed` event from the rebuild path in `client_subscription_reconnection.ts`, carrying the new and previous ids.
- Documents the event in `creating_a_client_typescript.md`.

## Test plan
- [x] `tsc -b packages` across the workspace
- [x] `biome check`
- [x] Extended `test_e2e_subscription_survives_refused_transfer_on_reconnection.ts`: asserts the event fires with the correct before/after ids when the subscription is rebuilt, and does *not* fire when TransferSubscriptions succeeds and the id is preserved. Both scenarios pass.

Fixes #1368

🤖 Generated with [Claude Code](https://claude.com/claude-code)