### PR TITLE
perf(server): remove two complexity problems on the subscription notification path

### DIFF
--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -3674,18 +3674,20 @@ export class OPCUAServer extends OPCUABaseServer<OPCUAServerEvents> {
                     }
                 }
 
-                const resultsPromises = request.monitoredItemIds.map(async (monitoredItemId: number) => {
+                try {
+                    // The onDeleteMonitoredItem hook is per item and may be async, so it
+                    // still runs one at a time. The removal itself is done for the whole
+                    // batch, in a single pass over the pending notifications instead of
+                    // one pass per item.
                     if (this.options.onDeleteMonitoredItem) {
-                        const monitoredItem = subscription.getMonitoredItem(monitoredItemId);
-                        if (monitoredItem) {
-                            await this.options.onDeleteMonitoredItem(subscription, monitoredItem);
+                        for (const monitoredItemId of request.monitoredItemIds) {
+                            const monitoredItem = subscription.getMonitoredItem(monitoredItemId);
+                            if (monitoredItem) {
+                                await this.options.onDeleteMonitoredItem(subscription, monitoredItem);
+                            }
                         }
                     }
-                    return subscription.removeMonitoredItem(monitoredItemId);
-                });
-
-                try {
-                    const results = await Promise.all(resultsPromises);
+                    const results = subscription.removeMonitoredItems(request.monitoredItemIds);
 
                     const response = new DeleteMonitoredItemsResponse({
                         diagnosticInfos: undefined,

--- a/packages/node-opcua-server/source/server_subscription.ts
+++ b/packages/node-opcua-server/source/server_subscription.ts
@@ -445,6 +445,8 @@ export interface InternalNotification {
     notification: QueueItem | StatusChangeNotification;
     publishTime: Date;
     start_tick: number;
+    /** encoded size, measured once when the notification was queued; see _degradeIfUndeliverable */
+    size?: number;
 }
 
 export interface InternalCreateMonitoredItemResult {
@@ -1843,9 +1845,11 @@ export class Subscription extends EventEmitter {
         // c8 ignore next
         doDebug && debugLog(chalk.yellow("Subscription#_addNotificationMessage"), notificationData.toString());
 
+        const { notification, size } = this._degradeIfUndeliverable(notificationData);
         this._pending_notifications.push({
             monitoredItemId,
-            notification: this._degradeIfUndeliverable(notificationData),
+            notification,
+            size,
             publishTime: new Date(),
             start_tick: this.publishIntervalCount
         });
@@ -1865,21 +1869,29 @@ export class Subscription extends EventEmitter {
      * failed, the subscription lives, and the item recovers by itself when its
      * value next fits, the status change being a change like any other.
      */
-    private _degradeIfUndeliverable(notificationData: QueueItem | StatusChangeNotification): QueueItem | StatusChangeNotification {
+    private _degradeIfUndeliverable(notificationData: QueueItem | StatusChangeNotification): {
+        notification: QueueItem | StatusChangeNotification;
+        size: number | undefined;
+    } {
         const budget = this.maxNotificationMessageSize;
         if (!budget || !(notificationData instanceof MonitoredItemNotification)) {
-            return notificationData;
+            return { notification: notificationData, size: undefined };
         }
-        // measured against an empty message, not the remaining room: a value that
-        // would have fitted alone must not be degraded, only deferred
-        if (notificationData.binaryStoreSize() + notificationMessageOverhead <= budget) {
-            return notificationData;
+        // Measured once, here, and carried on the queue entry: binaryStoreSize
+        // walks the whole structure, and the batching loop needs the same number
+        // later. Cheap per notification - a traversal, no copying - but it is the
+        // hottest path in the server and there is no reason to walk twice.
+        const size = notificationData.binaryStoreSize();
+        // compared against an empty message, not the remaining room: a value that
+        // would have fitted alone must be deferred, never degraded
+        if (size + notificationMessageOverhead <= budget) {
+            return { notification: notificationData, size };
         }
         warningLog(
-            `a value for monitored item clientHandle=${notificationData.clientHandle} is ${notificationData.binaryStoreSize()} bytes,` +
+            `a value for monitored item clientHandle=${notificationData.clientHandle} is ${size} bytes,` +
                 ` more than this channel can carry (${budget}); reporting BadResponseTooLarge instead`
         );
-        return new MonitoredItemNotification({
+        const degraded = new MonitoredItemNotification({
             clientHandle: notificationData.clientHandle,
             value: new DataValue({
                 statusCode: StatusCodes.BadResponseTooLarge,
@@ -1887,6 +1899,7 @@ export class Subscription extends EventEmitter {
                 serverTimestamp: notificationData.value?.serverTimestamp
             })
         });
+        return { notification: degraded, size: degraded.binaryStoreSize() };
     }
 
     /**
@@ -1940,8 +1953,11 @@ export class Subscription extends EventEmitter {
                 }
             }
             if (budget) {
-                const next = this._pending_notifications.first()?.notification;
-                const size = next && !(next instanceof StatusChangeNotification) ? next.binaryStoreSize() : 0;
+                const entry = this._pending_notifications.first();
+                const next = entry?.notification;
+                // measured at capture; recomputed only if this entry predates a
+                // channel that announced a limit, when none was measured then
+                const size = next && !(next instanceof StatusChangeNotification) ? (entry?.size ?? next.binaryStoreSize()) : 0;
                 // `i > 0` is what guarantees progress: the first notification of
                 // a message is always taken, however heavy it is, so an outsized
                 // value leads the next message rather than being deferred for

--- a/packages/node-opcua-server/source/server_subscription.ts
+++ b/packages/node-opcua-server/source/server_subscription.ts
@@ -849,8 +849,8 @@ export class Subscription extends EventEmitter {
         doDebug && debugLog("terminating Subscription  ", this.id, " with ", this.monitoredItemCount, " monitored items");
 
         // dispose all monitoredItem
-        for (const monitoredItemId of [...this.monitoredItems.keys()]) {
-            const status = this.removeMonitoredItem(monitoredItemId);
+        // one pass over the pending list for the whole set, not one per item
+        for (const status of this.removeMonitoredItems([...this.monitoredItems.keys()])) {
             assert(status === StatusCodes.Good);
         }
         assert(this.monitoredItemCount === 0);
@@ -1197,6 +1197,39 @@ export class Subscription extends EventEmitter {
      * @param monitoredItemId : the id of the monitored item to get.
      */
     public removeMonitoredItem(monitoredItemId: number): StatusCode {
+        const status = this._detachMonitoredItem(monitoredItemId);
+        if (status === StatusCodes.Good) {
+            this._removePendingNotificationsFor(monitoredItemId);
+        }
+        return status;
+    }
+
+    /**
+     * Remove several monitored items, purging their queued notifications in one
+     * pass over the pending list.
+     *
+     * Removing them one at a time costs O(items x pending): dropping the queued
+     * notifications of a single item walks the whole pending list, and that walk
+     * is repeated for every item. The product is what hurts - it is invisible at
+     * ten items and grows quadratically when a subscription with a large backlog
+     * is torn down wholesale, which is exactly what DeleteMonitoredItems and
+     * terminate() do.
+     */
+    public removeMonitoredItems(monitoredItemIds: number[]): StatusCode[] {
+        const statuses = monitoredItemIds.map((id) => this._detachMonitoredItem(id));
+        const removed = new Set(monitoredItemIds.filter((_id, i) => statuses[i] === StatusCodes.Good));
+        if (removed.size) {
+            const n = this._pending_notifications.filterOut(
+                (e) => e.monitoredItemId !== undefined && removed.has(e.monitoredItemId)
+            );
+            // c8 ignore next
+            doDebug && debugLog(`Removed ${n} notifications for ${removed.size} monitored items`);
+        }
+        return statuses;
+    }
+
+    /** everything removing a monitored item does, except purging its pending notifications */
+    private _detachMonitoredItem(monitoredItemId: number): StatusCode {
         // c8 ignore next
         doDebug && debugLog("Removing monitoredIem ", monitoredItemId);
         const monitoredItem = this.monitoredItems.get(monitoredItemId);
@@ -1218,9 +1251,6 @@ export class Subscription extends EventEmitter {
         this.monitoredItems.delete(monitoredItemId);
         this.globalCounter.totalMonitoredItemCount -= 1;
 
-        this._removePendingNotificationsFor(monitoredItemId);
-        // flush pending notifications
-        // assert(this._pending_notifications.size === 0);
         return StatusCodes.Good;
     }
 

--- a/packages/node-opcua-server/test/test_remove_monitored_items_batch.ts
+++ b/packages/node-opcua-server/test/test_remove_monitored_items_batch.ts
@@ -1,0 +1,100 @@
+/**
+ * Removing monitored items must not walk the pending-notification list once per
+ * item.
+ *
+ * `_removePendingNotificationsFor` scans the whole pending queue, and it used to
+ * be called for every item removed, so tearing down a subscription cost
+ * O(items x pending). That is invisible at ten items and grows with the product:
+ * a subscription whose client is slow accumulates a long pending list, and
+ * DeleteMonitoredItems or terminate() then pays for it once per item.
+ *
+ * The assertion counts passes over the queue rather than measuring time, so it
+ * states the complexity directly and cannot flake on a loaded machine.
+ */
+import "should";
+import { StatusCodes } from "node-opcua-status-code";
+import sinon from "sinon";
+
+import { Subscription } from "../source/server_subscription.js";
+import { getFakePublishEngine } from "./helper_fake_publish_engine.js";
+
+/** the parts of a monitored item that removal touches */
+function fakeMonitoredItem(id: number) {
+    return {
+        monitoredItemId: id,
+        terminate() {
+            /* nothing to stop in a fake */
+        },
+        dispose() {
+            /* nothing to release in a fake */
+        }
+    };
+}
+
+interface SubscriptionInternals {
+    monitoredItems: Map<number, unknown>;
+    _pending_notifications: { filterOut(p: (e: unknown) => boolean): number };
+    globalCounter: { totalMonitoredItemCount: number };
+}
+
+function makeSubscriptionWith(itemCount: number) {
+    const subscription = new Subscription({
+        id: 1,
+        publishingInterval: 1000,
+        maxKeepAliveCount: 20,
+        lifeTimeCount: 100,
+        publishEngine: getFakePublishEngine(),
+        globalCounter: { totalMonitoredItemCount: 0 },
+        serverCapabilities: { maxMonitoredItems: 100000, maxMonitoredItemsPerSubscription: 100000 }
+    } as never);
+    const internals = subscription as unknown as SubscriptionInternals;
+    for (let id = 1; id <= itemCount; id++) {
+        internals.monitoredItems.set(id, fakeMonitoredItem(id));
+    }
+    internals.globalCounter.totalMonitoredItemCount = itemCount;
+    return { subscription, internals };
+}
+
+describe("RMB - removing monitored items scans the pending queue once, not once per item", () => {
+    it("RMB-1 removeMonitoredItems makes a single pass whatever the item count", () => {
+        for (const itemCount of [1, 10, 500]) {
+            const { subscription, internals } = makeSubscriptionWith(itemCount);
+            const spy = sinon.spy(internals._pending_notifications, "filterOut");
+
+            const statuses = subscription.removeMonitoredItems([...internals.monitoredItems.keys()] as number[]);
+
+            statuses.length.should.eql(itemCount);
+            statuses.every((s) => s === StatusCodes.Good).should.eql(true, "every item was removed");
+            spy.callCount.should.eql(1, `expected one pass over the pending queue, saw ${spy.callCount} for ${itemCount} items`);
+            internals.monitoredItems.size.should.eql(0);
+
+            spy.restore();
+            subscription.terminate();
+            subscription.dispose();
+        }
+    });
+
+    it("RMB-2 terminate() also makes a single pass", () => {
+        const { subscription, internals } = makeSubscriptionWith(300);
+        const spy = sinon.spy(internals._pending_notifications, "filterOut");
+
+        subscription.terminate();
+
+        spy.callCount.should.eql(1, `terminate made ${spy.callCount} passes over the pending queue`);
+        internals.monitoredItems.size.should.eql(0);
+
+        spy.restore();
+        subscription.dispose();
+    });
+
+    it("RMB-3 an unknown id is reported without disturbing the others", () => {
+        const { subscription, internals } = makeSubscriptionWith(3);
+        const statuses = subscription.removeMonitoredItems([1, 999, 3]);
+
+        statuses.should.eql([StatusCodes.Good, StatusCodes.BadMonitoredItemIdInvalid, StatusCodes.Good]);
+        internals.monitoredItems.size.should.eql(1, "the item that was not named survives");
+
+        subscription.terminate();
+        subscription.dispose();
+    });
+});


### PR DESCRIPTION
Two complexity fixes on the subscription notification path, found while profiling a server under an OPC Foundation CTT run. Both are about doing work proportional to what is being done, not about a measured speed-up — see **Honest scope** below.

## 1. Purging pending notifications was O(items × pending)

Removing a monitored item drops its queued notifications by walking the whole pending list:

```ts
private _removePendingNotificationsFor(monitoredItemId: number) {
    this._pending_notifications.filterOut((e) => e.monitoredItemId === monitoredItemId);
}
```

and that walk was repeated for **every** item removed:

```ts
for (const monitoredItemId of [...this.monitoredItems.keys()]) {
    this.removeMonitoredItem(monitoredItemId);   // → one full scan each
}
```

The product is what hurts. At ten items it is invisible; at a few thousand, with a client slow enough to let the pending queue grow, `DeleteMonitoredItems` and `terminate()` both pay for it once per item.

`removeMonitoredItems(ids)` detaches the whole set and then makes a **single pass** with a `Set` membership test. `removeMonitoredItem()` keeps its single-item path for callers that genuinely remove one. The `onDeleteMonitoredItem` hook still runs per item, because it is asynchronous and may inspect each one.

## 2. Each notification was measured twice

Sizing a `PublishResponse` walks each notification with `binaryStoreSize()` — a traversal that accumulates lengths, no copying — to decide what fits. That walk happened twice: once at capture, to decide whether the value could ever be delivered, and again when the message was assembled.

The size measured at capture is now carried on the queue entry and read back when batching:

```ts
export interface InternalNotification {
    ...
    /** encoded size, measured once when the notification was queued */
    size?: number;
}
```

A fallback remains, for correctness rather than speed: a notification queued while no budget applied carries no size, and a subscription later transferred to a session whose channel *does* announce a limit must measure it then rather than treat it as free.

## Tests

`test_remove_monitored_items_batch.ts` asserts the **number of passes over the pending queue**, not elapsed time — so it states the complexity directly and cannot flake on a loaded machine:

| | |
|---|---|
| RMB-1 | one pass whether the batch holds 1, 10 or 500 items |
| RMB-2 | `terminate()` also makes exactly one |
| RMB-3 | an unknown id is reported without disturbing the rest |

The existing sizing tests (`test_publish_response_sizing.ts`) are unchanged and still pass, which is the check that (2) altered nothing observable. Full package suite: **494 passing**.

## Honest scope

These were found while chasing multi-second delays the CTT reported on bulk operations. **They do not explain those delays**, and I would rather say so than let the framing imply otherwise:

| measured against a live server | result |
|---|---|
| `DeleteMonitoredItems`, 250 → 2000 items | 2 ms → 47 ms (superlinear, confirmed) |
| `Read` of 1000 nodes | 17–65 ms |
| `CreateMonitoredItems`, 1000 | 13–32 ms |
| SignAndEncrypt vs None | no measurable difference |
| chunk size 8 kB → 512 kB | no trend |

Every server-side path is linear or better and lands in tens of milliseconds — two orders of magnitude short of the 1.5–3.9 s reported. The remaining delay appears to be client-side: the CTT measures from when *it* examines the response, so its own validation backlog inflates the figure.

So the value here is asymptotic: the quadratic is real and will bite someone with a large subscription and a slow client, and measuring the same notification twice on the hottest path is waste. Neither is a performance fix I can put numbers behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
