### PR TITLE
fix: three SDK conformance bugs found by the OPC Foundation CTT, plus the fixture nodes it needs

### DIFF
--- a/packages/node-opcua-address-space-for-conformance-testing/src/address_space_for_conformance_testing.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/address_space_for_conformance_testing.ts
@@ -8,6 +8,7 @@ import { add_eventGeneratorObject } from "node-opcua-address-space/testHelpers";
 import { addAccessRightVariables } from "./conformance_testing/access_right_variables.js";
 import { addAnalogDataItems } from "./conformance_testing/analog_data_items.js";
 import { addCttFolder } from "./conformance_testing/ctt_folder.js";
+import { type CustomExtensionObjectOptions, resolveCustomExtensionObject } from "./conformance_testing/custom_extension_object.js";
 import {
     addMultiStateDiscreteVariable,
     addMultiStateValueDiscreteVariables,
@@ -23,14 +24,29 @@ import { addSimulationVariables } from "./conformance_testing/simulation_variabl
 import { addStaticVariables } from "./conformance_testing/static_variables.js";
 import { addTriggerNodes } from "./conformance_testing/trigger_nodes.js";
 
+export type { CustomExtensionObjectOptions } from "./conformance_testing/custom_extension_object.js";
+
+export interface BuildAddressSpaceForConformanceTestingOptions {
+    mass_variable?: boolean;
+    mass_variables?: boolean;
+    /**
+     * The concrete structure the ExtensionObject variables hold. Namespace zero
+     * has none worth exercising, so a caller that has loaded a companion nodeset
+     * passes one in; without it those variables keep a null ExtensionObject.
+     * See ./conformance_testing/custom_extension_object.ts.
+     */
+    extensionObject?: CustomExtensionObjectOptions;
+}
+
 export async function build_address_space_for_conformance_testing(
     addressSpace: AddressSpace,
-    options?: { mass_variable?: boolean; mass_variables?: boolean }
+    options?: BuildAddressSpaceForConformanceTestingOptions
 ): Promise<void> {
     const namespace = addressSpace.registerNamespace("urn://node-opcua-simulator");
 
     options = options || {};
     options.mass_variable = options.mass_variable || false;
+    const custom = resolveCustomExtensionObject(addressSpace, options.extensionObject);
 
     const objectsFolder = addressSpace.findNode("ObjectsFolder") as UAObject;
 
@@ -50,19 +66,19 @@ export async function build_address_space_for_conformance_testing(
     });
 
     // Scalars/Array/MultiDim array of all sorts
-    await addStaticVariables(namespace, allProfileFolder);
+    await addStaticVariables(namespace, allProfileFolder, custom);
 
     if (options.mass_variables) {
-        addMassVariables(namespace, allProfileFolder);
+        addMassVariables(namespace, allProfileFolder, custom);
     }
     addAnalogDataItems(namespace, allProfileFolder);
 
     const dynamicVariablesFolder = namespace.addFolder(simulationFolder, {
         browseName: "Dynamic"
     });
-    addSimulationVariables(namespace, dynamicVariablesFolder);
+    addSimulationVariables(namespace, dynamicVariablesFolder, custom);
 
-    addVeryLargeArrayVariables(namespace, staticVariablesFolder);
+    addVeryLargeArrayVariables(namespace, staticVariablesFolder, custom);
 
     addPath10Deep(namespace, simulationFolder);
 

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/alarm_input_nodes.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/alarm_input_nodes.ts
@@ -1,0 +1,151 @@
+/**
+ * The Alarms & Conditions input nodes of the CTT server project.
+ *
+ * A setting named "<X>Type Input Nodes" wants the *source* Variable an alarm of
+ * that type watches, not the alarm itself: the CTT writes to that Variable and
+ * expects the alarm to change state and report an event. So each entry here is
+ * a writable scalar plus an alarm instantiated on it. The two "Setpoint Source"
+ * settings are the odd ones out - they name the setpoint Variable of the
+ * matching deviation alarm, which is created alongside its input node.
+ *
+ * All alarms hang off a single `AlarmSource` object which is an event source of
+ * the Server object, so the events reach a client subscribed to Server (i=2253)
+ * - which is what the CTT subscribes to. `conditionSource` refuses a node that
+ * is not an event source of anything.
+ *
+ * Not built: `DiscrepancyAlarmType Input Nodes`. DiscrepancyAlarmType derives
+ * straight from AlarmConditionType and its mandatory TargetValueNode /
+ * ExpectedTime / Tolerance children have no implementation behind them in
+ * node-opcua, so an instance would be an inert shell. The two RateOfChange
+ * types, by contrast, derive from the two limit alarm types and instantiate
+ * through them; they carry no rate-of-change behaviour either, but the CTT's
+ * limit-alarm tests exercise them meaningfully.
+ */
+import type { Namespace, UAObject, UAVariable } from "node-opcua-address-space";
+import { DataType, Variant } from "node-opcua-variant";
+
+import type { CttFolder } from "./ctt_tree.js";
+
+/** where the CTT keeps these settings; outside "Server Test/NodeIds", so the whole path is the key */
+const GROUP = "Server Test/Alarms and Conditions/Supported Condition Types";
+
+/** the limits every limit-derived alarm here is given, in the units of a 0..100 input */
+const LIMITS = { lowLowLimit: 10, lowLimit: 25, highLimit: 75, highHighLimit: 90 };
+
+const double = (value: number) => new Variant({ dataType: DataType.Double, value });
+const boolean = (value: boolean) => new Variant({ dataType: DataType.Boolean, value });
+
+/**
+ * The object every alarm is a condition of. It must be an event source of
+ * something, or `conditionSource` throws; making it an event source of the
+ * Server object is what puts its events on the Server notifier the CTT
+ * subscribes to.
+ */
+function addAlarmSource(ctt: CttFolder): UAObject {
+    const server = ctt.addressSpace.rootFolder.objects.server;
+    return ctt.namespace.addObject({
+        browseName: "AlarmSource",
+        nodeId: ctt.nodeId("Server Test/Alarms and Conditions/AlarmSource"),
+        organizedBy: ctt.folder("Server Test/Alarms and Conditions"),
+        description: "condition source of the CTT alarm input nodes",
+        eventSourceOf: server
+    });
+}
+
+export function addAlarmInputNodes(ctt: CttFolder): void {
+    const namespace: Namespace = ctt.namespace;
+    const conditionSource = addAlarmSource(ctt);
+
+    /** the writable Variable a CTT alarm setting points at; 50 sits inside LIMITS, so alarms start inactive */
+    const inputNode = (leaf: string, kind: "Double" | "Boolean"): UAVariable =>
+        ctt.variable(`${GROUP}/${leaf}`, kind, -1, kind === "Double" ? double(50) : boolean(false), null);
+
+    /** a deviation setpoint, at 0 so the deviation the alarm evaluates is the input value itself */
+    const setpointNode = (leaf: string): UAVariable => ctt.variable(`${GROUP}/${leaf}`, "Double", -1, double(0), null);
+
+    const alarmOptions = (browseName: string, input: UAVariable) => ({
+        browseName,
+        nodeId: ctt.nodeId(`Server Test/Alarms and Conditions/${browseName}`),
+        conditionSource,
+        inputNode: input
+    });
+
+    // ── AlarmConditionType ──────────────────────────────────────────────
+    // the base type has no sub-state model: the CTT drives ActiveState itself
+    namespace.instantiateAlarmCondition(
+        "AlarmConditionType",
+        alarmOptions("AlarmCondition", inputNode("AlarmConditionType Input Nodes", "Double"))
+    );
+
+    // ── the limit family ────────────────────────────────────────────────
+    namespace.instantiateLimitAlarm("LimitAlarmType", {
+        ...alarmOptions("LimitAlarm", inputNode("LimitAlarmType Input Nodes", "Double")),
+        ...LIMITS
+    });
+
+    for (const [typeName, leaf] of [
+        ["ExclusiveLimitAlarmType", "ExclusiveLimitAlarmType Input Nodes"],
+        ["ExclusiveLevelAlarmType", "ExclusiveLevelAlarmType Input Nodes"],
+        ["ExclusiveRateOfChangeAlarmType", "ExclusiveRateOfChangeAlarmType Input Nodes"]
+    ]) {
+        namespace.instantiateExclusiveLimitAlarm(typeName, {
+            ...alarmOptions(typeName.replace(/Type$/, ""), inputNode(leaf, "Double")),
+            ...LIMITS
+        });
+    }
+
+    for (const [typeName, leaf] of [
+        ["NonExclusiveLimitAlarmType", "NonExclusiveLimitAlarmType Input Nodes"],
+        ["NonExclusiveLevelAlarmType", "NonExclusiveLevelAlarmType Input Nodes"],
+        ["NonExclusiveRateOfChangeAlarmType", "NonExclusiveRateOfChangeAlarmType Input Nodes"]
+    ]) {
+        namespace.instantiateNonExclusiveLimitAlarm(typeName, {
+            ...alarmOptions(typeName.replace(/Type$/, ""), inputNode(leaf, "Double")),
+            ...LIMITS
+        });
+    }
+
+    // ── the deviation pairs: the setpoint is a setting of its own ───────
+    const exclusiveSetpoint = setpointNode("Exclusive Deviation Setpoint Source");
+    namespace.instantiateExclusiveDeviationAlarm({
+        ...alarmOptions("ExclusiveDeviationAlarm", inputNode("ExclusiveDeviationAlarmType Input Nodes", "Double")),
+        ...LIMITS,
+        setpointNode: exclusiveSetpoint as Parameters<Namespace["instantiateExclusiveDeviationAlarm"]>[0]["setpointNode"]
+    });
+
+    const nonExclusiveSetpoint = setpointNode("NonExclusive Deviation Setpoint Source");
+    namespace.instantiateNonExclusiveDeviationAlarm({
+        ...alarmOptions("NonExclusiveDeviationAlarm", inputNode("NonExclusiveDeviationAlarmType Input Nodes", "Double")),
+        ...LIMITS,
+        setpointNode: nonExclusiveSetpoint as Parameters<Namespace["instantiateNonExclusiveDeviationAlarm"]>[0]["setpointNode"]
+    });
+
+    // ── the discrete family ─────────────────────────────────────────────
+    namespace.instantiateDiscreteAlarm(
+        "DiscreteAlarmType",
+        alarmOptions("DiscreteAlarm", inputNode("DiscreteAlarmType Input Nodes", "Boolean"))
+    );
+
+    // OffNormalAlarmType is active while its input differs from NormalState
+    const normalState = namespace.addVariable({
+        browseName: "OffNormalNormalState",
+        nodeId: ctt.nodeId("Server Test/Alarms and Conditions/OffNormalNormalState"),
+        componentOf: ctt.folder("Server Test/Alarms and Conditions"),
+        description: "the value OffNormalAlarmType considers normal",
+        dataType: "Boolean",
+        value: boolean(false)
+    });
+    namespace.instantiateOffNormalAlarm({
+        ...alarmOptions("OffNormalAlarm", inputNode("OffNormalAlarmType Input Nodes", "Boolean")),
+        normalState
+    });
+
+    // `instantiateOffNormalAlarm` is hardwired to OffNormalAlarmType and
+    // UASystemOffNormalAlarmImpl is not exported, so the derived type is
+    // instantiated generically: the node and its mandatory children exist,
+    // the NormalState comparison is not wired.
+    namespace.instantiateAlarmCondition(
+        "SystemOffNormalAlarmType",
+        alarmOptions("SystemOffNormalAlarm", inputNode("SystemOffNormalAlarmType Input Nodes", "Boolean"))
+    );
+}

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_folder.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_folder.ts
@@ -8,107 +8,28 @@
  * is served by
  *   Objects/CTT/Static/HA Profile/Arrays/Int162D   (NodeId s=CTT/Static/HA Profile/Arrays/Int162D)
  * so a CTT project generator can fill the setting by browsing, without any
- * hand-maintained map. Only settings the rest of this address space does not
- * already serve are built here.
+ * hand-maintained map. See ./ctt_tree.ts for how a setting outside that prefix
+ * is keyed. Only settings the rest of this address space does not already serve
+ * are built here - plus the two Bool settings, see addBooleanScalarAndArray().
  *
- * Not covered (the server needs more than an address space for them):
- * Decimal, the HA Aggregates nodes, NodeDoesNotSupportServerTimestamp,
- * NodeManagement/RootNode, the alarm input nodes.
+ * Not covered, and why:
+ *   Decimal                             deprecated in OPC UA 1.05
+ *   the HA Aggregates nodes             need node-opcua-aggregates and a seeded
+ *                                       history matching the CTT's StartOfBadData*
+ *   NodeDoesNotSupportServerTimestamp   needs the variable read path to omit it
+ *   NodeManagement/RootNode             the server has no AddNodes service
+ *   Chattering Alarms                   needs an alarm that flips state on its own
+ *   DiscrepancyAlarmType Input Nodes    see ./alarm_input_nodes.ts
  */
 import fs from "node:fs";
 import path from "node:path";
 import type { AddressSpace, Namespace, UAObject, UAVariable } from "node-opcua-address-space";
 import { standardUnits } from "node-opcua-data-access";
-import { AccessLevelFlag, makeAccessLevelFlag } from "node-opcua-data-model";
+import { AccessLevelFlag } from "node-opcua-data-model";
 import { buildVariantArray, DataType, Variant, VariantArrayType } from "node-opcua-variant";
 
-import { typeAndDefaultValue } from "./type_defaults.js";
-
-const readWrite = makeAccessLevelFlag("CurrentRead | CurrentWrite");
-
-/** setting leaf -> OPC UA DataType name */
-const TYPE_ALIAS: Record<string, string> = { Bool: "Boolean" };
-
-function defaultValueOf(dataTypeName: string): unknown {
-    const e = typeAndDefaultValue.find((t) => t.type === dataTypeName);
-    if (!e) throw new Error(`no default value for ${dataTypeName}`);
-    return typeof e.defaultValue === "function" ? e.defaultValue() : e.defaultValue;
-}
-
-function variantFor(dataTypeName: string, valueRank: number): { variant: Variant; arrayDimensions: number[] | null } {
-    const dataType = DataType[dataTypeName as keyof typeof DataType];
-    const defaultValue = defaultValueOf(dataTypeName);
-    if (valueRank === -1) {
-        return {
-            variant: new Variant({ dataType, arrayType: VariantArrayType.Scalar, value: defaultValue }),
-            arrayDimensions: null
-        };
-    }
-    const dimensions = valueRank === 1 ? [5] : [2, 3];
-    const length = dimensions.reduce((a, b) => a * b, 1);
-    return {
-        variant: new Variant({
-            dataType,
-            arrayType: valueRank === 1 ? VariantArrayType.Array : VariantArrayType.Matrix,
-            dimensions: valueRank === 1 ? null : dimensions,
-            value: buildVariantArray(dataType, length, defaultValue)
-        }),
-        arrayDimensions: dimensions
-    };
-}
-
-class CttFolder {
-    private readonly folders = new Map<string, UAObject>();
-
-    constructor(
-        readonly namespace: Namespace,
-        root: UAObject
-    ) {
-        this.folders.set("", root);
-    }
-
-    get addressSpace(): AddressSpace {
-        return this.namespace.addressSpace as AddressSpace;
-    }
-
-    /** the folder for a setting group, created on demand, e.g. "Static/HA Profile/Arrays" */
-    folder(relPath: string): UAObject {
-        const existing = this.folders.get(relPath);
-        if (existing) return existing;
-        const i = relPath.lastIndexOf("/");
-        const parent = this.folder(i < 0 ? "" : relPath.slice(0, i));
-        const browseName = i < 0 ? relPath : relPath.slice(i + 1);
-        const f = this.namespace.addFolder(parent, { browseName, nodeId: `s=CTT/${relPath}` });
-        this.folders.set(relPath, f);
-        return f;
-    }
-
-    nodeId(relPath: string): string {
-        return `s=CTT/${relPath}`;
-    }
-
-    /** a plain read/write variable at the given setting path */
-    variable(relPath: string, dataType: string, valueRank: number, value: Variant, arrayDimensions: number[] | null): UAVariable {
-        const i = relPath.lastIndexOf("/");
-        return this.namespace.addVariable({
-            componentOf: this.folder(relPath.slice(0, i)),
-            browseName: relPath.slice(i + 1),
-            nodeId: this.nodeId(relPath),
-            description: `CTT setting ${relPath}`,
-            dataType,
-            valueRank,
-            arrayDimensions,
-            accessLevel: readWrite,
-            userAccessLevel: readWrite,
-            value
-        });
-    }
-
-    typedVariable(relPath: string, dataTypeName: string, valueRank: number): UAVariable {
-        const { variant, arrayDimensions } = variantFor(dataTypeName, valueRank);
-        return this.variable(relPath, dataTypeName, valueRank, variant, arrayDimensions);
-    }
-}
+import { addAlarmInputNodes } from "./alarm_input_nodes.js";
+import { CttFolder, readWrite, TYPE_ALIAS } from "./ctt_tree.js";
 
 // ─── Static / All Profiles ──────────────────────────────────────────────
 
@@ -151,6 +72,40 @@ function addVariantVariables(ctt: CttFolder): void {
         }),
         [2, 3]
     );
