### PR TITLE
fix(server): arbitrate Publish requests by priority, not tick order

### DIFF
--- a/packages/node-opcua-server/source/i_server_side_publish_engine.ts
+++ b/packages/node-opcua-server/source/i_server_side_publish_engine.ts
@@ -17,6 +17,13 @@ export interface IServerSidePublishEngine {
     _on_tick(): void;
     send_keep_alive_response(subscriptionId: number, future_sequence_number: number): boolean;
     _send_response(subscription: Subscription, options: PublishResponseOptions): void;
+    /**
+     * Arbitrate across every subscription this engine owns and feed the queued PublishRequests
+     * to whichever ready subscription (highest priority, then longest since last served) deserves
+     * them, instead of letting a subscription serve itself just because its own timer fired first.
+     * Optional so lightweight test doubles that only ever drive a single subscription need not implement it.
+     */
+    feedReadySubscriptions?(): void;
 }
 
 export interface IClosedOrTransferredSubscription {

--- a/packages/node-opcua-server/source/server_publish_engine.ts
+++ b/packages/node-opcua-server/source/server_publish_engine.ts
@@ -184,6 +184,10 @@ export class ServerSidePublishEngine extends EventEmitter implements IServerSide
     private _publish_request_queue: PublishData[] = [];
     private _subscriptions: { [key: string]: Subscription };
     private _closed_subscriptions: IClosedOrTransferredSubscription[] = [];
+    // used by feedReadySubscriptions to arbitrate fairly, by priority then turn order, across
+    // subscriptions of this session instead of letting whichever one ticks first monopolize the queue
+    #serveSequence = 0;
+    #lastServedAt = new WeakMap<Subscription, number>();
 
     constructor(options?: ServerSidePublishEngineOptions) {
         super();
@@ -472,6 +476,51 @@ export class ServerSidePublishEngine extends EventEmitter implements IServerSide
             this.#_feed_late_subscription();
 
             this.#_handle_too_many_requests();
+        }
+    }
+
+    #_pickMostDeservingReadySubscription(): Subscription | null {
+        let best: Subscription | null = null;
+        let bestLastServed = Number.POSITIVE_INFINITY;
+        for (const subscription of this.subscriptions) {
+            if (!subscription.publishingEnabled) {
+                continue;
+            }
+            if (!subscription.hasPendingNotifications && !subscription.hasUncollectedMonitoredItemNotifications) {
+                continue;
+            }
+            const lastServed = this.#lastServedAt.get(subscription) ?? -1;
+            if (
+                !best ||
+                subscription.priority > best.priority ||
+                (subscription.priority === best.priority && lastServed < bestLastServed)
+            ) {
+                best = subscription;
+                bestLastServed = lastServed;
+            }
+        }
+        return best;
+    }
+
+    /**
+     * Feed every queued PublishRequest to the most deserving ready subscription of this session
+     * (highest priority, then whoever has waited longest since its last turn), instead of letting
+     * a subscription serve itself from server_subscription.ts#_tick just because its own timer
+     * happened to fire first. See FEAT-24.
+     */
+    public feedReadySubscriptions(): void {
+        while (this.pendingPublishRequestCount > 0) {
+            const subscription = this.#_pickMostDeservingReadySubscription();
+            if (!subscription) {
+                break;
+            }
+            const countBefore = this.pendingPublishRequestCount;
+            subscription.process_subscription();
+            if (this.pendingPublishRequestCount >= countBefore) {
+                // no progress: avoid spinning forever on a subscription that cannot actually consume a slot
+                break;
+            }
+            this.#lastServedAt.set(subscription, ++this.#serveSequence);
         }
     }
 

