### PR TITLE
fix(server): bind ServerCapabilities.ConformanceUnits (i=24101)

### DIFF
--- a/packages/node-opcua-server/source/server_capabilities.ts
+++ b/packages/node-opcua-server/source/server_capabilities.ts
@@ -148,8 +148,15 @@ export interface IServerCapabilities {
     /**
      *
      * ConformanceUnits is a QualifiedName array specifying the set of conformance units
-     * the Server supports. This list should be limited to the ConformanceUnits the Server
-     * supports in its current configuration.
+     * the Server supports (Part 5, Server/ServerCapabilities/ConformanceUnits, i=24101,
+     * new in OPC UA 1.05). Part 7 1.05 wants this list limited to the ConformanceUnits
+     * the Server supports in its current configuration, e.g.
+     * `[new QualifiedName({ name: "Base Info Core Structure 2" })]`.
+     *
+     * The variable reads the list live: assigning or pushing to
+     * `server.engine.serverCapabilities.conformanceUnits` after the server has started
+     * is reflected in the next Read. It is read-only for clients. Default: empty, which is
+     * served as a typed empty QualifiedName array (not a Null variant).
      *
      */
     conformanceUnits: QualifiedName[];
@@ -287,6 +294,7 @@ export class ServerCapabilities implements IServerCapabilities {
         this.maxWhereClauseParameters = options.maxWhereClauseParameters || defaultServerCapabilities.maxWhereClauseParameters;
         this.maxMonitoredItemsQueueSize =
             options.maxMonitoredItemsQueueSize || defaultServerCapabilities.maxMonitoredItemsQueueSize;
-        this.conformanceUnits = options.conformanceUnits || defaultServerCapabilities.conformanceUnits;
+        // a copy: the default is a shared array and the list is meant to be edited after start
+        this.conformanceUnits = [...(options.conformanceUnits || defaultServerCapabilities.conformanceUnits)];
     }
 }

--- a/packages/node-opcua-server/source/server_engine.ts
+++ b/packages/node-opcua-server/source/server_engine.ts
@@ -39,7 +39,14 @@ import {
     SubscriptionDiagnosticsDataType
 } from "node-opcua-common";
 import { DataTypeIds, MethodIds, ObjectIds, VariableIds } from "node-opcua-constants";
-import { AttributeIds, coerceLocalizedText, type LocalizedTextLike, makeAccessLevelFlag, NodeClass } from "node-opcua-data-model";
+import {
+    AttributeIds,
+    coerceLocalizedText,
+    coerceQualifiedName,
+    type LocalizedTextLike,
+    makeAccessLevelFlag,
+    NodeClass
+} from "node-opcua-data-model";
 import type { DataValue } from "node-opcua-data-value";
 import { getCurrentClock, getMinOPCUADate } from "node-opcua-date-time";
 import { checkDebugFlag, make_debugLog, make_errorLog, make_warningLog, traceFromThisProjectOnly } from "node-opcua-debug";
@@ -1222,9 +1229,19 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
                     bindStandardScalar(VariableIds.Server_ServerCapabilities_MaxWhereClauseParameters, DataType.UInt32, () => {
                         return this.serverCapabilities.maxWhereClauseParameters;
                     });
-                    //bindStandardArray(VariableIds.Server_ServerCapabilities_ConformanceUnits, DataType.QualifiedName, () => {
-                    //    return this.serverCapabilities.conformanceUnits;
-                    //});
+                    // ConformanceUnits (i=24101, new in 1.05): the conformance units the server claims.
+                    // Part 7 wants the list limited to the units the server supports in its current
+                    // configuration, so it is read live from serverCapabilities.conformanceUnits and an
+                    // application can fill it after the server has started. An empty list must still
+                    // reach the wire as a typed empty QualifiedName array, never as a Null variant: the
+                    // CTT (Base Info Core Structure 2 / 001.js) checks the Value's DataType against the
+                    // Attribute's. Elements are coerced because encodeQualifiedName needs real instances.
+                    bindStandardArray(
+                        VariableIds.Server_ServerCapabilities_ConformanceUnits,
+                        DataType.QualifiedName,
+                        "QualifiedName",
+                        () => this.serverCapabilities.conformanceUnits.map((unit) => coerceQualifiedName(unit))
+                    );
                     bindStandardScalar(
                         VariableIds.Server_ServerCapabilities_MaxMonitoredItemsPerSubscription,
                         DataType.UInt32,

--- a/packages/node-opcua-server/test/test_server_engine.ts
+++ b/packages/node-opcua-server/test/test_server_engine.ts
@@ -2305,3 +2305,110 @@ describe("US-033: ServerEngine.setInApplicationSetup / getInApplicationSetup", (
         engine.getInApplicationSetup().should.eql(false);
     });
 });