+}
+
+/**
+ * `Static/All Profiles/Scalar/Bool` and `.../Arrays/Bool`, which the Simulation
+ * folder would otherwise serve.
+ *
+ * A generator resolves a setting by overlay, then convention, then the CTT's own
+ * default, then by *browse name*, then by rule. The HA Profile nodes below are
+ * browse-named after their setting leaf, so `Static/HA Profile/Scalar/Bool` is
+ * literally named `Bool` - and the name step matches it against the All Profiles
+ * `Bool` settings, for which there is no convention node, while the Simulation
+ * node named `Boolean` matches neither. The name step runs before the rule step,
+ * so those two settings would silently resolve to a historizing node. Every other
+ * type name is safe: `Byte`, `Double` and the rest match both nodes and the rule
+ * scoring then prefers the non-historizing one.
+ *
+ * Building the two nodes here makes the convention step answer first, which is
+ * both deterministic and where the CTT-specific extras belong - hence the two
+ * Description properties, which View Minimum Continuation Point 01 012 needs
+ * (it browses the Scalar/Bool setting node with a NodeClassMask of Variable and
+ * wants at least two such references).
+ */
+function addBooleanScalarAndArray(ctt: CttFolder): void {
+    const scalar = ctt.typedVariable("Static/All Profiles/Scalar/Bool", "Boolean", -1);
+    for (const name of ["Description1", "Description2"]) {
+        ctt.namespace.addVariable({
+            propertyOf: scalar,
+            browseName: name,
+            nodeId: ctt.nodeId(`Static/All Profiles/Scalar/Bool/${name}`),
+            dataType: "String",
+            value: new Variant({ dataType: DataType.String, value: `${name} of the static Boolean` })
+        });
+    }
+    ctt.typedVariable("Static/All Profiles/Arrays/Bool", "Boolean", 1);
 }
 
 function addImageVariable(ctt: CttFolder): void {
@@ -474,10 +429,12 @@ export function addCttFolder(namespace: Namespace, objectsFolder: UAObject): UAO
     });
     const ctt = new CttFolder(namespace, root);
     addVariantVariables(ctt);