--- a/packages/node-opcua-server/source/server_subscription.ts
+++ b/packages/node-opcua-server/source/server_subscription.ts
@@ -1759,11 +1759,18 @@ export class Subscription extends EventEmitter {
         }
 
         if (publishEngine.pendingPublishRequestCount > 0) {
-            if (this.hasPendingNotifications) {
-                // simply pop pending notification and send it
-                this.process_subscription();
-            } else if (this.hasUncollectedMonitoredItemNotifications) {
-                this.process_subscription();
+            if (this.hasPendingNotifications || this.hasUncollectedMonitoredItemNotifications) {
+                // A sibling subscription on this same session may deserve the next queued
+                // PublishRequest more (higher priority, or waited longer at equal priority).
+                // Let the engine arbitrate across every ready subscription it owns instead of
+                // this one serving itself just because its own timer fired first (FEAT-24).
+                // Fall back to self-service for lightweight engine doubles (unit tests) that
+                // only ever attach a single subscription.
+                if (publishEngine.feedReadySubscriptions) {
+                    publishEngine.feedReadySubscriptions();
+                } else {
+                    this.process_subscription();
+                }
             } else {
                 this._process_keepAlive();
             }

--- a/packages/node-opcua-server/test/test_server_publish_engine.ts
+++ b/packages/node-opcua-server/test/test_server_publish_engine.ts
@@ -981,6 +981,141 @@ describe("Testing the server publish engine", function (this: Mocha.Suite) {
         }
     });
 
+    it("FEAT-24 a higher priority subscription should be served before a lower priority one when both compete for a scarce PublishRequest on the same session", () => {
+        const publish_server = new ServerSidePublishEngine();
+
+        // maxNotificationsPerPublish: 1 makes each serve drain exactly one backlogged item, so a
+        // subscription with several items queued stays ready across several serves in a row - this
+        // keeps the test's outcome independent of exactly how many times a tick or its self-retrigger
+        // (server_subscription.ts's process_subscription) happens to run.
+        const low = makeSubscription({
+            id: 1,
+            publishingInterval: 1000,
+            lifeTimeCount: 1000,
+            maxKeepAliveCount: 20,
+            priority: 0,
+            maxNotificationsPerPublish: 1,
+            publishEngine: publish_server,
+            globalCounter: { totalMonitoredItemCount: 0 },
+            serverCapabilities: { maxMonitoredItems: 10000, maxMonitoredItemsPerSubscription: 1000 }
+        });
+        publish_server.add_subscription(low);
+
+        const high = makeSubscription({
+            id: 2,
+            publishingInterval: 1000,
+            lifeTimeCount: 1000,
+            maxKeepAliveCount: 20,
+            priority: 10,
+            maxNotificationsPerPublish: 1,
+            publishEngine: publish_server,
+            globalCounter: { totalMonitoredItemCount: 0 },
+            serverCapabilities: { maxMonitoredItems: 10000, maxMonitoredItemsPerSubscription: 1000 }
+        });
+        publish_server.add_subscription(high);
+
+        const lowItem = add_mock_monitored_item(low);
+        const highItem = add_mock_monitored_item(high);
+
+        try {
+            // let both subscriptions send their initial value and reach steady state (NORMAL, messageSent)
+            publish_server._on_PublishRequest(new PublishRequest());
+            publish_server._on_PublishRequest(new PublishRequest());
+            test.clock.tick(low.publishingInterval);
+            low.sentNotificationMessageCount.should.eql(1);
+            high.sentNotificationMessageCount.should.eql(1);
+
+            // give both a deep backlog (5 changes each, drained one at a time) then starve them of
+            // requests: only 3 for 5+5 demand. Priority alone must decide who is served; `low` must
+            // not get a single one of the 3, since `high` never runs out of backlog to justify a switch.
+            for (let k = 0; k < 5; k++) {
+                lowItem.simulateMonitoredItemAddingNotification();
+                highItem.simulateMonitoredItemAddingNotification();
+            }
+            publish_server._on_PublishRequest(new PublishRequest());
+            publish_server._on_PublishRequest(new PublishRequest());
+            publish_server._on_PublishRequest(new PublishRequest());
+            test.clock.tick(low.publishingInterval);
+            test.clock.tick(0); // let any trailing re-trigger settle
+
+            high.sentNotificationMessageCount.should.eql(1 + 3);
+            low.sentNotificationMessageCount.should.eql(1);
+            publish_server.pendingPublishRequestCount.should.eql(0);
+        } finally {
+            low.terminate();
+            low.dispose();
+            high.terminate();
+            high.dispose();
+            publish_server.shutdown();
+            publish_server.dispose();
+        }
+    });
+
+    it("FEAT-24 a subscription must not be able to starve a higher priority sibling merely because its own timer fires first", () => {
+        const publish_server = new ServerSidePublishEngine();
+
+        // `low` is added (and so starts its setInterval) before `high`: on a real server, sibling
+        // subscriptions' timers are never coordinated, and this is the registration order that let
+        // whichever ticked first monopolize the queue regardless of priority (FEAT-24).
+        const low = makeSubscription({
+            id: 1,
+            publishingInterval: 1000,
+            lifeTimeCount: 1000,
+            maxKeepAliveCount: 20,
+            priority: 0,
+            publishEngine: publish_server,
+            globalCounter: { totalMonitoredItemCount: 0 },
+            serverCapabilities: { maxMonitoredItems: 10000, maxMonitoredItemsPerSubscription: 1000 }
+        });
+        publish_server.add_subscription(low);
+
+        const high = makeSubscription({
+            id: 2,
+            publishingInterval: 1000,
+            lifeTimeCount: 1000,
+            maxKeepAliveCount: 20,
+            priority: 10,
+            publishEngine: publish_server,
+            globalCounter: { totalMonitoredItemCount: 0 },
+            serverCapabilities: { maxMonitoredItems: 10000, maxMonitoredItemsPerSubscription: 1000 }
+        });
+        publish_server.add_subscription(high);
+
+        const lowItem = add_mock_monitored_item(low);
+        const highItem = add_mock_monitored_item(high);
+
+        try {
+            // let both subscriptions send their initial value and reach steady state, fully drained
+            publish_server._on_PublishRequest(new PublishRequest());
+            publish_server._on_PublishRequest(new PublishRequest());
+            test.clock.tick(low.publishingInterval);
+            low.sentNotificationMessageCount.should.eql(1);
+            high.sentNotificationMessageCount.should.eql(1);
+
+            // queue exactly one PublishRequest while NEITHER subscription is ready: it just sits there.
+            publish_server._on_PublishRequest(new PublishRequest());
+            flushPending();
+            publish_server.pendingPublishRequestCount.should.eql(1);
+
+            // now make both ready, then let their independent timers fire (low's registered first).
+            // it must still be `high` that gets served: fairness must not depend on tick order.
+            lowItem.simulateMonitoredItemAddingNotification();
+            highItem.simulateMonitoredItemAddingNotification();
+            test.clock.tick(low.publishingInterval);
+
+            high.sentNotificationMessageCount.should.eql(2);
+            low.sentNotificationMessageCount.should.eql(1);
+            publish_server.pendingPublishRequestCount.should.eql(0);
+        } finally {
+            low.terminate();
+            low.dispose();
+            high.terminate();
+            high.dispose();
+            publish_server.shutdown();
+            publish_server.dispose();
+        }
+    });
+
     it("ZDZ-J PublishRequest timeout, the publish engine shall return a publish response with serviceResult = BadTimeout when Publish requests have timed out", () => {
         const publish_server = new ServerSidePublishEngine();
 


### PR DESCRIPTION
## Summary
- Each subscription on a session ran its own independent timer and served itself directly from the shared PublishRequest queue whenever it had data ready, with no check on whether a higher-priority sibling was also ready - whichever timer happened to fire first always won.
- `ServerSidePublishEngine#feedReadySubscriptions` now arbitrates across every ready subscription of a session by priority, then by longest-since-served, matching OPC UA Part 4's Subscription services: priority orders who is served but is not a licence to starve the others.
- `Subscription#_tick` now calls into that arbitration instead of serving itself; the existing late-subscription/keep-alive feeding path (triggered when a new PublishRequest arrives) is untouched.

## Test plan
- [x] Two new regression tests in `test_server_publish_engine.ts` reproduce the race deterministically with fake timers; both fail on the pre-fix code and pass after the fix.
- [x] Full `node-opcua-server` test suite passes (496 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)