### PR TITLE
fix(server): keep PublishSubscribe SecurityGroups methods browsable when only SecurityKeyServerAdmin may Browse them

### DIFF
--- a/packages/node-opcua-address-space/CHANGELOG.md
+++ b/packages/node-opcua-address-space/CHANGELOG.md
@@ -299,6 +299,17 @@ can be set to `"deny"` by products that drive access entirely from declared poli
 
 ### Fixed
 
+#### The mandatory methods of `Server/PublishSubscribe/SecurityGroups` are browsable again
+
+`Opc.Ua.NodeSet2.xml` reserves Browse of eleven nodes under `Server/PublishSubscribe` - the methods of
+`SecurityGroups` and `KeyPushTargets`, with their arguments - to the `SecurityKeyServerAdmin` role, and since
+2.180.0 the loader applies the RolePermissions a nodeset declares. No user manager of node-opcua assigns that
+role, so no session could see them, and `SecurityGroups`, browsable by everyone, showed an instance without the
+mandatory methods of `SecurityGroupFolderType` (CTT Base Info Core Structure 002, FEAT-30). The loader is
+faithful to the document and stays so; `ensureStructureIsBrowsable` grants Browse to Anonymous and
+AuthenticatedUser on such nodes, leaving Read, Write and Call with the roles the nodeset named, and
+`OPCUAServer` applies it to `Server/PublishSubscribe` at initialization, next to the RoleSet.
+
 #### Two type lookups corrected
 
 - `addReference({ referenceType: "GeneratesEvent" })` kept the direction given only when the type's inverse name

--- a/packages/node-opcua-address-space/api/helpers/ensure_secure_access.ts
+++ b/packages/node-opcua-address-space/api/helpers/ensure_secure_access.ts
@@ -1,6 +1,13 @@
 import type { BaseNode, IChannelBase, UAMethod, UAObject, UAVariable } from "node-opcua-address-space-base";