+    addBooleanScalarAndArray(ctt);
     addImageVariable(ctt);
     addStructureVariables(ctt);
     addAnalogItemArrays(ctt);
     addArrayItems(ctt);
     addHistorizingVariables(ctt);
+    addAlarmInputNodes(ctt);
     return root;
 }

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_folder.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_folder.ts
@@ -116,11 +116,27 @@ function addVariantVariables(ctt: CttFolder): void {
     // "Variant" in CTT terms: a Variable whose DataType attribute is BaseDataType
     const scalar = new Variant({ dataType: DataType.Double, value: 3.14 });
     ctt.variable("Static/All Profiles/Scalar/Variant", "BaseDataType", -1, scalar, null);
+    // The array is the one case the CTT actually type-checks: Attribute Read 023.js
+    // asserts AssertUaValueOfType(BuiltInType.Variant, ...) against this node, so the
+    // *value* has to be Variant-encoded (BuiltInType 24), not merely stored on a
+    // BaseDataType-typed Variable. A Float64Array reads back as Double (11) and fails
+    // that assertion. Mixed element types are also the point of the type, and exercise
+    // the encoder the way the test intends.
     ctt.variable(
         "Static/All Profiles/Arrays/Variant",
         "BaseDataType",
         1,
-        new Variant({ dataType: DataType.Double, arrayType: VariantArrayType.Array, value: new Float64Array([1, 2, 3, 4, 5]) }),
+        new Variant({
+            dataType: DataType.Variant,
+            arrayType: VariantArrayType.Array,
+            value: [
+                new Variant({ dataType: DataType.Double, value: 1 }),
+                new Variant({ dataType: DataType.UInt32, value: 2 }),
+                new Variant({ dataType: DataType.String, value: "three" }),
+                new Variant({ dataType: DataType.Boolean, value: true }),
+                new Variant({ dataType: DataType.Float, value: 5.5 })
+            ]
+        }),
         [5]
     );
     ctt.variable(

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_tree.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_tree.ts
@@ -1,0 +1,105 @@
+/**
+ * The node tree below `Objects/CTT`, shared by the builders that populate it.
+ *
+ * A CTT project generator fills a NodeId setting by browsing: the browse path
+ * below `Objects/CTT` mirrors the setting path, with only the
+ * "Server Test/NodeIds/" prefix stripped. So
+ *   Server Test/NodeIds/Static/HA Profile/Arrays/Int162D
+ * is served by
+ *   Objects/CTT/Static/HA Profile/Arrays/Int162D
+ * while a setting outside that prefix keeps its whole path, e.g.
+ *   Server Test/Alarms and Conditions/Supported Condition Types/LimitAlarmType Input Nodes
+ * is served by
+ *   Objects/CTT/Server Test/Alarms and Conditions/Supported Condition Types/LimitAlarmType Input Nodes
+ */
+import type { AddressSpace, Namespace, UAObject, UAVariable } from "node-opcua-address-space";
+import { makeAccessLevelFlag } from "node-opcua-data-model";
+import { buildVariantArray, DataType, Variant, VariantArrayType } from "node-opcua-variant";
+
+import { typeAndDefaultValue } from "./type_defaults.js";
+
+export const readWrite = makeAccessLevelFlag("CurrentRead | CurrentWrite");
+
+/** setting leaf -> OPC UA DataType name */
+export const TYPE_ALIAS: Record<string, string> = { Bool: "Boolean" };
+
+function defaultValueOf(dataTypeName: string): unknown {
+    const e = typeAndDefaultValue.find((t) => t.type === dataTypeName);
+    if (!e) throw new Error(`no default value for ${dataTypeName}`);
+    return typeof e.defaultValue === "function" ? e.defaultValue() : e.defaultValue;
+}
+
+export function variantFor(dataTypeName: string, valueRank: number): { variant: Variant; arrayDimensions: number[] | null } {
+    const dataType = DataType[dataTypeName as keyof typeof DataType];
+    const defaultValue = defaultValueOf(dataTypeName);
+    if (valueRank === -1) {
+        return {
+            variant: new Variant({ dataType, arrayType: VariantArrayType.Scalar, value: defaultValue }),
+            arrayDimensions: null
+        };
+    }
+    const dimensions = valueRank === 1 ? [5] : [2, 3];
+    const length = dimensions.reduce((a, b) => a * b, 1);
+    return {
+        variant: new Variant({
+            dataType,
+            arrayType: valueRank === 1 ? VariantArrayType.Array : VariantArrayType.Matrix,
+            dimensions: valueRank === 1 ? null : dimensions,
+            value: buildVariantArray(dataType, length, defaultValue)
+        }),
+        arrayDimensions: dimensions
+    };
+}
+
+export class CttFolder {
+    private readonly folders = new Map<string, UAObject>();
+
+    constructor(
+        readonly namespace: Namespace,
+        root: UAObject
+    ) {
+        this.folders.set("", root);
+    }
+
+    get addressSpace(): AddressSpace {
+        return this.namespace.addressSpace as AddressSpace;
+    }
+
+    /** the folder for a setting group, created on demand, e.g. "Static/HA Profile/Arrays" */
+    folder(relPath: string): UAObject {
+        const existing = this.folders.get(relPath);
+        if (existing) return existing;
+        const i = relPath.lastIndexOf("/");
+        const parent = this.folder(i < 0 ? "" : relPath.slice(0, i));
+        const browseName = i < 0 ? relPath : relPath.slice(i + 1);
+        const f = this.namespace.addFolder(parent, { browseName, nodeId: `s=CTT/${relPath}` });
+        this.folders.set(relPath, f);
+        return f;
+    }
+
+    nodeId(relPath: string): string {
+        return `s=CTT/${relPath}`;
+    }
+
+    /** a plain read/write variable at the given setting path */
+    variable(relPath: string, dataType: string, valueRank: number, value: Variant, arrayDimensions: number[] | null): UAVariable {
+        const i = relPath.lastIndexOf("/");
+        return this.namespace.addVariable({
+            componentOf: this.folder(relPath.slice(0, i)),
+            browseName: relPath.slice(i + 1),
+            nodeId: this.nodeId(relPath),
+            description: `CTT setting ${relPath}`,
+            dataType,
+            valueRank,
+            arrayDimensions,
+            accessLevel: readWrite,
+            userAccessLevel: readWrite,
+            value
+        });
+    }
+
+    typedVariable(relPath: string, dataTypeName: string, valueRank: number): UAVariable {
+        const { variant, arrayDimensions } = variantFor(dataTypeName, valueRank);
+        return this.variable(relPath, dataTypeName, valueRank, variant, arrayDimensions);
+    }
+}

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/custom_extension_object.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/custom_extension_object.ts
@@ -1,0 +1,105 @@
+/**
+ * The concrete ExtensionObject the Static, Dynamic and Mass folders hold.
+ *
+ * This package cannot choose one on its own. Namespace zero has no concrete
+ * structure worth exercising here - `Structure` (i=22) is abstract and the
+ * rest are service types - and a usable one lives in a companion nodeset that
+ * only the caller knows it has loaded. So the caller passes the behaviour in:
+ * which DataType to build, and how to move its fields for the Dynamic folder.
+ *
+ * Without these options every ExtensionObject variable keeps a null
+ * ExtensionObject, which is what the package did before and what its own tests
+ * (namespace zero only) still exercise.
+ *
+ * A CTT server that has loaded the AutoID nodeset, for instance:
+ *
+ *     build_address_space_for_conformance_testing(addressSpace, {
+ *         extensionObject: {
+ *             dataType: "RfidSighting",
+ *             randomFields: () => ({
+ *                 antenna: 1 + Math.floor(Math.random() * 4),
+ *                 strength: -80 + Math.floor(Math.random() * 60),
+ *                 currentPowerLevel: 10 + Math.floor(Math.random() * 20),
+ *                 timestamp: new Date()
+ *             })
+ *         }
+ *     });
+ */
+import type { AddressSpace } from "node-opcua-address-space";
+import type { NodeIdLike } from "node-opcua-nodeid";
+
+export interface CustomExtensionObjectOptions {
+    /**
+     * DataType of the structure to build: a browse name ("RfidSighting") or a
+     * NodeId, in a namespace the caller has already loaded. A DataType this
+     * address space cannot find is an error - a silent fallback to null would
+     * look like the option had been ignored.
+     */
+    dataType: NodeIdLike;
+    /** field values of the static instances; the DataType's own defaults when omitted */
+    initialFields?: Record<string, unknown>;
+    /** field values for the Dynamic folder, called on every simulation tick */
+    randomFields?: () => Record<string, unknown>;
+}
+
+export interface CustomExtensionObject {
+    /** browse name of the structure, for descriptions */
+    readonly typeName: string;
+    /** a fresh instance carrying the initial field values */
+    initialValue(): unknown;
+    /** a fresh instance carrying new field values, or the initial one when no randomFields was given */
+    random(): unknown;
+}
+
+/**
+ * `findDataType("RfidSighting")` searches namespace zero only, and a companion
+ * structure is never there. A bare browse name is therefore looked up in every
+ * loaded namespace, so the caller does not have to know the index the nodeset
+ * happened to land on. A NodeId, or a "1:RfidSighting" qualified name, still
+ * resolves directly.
+ */
+function findDataTypeAnywhere(addressSpace: AddressSpace, dataType: NodeIdLike) {
+    const direct = addressSpace.findDataType(dataType as string);
+    if (direct) return direct;
+    if (typeof dataType !== "string" || dataType.includes("=") || dataType.includes(":")) return null;
+    for (let index = 1; index < addressSpace.getNamespaceArray().length; index++) {
+        const found = addressSpace.findDataType(dataType, index);
+        if (found) return found;
+    }
+    return null;
+}
+
+/** one row of the typeAndDefaultValue table, as the builders see it */
+interface TypeEntry {
+    type: string;
+    realType?: string;
+    defaultValue: unknown;
+}
+
+/**
+ * The initial value of a typeAndDefaultValue row, with the caller's structure
+ * standing in for the ExtensionObject row when one was supplied.
+ */
+export function initialValueFor(entry: TypeEntry, custom?: CustomExtensionObject): unknown {
+    if (custom && (entry.realType ?? entry.type) === "ExtensionObject") return custom.initialValue();
+    return typeof entry.defaultValue === "function" ? (entry.defaultValue as () => unknown)() : entry.defaultValue;
+}
+
+export function resolveCustomExtensionObject(
+    addressSpace: AddressSpace,
+    options?: CustomExtensionObjectOptions
+): CustomExtensionObject | undefined {
+    if (!options) return undefined;
+    const dataType = findDataTypeAnywhere(addressSpace, options.dataType);
+    if (!dataType) {
+        throw new Error(
+            `extensionObject.dataType ${options.dataType} is not in the address space: load the nodeset that defines it first`
+        );
+    }
+    const build = (fields?: Record<string, unknown>) => addressSpace.constructExtensionObject(dataType, fields ?? {});
+    return {
+        typeName: dataType.browseName.name ?? String(options.dataType),
+        initialValue: () => build(options.initialFields),
+        random: () => build(options.randomFields ? options.randomFields() : options.initialFields)
+    };
+}

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/helpers.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/helpers.ts
@@ -5,10 +5,13 @@ import type { Namespace, UAObject, UAVariable } from "node-opcua-address-space";
 import { assert } from "node-opcua-assert";
 import * as ec from "node-opcua-basic-types";
 import { randomString } from "node-opcua-basic-types";
-import { AccessLevelFlag, LocalizedText, makeAccessLevelFlag, QualifiedName } from "node-opcua-data-model";
+import { AccessLevelFlag, DiagnosticInfo, LocalizedText, makeAccessLevelFlag, QualifiedName } from "node-opcua-data-model";
+import { DataValue } from "node-opcua-data-value";
 import { checkDebugFlag, make_debugLog, make_warningLog } from "node-opcua-debug";
 import { findBuiltInType } from "node-opcua-factory";
 import { buildVariantArray, DataType, Variant, VariantArrayType } from "node-opcua-variant";
+
+import type { CustomExtensionObject } from "./custom_extension_object.js";
 
 const debugLog = make_debugLog("helpers");
 const doDebug = checkDebugFlag("helpers");
@@ -25,7 +28,7 @@ export function getValidatorFuncForType(dataType: DataType): (value: unknown) =>
     return (f as (value: unknown) => boolean) || defaultValidator;
 }
 
-export function getRandomFuncForType(dataType: DataType): () => unknown {
+export function getRandomFuncForType(dataType: DataType, custom?: CustomExtensionObject): () => unknown {
     const dataTypeName = DataType[dataType];
     const f = (ec as Record<string, unknown>)[`random${dataTypeName}`];
 
@@ -35,9 +38,26 @@ export function getRandomFuncForType(dataType: DataType): () => unknown {
 
     switch (dataTypeName) {
         case "Variant":
+            // the value of a Variant-typed variable is itself a Variant
             return () => {
-                return new Variant();
+                return new Variant({ dataType: DataType.Double, value: Math.random() * 100 });
             };
+        case "DataValue":
+            return () => {
+                return new DataValue({
+                    value: new Variant({ dataType: DataType.Double, value: Math.random() * 100 }),
+                    sourceTimestamp: new Date()
+                });
+            };
+        case "DiagnosticInfo":
+            return () => {
+                return new DiagnosticInfo({ additionalInfo: randomString() });
+            };
+        case "ExtensionObject":
+            // the one type with no namespace-zero answer: without a concrete
+            // structure from the caller the only valid value is a null
+            // ExtensionObject, which never changes - see ./custom_extension_object.ts
+            return custom ? () => custom.random() : () => null;
         case "QualifiedName":
             return () => {
                 return new QualifiedName({ name: randomString() });

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/mass_variables.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/mass_variables.ts
@@ -3,6 +3,7 @@
  */
 import type { Namespace, UAObject } from "node-opcua-address-space";
 
+import { type CustomExtensionObject, initialValueFor } from "./custom_extension_object.js";
 import { addVariable } from "./helpers.js";
 import { typeAndDefaultValue } from "./type_defaults.js";
 
@@ -28,7 +29,7 @@ function addMassVariablesOfType(
     }
 }
 
-export function addMassVariables(namespace: Namespace, scalarFolder: UAObject): void {
+export function addMassVariables(namespace: Namespace, scalarFolder: UAObject, custom?: CustomExtensionObject): void {
     const scalarMass = namespace.addFolder(scalarFolder, {
         browseName: "Scalar_Mass",
         description: "This folder will contain 100 items per supported data-type.",
@@ -37,6 +38,6 @@ export function addMassVariables(namespace: Namespace, scalarFolder: UAObject): 
 
     for (const e of typeAndDefaultValue) {
         const realType = e.realType || e.type;
-        addMassVariablesOfType(namespace, scalarMass, e.type, e.defaultValue, realType);
+        addMassVariablesOfType(namespace, scalarMass, e.type, initialValueFor(e, custom), realType);
     }
 }

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/path_and_large_arrays.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/path_and_large_arrays.ts
@@ -3,6 +3,7 @@
  */
 import type { Namespace, UAObject } from "node-opcua-address-space";
 
+import { type CustomExtensionObject, initialValueFor } from "./custom_extension_object.js";
 import { addArrayVariable } from "./helpers.js";
 import { typeAndDefaultValue } from "./type_defaults.js";
 
@@ -21,7 +22,7 @@ export function addPath10Deep(namespace: Namespace, simulation_folder: UAObject)
     }
 }
 
-export function addVeryLargeArrayVariables(namespace: Namespace, objectsFolder: UAObject): void {
+export function addVeryLargeArrayVariables(namespace: Namespace, objectsFolder: UAObject, custom?: CustomExtensionObject): void {
     const scalarStaticLargeArray = namespace.addObject({
         organizedBy: objectsFolder,
         browseName: "Static_Scalar_Large_Array",
@@ -30,6 +31,6 @@ export function addVeryLargeArrayVariables(namespace: Namespace, objectsFolder: 
     });
     for (const e of typeAndDefaultValue) {
         const realType = e.realType || e.type;
-        addArrayVariable(namespace, scalarStaticLargeArray, e.type, e.defaultValue, realType, 50 * 1024, "");
+        addArrayVariable(namespace, scalarStaticLargeArray, e.type, initialValueFor(e, custom), realType, 50 * 1024, "");
     }
 }

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/simulation_variables.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/simulation_variables.ts
@@ -6,10 +6,11 @@ import { assert } from "node-opcua-assert";
 import { isValidBoolean, isValidUInt16 } from "node-opcua-basic-types";
 import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
 
+import { type CustomExtensionObject, initialValueFor } from "./custom_extension_object.js";
 import { addVariable, findDataType, getRandomFuncForType } from "./helpers.js";
 import { typeAndDefaultValue } from "./type_defaults.js";
 
-export function addSimulationVariables(namespace: Namespace, scalarFolder: UAObject): void {
+export function addSimulationVariables(namespace: Namespace, scalarFolder: UAObject, custom?: CustomExtensionObject): void {
     let values_to_change: { dataType: DataType; randomFunc: () => unknown; variable: UAVariable }[] = [];
 
     function add_simulation_variable(
@@ -20,7 +21,7 @@ export function addSimulationVariables(namespace: Namespace, scalarFolder: UAObj
     ): UAVariable {
         realTypeName = realTypeName || dataTypeName;
         const dataType = findDataType(realTypeName);
-        const randomFunc = getRandomFuncForType(dataType);
+        const randomFunc = getRandomFuncForType(dataType, custom);
 
         // c8 ignore next
         if (typeof randomFunc !== "function") {
@@ -41,9 +42,8 @@ export function addSimulationVariables(namespace: Namespace, scalarFolder: UAObj
 
     for (const e of typeAndDefaultValue) {
         const dataType = e.type;
-        const defaultValue = typeof e.defaultValue === "function" ? e.defaultValue() : e.defaultValue;
         const realType = e.realType || dataType;
-        add_simulation_variable(simulation, dataType, defaultValue, realType);
+        add_simulation_variable(simulation, dataType, initialValueFor(e, custom), realType);
     }
 
     // Management nodes

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/static_variables.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/static_variables.ts
@@ -7,6 +7,7 @@ import type { Namespace, UAObject, UAVariable } from "node-opcua-address-space";
 import { make_errorLog } from "node-opcua-debug";
 import { DataType, Variant } from "node-opcua-variant";
 
+import { type CustomExtensionObject, initialValueFor } from "./custom_extension_object.js";
 import { addArrayVariable, addMultiDimensionalArrayVariable, addScalarVariable } from "./helpers.js";
 import { typeAndDefaultValue } from "./type_defaults.js";
 
@@ -17,7 +18,11 @@ const errorLog = make_errorLog("static_variables");
 // has this single line to change rather than several scattered uses.
 const here = __dirname;
 
-export async function addStaticVariables(namespace: Namespace, scalarFolder: UAObject): Promise<void> {
+export async function addStaticVariables(
+    namespace: Namespace,
+    scalarFolder: UAObject,
+    custom?: CustomExtensionObject
+): Promise<void> {
     const staticScalarFolder = namespace.addObject({
         organizedBy: scalarFolder,
         browseName: "Scalars",
@@ -29,22 +34,12 @@ export async function addStaticVariables(namespace: Namespace, scalarFolder: UAO
     for (const e of typeAndDefaultValue) {
         const dataType = e.type;
         const realType = e.realType || dataType;
-        const defaultValue = typeof e.defaultValue === "function" ? e.defaultValue() : e.defaultValue;
-        addScalarVariable(namespace, staticScalarFolder, dataType, realType, defaultValue, "");
+        addScalarVariable(namespace, staticScalarFolder, dataType, realType, initialValueFor(e, custom), "");
     }
 
-    // CTT View Minimum Continuation Point 01 012 browses the Scalar/Bool setting node
-    // with a NodeClassMask of Variable and needs at least two such references on it
-    const booleanScalar = namespace.findNode("s=Static_Scalar_Boolean") as UAVariable;
-    for (const name of ["Description1", "Description2"]) {
-        namespace.addVariable({
-            propertyOf: booleanScalar,
-            browseName: name,
-            nodeId: `s=Static_Scalar_Boolean_${name}`,
-            dataType: "String",
-            value: { dataType: DataType.String, value: `${name} of the static Boolean` }
-        });
-    }
+    // The two Description properties View Minimum Continuation Point 01 012 needs
+    // now live on the node that actually serves Static/All Profiles/Scalar/Bool -
+    // see addBooleanScalarAndArray() in ctt_folder.ts.
 
     // Load images
     async function setImage(imageType: string, filename: string): Promise<void> {
@@ -73,7 +68,7 @@ export async function addStaticVariables(namespace: Namespace, scalarFolder: UAO
     });
     for (const e of typeAndDefaultValue) {
         const realType = e.realType || e.type;
-        addArrayVariable(namespace, staticArraysFolders, e.type, e.defaultValue, realType, 10, "");
+        addArrayVariable(namespace, staticArraysFolders, e.type, initialValueFor(e, custom), realType, 10, "");
     }
 
     // Multi-dimensional array variables
@@ -86,6 +81,15 @@ export async function addStaticVariables(namespace: Namespace, scalarFolder: UAO
     });
     for (const e of typeAndDefaultValue) {
         const realType = e.realType || e.type;
-        addMultiDimensionalArrayVariable(namespace, staticMultiDimensionalArrays, e.type, e.defaultValue, realType, 2, 3, "");
+        addMultiDimensionalArrayVariable(
+            namespace,
+            staticMultiDimensionalArrays,
+            e.type,
+            initialValueFor(e, custom),
+            realType,
+            2,
+            3,
+            ""
+        );
     }
 }

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/type_defaults.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/type_defaults.ts
@@ -4,8 +4,10 @@
 
 import * as ec from "node-opcua-basic-types";
 import { emptyGuid } from "node-opcua-basic-types";
-import { LocalizedText, QualifiedName } from "node-opcua-data-model";
+import { DiagnosticInfo, LocalizedText, QualifiedName } from "node-opcua-data-model";
+import { DataValue } from "node-opcua-data-value";
 import { coerceNodeId } from "node-opcua-nodeid";
+import { DataType, Variant } from "node-opcua-variant";
 
 export const typeAndDefaultValue = [
     { type: "Boolean", defaultValue: false },
@@ -57,5 +59,32 @@ export const typeAndDefaultValue = [
     { type: "ImageBMP", realType: "ByteString", defaultValue: null },
     { type: "ImageGIF", realType: "ByteString", defaultValue: null },
     { type: "ImageJPG", realType: "ByteString", defaultValue: null },
-    { type: "ImagePNG", realType: "ByteString", defaultValue: null }
+    { type: "ImagePNG", realType: "ByteString", defaultValue: null },
+    // The last four built-in types. `type` is the browse name *and* the DataType
+    // attribute, so it has to be a DataType the address space can resolve, while
+    // `realType` names the built-in encoding of the value. Two of them differ:
+    // the Variant DataType node is BaseDataType (i=24) and the ExtensionObject
+    // one is Structure (i=22) - "Variant" and "ExtensionObject" are encodings,
+    // not browse names, and addVariable() rejects them as DataTypes.
+    {
+        type: "BaseDataType",
+        realType: "Variant",
+        defaultValue() {
+            return new Variant({ dataType: DataType.Double, value: 0.0 });
+        }
+    },
+    // a null ExtensionObject: TypeId 0, no body - what an unassigned Structure is
+    { type: "Structure", realType: "ExtensionObject", defaultValue: null },
+    {
+        type: "DataValue",
+        defaultValue() {
+            return new DataValue({ value: new Variant({ dataType: DataType.Double, value: 0.0 }) });
+        }
+    },
+    {
+        type: "DiagnosticInfo",
+        defaultValue() {
+            return new DiagnosticInfo({});
+        }
+    }
 ];

--- a/packages/node-opcua-address-space-for-conformance-testing/test/test_ctt_folder.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/test/test_ctt_folder.ts
@@ -83,6 +83,59 @@ describe("the CTT folder", function () {
         for (let i = 1; i <= 5; i++) names.should.containEql(i === 3 ? "twoStateDiscrete003" : `TwoStateDiscrete00${i}`);
     });
 
+    it("serves the two Bool settings itself, so the browse-name step cannot claim them", () => {
+        // Static/HA Profile/Scalar/Bool is browse-named `Bool` and would otherwise be
+        // matched by name against Static/All Profiles/Scalar|Arrays/Bool
+        const scalar = byPath("Static/All Profiles/Scalar/Bool");
+        scalar.dataType.toString().should.eql("ns=0;i=1");
+        scalar.valueRank.should.eql(-1);
+        scalar.historizing.should.eql(false);
+        // View Minimum Continuation Point 01 012 browses this node for Variables
+        should.exist(scalar.getPropertyByName("Description1"));
+        should.exist(scalar.getPropertyByName("Description2"));
+        const array = byPath("Static/All Profiles/Arrays/Bool");
+        array.valueRank.should.eql(1);
+        array.historizing.should.eql(false);
+    });
+
+    it("serves the alarm input nodes, each watched by an alarm of its type", () => {
+        const group = "Server Test/Alarms and Conditions/Supported Condition Types";
+        const expected: [string, string][] = [
+            ["AlarmConditionType Input Nodes", "AlarmConditionType"],
+            ["LimitAlarmType Input Nodes", "LimitAlarmType"],
+            ["ExclusiveLimitAlarmType Input Nodes", "ExclusiveLimitAlarmType"],
+            ["ExclusiveLevelAlarmType Input Nodes", "ExclusiveLevelAlarmType"],
+            ["ExclusiveRateOfChangeAlarmType Input Nodes", "ExclusiveRateOfChangeAlarmType"],
+            ["ExclusiveDeviationAlarmType Input Nodes", "ExclusiveDeviationAlarmType"],
+            ["NonExclusiveLimitAlarmType Input Nodes", "NonExclusiveLimitAlarmType"],
+            ["NonExclusiveLevelAlarmType Input Nodes", "NonExclusiveLevelAlarmType"],
+            ["NonExclusiveRateOfChangeAlarmType Input Nodes", "NonExclusiveRateOfChangeAlarmType"],
+            ["NonExclusiveDeviationAlarmType Input Nodes", "NonExclusiveDeviationAlarmType"],
+            ["DiscreteAlarmType Input Nodes", "DiscreteAlarmType"],
+            ["OffNormalAlarmType Input Nodes", "OffNormalAlarmType"],
+            ["SystemOffNormalAlarmType Input Nodes", "SystemOffNormalAlarmType"]
+        ];
+        // every alarm's InputNode property must point back at the setting's node
+        const inputNodeOf = new Map<string, string>();
+        const ns = addressSpace.getNamespaceIndex("urn://node-opcua-simulator");
+        const alarmSource = addressSpace.findNode(`ns=${ns};s=CTT/Server Test/Alarms and Conditions/AlarmSource`) as UAObject;
+        should.exist(alarmSource);
+        for (const alarm of alarmSource.findReferencesExAsObject("HasCondition") as UAObject[]) {
+            const inputNode = (alarm as unknown as { inputNode: UAVariable }).inputNode;
+            inputNodeOf.set(inputNode.readValue().value.value.toString(), alarm.typeDefinitionObj.browseName.name!);
+        }
+        for (const [leaf, typeName] of expected) {
+            const v = byPath(`${group}/${leaf}`);
+            v.valueRank.should.eql(-1);
+            (v.accessLevel & 3).should.eql(3, `${leaf} must be writable`);
+            should(inputNodeOf.get(v.nodeId.toString())).eql(typeName, `${leaf} must be watched by a ${typeName}`);
+        }
+        // the two setpoint settings are the deviation alarms' setpoints, not input nodes
+        for (const leaf of ["Exclusive Deviation Setpoint Source", "NonExclusive Deviation Setpoint Source"]) {
+            byPath(`${group}/${leaf}`).dataType.toString().should.eql("ns=0;i=11");
+        }
+    });
+
     it("serves historizing scalars, arrays and access-right variables", () => {
         const v = byPath("Static/HA Profile/Scalar/Bool");
         v.historizing.should.eql(true);

--- a/packages/node-opcua-address-space-for-conformance-testing/test/test_custom_extension_object.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/test/test_custom_extension_object.ts
@@ -1,0 +1,74 @@
+import { AddressSpace, type UAVariable } from "node-opcua-address-space";
+import { generateAddressSpace } from "node-opcua-address-space/nodeJS";
+import { nodesets } from "node-opcua-nodesets";
+import should from "should";
+
+import { build_address_space_for_conformance_testing } from "../dist/index.js";
+
+// AutoID's RfidSighting: Antenna/Strength/CurrentPowerLevel (Int32) + Timestamp.
+// A companion nodeset, which is the point - namespace zero has no concrete
+// structure the ExtensionObject variables could hold.
+const randomFields = () => ({
+    antenna: 1 + Math.floor(Math.random() * 4),
+    strength: -80 + Math.floor(Math.random() * 60),
+    currentPowerLevel: 10 + Math.floor(Math.random() * 20),
+    timestamp: new Date()
+});
+
+describe("the caller-supplied ExtensionObject", function () {
+    this.timeout(60_000);
+
+    let addressSpace: AddressSpace;
+    let ns: number;
+    const value = (id: string) => {
+        const node = addressSpace.findNode(`ns=${ns};${id}`) as UAVariable;
+        should.exist(node, id);
+        const variant = node.readValue().value;
+        return Array.isArray(variant.value) ? variant.value[0] : variant.value;
+    };
+
+    before(async () => {
+        addressSpace = AddressSpace.create();
+        await generateAddressSpace(addressSpace, [nodesets.standard, nodesets.di, nodesets.autoId]);
+        addressSpace.registerNamespace("urn:test");
+        await build_address_space_for_conformance_testing(addressSpace, {
+            extensionObject: { dataType: "RfidSighting", initialFields: randomFields(), randomFields }
+        });
+        ns = addressSpace.getNamespaceIndex("urn://node-opcua-simulator");
+    });
+    after(async () => {
+        await addressSpace.shutdown();
+        addressSpace.dispose();
+    });
+
+    it("fills the Static, Array and Multi-Dimensional ExtensionObject variables", () => {
+        for (const id of [
+            "s=Static_Scalar_Structure",
+            "s=Static_Array_Structure",
+            "s=Static_MultiDimensional_Array_Structure",
+            "s=Scalar_Simulation_Structure"
+        ]) {
+            should(value(id)?.constructor.name).eql("RfidSighting", id);
+        }
+    });
+
+    it("moves the fields of the Dynamic one", async () => {
+        const before = JSON.stringify(value("s=Scalar_Simulation_Structure"));
+        // the simulation timer ticks every 2s
+        await new Promise((resolve) => setTimeout(resolve, 2500));
+        JSON.stringify(value("s=Scalar_Simulation_Structure")).should.not.eql(before);
+    });
+
+    it("refuses a DataType that is not loaded, rather than silently falling back", async () => {
+        const other = AddressSpace.create();
+        try {
+            await generateAddressSpace(other, [nodesets.standard]);
+            await build_address_space_for_conformance_testing(other, {
+                extensionObject: { dataType: "RfidSighting" }
+            }).should.be.rejectedWith(/is not in the address space/);
+        } finally {
+            await other.shutdown();
+            other.dispose();
+        }
+    });
+});

--- a/packages/node-opcua-address-space/impl/validate_data_type_correctness.ts
+++ b/packages/node-opcua-address-space/impl/validate_data_type_correctness.ts
@@ -3,7 +3,7 @@ import type { IAddressSpace, UADataType } from "node-opcua-address-space-base";
 import { assert } from "node-opcua-assert";
 import { DataType } from "node-opcua-basic-types";
 import { checkDebugFlag, make_debugLog } from "node-opcua-debug";
-import type { NodeId } from "node-opcua-nodeid";
+import { makeNodeId, type NodeId } from "node-opcua-nodeid";
 
 const debugLog = make_debugLog("validate_data_type_correctness");
 const doDebug = checkDebugFlag("validate_data_type_correctness");
@@ -12,7 +12,15 @@ function _dataType_toUADataType(addressSpace: IAddressSpace, dataType: DataType)
     assert(addressSpace);
     assert(dataType !== DataType.Null);
 
-    const dataTypeNode = addressSpace.findDataType(DataType[dataType]);
+    // Resolved by NodeId rather than by name: a built-in type's enum value is its
+    // ns=0 identifier, whereas the DataType enum's names do not all match the
+    // nodeset's browse names. DataType[24] is "Variant" but node i=24 is
+    // "BaseDataType", and DataType[22] is "ExtensionObject" but node i=22 is
+    // "Structure" - so a by-name lookup threw for any Variant-encoded value, and
+    // the escaping exception surfaced to the client as BadInternalError. (The
+    // ExtensionObject case is caught by an earlier branch and never reached here.)
+    const dataTypeNode =
+        addressSpace.findDataType(makeNodeId(dataType as number, 0)) ?? addressSpace.findDataType(DataType[dataType]);
     /* c8 ignore next */
     if (!dataTypeNode) {
         throw new Error(` Cannot find DataType ${DataType[dataType]} in address Space`);

--- a/packages/node-opcua-address-space/test/test_validate_data_type_correctness.ts
+++ b/packages/node-opcua-address-space/test/test_validate_data_type_correctness.ts
@@ -149,6 +149,21 @@ describe("testing validateDataTypeCorrectness", () => {
         validateDataTypeCorrectness(addressSpace, dataType, DataType.Int32, false).should.eql(false);
     });
 
+    // The DataType enum's names do not all match the nodeset's browse names: 24 is
+    // "Variant" in the enum but "BaseDataType" as a node, 22 is "ExtensionObject" but
+    // "Structure". Resolving the incoming type by name therefore threw for any
+    // Variant-encoded value, and the escaping exception reached the client as
+    // BadInternalError - a server could not even write back a value it had just served.
+    it("0:BaseDataType: should accept a DataType.Variant variant", async () => {
+        const dataType = addressSpace.findDataType("BaseDataType")!.nodeId;
+        should.exist(dataType);
+        validateDataTypeCorrectness(addressSpace, dataType, DataType.Variant, false).should.eql(true);
+    });
+    it("0:BaseDataType: should accept a DataType.Variant variant without throwing", async () => {
+        const dataType = addressSpace.findDataType("BaseDataType")!.nodeId;
+        (() => validateDataTypeCorrectness(addressSpace, dataType, DataType.Variant, false)).should.not.throw();
+    });
+
     it("DataType.Null: should accept DataType.Null if allow Null", async () => {
         const ns = addressSpace.getNamespaceIndex("http://myorganisation.org/customTypes");
         ns.should.not.eql(-1);

--- a/packages/node-opcua-server/source/monitored_item.ts
+++ b/packages/node-opcua-server/source/monitored_item.ts
@@ -492,12 +492,17 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
     }
 
     public setMonitoringMode(monitoringMode: MonitoringMode): StatusCode {
-        if (monitoringMode === this.monitoringMode) {
-            // nothing to do
-            return StatusCodes.BadNothingToDo;
-        }
         if (monitoringMode === MonitoringMode.Invalid) {
             return StatusCodes.BadInvalidArgument;
+        }
+        if (monitoringMode === this.monitoringMode) {
+            // Already in that mode: the request is satisfied, so the operation is
+            // Good. OPC 10000-4 5.12.4 lists Good and Bad_MonitoredItemIdInvalid as
+            // the *operation* results of SetMonitoringMode; Bad_NothingToDo is a
+            // *service* result, for a request carrying no monitoredItemIds at all.
+            // Returning it per item made an idempotent set fail: CTT Monitor Basic
+            // 020 sets an already disabled item to Disabled and requires Good.
+            return StatusCodes.Good;
         }
         const old_monitoringMode = this.monitoringMode;
 

--- a/packages/node-opcua-server/source/server_subscription.ts
+++ b/packages/node-opcua-server/source/server_subscription.ts
@@ -1527,6 +1527,18 @@ export class Subscription extends EventEmitter {
     }
 
     private _process_keepAlive() {
+        // Still inside the very first publishing cycle: nothing may be sent yet.
+        // OPC 10000-4 5.13.1 has the first Message go out "at the end of the first
+        // publishing cycle", and _start_timer pre-loads the keep-alive counter to
+        // maxKeepAliveCount - 1 precisely so the first *tick* emits it. A
+        // PublishRequest arriving before that tick reaches here through
+        // process_subscription and would find the counter already at its limit,
+        // sending the keep-alive immediately: CTT Subscription Basic 018 asks for
+        // the first Publish response after 1 RevisedPublishingInterval and measured
+        // 19 ms. publishIntervalCount is 0 until the first tick.
+        if (this.publishIntervalCount === 0) {
+            return;
+        }
         this.increaseKeepAliveCounter();
 
         if (this.keepAliveCounterHasExpired) {

--- a/packages/node-opcua-server/test/test_monitored_item.ts
+++ b/packages/node-opcua-server/test/test_monitored_item.ts
@@ -899,9 +899,13 @@ describe("Server Side MonitoredItem", () => {
         statusCode1.should.eql(StatusCodes.Good);
         monitoredItem.monitoringMode.should.eql(MonitoringMode.Disabled);
 
-        // set mode to disabled again
+        // set mode to disabled again: idempotent, and Good. Bad_NothingToDo is a
+        // service result for a request carrying no monitoredItemIds, not an
+        // operation result of SetMonitoringMode (OPC 10000-4 5.12.4), and CTT
+        // Monitor Basic 020 sets an already disabled item to Disabled and
+        // requires Good.
         const statusCode1b = monitoredItem.setMonitoringMode(MonitoringMode.Disabled);
-        statusCode1b.should.eql(StatusCodes.BadNothingToDo);
+        statusCode1b.should.eql(StatusCodes.Good);
         monitoredItem.monitoringMode.should.eql(MonitoringMode.Disabled);
 
         // set mode to reporting
@@ -913,14 +917,14 @@ describe("Server Side MonitoredItem", () => {
         const statusCode3 = monitoredItem.setMonitoringMode(MonitoringMode.Sampling);
         statusCode3.should.eql(StatusCodes.Good);
 
-        // set mode to sampling againg
+        // set mode to sampling again: still Good, and still Sampling
         const statusCode4 = monitoredItem.setMonitoringMode(MonitoringMode.Sampling);
-        statusCode4.should.eql(StatusCodes.BadNothingToDo);
+        statusCode4.should.eql(StatusCodes.Good);
         monitoredItem.monitoringMode.should.eql(MonitoringMode.Sampling);
 
-        // set mode to sampling againg
+        // and again, to show it stays idempotent rather than degrading
         const statusCode5 = monitoredItem.setMonitoringMode(MonitoringMode.Sampling);
-        statusCode5.should.eql(StatusCodes.BadNothingToDo);
+        statusCode5.should.eql(StatusCodes.Good);
         monitoredItem.monitoringMode.should.eql(MonitoringMode.Sampling);
 
         const statusCode6 = monitoredItem.setMonitoringMode(MonitoringMode.Invalid);
@@ -931,9 +935,10 @@ describe("Server Side MonitoredItem", () => {
         statusCode8.should.eql(StatusCodes.BadInternalError);
         monitoredItem.monitoringMode.should.not.eql(MonitoringMode.Invalid);
 
+        // and after a rejected mode, setting the current one is still Good
         const statusCode9 = monitoredItem.setMonitoringMode(MonitoringMode.Sampling);
         monitoredItem.monitoringMode.should.eql(MonitoringMode.Sampling);
-        statusCode9.should.eql(StatusCodes.BadNothingToDo);
+        statusCode9.should.eql(StatusCodes.Good);
 
         monitoredItem.terminate();
         monitoredItem.dispose();

--- a/packages/node-opcua-server/test/test_server_engine_subscription.ts
+++ b/packages/node-opcua-server/test/test_server_engine_subscription.ts
@@ -594,10 +594,15 @@ describe("ServerEngine Subscriptions service", function (this: ITestContext) {
             publishResponse2.responseHeader.requestHandle.should.eql(101);
 
             // verify that the first keep alive message was sent after  1 time publishing interval milliseconds
+            // This asserted approximately(0) while the test title and the line above both said one
+            // publishing interval: the assertion had been fitted to a server that answered the first
+            // PublishRequest at once. OPC 10000-4 5.13.1 sends the first Message "at the end of the
+            // first publishing cycle", and CTT Subscription Basic 018 measured 19 ms where it
+            // required one RevisedPublishingInterval.
             const resultDate1 = publishResponse1.responseHeader.timestamp!;
             const delayBetweenCreateAndFirstKeepAlive = resultDate1.getTime() - creationDate.getTime();
             console.log("delayBetweenCreateAndFirstKeepAlive", delayBetweenCreateAndFirstKeepAlive);
-            delayBetweenCreateAndFirstKeepAlive.should.be.approximately(0, 100);
+            delayBetweenCreateAndFirstKeepAlive.should.be.approximately(subscription1.publishingInterval, 100);
 
             // verify that the delay between the first and second keep alive is approximately 10 x publishingInterval
             const resultDate2 = publishResponse2.responseHeader.timestamp!;

--- a/packages/node-opcua-server/test/test_subscription.ts
+++ b/packages/node-opcua-server/test/test_subscription.ts
@@ -519,13 +519,25 @@ describe("Subscriptions", function (this: Mocha.Suite) {
             // in this case the subscription received a first publish request before the first tick is processed
 
             simulate_client_adding_publish_request(subscription.publishEngine);
-            subscription.state.should.eql(SubscriptionState.KEEPALIVE);
+            // The request is queued, but the subscription is still inside its first
+            // publishing cycle and nothing may go out yet: OPC 10000-4 5.13.1 sends
+            // the first Message "at the end of the first publishing cycle". This
+            // previously read KEEPALIVE, which is only reachable by having already
+            // sent the keep-alive - CTT Subscription Basic 018 measured that first
+            // response at 19 ms instead of one RevisedPublishingInterval.
+            subscription.state.should.eql(SubscriptionState.CREATING);
+            keepalive_event_spy.callCount.should.eql(0);
 
             test.clock.tick(subscription.publishingInterval);
             subscription.state.should.eql(SubscriptionState.KEEPALIVE);
             keepalive_event_spy.callCount.should.eql(1);
 
-            test.clock.tick(subscription.publishingInterval * (subscription.maxKeepAliveCount - 1));
+            // the queued request was consumed by that keep-alive; with none left the
+            // subscription starves and goes LATE once the keep-alive budget expires.
+            // A full maxKeepAliveCount of intervals is needed, not one less: the
+            // first keep-alive now lands at the end of cycle 1 rather than at t=0,
+            // so everything after it shifts by one interval.
+            test.clock.tick(subscription.publishingInterval * subscription.maxKeepAliveCount);
             subscription.state.should.eql(SubscriptionState.LATE);
             keepalive_event_spy.callCount.should.eql(1);
 

--- a/packages/node-opcua-server/test/test_subscription_with_monitored_items.ts
+++ b/packages/node-opcua-server/test/test_subscription_with_monitored_items.ts
@@ -401,7 +401,11 @@ describe("SM1 - Subscriptions and MonitoredItems", function (this: ITestContext)
 
         simulate_client_adding_publish_request(subscription.publishEngine);
 
-        test.clock.tick(subscription.publishingInterval * subscription.maxKeepAliveCount);
+        // The queued request is answered by the first keep-alive, which now goes out
+        // at the end of the first publishing cycle rather than at once (OPC 10000-4
+        // 5.13.1). Starvation therefore arrives one interval later, so the keep-alive
+        // budget plus that first cycle is needed before the subscription is LATE.
+        test.clock.tick(subscription.publishingInterval * (subscription.maxKeepAliveCount + 1));
         subscription.state.should.eql(SubscriptionState.LATE);
 
         // Monitored item will report a new value every tick => 100 ms


### PR DESCRIPTION
## Summary

Five commits from running the OPC Foundation CTT against a node-opcua server: three SDK bugs, and the conformance fixture the CTT's settings require.

### 1. A server could not write back a Variant-encoded value it had just served

`validateDataTypeCorrectness` resolved the incoming value's type by *name*, via `findDataType(DataType[dataType])`. The `DataType` enum's names do not all match the nodeset's browse names:

| enum | nodeset node |
|---|---|
| `DataType[22]` = `ExtensionObject` | `i=22` = **Structure** |
| `DataType[24]` = `Variant` | `i=24` = **BaseDataType** |

No node is named `"Variant"`, so the lookup threw for *any* Variant-encoded value and the escaping exception surfaced as a service-level `BadInternalError`. Now resolved by NodeId: a built-in type's enum value *is* its `ns=0` identifier.

```
read  ns=16;s=CTT/Static/All Profiles/Arrays/Variant  -> dataType 24, arrayType 1
write that identical value back                       -> BadInternalError (0x80020000)
```

### 2. `SetMonitoringMode` failed when the item was already in that mode

It returned `Bad_NothingToDo` per item when the requested mode equalled the current one, so an idempotent call failed. OPC 10000-4 §5.12.4 lists `Good` and `Bad_MonitoredItemIdInvalid` as the **operation** results; `Bad_NothingToDo` is a **service** result, for a request carrying no `monitoredItemIds` at all — which the server already returns correctly from `_on_SetMonitoringModeRequest`.

CTT `Monitor Basic 020` sets an already disabled item to Disabled, publishes to check no notification arrives, and requires `Good`:

```
SetMonitoringMode().Results[0] is not good: BadNothingToDo (0x800f0000)
```

The `Invalid` check now runs first, so an Invalid mode is still `Bad_InvalidArgument` rather than being mistaken for "already in that mode".

### 3. A subscription's first message was sent immediately, not after one cycle

A `PublishRequest` arriving before a new subscription's first tick was answered at once, so the first keep-alive went out in ~20 ms instead of one publishing interval. CTT `Subscription Basic 018`:

```
Expected the first Publish response after 1 RevisedPublishingInterval.
Expected a value greater than <2000> and less than <4000>; but received <19>.
```

`_start_timer` pre-loads the keep-alive counter to `maxKeepAliveCount - 1` so the first **tick** emits the message, exactly as OPC 10000-4 §5.13.1 requires. But an early `PublishRequest` reaches `_process_keepAlive` through `process_subscription` without any tick, finds the counter already at its limit, and sends. `_process_keepAlive` now returns while `publishIntervalCount` is still 0, leaving the timer as the only thing that can emit that first message.

### 4. The conformance fixture's Variant array was not Variant-encoded

`Static/All Profiles/Arrays/Variant` was declared `BaseDataType` (correct) but filled with a `Float64Array`, so it read back as `Double` (11). CTT `Attribute Read 023.js` asserts `AssertUaValueOfType(BuiltInType.Variant, ...)`, so the *value* has to be Variant-encoded. It now holds genuinely mixed element types.

### 5. The conformance address space serves the CTT's alarm input nodes

A setting named `<X>Type Input Nodes` wants the **source** Variable an alarm of that type watches, not the alarm itself: the CTT writes to that Variable and expects the alarm to change state and report an event. Each entry is therefore a writable scalar with an alarm instantiated on it. The two `Setpoint Source` settings name the setpoint Variable of the matching deviation alarm, created alongside its input node.

All alarms hang off a single `AlarmSource` object that is an event source of the Server object, so events reach a client subscribed to `i=2253` — which is what the CTT subscribes to.

`DiscrepancyAlarmType Input Nodes` is deliberately **not** built. `DiscrepancyAlarmType` derives straight from `AlarmConditionType`, and its mandatory `TargetValueNode` / `ExpectedTime` / `Tolerance` children have no implementation behind them in node-opcua, so an instance would be an inert shell. The two RateOfChange types derive from the two limit alarm types and instantiate through them, so the CTT's limit-alarm tests still exercise them meaningfully.

Three smaller fixture fixes ride along, all found while getting that to build:

- The HA Profile leaf named `Bool` was claiming `Static/All Profiles/Scalar/Bool` and `.../Arrays/Bool` by browse name, so those two settings now get convention nodes of their own.
- The last four built-in types now build. The `Variant` and `ExtensionObject` DataType nodes are `BaseDataType` and `Structure` rather than their encoding names — the same enum-versus-nodeset-name trap as fix 1, in a second place.
- The ExtensionObject variables take a concrete structure from the caller through a new optional `extensionObject` option, namespace zero having none worth exercising. Without it those variables keep a null ExtensionObject, so existing callers are unaffected.

New tests cover the CTT folder and the caller-supplied ExtensionObject: `test_ctt_folder.ts` and `test_custom_extension_object.ts`, 11 tests in the package.

## Note on three updated tests

Fix 3 changes observable timing, and three tests encoded the previous behaviour. `AZW3` is the clearest — its title and the comment directly above the assertion both say *"after one publishing interval"* while the assertion demanded `approximately(0, 100)`:

```js
// verify that the first keep alive message was sent after  1 time publishing interval milliseconds
delayBetweenCreateAndFirstKeepAlive.should.be.approximately(0, 100);
```

It had been fitted to the behaviour rather than to the specification. `T6-1` asserted `KEEPALIVE` before any tick — a state only reachable by having already sent — and two starvation timelines shift by the one interval the first keep-alive no longer skips.
