### PR TITLE
fix(address-space): correct two write-rejection status codes

### DIFF
--- a/packages/node-opcua-address-space/impl/ua_variable_impl.ts
+++ b/packages/node-opcua-address-space/impl/ua_variable_impl.ts
@@ -1073,9 +1073,11 @@ export class UAVariableImpl<T extends UAVariableEvents & ListenerSignature<T> = 
                     break;
                 }
 
-                // if the variable has no historizing in place reject
+                // Historizing is a real, writable attribute of a Variable (Part 3 5.6.2); a node
+                // without an HA Configuration simply cannot honour it right now, which is
+                // BadNotWritable, not BadNotSupported (that would mean the attribute never applies).
                 if (!this.getChildByName("HA Configuration")) {
-                    callback(null, StatusCodes.BadNotSupported);
+                    callback(null, StatusCodes.BadNotWritable);
                     break;
                 }
                 // check if user is allowed to do that !

--- a/packages/node-opcua-address-space/impl/ua_variable_impl.ts
+++ b/packages/node-opcua-address-space/impl/ua_variable_impl.ts
@@ -916,8 +916,11 @@ export class UAVariableImpl<T extends UAVariableEvents & ListenerSignature<T> = 
             return;
         }
 
+        // isWritable() and the role permission above already passed, so a false result
+        // here can only come from the UserAccessLevel attribute withholding CurrentWrite
+        // for this user (Part 3 5.6.3): that is an access decision, not an unsupported call.
         if (!this.isUserWritable(context)) {
-            callback?.(null, StatusCodes.BadWriteNotSupported);
+            callback?.(null, StatusCodes.BadUserAccessDenied);
             return;
         }
 

--- a/packages/node-opcua-address-space/test/test_variable_write_status_codes.ts
+++ b/packages/node-opcua-address-space/test/test_variable_write_status_codes.ts
@@ -1,4 +1,5 @@
 import { AttributeIds } from "node-opcua-data-model";
+import { DataValue } from "node-opcua-data-value";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import { nodesets } from "node-opcua-nodesets";
 import { StatusCodes } from "node-opcua-status-code";
@@ -20,6 +21,24 @@ describe("testing the StatusCode returned when a Variable write is rejected", ()
     });
     after(() => {
         addressSpace.dispose();
+    });
+
+    it("should reject a Value write with BadUserAccessDenied when UserAccessLevel withholds CurrentWrite", async () => {
+        const namespace = addressSpace.getOwnNamespace();
+        const variable = namespace.addVariable({
+            browseName: "RestrictedToRead",
+            dataType: DataType.Double,
+            organizedBy: addressSpace.rootFolder.objects,
+            accessLevel: "CurrentRead | CurrentWrite",
+            userAccessLevel: "CurrentRead",
+            value: { dataType: DataType.Double, value: 0 }
+        }) as UAVariable;
+
+        const dataValue = new DataValue({ value: { dataType: DataType.Double, value: 42 } });
+        const statusCode = await variable.writeValue(context, dataValue);
+        // AccessLevel allows the write in general; it is this user's UserAccessLevel that
+        // forbids it here, which is an access decision, not "writing is unsupported".
+        statusCode.should.eql(StatusCodes.BadUserAccessDenied);
     });
 
     it("should reject a Historizing write with BadNotWritable when the node has no HA Configuration", async () => {

--- a/packages/node-opcua-address-space/test/test_variable_write_status_codes.ts
+++ b/packages/node-opcua-address-space/test/test_variable_write_status_codes.ts
@@ -1,0 +1,45 @@
+import { AttributeIds } from "node-opcua-data-model";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { nodesets } from "node-opcua-nodesets";
+import { StatusCodes } from "node-opcua-status-code";
+import type { WriteValueOptions } from "node-opcua-types";
+import { DataType } from "node-opcua-variant";
+import should from "should";
+import { AddressSpace, SessionContext, type UAVariable } from "../dist/api/index.js";
+import { generateAddressSpace } from "../nodeJS.js";
+
+const context = SessionContext.defaultContext;
+
+describe("testing the StatusCode returned when a Variable write is rejected", () => {
+    let addressSpace: AddressSpace;
+
+    before(async () => {
+        addressSpace = AddressSpace.create();
+        addressSpace.registerNamespace("http://sterfive.com/UA/WriteStatusCodes/");
+        await generateAddressSpace(addressSpace, [nodesets.standard]);
+    });
+    after(() => {
+        addressSpace.dispose();
+    });
+
+    it("should reject a Historizing write with BadNotWritable when the node has no HA Configuration", async () => {
+        const namespace = addressSpace.getOwnNamespace();
+        const variable = namespace.addVariable({
+            browseName: "NotHistorized",
+            dataType: DataType.Double,
+            organizedBy: addressSpace.rootFolder.objects,
+            value: { dataType: DataType.Double, value: 0 }
+        }) as UAVariable;
+        should(variable.getChildByName("HA Configuration")).eql(null);
+
+        const writeValue: WriteValueOptions = {
+            attributeId: AttributeIds.Historizing,
+            value: { value: { dataType: DataType.Boolean, value: true } }
+        };
+        const statusCode = await variable.writeAttribute(context, writeValue);
+        // Historizing is a real attribute of a Variable; nothing about this node makes the
+        // attribute inapplicable (that would be BadAttributeIdInvalid), it just cannot be
+        // turned on without an HA Configuration.
+        statusCode.should.eql(StatusCodes.BadNotWritable);
+    });
+});


### PR DESCRIPTION
## Summary
- A variable's Historizing attribute is genuinely writable but cannot be turned on without an HA Configuration; that now returns `BadNotWritable` instead of the misleading `BadNotSupported`.
- A write allowed by AccessLevel but withheld by UserAccessLevel for the current user now returns `BadUserAccessDenied` instead of `BadWriteNotSupported`.

Both are access-control status codes returned from the wrong branch of the write logic in `UAVariableImpl`; each now matches the specific reason the write was refused.

## Test plan
- [x] `packages/node-opcua-address-space/test/test_variable_write_status_codes.ts` (new): one test per fix
- [x] `packages/node-opcua-address-space/test/test_variable.ts`, `test_set_permissions.ts`: no regressions
- [x] typecheck, biome, check:importext, check:shortcircuit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
