### PR TITLE
fix(address-space): a variable of an abstract DataType can be written its own built-in encoding

### DIFF
--- a/packages/node-opcua-address-space/impl/validate_data_type_correctness.ts
+++ b/packages/node-opcua-address-space/impl/validate_data_type_correctness.ts
@@ -104,7 +104,17 @@ export function validateDataTypeCorrectness(
     // The value supplied for the attribute is not of the same type as the  value.
     const variantUADataType = _dataType_toUADataType(addressSpace, variantDataType);
 
-    const dest_isSubTypeOf_variant = variantUADataType.isSubtypeOf(builtInUADataType);
+    let dest_isSubTypeOf_variant = variantUADataType.isSubtypeOf(builtInUADataType);
+
+    // A family such as Image (-> ImageBMP/ImageGIF/ImageJPG/ImagePNG) is abstract, so the
+    // check above compares against Image itself; but none of its members have their own
+    // built-in encoding, so a Variant for one of them is always stamped with Image's own
+    // built-in ancestor (ByteString) - a supertype of Image, not a subtype of it, and the
+    // check above always fails for it. Accept a variant that matches that resolved ancestor.
+    if (!dest_isSubTypeOf_variant && destUADataType.isAbstract) {
+        const resolvedBuiltInType = addressSpace.findCorrespondingBasicDataType(destUADataType);
+        dest_isSubTypeOf_variant = resolvedBuiltInType !== DataType.Null && resolvedBuiltInType === variantDataType;
+    }
 
     // c8 ignore next
     if (doDebug) {

--- a/packages/node-opcua-address-space/test/test_validate_data_type_correctness.ts
+++ b/packages/node-opcua-address-space/test/test_validate_data_type_correctness.ts
@@ -135,6 +135,20 @@ describe("testing validateDataTypeCorrectness", () => {
         validateDataTypeCorrectness(addressSpace, dataType, DataType.QualifiedName, false).should.eql(false);
     });
 
+    // Image (-> ImageBMP/ImageGIF/ImageJPG/ImagePNG) is abstract and its members have no
+    // built-in encoding of their own: a Variant for any of them is stamped with ByteString,
+    // Image's own built-in ancestor - a supertype of Image, never a subtype.
+    it("0:Image: should accept a DataType.ByteString variant", async () => {
+        const dataType = addressSpace.findDataType("Image")!.nodeId;
+        should.exist(dataType);
+        validateDataTypeCorrectness(addressSpace, dataType, DataType.ByteString, false).should.eql(true);
+    });
+    it("0:Image: should reject a DataType.Int32 variant", async () => {
+        const dataType = addressSpace.findDataType("Image")!.nodeId;
+        should.exist(dataType);
+        validateDataTypeCorrectness(addressSpace, dataType, DataType.Int32, false).should.eql(false);
+    });
+
     it("DataType.Null: should accept DataType.Null if allow Null", async () => {
         const ns = addressSpace.getNamespaceIndex("http://myorganisation.org/customTypes");
         ns.should.not.eql(-1);


### PR DESCRIPTION
## Summary
- A write to a variable declared with an abstract DataType (e.g. `Image`) was rejected even when the incoming Variant carried exactly the type's own built-in encoding (`ByteString` for `Image`). The abstract-type branch of `validateDataTypeCorrectness` only checked subtype membership against the abstract type itself, which works for a family like `Number` (whose members carry distinct built-in encodings) but not for one like `Image`, whose members have no built-in encoding of their own and always arrive on the wire as the shared ancestor type.

## Test plan
- [x] `packages/node-opcua-address-space/test/test_validate_data_type_correctness.ts`: two new cases (accept ByteString, reject Int32) for the `Image` DataType
- [x] `packages/node-opcua-address-space/test/test_variable.ts`, `test_set_permissions.ts`: no regressions
- [x] typecheck, biome, check:importext, check:shortcircuit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