-import { allPermissions, BrowseDirection, makeAccessRestrictionsFlag, makePermissionFlag, NodeClass } from "node-opcua-data-model";
-import { MessageSecurityMode } from "node-opcua-types";
+import {
+    allPermissions,
+    BrowseDirection,
+    makeAccessRestrictionsFlag,
+    makePermissionFlag,
+    NodeClass,
+    PermissionFlag
+} from "node-opcua-data-model";
+import { MessageSecurityMode, type RolePermissionType } from "node-opcua-types";
 import { WellKnownRoles } from "../session_context.js";
 
 function _isChannelSecure(channel: IChannelBase): boolean {
@@ -74,5 +81,49 @@ export function ensureObjectIsSecure(node: BaseNode, options: EnsureObjectIsSecu
     const children = node.findReferencesExAsObject("Aggregates", BrowseDirection.Forward);
     for (const child of children) {
         ensureObjectIsSecure(child, options);
+    }
+}
+
+/** the two Roles every Session's permissions are evaluated against, granted Browse and nothing else */
+const browseForEverySession = [
+    { roleId: WellKnownRoles.Anonymous, permissions: makePermissionFlag("Browse") },
+    { roleId: WellKnownRoles.AuthenticatedUser, permissions: makePermissionFlag("Browse") }
+];
+
+function grantsBrowseToEverySession(rolePermissions: RolePermissionType[]): boolean {
+    return rolePermissions.some(
+        ({ roleId, permissions }) =>
+            (permissions & PermissionFlag.Browse) !== 0 &&
+            roleId.namespace === 0 &&
+            (roleId.value === WellKnownRoles.Anonymous || roleId.value === WellKnownRoles.AuthenticatedUser)
+    );
+}
+
+/**
+ * keep the structure of `node` and its aggregates browsable by every session, leaving every
+ * other permission as declared.
+ *
+ * A node whose RolePermissions grant Browse to neither Anonymous nor AuthenticatedUser is
+ * hidden from any session that holds none of the roles it names. Where those roles are ones
+ * the server never assigns, nobody sees the node, and its parent - browsable by everyone -
+ * shows an instance missing the mandatory children of its type. `Opc.Ua.NodeSet2.xml` does
+ * this to eleven nodes under Server/PublishSubscribe (the methods of SecurityGroups and
+ * KeyPushTargets, with their arguments), reserved to the SecurityKeyServerAdmin role
+ * (CTT Base Info Core Structure 002, FEAT-30).
+ *
+ * Such a node gains Browse for Anonymous and AuthenticatedUser, which every session's
+ * permissions are evaluated against; Read, Write and Call stay with the roles it named. A
+ * node without RolePermissions, or that already grants Browse to one of the two, is left as
+ * it is.
+ *
+ * @param node the node whose structure, and whose aggregates' structure, must stay visible
+ */
+export function ensureStructureIsBrowsable(node: BaseNode): void {
+    const rolePermissions = node.rolePermissions;
+    if (rolePermissions && !grantsBrowseToEverySession(rolePermissions)) {
+        node.setRolePermissions([...rolePermissions, ...browseForEverySession]);
+    }
+    for (const child of node.findReferencesExAsObject("Aggregates", BrowseDirection.Forward)) {
+        ensureStructureIsBrowsable(child);
     }
 }

--- a/packages/node-opcua-address-space/test/test_ensure_structure_browsable.ts
+++ b/packages/node-opcua-address-space/test/test_ensure_structure_browsable.ts
@@ -1,0 +1,178 @@
+/**
+ * Opc.Ua.NodeSet2.xml reserves Browse of the methods of Server/PublishSubscribe/SecurityGroups, and
+ * of KeyPushTargets, to the SecurityKeyServerAdmin role. The loader is faithful to it, so a session
+ * holding none of the SecurityKeyServer roles - every session of a node-opcua server - saw
+ * SecurityGroups without the mandatory methods of its type (CTT Base Info Core Structure 002,
+ * FEAT-30). ensureStructureIsBrowsable is what a server applies to keep the structure visible.
+ */
+import { ObjectIds } from "node-opcua-constants";
+import { BrowseDirection } from "node-opcua-data-model";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { resolveNodeId, sameNodeId } from "node-opcua-nodeid";
+import { nodesets } from "node-opcua-nodesets";
+import { PermissionType } from "node-opcua-types";
+import should from "should";
+import {
+    AddressSpace,
+    type BaseNode,
+    ensureStructureIsBrowsable,
+    type IServerBase,
+    type ISessionContext,
+    makeRoles,
+    WellKnownRoles
+} from "../dist/api/index.js";
+import { isMassivelyUsedReferenceType } from "../dist/impl/reference_impl.js";
+import { generateAddressSpace } from "../nodeJS.js";
+import { makeMockSessionContext } from "../testHelpers.js";
+
+const securityGroups = "i=15443";
+const addSecurityGroup = "i=15444";
+const removeSecurityGroup = "i=15447";
+const getSecurityKeys = "i=15215";
+
+/** the eleven nodes the nodeset reserves to the SecurityKeyServerAdmin role, in browse order */
+const reservedToSecurityKeyServerAdmin = [
+    "i=15444", // SecurityGroups/AddSecurityGroup
+    "i=15445", //   InputArguments
+    "i=15446", //   OutputArguments
+    "i=15447", // SecurityGroups/RemoveSecurityGroup
+    "i=15448", //   InputArguments
+    "i=25440", // KeyPushTargets
+    "i=25441", //   AddPushTarget
+    "i=25442", //     InputArguments
+    "i=25443", //     OutputArguments
+    "i=25444", //   RemovePushTarget
+    "i=25445" //      InputArguments
+].map((id) => resolveNodeId(id).toString());
+
+const serverFor = (roles: ReturnType<typeof makeRoles>): IServerBase => ({ userManager: { getUserRoles: () => roles } });
+const anonymousSession = () =>
+    makeMockSessionContext({ userName: "anonymous", server: serverFor(makeRoles([WellKnownRoles.Anonymous])) });
+/** the CTT's admin session: every administrative role a node-opcua user manager hands out */
+const rootSession = () =>
+    makeMockSessionContext({
+        userName: "root",
+        server: serverFor(
+            makeRoles([
+                WellKnownRoles.AuthenticatedUser,
+                WellKnownRoles.Supervisor,
+                WellKnownRoles.SecurityAdmin,
+                WellKnownRoles.ConfigureAdmin
+            ])
+        )
+    });
+const securityKeyServerAdminSession = () =>
+    makeMockSessionContext({
+        userName: "sks",
+        server: serverFor(makeRoles([WellKnownRoles.AuthenticatedUser, ObjectIds.WellKnownRole_SecurityKeyServerAdmin]))
+    });
+
+/** the aggregates of `node`, at any depth, that `context` may not browse */
+function hiddenAggregates(context: ISessionContext, node: BaseNode): string[] {
+    const hidden: string[] = [];
+    for (const child of node.findReferencesExAsObject("Aggregates", BrowseDirection.Forward)) {
+        if (context.isBrowseAccessRestricted(child)) {
+            hidden.push(child.nodeId.toString());
+        }
+        hidden.push(...hiddenAggregates(context, child));
+    }
+    return hidden;
+}
+
+describe("the structure of Server/PublishSubscribe stays browsable", function (this: Mocha.Suite) {
+    this.timeout(120000);
+    let addressSpace: AddressSpace;
+    before(async () => {
+        addressSpace = AddressSpace.create();
+        await generateAddressSpace(addressSpace, [nodesets.standard]);
+    });
+    after(() => addressSpace.dispose());
+
+    const forwardTargets = (nodeId: string, referenceType: string): string[] =>
+        addressSpace
+            .findNode(nodeId)!
+            .findReferencesEx(referenceType, BrowseDirection.Forward)
+            .map((reference) => reference.nodeId.toString());
+
+    it("the loader holds every reference the nodeset declares on SecurityGroups and its methods", () => {
+        forwardTargets(securityGroups, "HasComponent").should.containDeep([
+            resolveNodeId(addSecurityGroup).toString(),
+            resolveNodeId(removeSecurityGroup).toString()
+        ]);
+        forwardTargets(addSecurityGroup, "HasProperty").should.containDeep([
+            resolveNodeId("i=15445").toString(),
+            resolveNodeId("i=15446").toString()
+        ]);
+    });
+
+    it("every reference of the standard nodeset is held from both ends", () => {
+        // HasTypeDefinition and HasModellingRule are kept on the source only, by design
+        const namespace = addressSpace.getDefaultNamespace() as unknown as { nodeIterator(): Iterable<BaseNode> };
+        const missing: string[] = [];
+        let checked = 0;
+        for (const node of namespace.nodeIterator()) {
+            for (const reference of node.allReferences()) {
+                if (isMassivelyUsedReferenceType(reference.referenceType)) {
+                    continue;
+                }
+                const target = addressSpace.findNode(reference.nodeId);
+                if (!target) {
+                    missing.push(`${node.nodeId} -> ${reference.nodeId}: no such node`);
+                    continue;
+                }
+                checked++;
+                const inverse = target
+                    .allReferences()
+                    .some(
+                        (r) =>
+                            r.isForward !== reference.isForward &&
+                            sameNodeId(r.nodeId, node.nodeId) &&
+                            sameNodeId(r.referenceType, reference.referenceType)
+                    );
+                if (!inverse) {
+                    missing.push(
+                        `${node.nodeId} ${reference.isForward ? "->" : "<-"} ${reference.nodeId} (${reference.referenceType})`
+                    );
+                }
+            }
+        }
+        checked.should.be.greaterThan(10000); // 5476 nodes, 19109 references, 7000 of them HasTypeDefinition or HasModellingRule
+        missing.should.eql([]);
+    });
+
+    it("the nodeset reserves Browse of eleven nodes under PublishSubscribe to the SecurityKeyServerAdmin role", () => {
+        const publishSubscribe = addressSpace.findNode(ObjectIds.PublishSubscribe)!;
+        // the CTT's admin session holds every role a user manager hands out, and sees none of them
+        hiddenAggregates(rootSession(), publishSubscribe).should.eql(reservedToSecurityKeyServerAdmin);
+        hiddenAggregates(anonymousSession(), publishSubscribe).should.containDeep(reservedToSecurityKeyServerAdmin);
+        // the SecurityKeyServerAdmin sees the eleven; PubSubConfiguration keeps its own SecurityAdmin-only methods from it
+        hiddenAggregates(securityKeyServerAdminSession(), publishSubscribe)
+            .filter((id) => reservedToSecurityKeyServerAdmin.includes(id))
+            .should.eql([]);
+    });
+
+    it("ensureStructureIsBrowsable shows them to every session and leaves Call with the SecurityKeyServerAdmin", () => {
+        const publishSubscribe = addressSpace.findNode(ObjectIds.PublishSubscribe)!;
+        const untouched = addressSpace.findNode(getSecurityKeys)!; // grants Browse to Anonymous already
+        const before = JSON.stringify(untouched.rolePermissions);
+        const noPermissions = publishSubscribe
+            .findReferencesExAsObject("Aggregates", BrowseDirection.Forward)
+            .find((child) => child.rolePermissions === undefined)!;
+        should.exist(noPermissions);
+
+        ensureStructureIsBrowsable(publishSubscribe);
+        ensureStructureIsBrowsable(publishSubscribe); // idempotent
+
+        hiddenAggregates(rootSession(), publishSubscribe).should.eql([]);
+        hiddenAggregates(anonymousSession(), publishSubscribe).should.eql([]);
+
+        const method = addressSpace.findNode(addSecurityGroup)!;
+        rootSession().checkPermission(method, PermissionType.Call).should.eql(false);
+        anonymousSession().checkPermission(method, PermissionType.Call).should.eql(false);
+        securityKeyServerAdminSession().checkPermission(method, PermissionType.Call).should.eql(true);
+        should(method.rolePermissions?.length).eql(3, "the nodeset's entry, plus Browse for Anonymous and AuthenticatedUser");
+
+        JSON.stringify(untouched.rolePermissions).should.eql(before);
+        should.not.exist(noPermissions.rolePermissions);
+    });
+});

--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -164,6 +164,7 @@ import type { IChannelData } from "./i_channel_data.js";
 import type { IRegisterServerManager } from "./i_register_server_manager.js";
 import type { ISocketData } from "./i_socket_data.js";
 import { MonitoredItem } from "./monitored_item.js";
+import { ensurePublishSubscribeIsBrowsable } from "./publish_subscribe_structure.js";
 import { RegisterServerManager } from "./register_server_manager.js";
 import { RegisterServerManagerHidden } from "./register_server_manager_hidden.js";
 import { RegisterServerManagerMDNSONLY } from "./register_server_manager_mdns_only.js";
@@ -1632,6 +1633,7 @@ export class OPCUAServer extends OPCUABaseServer<OPCUAServerEvents> {
                         return;
                     }
                     bindRoleSet(this.userManager, this.engine.addressSpace);
+                    ensurePublishSubscribeIsBrowsable(this.engine.addressSpace);
                     setImmediate(() => {
                         this.emit("post_initialize");
                         done();

--- a/packages/node-opcua-server/source/publish_subscribe_structure.ts
+++ b/packages/node-opcua-server/source/publish_subscribe_structure.ts
@@ -1,0 +1,24 @@
+/**
+ * @module node-opcua-server
+ */
+import { ensureStructureIsBrowsable, type IAddressSpace } from "node-opcua-address-space";
+import { ObjectIds } from "node-opcua-constants";
+
+/**
+ * keep the structure of Server/PublishSubscribe visible to every session.
+ *
+ * `Opc.Ua.NodeSet2.xml` reserves Browse of eleven nodes under it - the methods of
+ * SecurityGroups and KeyPushTargets, with their arguments - to the SecurityKeyServerAdmin
+ * role, and the loader applies the nodeset's RolePermissions. No user manager of node-opcua
+ * assigns that role, so no session could see them, and SecurityGroups, browsable by everyone,
+ * showed an instance without the mandatory methods of SecurityGroupFolderType (CTT Base Info
+ * Core Structure 002, FEAT-30). Browse is granted to every session; Call stays with the role
+ * the nodeset named, as does every other permission.
+ */
+export function ensurePublishSubscribeIsBrowsable(addressSpace: IAddressSpace): void {
+    const publishSubscribe = addressSpace.findNode(ObjectIds.PublishSubscribe);
+    if (!publishSubscribe) {
+        return;
+    }
+    ensureStructureIsBrowsable(publishSubscribe);
+}

--- a/packages/node-opcua-server/test/test_publish_subscribe_browsable.ts
+++ b/packages/node-opcua-server/test/test_publish_subscribe_browsable.ts
@@ -1,0 +1,132 @@
+/**
+ * Server/PublishSubscribe/SecurityGroups shows the mandatory methods of SecurityGroupFolderType to
+ * every session over the Browse service, while calling them stays with the SecurityKeyServerAdmin
+ * role the nodeset named (CTT Base Info Core Structure 002, FEAT-30).
+ */
+import { type AddressSpace, type ISessionContext, makeRoles, type UAMethod, WellKnownRoles } from "node-opcua-address-space";
+import {
+    BrowseDirection,
+    type ClientSession,
+    MessageSecurityMode,
+    OPCUAClient,
+    SecurityPolicy,
+    type UserIdentityInfo,
+    UserTokenType
+} from "node-opcua-client";
+import { ObjectIds } from "node-opcua-constants";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { nodesets } from "node-opcua-nodesets";
+import { StatusCodes } from "node-opcua-status-code";
+import { DataType, type Variant } from "node-opcua-variant";
+import "should";
+import { OPCUAServer } from "../dist/index.js";
+
+const port = 5798;
+const securityGroups = "i=15443";
+const addSecurityGroup = "i=15444";
+
+const users: Record<string, ReturnType<typeof makeRoles>> = {
+    // every administrative role a user manager hands out, none of the SecurityKeyServer ones: the CTT's admin
+    root: makeRoles([
+        WellKnownRoles.AuthenticatedUser,
+        WellKnownRoles.Supervisor,
+        WellKnownRoles.SecurityAdmin,
+        WellKnownRoles.ConfigureAdmin
+    ]),
+    sks: makeRoles([WellKnownRoles.AuthenticatedUser, ObjectIds.WellKnownRole_SecurityKeyServerAdmin])
+};
+
+describe("Server/PublishSubscribe/SecurityGroups over the Browse service", function (this: Mocha.Suite) {
+    this.timeout(120000);
+    let server: OPCUAServer;
+    before(async () => {
+        server = new OPCUAServer({
+            port,
+            nodeset_filename: [nodesets.standard],
+            userManager: {
+                isValidUser: (userName: string, password: string) => userName in users && password === "secret",
+                getUserRoles: (userName: string) => users[userName] ?? makeRoles([WellKnownRoles.Anonymous])
+            }
+        });
+        await server.initialize();
+        // an unbound method answers BadNotExecutable before its permissions are looked at
+        const addressSpace = server.engine.addressSpace as AddressSpace;
+        (addressSpace.findNode(addSecurityGroup) as UAMethod).bindMethod(
+            async (_inputArguments: Variant[], _context: ISessionContext) => ({
+                statusCode: StatusCodes.Good,
+                outputArguments: [{ dataType: DataType.NodeId, value: addressSpace.findNode(securityGroups)!.nodeId }]
+            })
+        );
+        await server.start();
+    });
+    after(async () => {
+        await server.shutdown();
+    });
+
+    async function withSession<T>(identity: UserIdentityInfo, action: (session: ClientSession) => Promise<T>): Promise<T> {
+        const client = OPCUAClient.create({
+            endpointMustExist: false,
+            securityMode: MessageSecurityMode.None,
+            securityPolicy: SecurityPolicy.None
+        });
+        await client.connect(server.getEndpointUrl());
+        try {
+            const session = await client.createSession(identity);
+            try {
+                return await action(session);
+            } finally {
+                await session.close();
+            }
+        } finally {
+            await client.disconnect();
+        }
+    }
+
+    const anonymous: UserIdentityInfo = { type: UserTokenType.Anonymous };
+    const asUser = (userName: string): UserIdentityInfo => ({ type: UserTokenType.UserName, userName, password: "secret" });
+
+    async function componentsOfSecurityGroups(session: ClientSession): Promise<string[]> {
+        const result = await session.browse({
+            nodeId: securityGroups,
+            browseDirection: BrowseDirection.Forward,
+            referenceTypeId: "HasComponent",
+            includeSubtypes: true,
+            resultMask: 63
+        });
+        result.statusCode.should.eql(StatusCodes.Good);
+        return (result.references || []).map((reference) => reference.browseName.name || "");
+    }
+
+    const callAddSecurityGroup = (session: ClientSession) =>
+        session.call({
+            objectId: securityGroups,
+            methodId: addSecurityGroup,
+            inputArguments: [
+                { dataType: DataType.String, value: "Group1" },
+                { dataType: DataType.Double, value: 1000 },
+                { dataType: DataType.String, value: "http://opcfoundation.org/UA/SecurityPolicy#None" },
+                { dataType: DataType.UInt32, value: 1 },
+                { dataType: DataType.UInt32, value: 1 }
+            ]
+        });
+
+    it("an anonymous session sees AddSecurityGroup and RemoveSecurityGroup", async () => {
+        const components = await withSession(anonymous, componentsOfSecurityGroups);
+        components.should.eql(["AddSecurityGroup", "RemoveSecurityGroup"]);
+    });
+
+    it("an administrator without the SecurityKeyServerAdmin role sees them too", async () => {
+        const components = await withSession(asUser("root"), componentsOfSecurityGroups);
+        components.should.eql(["AddSecurityGroup", "RemoveSecurityGroup"]);
+    });
+
+    it("but cannot call AddSecurityGroup: Call stays with the role the nodeset named", async () => {
+        const result = await withSession(asUser("root"), callAddSecurityGroup);
+        result.statusCode.should.eql(StatusCodes.BadUserAccessDenied);
+    });
+
+    it("a SecurityKeyServerAdmin calls it", async () => {
+        const result = await withSession(asUser("sks"), callAddSecurityGroup);
+        result.statusCode.should.eql(StatusCodes.Good);
+    });
+});


### PR DESCRIPTION
## Why

The OPC Foundation Compliance Test Tool (1.05.513, Base Info Core Structure 2 / 001.js) reports on a stock server:

```
ERROR: SecurityGroupFolderType.AddSecurityGroup not found on instance with NodeId 'i=15443' even though it is Mandatory.
ERROR: SecurityGroupFolderType.RemoveSecurityGroup not found on instance with NodeId 'i=15443' even though it is Mandatory.
```

and rolls it up as "Object Server,PublishSubscribe,SecurityGroups is not compliant with the UA 1.04 NodeSetFile", failing a unit that is mandatory for Nano 2025, Embedded 2022/2025 and Standard 2025.

The nodes are loaded and linked correctly. Since v2.180.0 (#1552) the loader applies each node's `<RolePermissions>`, and `Opc.Ua.NodeSet2.xml` grants `AddSecurityGroup` (i=15444) a single entry, `Permissions="61455"` for `WellKnownRole_SecurityKeyServerAdmin` (i=25565). `SessionContext.isBrowseAccessRestricted` then hides from Browse every target the session's roles cannot Browse. No user manager of node-opcua assigns the SecurityKeyServer roles (`WellKnownRoles` does not define them), so no session, not even a SecurityAdmin over SignAndEncrypt, can see these nodes. Exactly 11 standard nodes are in that situation, all under `Server/PublishSubscribe`: AddSecurityGroup, RemoveSecurityGroup and their arguments (i=15444 to 15448), KeyPushTargets, AddPushTarget, RemovePushTarget and their arguments (i=25440 to 25445). `GetSecurityKeys` (i=15215) also grants Anonymous Browse and Call, which is why it shows.

Tracked as FEAT-30 on the CTT board (project 7).

## What

Mirrors the FEAT-5 precedent (28a71d16, a62d2cfd): the structure stays browsable, values and calls stay protected, applied at server start next to `bindRoleSet`.

- `node-opcua-address-space/api/helpers/ensure_secure_access.ts`: `ensureStructureIsBrowsable(node)`. For the node and its Aggregates, when the RolePermissions grant Browse to neither Anonymous nor AuthenticatedUser, append Browse for both; every other grant untouched; nodes without RolePermissions untouched; idempotent.
- `node-opcua-server/source/publish_subscribe_structure.ts` (new): `ensurePublishSubscribeIsBrowsable(addressSpace)`, called from `opcua_server.ts` right after `bindRoleSet`.
- CHANGELOG entry.
- Tests: loader references and a whole-ns0 reference symmetry sweep (11,964 references, kept as documentation); the 11-node class for anonymous, root and SKS-admin sessions; helper effect with Call still SKS-admin-only; a real-client test where anonymous and root see both methods, root's Call answers `BadUserAccessDenied`, an SKS-admin user's Call answers `Good`. With the hook disabled the Browse tests fail and the Call tests still pass: visibility only.

## Verification

Full `node-opcua-address-space` suite: 1284 passing, 1 pending, 0 failing. Related server tests 25/25. `tsc -b`, `test:check`, biome, `check:importext`, `check:debug-name`, `check:cycles`: clean.

## To weigh in review

- Scope: applied to `PublishSubscribe` (125 nodes) the helper touches 25: the 11 above plus 14 ConfigureAdmin/SecurityAdmin-only methods and arguments (AddConnection, RemoveConnection, PubSubConfiguration Write/ReserveIds/CloseAndUpdate, Diagnostics/Reset), which become browsable by anonymous too, Call unchanged. The same class exists under `ServerConfiguration`, `UserManagement` and `DefaultApplicationGroup` (SecurityAdmin-only) for an anonymous Nano run; not extended there, same mechanism if wanted.
- Alternative not taken: define the three SecurityKeyServer roles in `WellKnownRoles` and grant them to the CTT server's admin user. Spec-true, but it needs a server-side change and does nothing for anonymous sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
