### PR TITLE
docs(certificate-manager): rootFolder is the store, name is only a label

### DIFF
--- a/packages/node-opcua-certificate-manager/source/certificate_manager.ts
+++ b/packages/node-opcua-certificate-manager/source/certificate_manager.ts
@@ -50,16 +50,24 @@ export interface ICertificateManager {
 
 export interface OPCUACertificateManagerOptions {
     /**
-     * where to store the PKI
-     * default %APPDATA%/node-opcua-default
+     * The folder that **is** the PKI store: `own/`, `trusted/`, `issuers/` and
+     * `rejected/` are created directly under it. `name` is not appended.
+     *
+     * Two managers given the same `rootFolder` share one store and one
+     * private key, whatever their `name`. Give every application, and every
+     * side of an application (server side, client side), a folder of its own.
+     *
+     * @defaultValue the per-user config folder of node-opcua
+     *   (`%APPDATA%/node-opcua-default` on Windows, `~/.config/node-opcua-default` elsewhere)
      */
     rootFolder?: null | string;
 
     automaticallyAcceptUnknownCertificate?: boolean;
     /**
-     * the name of the pki store( default value = "pki" )
-     *
-     * the PKI folder will be <rootFolder>/<name>
+     * A label for this store. It does **not** change where the store lives:
+     * the folder is `rootFolder` alone. Callers that want one store per name
+     * build the path themselves, as {@link getDefaultCertificateManager} does
+     * with `rootFolder: path.join(config, name)`.
      */
     name?: string;
 

--- a/packages/node-opcua-certificate-manager/test/test_certificate_manager.ts
+++ b/packages/node-opcua-certificate-manager/test/test_certificate_manager.ts
@@ -462,3 +462,38 @@ describe("OPCUACertificateManager with privateKeyPassphrase", function (this: Mo
         }
     });
 });
+
+describe("OPCUACertificateManager rootFolder and name", function (this: Mocha.Suite) {
+    this.timeout(Math.max(40000, this.timeout()));
+
+    it("RF01- rootFolder is the store itself: name is not appended to the path", async () => {
+        const rootFolder = path.join(_tmpFolder, "testing_root_folder_is_store");
+        fs.rmSync(rootFolder, { recursive: true, force: true });
+        const cm = new OPCUACertificateManager({ rootFolder, name: "SomeName" });
+        try {
+            await cm.initialize();
+            path.resolve(cm.rootDir).should.eql(path.resolve(rootFolder));
+            fs.existsSync(path.join(rootFolder, "own", "private", "private_key.pem")).should.eql(true);
+            fs.existsSync(path.join(rootFolder, "SomeName")).should.eql(false);
+        } finally {
+            await cm.dispose();
+        }
+    });
+
+    it("RF02- two managers with the same rootFolder and different names share one store and one private key", async () => {
+        const rootFolder = path.join(_tmpFolder, "testing_root_folder_shared");
+        fs.rmSync(rootFolder, { recursive: true, force: true });
+        const cm1 = new OPCUACertificateManager({ rootFolder, name: "first" });
+        const cm2 = new OPCUACertificateManager({ rootFolder, name: "second" });
+        try {
+            await cm1.initialize();
+            await cm2.initialize();
+            cm1.rootDir.should.eql(cm2.rootDir);
+            cm1.privateKey.should.eql(cm2.privateKey);
+            fs.readFileSync(cm1.privateKey, "utf-8").should.eql(fs.readFileSync(cm2.privateKey, "utf-8"));
+        } finally {
+            await cm1.dispose();
+            await cm2.dispose();
+        }
+    });
+});


### PR DESCRIPTION
## Why

The comments on `OPCUACertificateManagerOptions` said the PKI folder is `<rootFolder>/<name>`. The implementation has never appended `name`: the store is `rootFolder` itself, with `own/`, `trusted/`, `issuers/` and `rejected/` directly under it. Two managers given the same `rootFolder` therefore share one store and one private key, whatever their `name`. That surprised a reader following the docs while setting up separate client-side and server-side stores.

## What

- Rewrites the `rootFolder` and `name` doc comments to describe the real behaviour and to point at `getDefaultCertificateManager`, which builds the per-name path itself.
- Adds two tests: RF01 checks `name` is not appended to the path, RF02 checks that two managers on one `rootFolder` share the store and the private key.

No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
