### PR TITLE
fix(server): a UserNameIdentityToken without the serverNonce is invalid

### DIFF
--- a/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_985.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_985.ts
@@ -346,7 +346,10 @@ describe("test reconnection when server stops and change it privateKey and certi
             await server.shutdown();
         }
         should.exist(_capturedError);
-        should(_capturedError?.message).match(/BadUserAccessDenied|BadIdentityTokenRejected/);
+        // the ciphertext is corrupted, so the blob either fails to decrypt or decrypts to
+        // garbage that carries no serverNonce: either way the token is malformed, and the
+        // server names that rather than claiming the credentials were refused.
+        should(_capturedError?.message).match(/BadIdentityTokenInvalid/);
         hacked.should.eql(true);
     });
     it("T6 - server shall not crash if the user identity token is corrupted ActivateSession", async () => {

--- a/packages/node-opcua-end2end-test/test/secure_connection/test_e2e_username_identity_token_missing_nonce.ts
+++ b/packages/node-opcua-end2end-test/test/secure_connection/test_e2e_username_identity_token_missing_nonce.ts
@@ -1,0 +1,123 @@
+import { createPublicKey } from "node:crypto";
+import "should";
+import {
+    ActivateSessionRequest,
+    getCryptoFactory,
+    MessageSecurityMode,
+    OPCUAClient,
+    OPCUAServer,
+    type Request,
+    SecurityPolicy,
+    UserNameIdentityToken,
+    UserTokenType
+} from "node-opcua";
+import { extractPublicKeyFromCertificateSync, toPem } from "node-opcua-crypto";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { assertThrow } from "../../test_helpers/assert_throw.js";
+import { createServerCertificateManager } from "../../test_helpers/createServerCertificateManager.js";
+
+// performMessageTransaction is public on the client implementation but not exposed on
+// the public OPCUAClient interface; reached here to inject a malformed ActivateSessionRequest.
+interface ClientWithTransaction {
+    performMessageTransaction(request: Request, callback: (error: Error | null) => void): void;
+}
+
+const port = 5797;
+
+const userManager = {
+    isValidUser(userName: string, password: string) {
+        return userName === "username" && password === "p@ssw0rd";
+    }
+};
+
+// the encrypted UserNameIdentityToken carries the SecurityPolicy only through its
+// encryptionAlgorithm: map it back to the crypto factory so we can re-encrypt the blob.
+function findCryptoFactoryFromEncryptionAlgorithm(encryptionAlgorithm: string | null) {
+    const candidates = [
+        SecurityPolicy.Basic128Rsa15,
+        SecurityPolicy.Basic256,
+        SecurityPolicy.Basic256Sha256,
+        SecurityPolicy.Aes128_Sha256_RsaOaep,
+        SecurityPolicy.Aes256_Sha256_RsaPss
+    ];
+    const found = candidates
+        .map((securityPolicy) => getCryptoFactory(securityPolicy))
+        .find((cryptoFactory) => cryptoFactory?.asymmetricEncryptionAlgorithm === encryptionAlgorithm);
+    if (!found) {
+        throw new Error(`cannot find a crypto factory matching ${encryptionAlgorithm}`);
+    }
+    return found;
+}
+
+/**
+ * OPC UA Part 4 - "Token Encryption and Proof of Possession": the client must append the
+ * serverNonce to the password before encrypting it. A token that omits the nonce is
+ * malformed - the server must reject it with BadIdentityTokenInvalid, and not with
+ * BadUserAccessDenied which would suggest that the credentials were merely wrong.
+ * (CTT: Security/Security User Name Password/006)
+ */
+describe("testing UserNameIdentityToken sent without the serverNonce appended to the password", () => {
+    let server: OPCUAServer;
+    let endpointUrl: string;
+
+    before(async () => {
+        const serverCertificateManager = await createServerCertificateManager(port);
+        server = new OPCUAServer({
+            port,
+            serverCertificateManager,
+            allowAnonymous: false,
+            userManager,
+            securityPolicies: [SecurityPolicy.None, SecurityPolicy.Basic256Sha256],
+            securityModes: [MessageSecurityMode.None, MessageSecurityMode.SignAndEncrypt]
+        });
+        await server.start();
+        endpointUrl = server.getEndpointUrl();
+    });
+
+    after(async () => {
+        await server.shutdown();
+    });
+
+    it("should reject the identity token with BadIdentityTokenInvalid when the serverNonce is not appended to the password", async () => {
+        const client = OPCUAClient.create({
+            securityMode: MessageSecurityMode.None,
+            securityPolicy: SecurityPolicy.None
+        });
+
+        const serverCertificate = server.getCertificate();
+        const publicKey = createPublicKey(extractPublicKeyFromCertificateSync(toPem(serverCertificate, "CERTIFICATE")));
+
+        let tampered = false;
+        const clientEx = client as unknown as ClientWithTransaction;
+        const original_performMessageTransaction = clientEx.performMessageTransaction;
+        clientEx.performMessageTransaction = (request: Request, callback: (error: Error | null) => void) => {
+            if (request instanceof ActivateSessionRequest && request.userIdentityToken instanceof UserNameIdentityToken) {
+                const token = request.userIdentityToken;
+                const cryptoFactory = findCryptoFactoryFromEncryptionAlgorithm(token.encryptionAlgorithm);
+                // rebuild the password blob with the correct password, but *without* the
+                // trailing serverNonce that the specification requires
+                const passwordBuffer = Buffer.from("p@ssw0rd", "utf-8");
+                const lengthBuffer = Buffer.alloc(4);
+                lengthBuffer.writeUInt32LE(passwordBuffer.length, 0);
+                token.password = cryptoFactory.asymmetricEncrypt(Buffer.concat([lengthBuffer, passwordBuffer]), publicKey);
+                tampered = true;
+            }
+            original_performMessageTransaction.call(client, request, callback);
+        };
+
+        await client.connect(endpointUrl);
+        try {
+            await assertThrow(async () => {
+                const session = await client.createSession({
+                    type: UserTokenType.UserName,
+                    userName: "username",
+                    password: "p@ssw0rd"
+                });
+                await session.close();
+            }, /BadIdentityTokenInvalid/);
+        } finally {
+            await client.disconnect();
+        }
+        tampered.should.eql(true, "the ActivateSessionRequest should have been tampered with");
+    });
+});

--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -2111,7 +2111,7 @@ export class OPCUAServer extends OPCUABaseServer<OPCUAServerEvents> {
         session: ServerSession,
         userTokenPolicy: UserTokenPolicy,
         userIdentityToken: UserNameIdentityToken,
-        callback: (err: Error | null, isAuthorized?: boolean) => void
+        callback: (err: Error | null, isAuthorized?: boolean, statusCode?: StatusCode) => void
     ): void {
         assert(userIdentityToken instanceof UserNameIdentityToken);
         // assert(this.isValidUserNameIdentityToken(channel, session, userTokenPolicy, userIdentityToken));
@@ -2160,15 +2160,18 @@ export class OPCUAServer extends OPCUABaseServer<OPCUAServerEvents> {
             (buff) => {
                 const result = extractPasswordFromDecryptedBlob(buff, serverNonce);
                 if (!result.valid) {
-                    return callback(null, false);
+                    // OPC UA Part 4 - Token Encryption and Proof of Possession:
+                    // the serverNonce must be appended to the password before
+                    // encryption. A blob that does not carry it is a malformed
+                    // token, not a wrong credential.
+                    return callback(null, false, StatusCodes.BadIdentityTokenInvalid);
                 }
                 validateUser(result.password);
             },
             () => {
-                // an undecryptable password blob is an authentication failure,
-                // not a server error (same observable outcome as the legacy
-                // decrypt-to-garbage-then-fail-validation path)
-                callback(null, false);
+                // an undecryptable password blob is a malformed identity token,
+                // not a server error
+                callback(null, false, StatusCodes.BadIdentityTokenInvalid);
             }
         );
     }
@@ -2224,7 +2227,7 @@ export class OPCUAServer extends OPCUABaseServer<OPCUAServerEvents> {
         channel: ServerSecureChannelLayer,
         session: ServerSession,
         userIdentityToken: UserIdentityToken,
-        callback: (err: Error | null, isAuthorized?: boolean) => void
+        callback: (err: Error | null, isAuthorized?: boolean, statusCode?: StatusCode) => void
     ): void {
         assert(userIdentityToken);
         assert(typeof callback === "function");
@@ -2674,14 +2677,14 @@ export class OPCUAServer extends OPCUABaseServer<OPCUAServerEvents> {
                     channel,
                     session,
                     request.userIdentityToken as UserIdentityToken,
-                    (err1: Error | null, authorized?: boolean) => {
+                    (err1: Error | null, authorized?: boolean, statusCode?: StatusCode) => {
                         /* c8 ignore next */
                         if (err1) {
                             return rejectConnection(this, StatusCodes.BadInternalError);
                         }
 
                         if (!authorized) {
-                            return rejectConnection(this, StatusCodes.BadUserAccessDenied);
+                            return rejectConnection(this, statusCode || StatusCodes.BadUserAccessDenied);
                         } else {
                             if (session.status === "active") {
                                 moveSessionToChannel(session, channel);


### PR DESCRIPTION
## Problem

OPC 10000-4, *Token Encryption and Proof of Possession*, requires a client to append the session's `serverNonce` to the password before encrypting a `UserNameIdentityToken`. The server correctly refused a token that omitted the nonce, but answered **`BadUserAccessDenied`** — which tells the client its *credentials* were refused and invites a retry — instead of **`BadIdentityTokenInvalid`**, which names the actual fault: a malformed token the client must fix.

CTT *Security / Security User Name Password / 006* exercises exactly this (insecure channel, valid username, empty password, nonce not appended) and reports:

```
RECOMMENDATION: The server returned 'BadUserAccessDenied (0x801f0000)' when sending an
empty password without nonce which is acceptable. According to the specification
'Part 4, Token Encryption and Proof of Possession' the server should return
Bad_IdentityTokenInvalid instead.
```

## Cause

`extractPasswordFromDecryptedBlob` already verified the trailing nonce, but the only channel back to the caller was a boolean:

```
userNameIdentityTokenAuthenticateUser  ->  callback(null, false)
isUserAuthorized                       ->  callback(null, false)
_on_ActivateSessionRequest             ->  rejectConnection(BadUserAccessDenied)
```

`!authorized` was hard-mapped to `BadUserAccessDenied`, so a malformed blob and a wrong password were indistinguishable by the time the status code was chosen.

## Change

The authorization callback gains an **optional third argument** carrying the precise rejection code:

- nonce missing / mismatched / blob malformed -> `BadIdentityTokenInvalid`
- blob that will not decrypt at all -> the same code (equally a malformed token, not a credential failure)
- `_on_ActivateSessionRequest` -> `rejectConnection(this, statusCode || StatusCodes.BadUserAccessDenied)`

The `|| BadUserAccessDenied` fallback keeps this non-breaking: `userNameIdentityTokenAuthenticateUser` and `isUserAuthorized` are `protected`, so any subclass override still calling `callback(null, false)` keeps today's behaviour. A genuinely wrong password — which reaches `userManager.isValidUser` only *after* the nonce check passes — still yields `BadUserAccessDenied`.

## Test

`test_e2e_username_identity_token_missing_nonce.ts` reproduces the CTT scenario against a real client/server pair: channel security `None`, server offering `None + Basic256Sha256` so the username policy is an encrypted one. It intercepts `performMessageTransaction` and re-encrypts the `ActivateSessionRequest` blob as `length | password` with **no trailing nonce** — using the *correct* password, so the token is proven to be rejected on its shape rather than on its credentials.

Verified both ways:

| | result |
|---|---|
| with the fix | passes |
| fix reverted, server rebuilt | fails: `expected 'BadUserAccessDenied (0x801f0000)' to match /BadIdentityTokenInvalid/` |

The existing `test_e2e_secure_UserNameIdentityToken.ts` suite (8 tests, including two that assert `BadUserAccessDenied` for wrong credentials) and the `extractPasswordFromDecryptedBlob` unit tests (7) still pass. `biome check`, `check-test-ports`, `check-import-extension` and `check-test-types` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
