### PR TITLE
fix(lds): require an authenticated SecureChannel for RegisterServer(2)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,11 @@ Local Discovery Server: registration conformance (OPC UA Part 4 §5.5.5 / §5.5.
   - new `onRegistrationRefused` event on `OPCUADiscoveryServer` (Part 4 asks Discovery Servers to audit
     failed registrations); refusals are also logged with the caller's address, security mode and
     certificate ApplicationUri
+  - `RegisterServerManager` now really falls back to a `Sign`, then `None`, LDS endpoint when the LDS
+    offers no `SignAndEncrypt` endpoint; the fallback filtered an already-empty list and could never
+    select anything
+  - `OPCUADiscoveryServer.shutdown()` no longer sleeps one second after the endpoints are closed; the
+    endpoint shutdown already waits for the listening socket to be released
 
 Private key passphrase protection
 ==================================

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,29 @@
 
+Local Discovery Server: registration conformance (OPC UA Part 4 §5.5.5 / §5.5.6)
+================================================================================
+
+  - **breaking** `OPCUADiscoveryServer` no longer accepts `RegisterServer` / `RegisterServer2`
+    from unauthenticated callers. As required by OPC UA Part 4 §5.5.5 / §5.5.6:
+    - a registration over a `MessageSecurityMode.None` SecureChannel (no client certificate) is refused
+      with `Bad_SecurityModeInsufficient`
+    - a registration whose `serverUri` does not match the ApplicationUri of the certificate that opened
+      the SecureChannel is refused with `Bad_ServerUriInvalid`
+    - the default certificate manager of the LDS no longer trusts unknown certificates: an unknown
+      registrant is refused at `OpenSecureChannel` and its certificate is placed in the `rejected` folder;
+      move it to `trusted/certs` to allow the registration (the LDS logs both paths at startup).
+      This is the OPC Foundation UA-LDS default and what Part 12 §5.3.5 describes as the primary
+      mechanism for establishing trust between applications.
+  - `FindServers`, `FindServersOnNetwork` and `GetEndpoints` are unchanged and remain available without
+    message security (Part 4 §5.5.1)
+  - migration: after upgrading, each server that registers with a node-opcua LDS must have its
+    certificate trusted by the LDS once. `OPCUAServer` already registers over `SignAndEncrypt`, so no
+    change is needed on the server side.
+  - legacy opt-ins on `OPCUADiscoveryServerOptions`, both disabled by default, both relaxing the Part 4
+    requirements: `allowUnsecuredRegistration: true` and `automaticallyAcceptUnknownCertificate: true`
+  - new `onRegistrationRefused` event on `OPCUADiscoveryServer` (Part 4 asks Discovery Servers to audit
+    failed registrations); refusals are also logged with the caller's address, security mode and
+    certificate ApplicationUri
+
 Private key passphrase protection
 ==================================
 

--- a/packages/node-opcua-end2end-test/test/discovery/helpers/_helper.ts
+++ b/packages/node-opcua-end2end-test/test/discovery/helpers/_helper.ts
@@ -10,12 +10,13 @@ import {
     makeApplicationUrn,
     makeSubject,
     type OPCUABaseServer,
+    type OPCUACertificateManager,
     OPCUADiscoveryServer,
     type OPCUADiscoveryServerOptions,
     OPCUAServer,
     RegisterServerMethod
 } from "node-opcua";
-import { readCertificateChain } from "node-opcua-crypto";
+import { publicKeyAndPrivateKeyMatches, readCertificate, readCertificateChain } from "node-opcua-crypto";
 import { checkDebugFlag, make_debugLog } from "node-opcua-debug";
 import "should";
 
@@ -29,27 +30,50 @@ const { yellow, cyan } = chalk;
 
 export const pause = wait;
 
+/**
+ * Create `certificateFile` as a self-signed certificate for the store's private key, unless a
+ * matching one already exists.
+ *
+ * The stores under `os.tmpdir()/node-opcua-tmp/server<port>` persist across test runs while their
+ * private key can be regenerated (store layout change, wiped `own/` folder, ...). A certificate left
+ * over from a previous run then no longer matches the key and `OPCUAServer.initializeCM()` fails
+ * with NODE-OPCUA-E01 for that name only, which showed up as a "random" failure in the
+ * frequent-restart tests (DISCO4-J) once earlier tests had consumed the fresh names.
+ */
+async function ensureSelfSignedCertificate(
+    certificateManager: OPCUACertificateManager,
+    certificateFile: string,
+    params: { applicationUri: string; subject: string }
+): Promise<void> {
+    if (fs.existsSync(certificateFile)) {
+        const privateKey = await certificateManager.getPrivateKey();
+        if (publicKeyAndPrivateKeyMatches(readCertificate(certificateFile), privateKey)) {
+            return;
+        }
+        debugLog(`stale certificate ${certificateFile} does not match the store private key: recreating it`);
+        fs.unlinkSync(certificateFile);
+    }
+    await certificateManager.createSelfSignedCertificate({
+        applicationUri: params.applicationUri,
+        dns: [os.hostname(), "localhost"],
+        outputFile: certificateFile,
+        subject: params.subject,
+        startDate: new Date(),
+        validity: 365 * 10
+    });
+}
+
 export async function createDiscovery(port: number): Promise<OPCUADiscoveryServer> {
     assert(typeof port === "number", "expecting a port number");
     const serverCertificateManager = await createServerCertificateManager(port);
 
-    const _privateKeyFile = serverCertificateManager.privateKey;
     const certificateFile = path.join(serverCertificateManager.rootDir, "certificate_discovery_server.pem");
 
     const applicationUri = `urn:localhost:LDS-${port}`;
-    if (!fs.existsSync(certificateFile)) {
-        await serverCertificateManager.createSelfSignedCertificate({
-            applicationUri,
-            dns: [os.hostname(), "localhost"],
-            // dns: argv.alternateHostname ? [argv.alternateHostname, fqdn] : [fqdn],
-            // ip: await getIpAddresses(),
-            outputFile: certificateFile,
-            subject: "/CN=Sterfive/DC=NodeOPCUA-LocalDiscoveryServer",
-
-            startDate: new Date(),
-            validity: 365 * 10
-        });
-    }
+    await ensureSelfSignedCertificate(serverCertificateManager, certificateFile, {
+        applicationUri,
+        subject: "/CN=Sterfive/DC=NodeOPCUA-LocalDiscoveryServer"
+    });
 
     const discoveryServer = new OPCUADiscoveryServer({
         port,
@@ -132,18 +156,10 @@ export async function createServerThatRegistersItselfToTheDiscoveryServer(
     const applicationName = name;
     const applicationUri = makeApplicationUrn(os.hostname(), name);
 
-    if (!fs.existsSync(certificateFile)) {
-        await serverCertificateManager.createSelfSignedCertificate({
-            applicationUri,
-            dns: [os.hostname(), "localhost"],
-            // dns: argv.alternateHostname ? [argv.alternateHostname, fqdn] : [fqdn],
-            // ip: await getIpAddresses(),
-            outputFile: certificateFile,
-            subject: makeSubject(applicationName, os.hostname()),
-            startDate: new Date(),
-            validity: 365 * 10
-        });
-    }
+    await ensureSelfSignedCertificate(serverCertificateManager, certificateFile, {
+        applicationUri,
+        subject: makeSubject(applicationName, os.hostname())
+    });
 
     const server = new OPCUAServer({
         port,

--- a/packages/node-opcua-end2end-test/test/discovery/helpers/_helper.ts
+++ b/packages/node-opcua-end2end-test/test/discovery/helpers/_helper.ts
@@ -11,6 +11,7 @@ import {
     makeSubject,
     type OPCUABaseServer,
     OPCUADiscoveryServer,
+    type OPCUADiscoveryServerOptions,
     OPCUAServer,
     RegisterServerMethod
 } from "node-opcua";
@@ -69,8 +70,13 @@ export async function startDiscovery(port: number): Promise<OPCUADiscoveryServer
     return discoveryServer;
 }
 
-export const makeDiscoveryServer = async (port_discovery: number, test: TestHarness) => {
+export const makeDiscoveryServer = async (
+    port_discovery: number,
+    test: TestHarness,
+    options?: Partial<OPCUADiscoveryServerOptions>
+) => {
     const discoveryServer = new OPCUADiscoveryServer({
+        ...options,
         port: port_discovery,
         serverCertificateManager: test.discoveryServerCertificateManager
     });

--- a/packages/node-opcua-end2end-test/test/discovery/u_test_discovery_server.ts
+++ b/packages/node-opcua-end2end-test/test/discovery/u_test_discovery_server.ts
@@ -325,7 +325,7 @@ export function t(test: TestHarness) {
                 should(response).be.instanceOf(RegisterServerResponse);
             });
             refused.length.should.eql(0);
-            discovery_server!.registeredServerCount.should.eql(1);
+            should(discovery_server?.registeredServerCount).eql(1);
         });
 
         it("DISCO1-5 should refuse RegisterServer over a MessageSecurityMode.None channel (BadSecurityModeInsufficient)", async () => {
@@ -341,7 +341,7 @@ export function t(test: TestHarness) {
                 { securityMode: MessageSecurityMode.None, securityPolicy: SecurityPolicy.None }
             );
 
-            discovery_server!.registeredServerCount.should.eql(0);
+            should(discovery_server?.registeredServerCount).eql(0);
             refused.length.should.eql(1);
             refused[0].statusCode.should.eql(StatusCodes.BadSecurityModeInsufficient);
             refused[0].securityMode.should.eql(MessageSecurityMode.None);
@@ -361,7 +361,7 @@ export function t(test: TestHarness) {
                 expectServiceFault(StatusCodes.BadSecurityModeInsufficient),
                 { securityMode: MessageSecurityMode.None, securityPolicy: SecurityPolicy.None }
             );
-            discovery_server!.registeredServerCount.should.eql(0);
+            should(discovery_server?.registeredServerCount).eql(0);
         });
 
         it("DISCO1-7 should accept an unsecured RegisterServer when allowUnsecuredRegistration is explicitly enabled", async () => {
@@ -378,7 +378,7 @@ export function t(test: TestHarness) {
                 },
                 { securityMode: MessageSecurityMode.None, securityPolicy: SecurityPolicy.None }
             );
-            discovery_server!.registeredServerCount.should.eql(1);
+            should(discovery_server?.registeredServerCount).eql(1);
         });
 
         it("DISCO1-8 should refuse a registration whose serverUri does not match the certificate ApplicationUri (BadServerUriInvalid)", async () => {
@@ -395,7 +395,7 @@ export function t(test: TestHarness) {
                 expectServiceFault(StatusCodes.BadServerUriInvalid)
             );
 
-            discovery_server!.registeredServerCount.should.eql(0);
+            should(discovery_server?.registeredServerCount).eql(0);
             refused.length.should.eql(1);
             refused[0].statusCode.should.eql(StatusCodes.BadServerUriInvalid);
             refused[0].securityMode.should.eql(MessageSecurityMode.SignAndEncrypt);
@@ -442,8 +442,8 @@ export function t(test: TestHarness) {
             should.exist(connectError, "expecting OpenSecureChannel to be refused");
             // the LDS answers BadSecurityChecksFailed and closes the socket; depending on timing the
             // client sees either the status code or only the dropped connection
-            connectError!.message.should.match(/BadSecurityChecksFailed|BadCertificateUntrusted|rejected by server/);
-            discovery_server!.registeredServerCount.should.eql(0);
+            should(connectError?.message).match(/BadSecurityChecksFailed|BadCertificateUntrusted|rejected by server/);
+            should(discovery_server?.registeredServerCount).eql(0);
 
             stepLog("2. its certificate has been placed in the rejected folder");
             (await test.discoveryServerCertificateManager.getTrustStatus(unknownCertificate)).should.eql(
@@ -467,7 +467,7 @@ export function t(test: TestHarness) {
                 },
                 { identity: unknownIdentity }
             );
-            discovery_server!.registeredServerCount.should.eql(1);
+            should(discovery_server?.registeredServerCount).eql(1);
             registered.should.eql([{ serverUri: unknownApplicationUri, firstTime: true }]);
 
             // leave the store as we found it

--- a/packages/node-opcua-end2end-test/test/discovery/u_test_discovery_server.ts
+++ b/packages/node-opcua-end2end-test/test/discovery/u_test_discovery_server.ts
@@ -1,21 +1,31 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import chalk from "chalk";
 import {
     ApplicationType,
     findServers,
     findServersOnNetwork,
+    MessageSecurityMode,
+    makeApplicationUrn,
     OPCUAClient,
     type OPCUADiscoveryServer,
     OPCUAServer,
+    RegisterServer2Request,
+    RegisterServer2Response,
     RegisterServerRequest,
     RegisterServerResponse,
+    type RegistrationRefusedInfo,
+    SecurityPolicy,
     ServiceFault,
     StatusCodes
 } from "node-opcua";
 import { assert } from "node-opcua-assert";
-import { exploreCertificate } from "node-opcua-crypto";
+import { exploreCertificate, readCertificate } from "node-opcua-crypto";
 import { checkDebugFlag, make_debugLog } from "node-opcua-debug";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import should from "should";
+import { createServerCertificateManager } from "../../test_helpers/createServerCertificateManager.js";
 import { stepLog, waitUntilCondition } from "../../test_helpers/utils.js";
 import {
     addServerCertificateToTrustedCertificateInDiscoveryServer,
@@ -32,11 +42,11 @@ import {
 
 // RegisterServer is sent over the client's secure channel directly, without a session,
 // so performMessageTransaction here is deliberately outside the public OPCUAClient surface.
+type RegisterRequest = RegisterServerRequest | RegisterServer2Request;
+type RegisterResponse = RegisterServerResponse | RegisterServer2Response;
+type RegisteredServerOptions = NonNullable<NonNullable<ConstructorParameters<typeof RegisterServerRequest>[0]>["server"]>;
 interface ClientWithTransaction {
-    performMessageTransaction(
-        request: RegisterServerRequest,
-        callback: (err: Error | null, response?: RegisterServerResponse) => void
-    ): void;
+    performMessageTransaction(request: RegisterRequest, callback: (err: Error | null, response?: RegisterResponse) => void): void;
 }
 
 interface ErrorWithServiceFaultResponse extends Error {
@@ -83,12 +93,18 @@ export function t(test: TestHarness) {
             server = undefined;
         });
 
-        beforeEach(async () => {
-            await cleanUpmDNSandSanityCheck();
-            discovery_server = await makeDiscoveryServer(port_discovery, test);
+        async function startDiscoveryServer(options?: { allowUnsecuredRegistration?: boolean }) {
+            discovery_server = await makeDiscoveryServer(port_discovery, test, options);
             await discovery_server.start();
             discoveryServerEndpointUrl = discovery_server.getEndpointUrl();
             debugLog(" discovery_server_endpointUrl = ", discoveryServerEndpointUrl);
+            // the LDS only accepts registrations from applications it trusts (OPC UA Part 4 §5.5.5)
+            await addServerCertificateToTrustedCertificateInDiscoveryServer(server!, discovery_server);
+        }
+
+        beforeEach(async () => {
+            await cleanUpmDNSandSanityCheck();
+            await startDiscoveryServer();
         });
 
         afterEach(async () => {
@@ -96,32 +112,104 @@ export function t(test: TestHarness) {
             discovery_server = undefined;
         });
 
+        interface RegistrantIdentity {
+            certificateFile: string;
+            privateKeyFile: string;
+            applicationUri: string;
+        }
+        /** the identity of the (trusted) OPCUAServer created in `before` */
+        function trustedIdentity(): RegistrantIdentity {
+            return {
+                certificateFile: server!.certificateFile,
+                privateKeyFile: server!.privateKeyFile,
+                applicationUri: server!.serverInfo.applicationUri!
+            };
+        }
+
+        interface SendOptions {
+            securityMode?: MessageSecurityMode;
+            securityPolicy?: SecurityPolicy;
+            identity?: RegistrantIdentity;
+        }
+
+        /**
+         * open a SecureChannel to the LDS and send a raw RegisterServer(2) request on it.
+         * By default the channel is SignAndEncrypt with the trusted server identity.
+         */
         async function send_registered_server_request(
             discoveryServerEndpointUrl: string,
-            registerServerRequest: RegisterServerRequest,
-            externalFunc: (err: Error | null, response?: RegisterServerResponse) => void
+            registerServerRequest: RegisterRequest,
+            externalFunc: (err: Error | null, response?: RegisterResponse) => void,
+            options?: SendOptions
         ): Promise<void> {
+            const securityMode = options?.securityMode ?? MessageSecurityMode.SignAndEncrypt;
+            const securityPolicy = options?.securityPolicy ?? SecurityPolicy.Basic256Sha256;
+            const identity = options?.identity ?? trustedIdentity();
+
+            // a dedicated store that auto-accepts the LDS certificate; the identity is passed explicitly
+            const clientCertificateManager = await createServerCertificateManager(port0);
+
             const client = OPCUAClient.create({
                 endpointMustExist: false,
-                clientName: "u_test_discovery_server"
+                clientName: "u_test_discovery_server",
+                securityMode,
+                securityPolicy,
+                clientCertificateManager,
+                // a refused OpenSecureChannel must surface immediately, not retry forever
+                connectionStrategy: { maxRetry: 0 },
+                ...identity
             });
             client.on("backoff", () => {
                 debugLog(`cannot connect to ${discoveryServerEndpointUrl}`);
             });
 
             await client.connect(discoveryServerEndpointUrl);
-
-            await new Promise<void>((resolve) => {
-                (client as unknown as ClientWithTransaction).performMessageTransaction(registerServerRequest, (err, response) => {
-                    if (!err) {
-                        // RegisterServerResponse
-                        assert(response instanceof RegisterServerResponse);
-                    }
-                    externalFunc(err, response);
-                    resolve();
+            try {
+                await new Promise<void>((resolve, reject) => {
+                    (client as unknown as ClientWithTransaction).performMessageTransaction(
+                        registerServerRequest,
+                        (err, response) => {
+                            // an assertion failure inside the callback must fail the test, not hang it
+                            try {
+                                if (!err) {
+                                    assert(
+                                        response instanceof RegisterServerResponse || response instanceof RegisterServer2Response
+                                    );
+                                }
+                                externalFunc(err, response);
+                                resolve();
+                            } catch (assertionError) {
+                                reject(assertionError as Error);
+                            }
+                        }
+                    );
                 });
-            });
-            await client.disconnect();
+            } finally {
+                await client.disconnect();
+            }
+        }
+
+        function expectServiceFault(expected: (typeof StatusCodes)[keyof typeof StatusCodes]) {
+            return (err: Error | null, response?: RegisterResponse) => {
+                should.exist(err);
+                should.not.exist(response);
+                should((err as ErrorWithServiceFaultResponse).response).be.instanceOf(ServiceFault);
+                should((err as ErrorWithServiceFaultResponse).response?.responseHeader.serviceResult).eql(expected);
+            };
+        }
+
+        /** a well-formed registration for the trusted identity */
+        function validRegisteredServer(): RegisteredServerOptions {
+            return {
+                serverUri: trustedIdentity().applicationUri,
+                productUri: "productUri",
+                serverNames: [{ text: "some name" }],
+                serverType: ApplicationType.Server,
+                gatewayServerUri: null,
+                discoveryUrls: ["opc.tcp://localhost:2500"],
+                semaphoreFilePath: null,
+                isOnline: false
+            };
         }
 
         it("DISCO1-1 should fail to register server if discovery url is not specified (Bad_DiscoveryUrlMissing)", async () => {
@@ -129,7 +217,7 @@ export function t(test: TestHarness) {
                 server: {
                     // The globally unique identifier for the Server instance. The serverUri matches
                     // the applicationUri from the ApplicationDescription defined in 7.1.
-                    serverUri: "uri:MyServerURI",
+                    serverUri: trustedIdentity().applicationUri,
 
                     // The globally unique identifier for the Server product.
                     productUri: "productUri",
@@ -144,7 +232,7 @@ export function t(test: TestHarness) {
                 }
             });
 
-            function check_error_response(err: Error | null, response?: RegisterServerResponse): void {
+            function check_error_response(err: Error | null, response?: RegisterResponse): void {
                 should.exist(err);
                 should.not.exist(response);
                 should((err as ErrorWithServiceFaultResponse).response).be.instanceOf(ServiceFault);
@@ -161,7 +249,7 @@ export function t(test: TestHarness) {
                 server: {
                     // The globally unique identifier for the Server instance. The serverUri matches
                     // the applicationUri from the ApplicationDescription defined in 7.1.
-                    serverUri: "uri:MyServerURI",
+                    serverUri: trustedIdentity().applicationUri,
 
                     // The globally unique identifier for the Server product.
                     productUri: "productUri",
@@ -176,7 +264,7 @@ export function t(test: TestHarness) {
                 }
             });
 
-            function check_error_response(err: Error | null, response?: RegisterServerResponse) {
+            function check_error_response(err: Error | null, response?: RegisterResponse) {
                 should.exist(err);
                 should.not.exist(response);
                 //xx debugLog(response.toString());
@@ -194,7 +282,7 @@ export function t(test: TestHarness) {
                 server: {
                     // The globally unique identifier for the Server instance. The serverUri matches
                     // the applicationUri from the ApplicationDescription defined in 7.1.
-                    serverUri: "uri:MyServerURI",
+                    serverUri: trustedIdentity().applicationUri,
 
                     // The globally unique identifier for the Server product.
                     productUri: "productUri",
@@ -209,7 +297,7 @@ export function t(test: TestHarness) {
                 }
             });
 
-            function check_error_response(err: Error | null, response?: RegisterServerResponse) {
+            function check_error_response(err: Error | null, response?: RegisterResponse) {
                 should.exist(err);
                 should.not.exist(response);
                 should((err as ErrorWithServiceFaultResponse).response).be.instanceOf(ServiceFault);
@@ -219,6 +307,172 @@ export function t(test: TestHarness) {
             }
 
             await send_registered_server_request(discoveryServerEndpointUrl, request, check_error_response);
+        });
+
+        // ---------------------------------------------------------------------------------------------------
+        // RegisterServer(2) must only be accepted from an authenticated SecureChannel
+        // whose certificate ApplicationUri matches serverUri (OPC UA Part 4 §5.5.5 / §5.5.6)
+        // ---------------------------------------------------------------------------------------------------
+
+        it("DISCO1-4 should accept a well-formed RegisterServer over an authenticated SecureChannel", async () => {
+            const request = new RegisterServerRequest({ server: { ...validRegisteredServer(), isOnline: true } });
+
+            const refused: RegistrationRefusedInfo[] = [];
+            discovery_server!.on("onRegistrationRefused", (_server, info) => refused.push(info));
+
+            await send_registered_server_request(discoveryServerEndpointUrl, request, (err, response) => {
+                should.not.exist(err);
+                should(response).be.instanceOf(RegisterServerResponse);
+            });
+            refused.length.should.eql(0);
+            discovery_server!.registeredServerCount.should.eql(1);
+        });
+
+        it("DISCO1-5 should refuse RegisterServer over a MessageSecurityMode.None channel (BadSecurityModeInsufficient)", async () => {
+            const request = new RegisterServerRequest({ server: { ...validRegisteredServer(), isOnline: true } });
+
+            const refused: RegistrationRefusedInfo[] = [];
+            discovery_server!.on("onRegistrationRefused", (_server, info) => refused.push(info));
+
+            await send_registered_server_request(
+                discoveryServerEndpointUrl,
+                request,
+                expectServiceFault(StatusCodes.BadSecurityModeInsufficient),
+                { securityMode: MessageSecurityMode.None, securityPolicy: SecurityPolicy.None }
+            );
+
+            discovery_server!.registeredServerCount.should.eql(0);
+            refused.length.should.eql(1);
+            refused[0].statusCode.should.eql(StatusCodes.BadSecurityModeInsufficient);
+            refused[0].securityMode.should.eql(MessageSecurityMode.None);
+            refused[0].certificateApplicationUris.should.eql([]);
+            refused[0].remoteAddress.should.be.a.String();
+        });
+
+        it("DISCO1-6 should refuse RegisterServer2 over a MessageSecurityMode.None channel (BadSecurityModeInsufficient)", async () => {
+            const request = new RegisterServer2Request({
+                server: { ...validRegisteredServer(), isOnline: true },
+                discoveryConfiguration: []
+            });
+
+            await send_registered_server_request(
+                discoveryServerEndpointUrl,
+                request,
+                expectServiceFault(StatusCodes.BadSecurityModeInsufficient),
+                { securityMode: MessageSecurityMode.None, securityPolicy: SecurityPolicy.None }
+            );
+            discovery_server!.registeredServerCount.should.eql(0);
+        });
+
+        it("DISCO1-7 should accept an unsecured RegisterServer when allowUnsecuredRegistration is explicitly enabled", async () => {
+            await discovery_server!.shutdown();
+            await startDiscoveryServer({ allowUnsecuredRegistration: true });
+
+            const request = new RegisterServerRequest({ server: { ...validRegisteredServer(), isOnline: true } });
+            await send_registered_server_request(
+                discoveryServerEndpointUrl,
+                request,
+                (err, response) => {
+                    should.not.exist(err);
+                    should(response).be.instanceOf(RegisterServerResponse);
+                },
+                { securityMode: MessageSecurityMode.None, securityPolicy: SecurityPolicy.None }
+            );
+            discovery_server!.registeredServerCount.should.eql(1);
+        });
+
+        it("DISCO1-8 should refuse a registration whose serverUri does not match the certificate ApplicationUri (BadServerUriInvalid)", async () => {
+            const request = new RegisterServerRequest({
+                server: { ...validRegisteredServer(), serverUri: "urn:some:other:server", isOnline: true }
+            });
+
+            const refused: RegistrationRefusedInfo[] = [];
+            discovery_server!.on("onRegistrationRefused", (_server, info) => refused.push(info));
+
+            await send_registered_server_request(
+                discoveryServerEndpointUrl,
+                request,
+                expectServiceFault(StatusCodes.BadServerUriInvalid)
+            );
+
+            discovery_server!.registeredServerCount.should.eql(0);
+            refused.length.should.eql(1);
+            refused[0].statusCode.should.eql(StatusCodes.BadServerUriInvalid);
+            refused[0].securityMode.should.eql(MessageSecurityMode.SignAndEncrypt);
+            refused[0].certificateApplicationUris.should.eql([trustedIdentity().applicationUri]);
+        });
+
+        it("DISCO1-9 should refuse a registrant with an unknown certificate at OpenSecureChannel, and accept it once trusted", async () => {
+            // an application the LDS has never seen, with a certificate whose ApplicationUri matches its serverUri
+            const unknownCertificateManager = await createServerCertificateManager(port5);
+            const unknownApplicationUri = makeApplicationUrn(os.hostname(), "UnknownRegistrant");
+            const unknownCertificateFile = path.join(unknownCertificateManager.rootDir, "certificate_unknown_registrant.pem");
+            if (!fs.existsSync(unknownCertificateFile)) {
+                await unknownCertificateManager.createSelfSignedCertificate({
+                    applicationUri: unknownApplicationUri,
+                    dns: [os.hostname(), "localhost"],
+                    outputFile: unknownCertificateFile,
+                    subject: "/CN=UnknownRegistrant",
+                    startDate: new Date(),
+                    validity: 365
+                });
+            }
+            const unknownCertificate = readCertificate(unknownCertificateFile);
+            const unknownIdentity: RegistrantIdentity = {
+                certificateFile: unknownCertificateFile,
+                privateKeyFile: unknownCertificateManager.privateKey as string,
+                applicationUri: unknownApplicationUri
+            };
+            // make sure a previous run has not left it trusted
+            await test.discoveryServerCertificateManager.rejectCertificate(unknownCertificate);
+
+            const request = new RegisterServerRequest({
+                server: { ...validRegisteredServer(), serverUri: unknownApplicationUri, isOnline: true }
+            });
+
+            stepLog("1. the unknown registrant cannot even open a SecureChannel to the LDS");
+            let connectError: Error | null = null;
+            try {
+                await send_registered_server_request(discoveryServerEndpointUrl, request, () => {}, {
+                    identity: unknownIdentity
+                });
+            } catch (err) {
+                connectError = err as Error;
+            }
+            should.exist(connectError, "expecting OpenSecureChannel to be refused");
+            // the LDS answers BadSecurityChecksFailed and closes the socket; depending on timing the
+            // client sees either the status code or only the dropped connection
+            connectError!.message.should.match(/BadSecurityChecksFailed|BadCertificateUntrusted|rejected by server/);
+            discovery_server!.registeredServerCount.should.eql(0);
+
+            stepLog("2. its certificate has been placed in the rejected folder");
+            (await test.discoveryServerCertificateManager.getTrustStatus(unknownCertificate)).should.eql(
+                StatusCodes.BadCertificateUntrusted
+            );
+            const rejectedFolder = path.join(test.discoveryServerCertificateManager.rootDir, "rejected");
+            fs.readdirSync(rejectedFolder).length.should.be.greaterThan(0);
+
+            stepLog("3. once the administrator trusts the certificate, the registration succeeds");
+            await test.discoveryServerCertificateManager.trustCertificate(unknownCertificate);
+
+            const registered: Array<{ serverUri: string | null; firstTime: boolean }> = [];
+            discovery_server!.on("onRegisterServer", (s, firstTime) => registered.push({ serverUri: s.serverUri, firstTime }));
+
+            await send_registered_server_request(
+                discoveryServerEndpointUrl,
+                request,
+                (err, response) => {
+                    should.not.exist(err);
+                    should(response).be.instanceOf(RegisterServerResponse);
+                },
+                { identity: unknownIdentity }
+            );
+            discovery_server!.registeredServerCount.should.eql(1);
+            registered.should.eql([{ serverUri: unknownApplicationUri, firstTime: true }]);
+
+            // leave the store as we found it
+            await test.discoveryServerCertificateManager.rejectCertificate(unknownCertificate);
+            await unknownCertificateManager.dispose();
         });
     });
 

--- a/packages/node-opcua-server-discovery/package.json
+++ b/packages/node-opcua-server-discovery/package.json
@@ -17,6 +17,7 @@
         "node-opcua-basic-types": "2.181.0",
         "node-opcua-certificate-manager": "2.181.0",
         "node-opcua-common": "2.181.0",
+        "node-opcua-crypto": "5.10.1",
         "node-opcua-debug": "2.181.0",
         "node-opcua-object-registry": "2.181.0",
         "node-opcua-secure-channel": "2.181.1",

--- a/packages/node-opcua-server-discovery/source/opcua_discovery_server.ts
+++ b/packages/node-opcua-server-discovery/source/opcua_discovery_server.ts
@@ -11,10 +11,11 @@ import { assert } from "node-opcua-assert";
 import type { UAString } from "node-opcua-basic-types";
 import { OPCUACertificateManager } from "node-opcua-certificate-manager";
 import { makeApplicationUrn } from "node-opcua-common";
-import { checkDebugFlag, make_debugLog, make_errorLog } from "node-opcua-debug";
+import { exploreCertificate, split_der } from "node-opcua-crypto";
+import { checkDebugFlag, make_debugLog, make_errorLog, make_warningLog } from "node-opcua-debug";
 import {
     type Message,
-    type MessageSecurityMode,
+    MessageSecurityMode,
     type Response,
     type SecurityPolicy,
     type ServerSecureChannelLayer,
@@ -49,6 +50,7 @@ import { MDNSResponder } from "./mdns_responder.js";
 const debugLog = make_debugLog("LDSSERVER");
 const doDebug = checkDebugFlag("LDSSERVER");
 const errorLog = make_errorLog("LDSSERVER");
+const warningLog = make_warningLog("LDSSERVER");
 
 function hasCapabilities(serverCapabilities: UAString[] | null, serverCapabilityFilter: string): boolean {
     if (serverCapabilities == null) {
@@ -67,6 +69,40 @@ export interface OPCUADiscoveryServerOptions extends OPCUABaseServerOptions {
     securityPolicies?: SecurityPolicy[];
     securityModes?: MessageSecurityMode[];
     hostname?: string;
+
+    /**
+     * Accept `RegisterServer` / `RegisterServer2` over a SecureChannel with
+     * `MessageSecurityMode.None`, i.e. from a caller that presented no
+     * application certificate.
+     *
+     * OPC UA Part 4 §5.5.5 / §5.5.6 require these services to be invoked
+     * over a SecureChannel that authenticates the caller. Enable only for
+     * legacy registrants that cannot open a secured channel, on a network
+     * you control.
+     *
+     * The `FindServers`, `FindServersOnNetwork` and `GetEndpoints` services
+     * are not affected: they stay available without message security, as
+     * Part 4 §5.5.1 requires.
+     *
+     * @default false
+     */
+    allowUnsecuredRegistration?: boolean;
+
+    /**
+     * Trust any unknown application certificate presented by a registrant.
+     * Only used when `serverCertificateManager` is not provided.
+     *
+     * When false (the default), a registrant whose certificate is not in the
+     * trusted folder is refused at `OpenSecureChannel` and its certificate is
+     * placed in the rejected folder; an administrator moves it to the trusted
+     * folder to allow the registration. This matches the OPC Foundation
+     * UA-LDS default and OPC UA Part 12 §5.3.5, which makes the
+     * administrator-managed trust list the primary mechanism for establishing
+     * trust between applications.
+     *
+     * @default false
+     */
+    automaticallyAcceptUnknownCertificate?: boolean;
 }
 
 interface RegisteredServerExtended extends RegisteredServer {
@@ -88,22 +124,50 @@ const defaultApplicationUri = makeApplicationUrn(os.hostname(), defaultProductUr
 
 let _discoveryDefaultCertificateManager: OPCUACertificateManager | undefined;
 
-function getDefaultCertificateManager(): OPCUACertificateManager {
+function getDefaultCertificateManager(automaticallyAcceptUnknownCertificate: boolean): OPCUACertificateManager {
     if (!_discoveryDefaultCertificateManager) {
         const config = envPaths(defaultProductUri).config;
         _discoveryDefaultCertificateManager = new OPCUACertificateManager({
             name: "PKI",
             rootFolder: path.join(config, "PKI"),
-            automaticallyAcceptUnknownCertificate: true
+            automaticallyAcceptUnknownCertificate
         });
     }
     _discoveryDefaultCertificateManager.referenceCounter++;
     return _discoveryDefaultCertificateManager;
 }
 
+/**
+ * ApplicationUri(s) carried by the SubjectAltName extension of the leaf certificate.
+ * Returns `null` when the certificate cannot be parsed.
+ */
+function extractApplicationUris(certificateChain: Buffer): string[] | null {
+    try {
+        const leaf = split_der(certificateChain)[0];
+        const info = exploreCertificate(leaf);
+        return info.tbsCertificate.extensions?.subjectAltName?.uniformResourceIdentifier ?? [];
+    } catch (_err) {
+        return null;
+    }
+}
+
+export interface RegistrationRefusedInfo {
+    statusCode: StatusCode;
+    remoteAddress: string;
+    remotePort: number;
+    securityMode: MessageSecurityMode;
+    /** ApplicationUri(s) found in the caller's certificate, empty when no certificate was presented */
+    certificateApplicationUris: string[];
+}
+
 export interface OPCUADiscoveryServerEvents extends OPCUABaseServerEvents {
     onUnregisterServer: [server: RegisteredServer, forced: boolean];
     onRegisterServer: [server: RegisteredServer, firstTime: boolean];
+    /**
+     * a `RegisterServer` / `RegisterServer2` request was refused before reaching the registry.
+     * (OPC UA Part 4 requires Discovery Servers to audit failed registrations.)
+     */
+    onRegistrationRefused: [server: RegisteredServer, info: RegistrationRefusedInfo];
 }
 
 // const weakMap = new WeakMap<MdnsDiscoveryConfiguration, BonjourHolder>;
@@ -114,6 +178,8 @@ export class OPCUADiscoveryServer extends OPCUABaseServer<OPCUADiscoveryServerEv
     public readonly registeredServers: RegisterServerMap;
 
     private _delayInit?: () => Promise<void>;
+
+    readonly #allowUnsecuredRegistration: boolean;
 
     constructor(options: OPCUADiscoveryServerOptions) {
         options.serverInfo = options.serverInfo || {};
@@ -134,9 +200,12 @@ export class OPCUADiscoveryServer extends OPCUABaseServer<OPCUADiscoveryServerEv
         serverInfo.discoveryProfileUri = serverInfo.discoveryProfileUri || "";
         serverInfo.discoveryUrls = serverInfo.discoveryUrls || [];
 
-        options.serverCertificateManager = options.serverCertificateManager || getDefaultCertificateManager();
+        options.serverCertificateManager =
+            options.serverCertificateManager || getDefaultCertificateManager(!!options.automaticallyAcceptUnknownCertificate);
 
         super(options);
+
+        this.#allowUnsecuredRegistration = !!options.allowUnsecuredRegistration;
 
         // see OPC UA Spec 1.2 part 6 : 7.4 Well Known Addresses
         // opc.tcp://localhost:4840/UADiscovery
@@ -187,6 +256,8 @@ export class OPCUADiscoveryServer extends OPCUABaseServer<OPCUADiscoveryServerEv
         });
 
         await new Promise<void>((resolve, reject) => super.start((err?: Error | null) => (err ? reject(err) : resolve())));
+
+        this.#logRegistrationPolicy();
 
         const endpointUri = this.getEndpointUrl();
         const { hostname } = new URL(endpointUri);
@@ -264,11 +335,97 @@ export class OPCUADiscoveryServer extends OPCUABaseServer<OPCUADiscoveryServerEv
         return servers;
     }
 
+    #logRegistrationPolicy(): void {
+        const cm = this.serverCertificateManager as OPCUACertificateManager;
+        if (!cm.automaticallyAcceptUnknownCertificate) {
+            warningLog(
+                `LDS: registrations from applications with an unknown certificate are refused.\n` +
+                    `     To allow a server, move its certificate from ${path.join(cm.rootDir, "rejected")}\n` +
+                    `     to ${path.join(cm.rootDir, "trusted", "certs")}`
+            );
+        } else {
+            warningLog(
+                "LDS: automaticallyAcceptUnknownCertificate is enabled: any application certificate is trusted (not recommended)"
+            );
+        }
+        if (this.#allowUnsecuredRegistration) {
+            warningLog(
+                "LDS: allowUnsecuredRegistration is enabled: RegisterServer over MessageSecurityMode.None is accepted (not conformant to OPC UA Part 4 §5.5.5)"
+            );
+        }
+    }
+
+    /**
+     * Enforce OPC UA Part 4 §5.5.5 / §5.5.6 on a registration request:
+     *
+     *  - "This Service can only be invoked via SecureChannels that support Client authentication."
+     *    A `MessageSecurityMode.None` channel carries no certificate (Part 4 §5.6.2), so it is refused
+     *    with `Bad_SecurityModeInsufficient` unless `allowUnsecuredRegistration` is set.
+     *    `Bad_ServiceUnsupported` is deliberately not used: Part 4 §5.5.6 tells the caller to fall back
+     *    to `RegisterServer` on that code, which is the wrong signal here.
+     *
+     *  - "Discovery Servers shall reject registrations if the serverUri provided does not match the
+     *    applicationUri in the Certificate used to create the SecureChannel." -> `Bad_ServerUriInvalid`.
+     *
+     * The certificate on `channel` was already validated against the trust list at `OpenSecureChannel`.
+     */
+    #checkRegistrationChannel(channel: ServerSecureChannelLayer, server: RegisteredServer): StatusCode {
+        const clientCertificate = channel.clientCertificate;
+
+        if (channel.securityMode === MessageSecurityMode.None || !clientCertificate || clientCertificate.length === 0) {
+            if (this.#allowUnsecuredRegistration) {
+                warningLog(`LDS: accepting unauthenticated registration of ${server.serverUri} (allowUnsecuredRegistration)`);
+                return StatusCodes.Good;
+            }
+            return StatusCodes.BadSecurityModeInsufficient;
+        }
+
+        const uris = extractApplicationUris(clientCertificate);
+        if (uris === null) {
+            return StatusCodes.BadCertificateInvalid;
+        }
+        if (!server.serverUri || !uris.includes(server.serverUri)) {
+            return StatusCodes.BadServerUriInvalid;
+        }
+        return StatusCodes.Good;
+    }
+
+    #refuseRegistration(
+        message: Message,
+        channel: ServerSecureChannelLayer,
+        server: RegisteredServer,
+        statusCode: StatusCode
+    ): void {
+        const uris = (channel.clientCertificate && extractApplicationUris(channel.clientCertificate)) || [];
+        const info: RegistrationRefusedInfo = {
+            statusCode,
+            remoteAddress: channel.remoteAddress,
+            remotePort: channel.remotePort,
+            securityMode: channel.securityMode,
+            certificateApplicationUris: uris
+        };
+        warningLog(
+            `LDS: registration refused ${statusCode.toString()}: serverUri=${server.serverUri} ` +
+                `serverNames=[${(server.serverNames || []).map((n) => n.text).join(", ")}] ` +
+                `discoveryUrls=[${(server.discoveryUrls || []).join(", ")}] ` +
+                `from ${info.remoteAddress}:${info.remotePort} securityMode=${MessageSecurityMode[info.securityMode]} ` +
+                `certificateApplicationUris=[${uris.join(", ")}]`
+        );
+        this.emit("onRegistrationRefused", server, info);
+        const response = new ServiceFault({ responseHeader: { serviceResult: statusCode } });
+        channel.send_response("MSG", response, message);
+    }
+
     protected _on_RegisterServer2Request(message: Message, channel: ServerSecureChannelLayer) {
         assert(message.request instanceof RegisterServer2Request);
         const request = message.request as RegisterServer2Request;
 
         assert(request.schema.name === "RegisterServer2Request");
+
+        const gate = this.#checkRegistrationChannel(channel, request.server);
+        if (gate.isNotGood()) {
+            return this.#refuseRegistration(message, channel, request.server, gate);
+        }
 
         request.discoveryConfiguration = request.discoveryConfiguration || [];
         this.#internalRegisterServer(
@@ -299,6 +456,12 @@ export class OPCUADiscoveryServer extends OPCUABaseServer<OPCUADiscoveryServerEv
         assert(message.request instanceof RegisterServerRequest);
         const request = message.request as RegisterServerRequest;
         assert(request.schema.name === "RegisterServerRequest");
+
+        const gate = this.#checkRegistrationChannel(channel, request.server);
+        if (gate.isNotGood()) {
+            return this.#refuseRegistration(message, channel, request.server, gate);
+        }
+
         this.#internalRegisterServer(RegisterServerResponse, request.server, undefined)
             .then((response) => {
                 channel.send_response("MSG", response, message);
@@ -464,7 +627,10 @@ export class OPCUADiscoveryServer extends OPCUABaseServer<OPCUADiscoveryServerEv
         // serverCapabilities [] String  The set of Server capabilities supported by the Server.
         //                               A Server capability is a short identifier for a feature
         //                               The set of allowed Server capabilities are defined in Part 12.
-        discoveryConfiguration.mdnsServerName ??= server1.serverNames?.[0].text || null;
+        // an absent name may be null, undefined or "" (the structure default), all mean "not specified"
+        if (!discoveryConfiguration.mdnsServerName) {
+            discoveryConfiguration.mdnsServerName = server1.serverNames?.[0]?.text || null;
+        }
 
         serverInfo.discoveryUrls ??= [];
 
@@ -636,8 +802,8 @@ export class OPCUADiscoveryServer extends OPCUABaseServer<OPCUADiscoveryServerEv
             return sendError(StatusCodes.BadDiscoveryUrlMissing);
         }
 
-        // BadServerUriInvalid
-        // TODO
+        // BadServerUriInvalid (serverUri vs certificate ApplicationUri) is enforced
+        // by #checkRegistrationChannel before we get here.
         // #endregion
 
         if (!discoveryConfigurations) {

--- a/packages/node-opcua-server-discovery/source/opcua_discovery_server.ts
+++ b/packages/node-opcua-server-discovery/source/opcua_discovery_server.ts
@@ -307,12 +307,11 @@ export class OPCUADiscoveryServer extends OPCUABaseServer<OPCUADiscoveryServerEv
 
         // c8 ignore next
         doDebug && debugLog("Shutting down Discovery Server");
+        // OPCUAServerEndPoint#shutdown only calls back once the listening socket has emitted
+        // 'close', so the port is free when this resolves: no extra delay is needed.
         await new Promise<void>((resolve, reject) => super.shutdown((err) => (err ? reject(err) : resolve())));
         // c8 ignore next
         doDebug && debugLog("stopping announcement of LDS on mDNS - DONE");
-        // add a extra delay to ensure that the port is really closed
-        // and registered server propagated the fact that LDS is not here anymore
-        await new Promise<void>((resolve) => setTimeout(resolve, 1000));
     }
 
     /**

--- a/packages/node-opcua-server/source/register_server_manager.ts
+++ b/packages/node-opcua-server/source/register_server_manager.ts
@@ -84,22 +84,20 @@ function findSecureEndpoint(endpoints: EndpointDescription[]): EndpointDescripti
         return e.transportProfileUri === "http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary";
     });
 
-    endpoints = endpoints.filter((e: EndpointDescription) => {
-        return e.securityMode === MessageSecurityMode.SignAndEncrypt;
-    });
+    // prefer SignAndEncrypt, then Sign, then None: filter the full list at each step,
+    // not the (already empty) result of the previous step
+    const byMode = (securityMode: MessageSecurityMode) =>
+        endpoints.filter((e: EndpointDescription) => e.securityMode === securityMode);
 
-    if (endpoints.length === 0) {
-        endpoints = endpoints.filter((e: EndpointDescription) => {
-            return e.securityMode === MessageSecurityMode.Sign;
-        });
+    let candidates = byMode(MessageSecurityMode.SignAndEncrypt);
+    if (candidates.length === 0) {
+        candidates = byMode(MessageSecurityMode.Sign);
     }
-    if (endpoints.length === 0) {
-        endpoints = endpoints.filter((e: EndpointDescription) => {
-            return e.securityMode === MessageSecurityMode.None;
-        });
+    if (candidates.length === 0) {
+        candidates = byMode(MessageSecurityMode.None);
     }
-    endpoints = sortEndpointBySecurityLevel(endpoints);
-    return endpoints[0];
+    candidates = sortEndpointBySecurityLevel(candidates);
+    return candidates[0] ?? null;
 }
 
 function constructRegisteredServer(server: IPartialServer, isOnline: boolean): RegisteredServerOptions {

--- a/packages/node-opcua/source/server-stuff.ts
+++ b/packages/node-opcua/source/server-stuff.ts
@@ -6,4 +6,8 @@ export * from "node-opcua-address-space";
 export * from "node-opcua-certificate-manager";
 export * from "node-opcua-server";
 
-export { OPCUADiscoveryServer } from "node-opcua-server-discovery";
+export {
+    OPCUADiscoveryServer,
+    type OPCUADiscoveryServerOptions,
+    type RegistrationRefusedInfo
+} from "node-opcua-server-discovery";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3694,6 +3694,9 @@ importers:
       node-opcua-common:
         specifier: 2.181.0
         version: link:../node-opcua-common
+      node-opcua-crypto:
+        specifier: 5.10.1
+        version: 5.10.1
       node-opcua-debug:
         specifier: 2.181.0
         version: link:../node-opcua-debug


### PR DESCRIPTION
## Summary

Bring `OPCUADiscoveryServer` in line with OPC UA Part 4 §5.5.5 / §5.5.6 for `RegisterServer` / `RegisterServer2`: the services "can only be invoked via SecureChannels that support Client authentication", and "Discovery Servers shall reject registrations if the serverUri provided does not match the applicationUri in the Certificate used to create the SecureChannel". Neither check was enforced.

## Changes

| Commit | What |
|---|---|
| `fix(lds)` | Registration gate: `Bad_SecurityModeInsufficient` on a `MessageSecurityMode.None` channel, `Bad_ServerUriInvalid` when `serverUri` is not in the certificate SubjectAltName. LDS default store no longer auto-trusts unknown certificates (UA-LDS default, Part 12 §5.3.5). Opt-ins `allowUnsecuredRegistration` and `automaticallyAcceptUnknownCertificate`, both off. New `onRegistrationRefused` event and refusal log (Part 4 audit requirement). Also fixes plain `RegisterServer` with `isOnline: true` failing in the mDNS announcer on an empty `mdnsServerName`. |
| `fix(server)` | `RegisterServerManager.findSecureEndpoint` fallbacks to `Sign` / `None` were dead code (filtered an already-empty list). |
| `test(discovery)` | DISCO4-J failed in full runs but passed alone: stale certificates in the persistent temp stores no longer matched a regenerated store key. The helper now recreates a certificate that does not match the key. |
| `perf(lds)` | Removes the one-second sleep at the end of `OPCUADiscoveryServer.shutdown`; endpoint shutdown already awaits the listener `close`. |

`Bad_ServiceUnsupported` is deliberately not used for the refusal: Part 4 §5.5.6 tells callers receiving it to fall back to `RegisterServer`.

## Breaking change

Deployments relying on the default LDS trust behaviour must trust each registering server's certificate once (move it from `rejected` to `trusted/certs`; the LDS logs both paths at startup). `OPCUAServer` already registers over `SignAndEncrypt`, so nothing changes on the server side. `FindServers`, `FindServersOnNetwork` and `GetEndpoints` stay available without message security (Part 4 §5.5.1).

## Tests

- DISCO1: existing cases now run over a trusted `SignAndEncrypt` channel; new DISCO1-4 to DISCO1-9 cover accept, None refusal for both services, the opt-in, URI mismatch, and reject-then-trust.
- Full discovery suite: 43 passing, 0 failing (baseline on `origin/master`: DISCO4-J failing with the stale-certificate error).
- `pnpm check:ports`: 225 fixed ports, no collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
