### PR TITLE
fix(server): revisedSamplingInterval is never below the advertised MinSupportedSampleRate

### DIFF
--- a/packages/node-opcua-server/source/monitored_item.ts
+++ b/packages/node-opcua-server/source/monitored_item.ts
@@ -73,13 +73,29 @@ const doDebug = checkDebugFlag("monitored_item");
 const doDebug2 = doDebug && false;
 const warningLog = make_warningLog("monitored_item");
 
-function _adjust_sampling_interval(samplingInterval: number, node_minimumSamplingInterval: number): number {
+/**
+ * @param samplingInterval the requested sampling interval
+ * @param node_minimumSamplingInterval the MinimumSamplingInterval attribute of the monitored Variable (0 = exception-based)
+ * @param minSupportedSampleRate the MinSupportedSampleRate the server advertises in ServerCapabilities
+ */
+function _adjust_sampling_interval(
+    samplingInterval: number,
+    node_minimumSamplingInterval: number,
+    minSupportedSampleRate: number
+): number {
     assert(typeof node_minimumSamplingInterval === "number", "expecting a number");
 
     if (samplingInterval === 0) {
-        return node_minimumSamplingInterval === 0
-            ? samplingInterval
-            : Math.max(MonitoredItem.minimumSamplingInterval, node_minimumSamplingInterval);
+        // OPC 10000-4 5.12.1.2: 0 asks for the fastest practical rate, and the revised value is
+        // never below the MinSupportedSampleRate the server advertises (CTT Monitor Basic 038).
+        // A Variable whose MinimumSamplingInterval is 0 is still served exception-based, without a
+        // sampling timer (see MonitoredItem#isExceptionBased): the revised interval is then the
+        // window over which value changes are coalesced, the bound on how stale a reported value
+        // can be. Only a server that advertises 0 answers 0, and then delivers every change.
+        if (node_minimumSamplingInterval === 0) {
+            return minSupportedSampleRate;
+        }
+        return Math.max(MonitoredItem.minimumSamplingInterval, node_minimumSamplingInterval);
     }
     assert(samplingInterval >= 0, " this case should have been prevented outside");
     samplingInterval = samplingInterval || MonitoredItem.defaultSamplingInterval;
@@ -320,6 +336,11 @@ export interface MonitoredItemOptions extends MonitoringParameters {
     monitoredItemId: number;
     itemToMonitor?: ReadValueIdOptions;
     timestampsToReturn?: TimestampsToReturn;
+    /**
+     * the MinSupportedSampleRate the server advertises: the floor of the revised sampling
+     * interval when 0 is requested. Defaults to MonitoredItem.minimumSamplingInterval.
+     */
+    minSupportedSampleRate?: number;
 
     // MonitoringParameters
     filter: ExtensionObject | null;
@@ -436,6 +457,19 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
     private _linkedItems?: number[];
     private _triggeredNotifications?: QueueItem[];
 
+    private readonly _minSupportedSampleRate: number;
+    /**
+     * true when the Value is delivered on change (value_changed listener, no sampling timer):
+     * 0 was requested on a Variable whose MinimumSamplingInterval is 0.
+     */
+    private _exceptionBased = false;
+    /**
+     * the coalescing window of an exception-based item: while it is open, further changes are
+     * folded into _pendingDataValue and the latest one is recorded when the window ends.
+     */
+    private _coalesceTimer: NodeJS.Timeout | null = null;
+    private _pendingDataValue: DataValue | null = null;
+
     constructor(options: MonitoredItemOptions) {
         super();
 
@@ -443,7 +477,10 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
         assert(!options.monitoringMode, "use setMonitoring mode explicitly to activate the monitored item");
 
         options.itemToMonitor = options.itemToMonitor || defaultItemToMonitor;
+        // _set_parameters reads the attributeId: an item on a non-Value attribute keeps a requested 0
+        this.itemToMonitor = options.itemToMonitor as ReadValueIdOptions & { attributeId: AttributeIds };
 
+        this._minSupportedSampleRate = options.minSupportedSampleRate ?? MonitoredItem.minimumSamplingInterval;
         this._samplingId = undefined;
         this.clientHandle = 0; // invalid
         this.filter = null;
@@ -460,8 +497,6 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
         this.#monitoringMode = MonitoringMode.Invalid;
 
         this.timestampsToReturn = coerceTimestampsToReturn(options.timestampsToReturn);
-
-        this.itemToMonitor = options.itemToMonitor as ReadValueIdOptions & { attributeId: AttributeIds };
 
         this._node = null;
         this._semantic_version = 0;
@@ -568,6 +603,7 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
         this.removeAllListeners();
 
         assert(!this._samplingId);
+        assert(!this._coalesceTimer);
         assert(!this._value_changed_callback);
         assert(!this._semantic_changed_callback);
         assert(!this._attribute_changed_callback);
@@ -584,6 +620,15 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
             typeof this._value_changed_callback === "function" ||
             typeof this._attribute_changed_callback === "function"
         );
+    }
+
+    /**
+     * true when the Value attribute is delivered on change rather than sampled by a timer:
+     * the client requested a samplingInterval of 0 on a Variable whose MinimumSamplingInterval
+     * is 0. The revised samplingInterval is then the coalescing window (0 = every change).
+     */
+    public get isExceptionBased(): boolean {
+        return this._exceptionBased;
     }
 
     public toJSON(): Record<string, string | number | undefined> {
@@ -841,6 +886,7 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
         assert(monitoringParameters instanceof MonitoringParameters);
 
         const old_samplingInterval = this.samplingInterval;
+        const old_exceptionBased = this._exceptionBased;
 
         this.timestampsToReturn = timestampsToReturn || this.timestampsToReturn;
 
@@ -852,7 +898,13 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
                 statusCode: StatusCodes.Good
             });
         }