+
+describe("FEAT-29: ServerEngine ServerCapabilities.ConformanceUnits (i=24101)", () => {
+    const conformanceUnitsId = makeNodeId(VariableIds.Server_ServerCapabilities_ConformanceUnits); // ns=0;i=24101
+
+    async function readConformanceUnits(engine: ServerEngine): Promise<DataValue> {
+        const dataValues = await engine.read(
+            context,
+            new ReadRequest({ nodesToRead: [{ nodeId: conformanceUnitsId, attributeId: AttributeIds.Value }] })
+        );
+        return dataValues[0];
+    }
+
+    function unitNames(dataValue: DataValue): string[] {
+        return (dataValue.value.value as QualifiedName[]).map((q) => q.toString());
+    }
+
+    function makeEngine(serverCapabilities?: { conformanceUnits: QualifiedName[] }): Promise<ServerEngine> {
+        const engine = new ServerEngine({
+            applicationUri: "URI:NODEOPCUA-CONFORMANCE-UNITS-TEST",
+            buildInfo: { productName: "CONFORMANCE-UNITS-TEST", productUri: "URI:CONFORMANCE-UNITS-TEST" },
+            serverCapabilities
+        });
+        return new Promise((resolve) => engine.initialize({ nodeset_filename: nodesets.standard }, () => resolve(engine)));
+    }
+
+    describe("default configuration", () => {
+        let engine: ServerEngine;
+        before(async function (this: Mocha.Context) {
+            this.timeout(30000);
+            engine = await makeEngine();
+        });
+        after(async () => {
+            await engine.shutdown();
+        });
+
+        it("should serve an empty, typed QualifiedName array - not a Null variant", async () => {
+            const dataValue = await readConformanceUnits(engine);
+            dataValue.statusCode.should.eql(StatusCodes.Good);
+            dataValue.value.dataType.should.eql(DataType.QualifiedName);
+            dataValue.value.arrayType.should.eql(VariantArrayType.Array);
+            should(dataValue.value.value).eql([]);
+        });
+
+        it("should keep the default list private to the engine", async () => {
+            // the default is a shared array: an engine must not hand out that very instance,
+            // or a push on one server would leak into every other one
+            engine.serverCapabilities.conformanceUnits.push(new QualifiedName({ name: "leak" }));
+            const other = new ServerEngine({ applicationUri: "URI:OTHER" });
+            other.serverCapabilities.conformanceUnits.should.eql([]);
+            await other.shutdown();
+        });
+    });
+
+    describe("configured list", () => {
+        let engine: ServerEngine;
+        before(async function (this: Mocha.Context) {
+            this.timeout(30000);
+            engine = await makeEngine({
+                conformanceUnits: [
+                    new QualifiedName({ name: "Base Info Core Structure 2" }),
+                    new QualifiedName({ name: "Attribute Read" })
+                ]
+            });
+        });
+        after(async () => {
+            await engine.shutdown();
+        });
+
+        it("should serve the configured conformance units as a QualifiedName array", async () => {
+            const dataValue = await readConformanceUnits(engine);
+            dataValue.statusCode.should.eql(StatusCodes.Good);
+            dataValue.value.dataType.should.eql(DataType.QualifiedName);
+            dataValue.value.arrayType.should.eql(VariantArrayType.Array);
+            dataValue.value.value[0].should.be.instanceOf(QualifiedName);
+            unitNames(dataValue).should.eql(["Base Info Core Structure 2", "Attribute Read"]);
+        });
+
+        it("should reflect a list changed after the engine started (Part 7 1.05: only the units supported in the current configuration)", async () => {
+            engine.serverCapabilities.conformanceUnits.push(new QualifiedName({ name: "Attribute Write Values" }));
+            unitNames(await readConformanceUnits(engine)).should.eql([
+                "Base Info Core Structure 2",
+                "Attribute Read",
+                "Attribute Write Values"
+            ]);
+
+            engine.serverCapabilities.conformanceUnits = [new QualifiedName({ name: "Base Info Core Structure" })];
+            unitNames(await readConformanceUnits(engine)).should.eql(["Base Info Core Structure"]);
+        });
+
+        it("should be read-only for clients", async () => {
+            const writeValue = new WriteValue({
+                nodeId: conformanceUnitsId,
+                attributeId: AttributeIds.Value,
+                value: {
+                    value: {
+                        dataType: DataType.QualifiedName,
+                        arrayType: VariantArrayType.Array,
+                        value: [new QualifiedName({ name: "not mine" })]
+                    }
+                }
+            });
+            const statusCode = (await engine.write(context, [writeValue]))[0];
+            statusCode.should.not.eql(StatusCodes.Good);
+            unitNames(await readConformanceUnits(engine)).should.eql(["Base Info Core Structure"]);
+        });
+    });
+});

