### PR TITLE
fix(server): reject CloseSession sent from a foreign SecureChannel

### DIFF
--- a/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_transfer_session.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_transfer_session.ts
@@ -491,5 +491,80 @@ export function t(test: { endpointUrl: string; server: OPCUAServer }) {
             }
             test.server.engine.currentSessionCount.should.eql(0);
         });
+
+        // CTT 1.05.513 Session Services / Session Multiple / Err-001.js
+        // A Session belongs to the SecureChannel that created it. ActivateSession is the
+        // only Service allowed to move it to a different SecureChannel. CloseSession sent
+        // over an unrelated SecureChannel - even carrying a valid SessionId and
+        // AuthenticationToken - must be rejected with Bad_SessionIdInvalid, otherwise any
+        // peer that learns another Client's SessionId/AuthenticationToken could terminate
+        // that Client's Session.
+        it("RQB11 - server should reject a CloseSession sent from a different channel than the one owning the session (not activated)", async () => {
+            const client1 = OPCUAClient.create({});
+            await client1.connect(test.endpointUrl);
+            const client2 = OPCUAClient.create({});
+            await client2.connect(test.endpointUrl);
+            try {
+                // create a session using client1, without activating it
+                const session1 = await _createSession(client1);
+                test.server.engine.currentSessionCount.should.eql(1);
+
+                // send CloseSession for session1 over client2's (unrelated) channel
+                const request = new CloseSessionRequest({
+                    deleteSubscriptions: true
+                });
+                request.requestHeader.authenticationToken = session1.authenticationToken as import("node-opcua").NodeId;
+
+                await should(perform(client2, request))
+                    .be.rejectedWith(/BadSessionIdInvalid/)
+                    .then((err) => {
+                        err.response.should.be.instanceOf(ServiceFault);
+                        err.response.responseHeader.serviceResult.should.eql(StatusCodes.BadSessionIdInvalid);
+                    });
+
+                // the session must still be alive, and closeable from its own channel
+                test.server.engine.currentSessionCount.should.eql(1);
+                await should(client1.closeSession(session1, /* deleteSubscriptions =*/ true)).be.fulfilled();
+            } finally {
+                await client1.disconnect();
+                await client2.disconnect();
+            }
+            test.server.engine.currentSessionCount.should.eql(0);
+        });
+
+        it("RQB12 - server should reject a CloseSession sent from a different channel than the one owning the session (activated)", async () => {
+            const client1 = OPCUAClient.create({});
+            await client1.connect(test.endpointUrl);
+            const client2 = OPCUAClient.create({});
+            await client2.connect(test.endpointUrl);
+            try {
+                // create and activate a session using client1
+                const session1 = await _createSession(client1);
+                const userIdentityInfo: UserIdentityInfo = { type: UserTokenType.Anonymous };
+                await _activateSession(client1, session1, userIdentityInfo);
+                test.server.engine.currentSessionCount.should.eql(1);
+
+                // send CloseSession for session1 over client2's (unrelated) channel
+                const request = new CloseSessionRequest({
+                    deleteSubscriptions: true
+                });
+                request.requestHeader.authenticationToken = session1.authenticationToken as import("node-opcua").NodeId;
+
+                await should(perform(client2, request))
+                    .be.rejectedWith(/BadSessionIdInvalid/)
+                    .then((err) => {
+                        err.response.should.be.instanceOf(ServiceFault);
+                        err.response.responseHeader.serviceResult.should.eql(StatusCodes.BadSessionIdInvalid);
+                    });
+
+                // the session must still be alive, and closeable from its own channel
+                test.server.engine.currentSessionCount.should.eql(1);
+                await should(client1.closeSession(session1, /* deleteSubscriptions =*/ true)).be.fulfilled();
+            } finally {
+                await client1.disconnect();
+                await client2.disconnect();
+            }
+            test.server.engine.currentSessionCount.should.eql(0);
+        });
     });
 }

--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -3026,8 +3026,19 @@ export class OPCUAServer extends OPCUABaseServer<OPCUAServerEvents> {
         // this._apply_on_SessionObject(CloseSessionResponse, message, channel, function (session) {
         // });
 
-        const session = message.session;
+        const session = message.session as ServerSession | undefined;
         if (!session) {
+            sendError(StatusCodes.BadSessionIdInvalid);
+            return;
+        }
+
+        // OPC 10000-4 §5.6.4: a Session belongs to the SecureChannel that created it (or
+        // that ActivateSession last rebound it to); ActivateSession is the only Service
+        // allowed to move it. A CloseSession arriving on any other channel must be
+        // rejected with Bad_SessionIdInvalid, otherwise a peer that merely learns another
+        // Client's SessionId/AuthenticationToken could terminate that Client's Session
+        // from an unrelated channel.
+        if (session.channel !== channel) {
             sendError(StatusCodes.BadSessionIdInvalid);
             return;
         }


### PR DESCRIPTION
## Summary

- `CreateSession` binds a Session to the SecureChannel that created it; per OPC 10000-4 §5.6.4, `ActivateSession` is the only Service allowed to rebind a Session to a different channel.
- `_on_CloseSessionRequest` resolved the Session purely from the request's `AuthenticationToken` and never compared the Session's owning channel to the channel the request arrived on, so `CloseSession` sent over any channel that merely knew a valid `SessionId`/`AuthenticationToken` would succeed and terminate that Session.
- Every other Service already goes through `prepare()` / `_apply_on_SessionObject`, which does perform this comparison — `CloseSession` deliberately bypasses that helper (so it can still close a Session that was created but never activated) and lost the channel check along the way.
- Fix: in `_on_CloseSessionRequest`, reject with `Bad_SessionIdInvalid` when `session.channel !== channel`, before proceeding to close it.

## Test plan

- [x] Added two end-to-end regression tests in `u_test_e2e_transfer_session.ts` (`RQB11`, `RQB12`): create a Session on one SecureChannel (not activated / activated), send `CloseSession` for it over an unrelated second channel, and assert `Bad_SessionIdInvalid` plus that the Session is still alive and closeable from its own channel afterwards.
- [x] `pnpm --filter node-opcua-server run build` — clean.
- [x] `npx mocha test/end_to_end/test_umbrella_e2e_seriesD.ts` in `node-opcua-end2end-test` — 43 passing, no regressions.
- [x] `biome check` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)