-        if (old_samplingInterval !== 0 && monitoringParameters.samplingInterval === 0) {
+        if (
+            this.itemToMonitor.attributeId === AttributeIds.Value &&
+            !old_exceptionBased &&
+            monitoringParameters.samplingInterval === 0
+        ) {
+            // a sampled item stays sampled: 0 asks for the fastest timer, not for on-change delivery
+            // (an item on another attribute is never sampled: it keeps the 0 it asked for)
             monitoringParameters.samplingInterval = MonitoredItem.minimumSamplingInterval; // fastest possible
         }
 
@@ -862,7 +914,7 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
 
         this._adjust_queue_to_match_new_queue_size();
 
-        this._adjustSampling(old_samplingInterval);
+        this._adjustSampling(old_samplingInterval, old_exceptionBased);
 
         if (monitoringParameters.filter) {
             if (!this.node) {
@@ -1021,13 +1073,13 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
         }
 
         if (this._value_changed_callback) {
-            // samplingInterval was 0 for a exception-based data Item
-            // we setup a event listener that we need to unwind here
+            // exception-based data item: we setup a event listener that we need to unwind here
             assert(typeof this._value_changed_callback === "function");
             assert(!this._samplingId);
 
             (this.node as UAVariable).removeListener("value_changed", this._value_changed_callback);
             this._value_changed_callback = null;
+            this._close_coalesce_window();
         }
 
         if (this._semantic_changed_callback) {
@@ -1041,6 +1093,7 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
         }
 
         assert(!this._samplingId);
+        assert(!this._coalesceTimer);
         assert(!this._value_changed_callback);
         assert(!this._semantic_changed_callback);
         assert(!this._attribute_changed_callback);
@@ -1050,6 +1103,70 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
     private _on_value_changed(dataValue: DataValue, indexRange?: NumericRange | null) {
         assert(dataValue instanceof DataValue);
         this.recordValue(dataValue, false, indexRange ?? undefined);
+    }
+
+    /**
+     * the value_changed listener of an exception-based item.
+     *
+     * At most one notification per revised samplingInterval: the first change after a quiet
+     * period is recorded at once and opens a window; changes inside the window are folded, the
+     * latest one being recorded when the window ends - what a sampling server would deliver
+     * at that instant. The DataChangeFilter and the queue logic are applied by recordValue as
+     * usual. This also bounds the cost of a fast writer, which the queue alone did not.
+     */
+    private _on_value_changed_exception_based(dataValue: DataValue, indexRange?: NumericRange | null) {
+        if (this.samplingInterval <= 0) {
+            // the server advertises MinSupportedSampleRate 0: every change goes out
+            this._on_value_changed(dataValue, indexRange);
+            return;
+        }
+        if (!this._coalesceTimer) {
+            this._on_value_changed(dataValue, indexRange);
+            this._coalesceTimer = setTimeout(() => this._on_coalesce_window_end(), this.samplingInterval);
+            return;
+        }
+        // inside the window: recordValue would ignore a write outside the monitored range, so do not
+        // let it stand for the value at the end of the window
+        if (
+            indexRange &&
+            this.itemToMonitor.indexRange &&
+            !NumericRange.overlap(indexRange as NumericalRange0, this.itemToMonitor.indexRange as NumericalRange0)
+        ) {
+            return;
+        }
+        this._pendingDataValue = dataValue;
+    }
+
+    private _on_coalesce_window_end() {
+        this._coalesceTimer = null;
+        if (!this._pendingDataValue) {
+            return; // a quiet window: the next change is recorded at once
+        }
+        this._record_pending_value();
+        // something was folded: open the next window, so a steady writer stays at one
+        // notification per interval instead of two (the flush, then the next change at once)
+        this._coalesceTimer = setTimeout(() => this._on_coalesce_window_end(), this.samplingInterval);
+    }
+
+    private _record_pending_value() {
+        const dataValue = this._pendingDataValue;
+        this._pendingDataValue = null;
+        if (dataValue && this.itemToMonitor) {
+            // the folded writes all overlap the monitored range: let recordValue compare the values
+            this._on_value_changed(dataValue);
+        }
+    }
+
+    /**
+     * ends the coalescing window; a folded value is recorded rather than lost, so that
+     * a modify() restarting the item, or a disable, sees the latest value in the queue.
+     */
+    private _close_coalesce_window() {
+        if (this._coalesceTimer) {
+            clearTimeout(this._coalesceTimer);
+            this._coalesceTimer = null;
+        }
+        this._record_pending_value();
     }
 
     private _on_semantic_changed() {
@@ -1186,12 +1303,12 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
             return;
         }
 
-        if (this.samplingInterval === 0) {
+        if (this._exceptionBased) {
             // we have a exception-based dataItem : event based model, so we do not need a timer
-            // rather , we setup the "value_changed_event";
+            // rather , we setup the "value_changed_event"; samplingInterval is the coalescing window
             if (!this._value_changed_callback) {
                 assert(!this._semantic_changed_callback);
-                this._value_changed_callback = this._on_value_changed.bind(this);
+                this._value_changed_callback = this._on_value_changed_exception_based.bind(this);
                 this._semantic_changed_callback = this._on_semantic_changed.bind(this);
                 if (this.node.nodeClass === NodeClass.Variable) {
                     this.node.on("value_changed", this._value_changed_callback);
@@ -1238,15 +1355,23 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
         // exception-based model. The fastest supported sampling interval may be equal to 0, which indicates
         // that the data item is exception-based rather than being sampled at some period. An exception-based
         // model means that the underlying system does not require sampling and reports data changes.
-        if (this.node && this.node.nodeClass === NodeClass.Variable) {
-            const variable = this.node as UAVariable;
-            this.samplingInterval = _adjust_sampling_interval(
-                monitoredParameters.samplingInterval,
-                variable.minimumSamplingInterval || 0
-            );
-        } else {
-            this.samplingInterval = _adjust_sampling_interval(monitoredParameters.samplingInterval, 0);
-        }
+        //
+        // A requested 0 on a Variable whose MinimumSamplingInterval is 0 selects the exception-based model;
+        // the revised samplingInterval is still floored by the advertised MinSupportedSampleRate and is
+        // then the window over which changes are coalesced (see _on_value_changed_exception_based).
+        //
+        // That floor is about sampling a Value. An item on any other attribute is delivered on change
+        // whatever it requested (see _start_sampling), and OPC 10000-4 5.12.1.2 says a Client shall
+        // request 0 when it subscribes for Events: such an item is answered the 0 it asked for.
+        const requestedSamplingInterval = monitoredParameters.samplingInterval;
+        const isValueAttribute = this.itemToMonitor.attributeId === AttributeIds.Value;
+        const node_minimumSamplingInterval =
+            this.node && this.node.nodeClass === NodeClass.Variable ? (this.node as UAVariable).minimumSamplingInterval || 0 : 0;
+        this.samplingInterval =
+            !isValueAttribute && requestedSamplingInterval === 0
+                ? 0
+                : _adjust_sampling_interval(requestedSamplingInterval, node_minimumSamplingInterval, this._minSupportedSampleRate);
+        this._exceptionBased = isValueAttribute && requestedSamplingInterval === 0 && node_minimumSamplingInterval === 0;
         this.discardOldest = monitoredParameters.discardOldest;
         this.queueSize = _adjust_queue_size(monitoredParameters.queueSize);
 
@@ -1470,13 +1595,16 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
         assert(this.queue.length <= this.queueSize);
     }
 
-    private _adjustSampling(old_samplingInterval: number) {
-        if (old_samplingInterval !== this.samplingInterval) {
+    private _adjustSampling(old_samplingInterval: number, old_exceptionBased: boolean) {
+        // a sampled item and an exception-based one can report the same interval: compare the mode too
+        if (old_samplingInterval !== this.samplingInterval || old_exceptionBased !== this._exceptionBased) {
             this._start_sampling(false);
         }
     }
 
     private _on_node_disposed(node: BaseNode) {
+        // a folded value must not land behind the BadNodeIdInvalid one
+        this._close_coalesce_window();
         this._on_value_changed(
             new DataValue({
                 sourceTimestamp: new Date(),

--- a/packages/node-opcua-server/source/server_capabilities.ts
+++ b/packages/node-opcua-server/source/server_capabilities.ts
@@ -66,6 +66,15 @@ export interface IServerCapabilities {
     maxArrayLength: number;
     maxByteStringLength: number;
     maxQueryContinuationPoints: number;
+    /**
+     * MinSupportedSampleRate, in milliseconds: the fastest sampling interval the server
+     * supports, and the floor of the revisedSamplingInterval it answers to a requested 0.
+     * Defaults to MonitoredItem.minimumSamplingInterval (50 ms). A Variable whose
+     * MinimumSamplingInterval is 0 is still delivered on change, the revised interval being
+     * the window over which changes are coalesced. Set it to 0 to claim exception-based
+     * acquisition: such items are then answered with a revisedSamplingInterval of 0 and every
+     * change is reported (the CTT flags this for manual verification).
+     */
     minSupportedSampleRate: Double;
     operationLimits: OperationLimitsOptions;
 
@@ -272,7 +281,7 @@ export class ServerCapabilities implements IServerCapabilities {
 
         this.operationLimits = new ServerOperationLimits(options.operationLimits);
 
-        this.minSupportedSampleRate = options.minSupportedSampleRate || defaultServerCapabilities.minSupportedSampleRate; // to do adjust me
+        this.minSupportedSampleRate = options.minSupportedSampleRate ?? defaultServerCapabilities.minSupportedSampleRate;
 
         // new in 1.05
         this.maxSessions = options.maxSessions || defaultServerCapabilities.maxSessions;

--- a/packages/node-opcua-server/source/server_engine.ts
+++ b/packages/node-opcua-server/source/server_engine.ts
@@ -480,9 +480,10 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
             // new SignedSoftwareCertificate({})
         ];
 
-        // make sure minSupportedSampleRate matches MonitoredItem.minimumSamplingInterval
+        // make sure minSupportedSampleRate matches MonitoredItem.minimumSamplingInterval unless configured;
+        // ?? and not ||, so that a server can claim 0 (exception-based items are then answered with 0)
         Object.defineProperty(this.serverCapabilities, "minSupportedSampleRate", {
-            get: () => options.serverCapabilities?.minSupportedSampleRate || MonitoredItem.minimumSamplingInterval,
+            get: () => options.serverCapabilities?.minSupportedSampleRate ?? MonitoredItem.minimumSamplingInterval,
             configurable: true
         });
 

--- a/packages/node-opcua-server/source/server_subscription.ts
+++ b/packages/node-opcua-server/source/server_subscription.ts
@@ -473,6 +473,11 @@ export interface ServerCapabilitiesPartial {
     maxMonitoredItemsPerSubscription: UInt32;
     maxWhereClauseParameters?: UInt32;
     maxSelectClauseParameters?: UInt32;
+    /**
+     * the advertised MinSupportedSampleRate: the floor of a revised samplingInterval when 0 is
+     * requested (undefined = MonitoredItem.minimumSamplingInterval)
+     */
+    minSupportedSampleRate?: number;
 }
 
 export interface IReadAttributeCapable {
@@ -2060,6 +2065,7 @@ export class Subscription extends EventEmitter {
 
         options.monitoredItemId = monitoredItemId;
         options.itemToMonitor = itemToMonitor;
+        options.minSupportedSampleRate = this.serverCapabilities.minSupportedSampleRate;
 
         const monitoredItem = new MonitoredItem(options);
         monitoredItem.timestampsToReturn = timestampsToReturn;

--- a/packages/node-opcua-server/test/test_monitored_item.ts
+++ b/packages/node-opcua-server/test/test_monitored_item.ts
@@ -94,6 +94,8 @@ const createMonitoredItem = (options: {
     timestampsToReturn?: TimestampsToReturn;
     discardOldest?: boolean;
     filter?: DataChangeFilter;
+    minSupportedSampleRate?: number;
+    itemToMonitor?: { attributeId: AttributeIds };
 }) => {
     const monitoredItem = new MonitoredItem(options as unknown as MonitoredItemOptions);
     return monitoredItem as unknown as Omit<MonitoredItem, "queue" | "$subscription"> & {
@@ -942,6 +944,209 @@ describe("Server Side MonitoredItem", () => {
 
         monitoredItem.terminate();
         monitoredItem.dispose();
+    });
+});
+
+// OPC 10000-4 5.12.1.2: a requested samplingInterval of 0 asks for the fastest practical rate and
+// the revised value is never below the MinSupportedSampleRate the server advertises (50 ms by
+// default). CTT Monitor Basic 038 warns on a revised 0. The fake node has no MinimumSamplingInterval,
+// so it counts as exception-based (0): the item is still delivered on change, without a timer,
+// the revised interval being the window over which changes are coalesced.
+describe("MonitoredItem requested with samplingInterval 0 (CTT Monitor Basic 038)", () => {
+    beforeEach(function (this: Mocha.Context) {
+        this.clock = sinon.useFakeTimers();
+    });
+
+    afterEach(function (this: Mocha.Context) {
+        this.clock.restore();
+    });
+
+    function makeExceptionBasedItem(extra: { minSupportedSampleRate?: number; filter?: DataChangeFilter } = {}) {
+        const monitoredItem = createMonitoredItem({
+            clientHandle: 1,
+            discardOldest: true,
+            queueSize: 100,
+            samplingInterval: 0,
+            // added by the server:
+            monitoredItemId: 50,
+            ...extra
+        });
+        monitoredItem.$subscription = fakeSubscription;
+        monitoredItem.setNode(fakeNode);
+        return monitoredItem;
+    }
+
+    // the recorded values, without the initial one (BadInvalidArgument from the fake node)
+    const values = (monitoredItem: IMonitoredItem) => monitoredItem.queue.slice(1).map((a) => a.value.value.value);
+
+    const change = (value: number) => {
+        fakeNode.emit("value_changed", new DataValue({ value: { dataType: DataType.UInt32, value } }));
+    };
+
+    it("answers the advertised MinSupportedSampleRate, not 0, and still delivers on change without a timer", function (this: Mocha.Context) {
+        const monitoredItem = makeExceptionBasedItem();
+        monitoredItem.samplingInterval.should.eql(MonitoredItem.minimumSamplingInterval);
+        monitoredItem.isExceptionBased.should.eql(true);
+
+        monitoredItem.setMonitoringMode(MonitoringMode.Reporting);
+        this.clock.tick(1);
+        monitoredItem.isSampling.should.eql(true);
+        should.not.exist(monitoredItem._samplingId);
+        fakeNode.listenerCount("value_changed").should.eql(1);
+
+        monitoredItem.terminate();
+        monitoredItem.isSampling.should.eql(false);
+        fakeNode.listenerCount("value_changed").should.eql(0);
+        monitoredItem.dispose();
+    });
+
+    it("answers 0 when the server advertises MinSupportedSampleRate 0, and then reports every change", function (this: Mocha.Context) {
+        const monitoredItem = makeExceptionBasedItem({ minSupportedSampleRate: 0 });
+        monitoredItem.samplingInterval.should.eql(0);
+        monitoredItem.isExceptionBased.should.eql(true);
+
+        monitoredItem.setMonitoringMode(MonitoringMode.Reporting);
+        this.clock.tick(1);
+        change(1);
+        change(2);
+        change(3);
+        values(monitoredItem).should.eql([1, 2, 3]);
+
+        monitoredItem.terminate();
+        monitoredItem.dispose();
+    });
+
+    it("coalesces the changes of one interval: the first at once, then the latest when the window ends", function (this: Mocha.Context) {
+        const monitoredItem = makeExceptionBasedItem();
+        monitoredItem.setMonitoringMode(MonitoringMode.Reporting);
+        this.clock.tick(1);
+        monitoredItem.queue.length.should.eql(1, "the initial value");
+
+        // a burst inside one interval
+        for (const v of [1, 2, 3, 4, 5]) {
+            change(v);
+        }
+        values(monitoredItem).should.eql([1], "the first change goes out at once, the others are folded");
+        this.clock.tick(MonitoredItem.minimumSamplingInterval);
+        values(monitoredItem).should.eql([1, 5], "the latest value of the window, not the three in between");
+
+        // the flush opened the next window: a steady writer gets one notification per interval
+        change(6);
+        change(7);
+        values(monitoredItem).should.eql([1, 5]);
+        this.clock.tick(MonitoredItem.minimumSamplingInterval);
+        values(monitoredItem).should.eql([1, 5, 7]);
+
+        // a quiet window closes: the next change is again recorded at once
+        this.clock.tick(MonitoredItem.minimumSamplingInterval);
+        change(8);
+        values(monitoredItem).should.eql([1, 5, 7, 8]);
+
+        monitoredItem.terminate();
+        monitoredItem.dispose();
+    });
+
+    it("applies the DataChangeFilter to the coalesced value, as to a sampled one", function (this: Mocha.Context) {
+        const monitoredItem = makeExceptionBasedItem({
+            filter: new DataChangeFilter({
+                trigger: DataChangeTrigger.StatusValue,
+                deadbandType: DeadbandType.Absolute,
+                deadbandValue: 8
+            })
+        });
+        monitoredItem.setMonitoringMode(MonitoringMode.Reporting);
+        this.clock.tick(1);
+
+        change(1);
+        change(5); // folded, and 5 - 1 is inside the deadband
+        this.clock.tick(MonitoredItem.minimumSamplingInterval);
+        values(monitoredItem).should.eql([1]);
+
+        change(20); // folded, and 20 - 1 is outside
+        this.clock.tick(MonitoredItem.minimumSamplingInterval);
+        values(monitoredItem).should.eql([1, 20]);
+
+        monitoredItem.terminate();
+        monitoredItem.dispose();
+    });
+
+    it("terminate() inside a window clears the deferred timer and the listener, and keeps the folded value", function (this: Mocha.Context) {
+        const monitoredItem = makeExceptionBasedItem();
+        monitoredItem.setMonitoringMode(MonitoringMode.Reporting);
+        this.clock.tick(1);
+
+        change(1);
+        change(2);
+        values(monitoredItem).should.eql([1]);
+
+        monitoredItem.terminate();
+        should.not.exist((monitoredItem as unknown as { _coalesceTimer: unknown })._coalesceTimer);
+        monitoredItem.isSampling.should.eql(false);
+        fakeNode.listenerCount("value_changed").should.eql(0);
+        values(monitoredItem).should.eql([1, 2], "the folded value is recorded rather than lost");
+
+        change(3);
+        this.clock.tick(10 * MonitoredItem.minimumSamplingInterval);
+        values(monitoredItem).should.eql([1, 2], "nothing is recorded after terminate");
+
+        monitoredItem.dispose();
+    });
+
+    it("modify: 0 keeps an exception-based item on change at the advertised interval, and a sampled item on the fastest timer", () => {
+        const monitoredItem = makeExceptionBasedItem();
+        const params = (samplingInterval: number) =>
+            new MonitoringParameters({ clientHandle: 1, discardOldest: true, queueSize: 10, samplingInterval });
+
+        let result = monitoredItem.modify(null, params(0));
+        result.revisedSamplingInterval.should.eql(MonitoredItem.minimumSamplingInterval);
+        monitoredItem.isExceptionBased.should.eql(true);
+
+        result = monitoredItem.modify(null, params(200));
+        result.revisedSamplingInterval.should.eql(200);
+        monitoredItem.isExceptionBased.should.eql(false);
+
+        result = monitoredItem.modify(null, params(0));
+        result.revisedSamplingInterval.should.eql(MonitoredItem.minimumSamplingInterval);
+        monitoredItem.isExceptionBased.should.eql(false, "a sampled item stays sampled");
+
+        monitoredItem.terminate();
+        monitoredItem.dispose();
+    });
+
+    it("an EventNotifier item requested with 0 answers 0 (create and modify): the floor only applies to a Value", () => {
+        // OPC 10000-4 5.12.1.2: a Client shall define a sampling interval of 0 when it subscribes for Events
+        const eventNode = new FakeNode();
+        eventNode.nodeClass = NodeClass.Object;
+        const eventItem = createMonitoredItem({
+            clientHandle: 1,
+            discardOldest: true,
+            queueSize: 100,
+            samplingInterval: 0,
+            monitoredItemId: 51,
+            itemToMonitor: { attributeId: AttributeIds.EventNotifier }
+        });
+        eventItem.$subscription = fakeSubscription;
+        eventItem.setNode(eventNode);
+        eventItem.samplingInterval.should.eql(0);
+        eventItem.isExceptionBased.should.eql(false, "on-change delivery of a Value only");
+
+        const params = (samplingInterval: number) =>
+            new MonitoringParameters({ clientHandle: 1, discardOldest: true, queueSize: 10, samplingInterval });
+        let result = eventItem.modify(null, params(0));
+        result.revisedSamplingInterval.should.eql(0);
+        result = eventItem.modify(null, params(200));
+        result.revisedSamplingInterval.should.eql(200);
+        result = eventItem.modify(null, params(0));
+        result.revisedSamplingInterval.should.eql(0, "an event item is never sampled: it keeps the 0 it asked for");
+        eventItem.terminate();
+        eventItem.dispose();
+
+        // the same request on a Value whose MinimumSamplingInterval is 0 is floored to the advertised rate
+        const valueItem = makeExceptionBasedItem();
+        valueItem.samplingInterval.should.eql(MonitoredItem.minimumSamplingInterval);
+        valueItem.modify(null, params(0)).revisedSamplingInterval.should.eql(MonitoredItem.minimumSamplingInterval);
+        valueItem.terminate();
+        valueItem.dispose();
     });
 });
 describe("MonitoredItem with DataChangeFilter", () => {

--- a/packages/node-opcua-server/test/test_subscription.ts
+++ b/packages/node-opcua-server/test/test_subscription.ts
@@ -1573,6 +1573,9 @@ describe("Subscription#adjustSamplingInterval", () => {
     });
 
     it("should leave sampling interval to 0 when requested sampling interval === 0 ( 0 means Event Based mode)", () => {
+        // 0 here selects the exception-based mode of the MonitoredItem; the item itself then floors the
+        // revised samplingInterval it answers at the advertised MinSupportedSampleRate (CTT Monitor Basic 038,
+        // see test_monitored_item.ts)
         const subscription = makeSubscription({
             publishingInterval: 1234,
             publishEngine: fake_publish_engine,

--- a/packages/node-opcua-server/test/test_subscription_with_monitored_items.ts
+++ b/packages/node-opcua-server/test/test_subscription_with_monitored_items.ts
@@ -1519,6 +1519,93 @@ describe("SM1 - Subscriptions and MonitoredItems", function (this: ITestContext)
             }
         });
     });
+
+    // OPC 10000-4 5.12.1.2: a requested 0 asks for the fastest practical rate, and the revised value
+    // is never below the MinSupportedSampleRate the server advertises. CTT Monitor Basic 038 warns
+    // when the answer is 0. A Variable whose MinimumSamplingInterval is 0 is still delivered on change,
+    // with the changes of one interval coalesced.
+    describe("SM1-E requested samplingInterval 0 (CTT Monitor Basic 038)", () => {
+        let uaExceptionBased: UAVariable;
+        before(() => {
+            uaExceptionBased = namespace.addVariable({
+                organizedBy: "RootFolder",
+                browseName: "ExceptionBasedVariable",
+                dataType: "UInt32",
+                value: { dataType: DataType.UInt32, value: 0 }
+            });
+            uaExceptionBased.minimumSamplingInterval.should.eql(0, "a variable without a getter is exception-based");
+        });
+
+        async function createItem(minSupportedSampleRate?: number) {
+            const subscription = makeSubscription({
+                publishingInterval: 1000,
+                maxKeepAliveCount: 20,
+                publishEngine: fake_publish_engine,
+                globalCounter: { totalMonitoredItemCount: 0 },
+                serverCapabilities: { maxMonitoredItems: 10000, maxMonitoredItemsPerSubscription: 1000, minSupportedSampleRate }
+            });
+            const samplingFunc = install_spying_samplingFunc();
+            subscription.on("monitoredItem", (monitoredItem) => {
+                monitoredItem.samplingFunc = samplingFunc;
+            });
+            const createResult = await subscription.createMonitoredItem(
+                addressSpace,
+                TimestampsToReturn.Both,
+                new MonitoredItemCreateRequest({
+                    itemToMonitor: { nodeId: uaExceptionBased.nodeId, attributeId: AttributeIds.Value },
+                    monitoringMode: MonitoringMode.Reporting,
+                    requestedParameters: { queueSize: 100, samplingInterval: 0 }
+                })
+            );
+            createResult.statusCode.should.eql(StatusCodes.Good);
+            const monitoredItem = subscription.getMonitoredItem(createResult.monitoredItemId)!;
+            // data collection is done asynchronously => let give some time for this to happen
+            test.clock.tick(5);
+            monitoredItem.queue.length.should.eql(1, "the initial value");
+            return { subscription, createResult, monitoredItem, samplingFunc };
+        }
+        const values = (monitoredItem: MonitoredItem) =>
+            monitoredItem.queue.slice(1).map((a) => (a as MonitoredItemNotification).value.value.value);
+
+        it("SM1-E-1 answers the advertised MinSupportedSampleRate and coalesces the changes of one interval", async () => {
+            const { subscription, createResult, monitoredItem, samplingFunc } = await createItem();
+            try {
+                createResult.revisedSamplingInterval.should.eql(MonitoredItem.minimumSamplingInterval);
+                monitoredItem.isExceptionBased.should.eql(true);
+
+                for (const v of [1, 2, 3, 4, 5]) {
+                    uaExceptionBased.setValueFromSource({ dataType: DataType.UInt32, value: v });
+                }
+                values(monitoredItem).should.eql([1], "the first change at once, the others folded");
+                test.clock.tick(MonitoredItem.minimumSamplingInterval);
+                values(monitoredItem).should.eql([1, 5], "the latest value when the window ends");
+
+                test.clock.tick(2 * MonitoredItem.minimumSamplingInterval);
+                uaExceptionBased.setValueFromSource({ dataType: DataType.UInt32, value: 6 });
+                values(monitoredItem).should.eql([1, 5, 6], "after a quiet window, at once again");
+
+                samplingFunc.callCount.should.eql(0, "no sampling timer");
+            } finally {
+                subscription.terminate();
+                subscription.dispose();
+            }
+        });
+
+        it("SM1-E-2 answers 0 when the server advertises MinSupportedSampleRate 0, and reports every change", async () => {
+            const { subscription, createResult, monitoredItem } = await createItem(0);
+            try {
+                createResult.revisedSamplingInterval.should.eql(0);
+                monitoredItem.isExceptionBased.should.eql(true);
+                for (const v of [7, 8, 9]) {
+                    uaExceptionBased.setValueFromSource({ dataType: DataType.UInt32, value: v });
+                }
+                values(monitoredItem).should.eql([7, 8, 9]);
+            } finally {
+                subscription.terminate();
+                subscription.dispose();
+            }
+        });
+    });
 });
 
 describe("SM2 - MonitoredItem advanced", function (this: ITestContext) {


### PR DESCRIPTION
## Why

The server advertises `ServerCapabilities.MinSupportedSampleRate` = `MonitoredItem.minimumSamplingInterval` (50 ms), yet `CreateMonitoredItems` answered `revisedSamplingInterval` 0 for a requested 0 on any Variable whose `MinimumSamplingInterval` attribute is 0, which is every variable created without a getter. The server contradicted its own advertisement, and `ModifyMonitoredItems` already answered 50 for the same request. The Compliance Test Tool (Monitor Basic / 038.js) flags it:

```
WARNING: Expected CreateMonitoredItems.Results[0].RevisedSamplingInterval to be
different than the requested 0 value ...
```

Specification, OPC 10000-4 1.05 5.12.1.2 and OPC 10000-3 1.05 5.6.2: a requested 0 is "the fastest practical rate"; a negative value is "the publishing interval of the Subscription"; `revisedSamplingInterval` is "equal or higher than the requested samplingInterval" and "equal or higher than the MinimumSamplingInterval"; and "A Client shall define a sampling interval of 0 if it subscribes for Events".

Tracked as FEAT-31 on the CTT board (project 7).

## What

- `_adjust_sampling_interval` takes the advertised `minSupportedSampleRate`: a requested 0 on an exception-based Variable (MinimumSamplingInterval 0) answers that floor (50 by default) instead of 0. The Value attribute only: an EventNotifier or any non-Value item that requests 0 is still answered 0, on create and on modify.
- On-change delivery is kept for exception-based items (`value_changed` listener, no timer, `isExceptionBased` flag) and now **coalesces** to at most one notification per reported interval per item: the first change after a quiet period is recorded at once, later changes inside the window are folded and the latest value goes through the unchanged filter/deadband/queue path when the window ends. That also bounds the cost of a fast writer, which used to be one filter, clone and queue operation per change per item with the queue as the only brake. Timer cleared on stop and dispose; a pending value is flushed on modify-restart and before node disposal.
- `minSupportedSampleRate` is plumbed from the subscription's server capabilities; `||` becomes `??` in `server_engine.ts` and `server_capabilities.ts` so a server that wants to claim 0 can (documented: 0 means exception-based items are answered 0).
- Two side fixes found on the way: `itemToMonitor` was assigned after `_set_parameters` in the constructor, so the attribute id was undefined while the parameters were parsed; `modify()` rewrote a requested 0 to 50 before parsing.

## Verification

- New tests: revised 50 with on-change delivery and no timer; revised 0 when the server is configured with 0; coalescing (first, latest, next window, quiet window); deadband applied to the coalesced value; `terminate()` mid-window leaves no timer or listener; modify semantics; EventNotifier item answers 0 on create and modify while a Value item answers 50; two subscription-level tests on a real UAVariable with `setValueFromSource`.
- Whole `node-opcua-server` suite: 505 passing, 0 failing. e2e subscription series E: 73 passing. `tsc` and `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