--- a/packages/node-opcua-variant/test/test_variant.ts
+++ b/packages/node-opcua-variant/test/test_variant.ts
@@ -1738,4 +1738,21 @@ describe("Preserving  null in Arrays or Matrices", () => {
         const v_reloaded = encode_decode_round_trip_test(v) as Variant;
         should(v_reloaded.value).eql(null);
     });
+    it("it should encode an empty QualifiedName array as a typed empty array, not as a Null variant", () => {
+        // Server/ServerCapabilities/ConformanceUnits (i=24101) is served empty by default; a
+        // conformance checker still expects the Value's DataType to be QualifiedName, which
+        // only the encoding byte can tell it when there is no element to look at.
+        const v = new Variant({ dataType: DataType.QualifiedName, value: [], arrayType: VariantArrayType.Array });
+        should(v.value).eql([]);
+        const v_reloaded = encode_decode_round_trip_test(v, (buffer: Buffer) => {
+            buffer.length.should.equal(5);
+            // encoding byte: DataType.QualifiedName with the array flag set
+            buffer[0].should.equal(DataType.QualifiedName | 0x80);
+            // array length 0, not 0xffffffff (the null array)
+            buffer.readUInt32LE(1).should.equal(0);
+        }) as Variant;
+        v_reloaded.dataType.should.eql(DataType.QualifiedName);
+        v_reloaded.arrayType.should.eql(VariantArrayType.Array);
+        should(v_reloaded.value).eql([]);
+    });
 });


### PR DESCRIPTION
## Why

The OPC Foundation Compliance Test Tool (1.05.513, Base Info Core Structure 2 / 001.js) rejects `Server/ServerCapabilities/ConformanceUnits` (i=24101, QualifiedName[], new in UA 1.05):

```
ERROR: Attribute.DataType (i=20) or the DataType of the Value (Value: Size: 0 ...)
of current Instance (i=24101) doesn't match the expectation (BuiltInType.QualifiedName)
```

The variable was never bound: the call in `server_engine.ts` was born commented out in f9c389a7 (June 2022) with a stale three-argument shape, so `serverCapabilities.conformanceUnits` (default `[]`) never reached the address space and a server could not declare its conformance units at all. Part 7 1.05 expects the list to be limited to the units the server supports.

Tracked as FEAT-29 on the CTT board (project 7).

## What

- `server_engine.ts`: bind i=24101 as a live-read QualifiedName array (values coerced, read-only). A nodeset without the node is a no-op, as for the other 1.05-only bindings.
- `server_capabilities.ts`: the constructor copies the option instead of aliasing the shared default `[]` (a `push` on one engine leaked into every other); doc comment with the Part 7 wording and an example.
- Tests: an empty QualifiedName array encodes on the wire as a typed empty array (`0xA0`, length 0), never as a Null variant; engine tests for the default, per-engine isolation, a configured list, runtime push and reassignment visible on the next Read, and a refused client Write.

## Verification

- `test_server_engine.ts`: 118 passing; other engine and publish-engine tests: 35 passing; `test_variant.ts`: 293 passing, 2 pending (pre-existing).
- `tsc -b` in node-opcua-server clean; `biome check` clean.

Follow-up outside this repo: `server-for-ctt-test` should pass the units it claims, derived from the CTT selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
