### PR TITLE
fix(server): keep a disabled subscription alive beside its siblings (Publish regression since 963aa003)

### DIFF
--- a/packages/node-opcua-server/source/server_publish_engine.ts
+++ b/packages/node-opcua-server/source/server_publish_engine.ts
@@ -188,6 +188,9 @@ export class ServerSidePublishEngine extends EventEmitter implements IServerSide
     // subscriptions of this session instead of letting whichever one ticks first monopolize the queue
     #serveSequence = 0;
     #lastServedAt = new WeakMap<Subscription, number>();
+    // valid PublishResponses sent so far: feedReadySubscriptions' measure of progress, which the
+    // queue length is not when the client re-sends its next Publish from the response callback
+    #responseCount = 0;
 
     constructor(options?: ServerSidePublishEngineOptions) {
         super();
@@ -479,23 +482,51 @@ export class ServerSidePublishEngine extends EventEmitter implements IServerSide
         }
     }
 
-    #_pickMostDeservingReadySubscription(): Subscription | null {
+    /**
+     * A subscription is *ready* when it may publish notifications now. A disabled one never is:
+     * SetPublishingMode(false) makes it hold its notifications back and owe nothing but keep-alives
+     * (Part 4 5.13.4), so its queued samples must neither qualify nor disqualify it here.
+     */
+    static #isReady(subscription: Subscription): boolean {
+        return (
+            subscription.publishingEnabled &&
+            (subscription.hasPendingNotifications || subscription.hasUncollectedMonitoredItemNotifications)
+        );
+    }
+
+    /**
+     * A subscription with nothing to publish whose keep-alive deadline has passed: its own tick
+     * found no PublishRequest when the keep-alive fell due (server_subscription.ts
+     * #_process_keepAlive). It goes first whatever its priority: a keep-alive is one small message
+     * per maxKeepAliveCount cycles, while a missed one has the client give the subscription up
+     * (FEAT-35: the CTT's Publish timed out on a disabled subscription beside a busy sibling).
+     */
+    static #owesKeepAlive(subscription: Subscription): boolean {
+        return !ServerSidePublishEngine.#isReady(subscription) && subscription.keepAliveCounterHasExpired;
+    }
+
+    #_pickMostDeservingSubscription(exhausted: Set<Subscription>): Subscription | null {
         let best: Subscription | null = null;
+        let bestOwesKeepAlive = false;
         let bestLastServed = Number.POSITIVE_INFINITY;
         for (const subscription of this.subscriptions) {
-            if (!subscription.publishingEnabled) {
+            if (exhausted.has(subscription)) {
                 continue;
             }
-            if (!subscription.hasPendingNotifications && !subscription.hasUncollectedMonitoredItemNotifications) {
+            const owesKeepAlive = ServerSidePublishEngine.#owesKeepAlive(subscription);
+            if (!owesKeepAlive && !ServerSidePublishEngine.#isReady(subscription)) {
                 continue;
             }
             const lastServed = this.#lastServedAt.get(subscription) ?? -1;
-            if (
+            const deservesMore =
                 !best ||
-                subscription.priority > best.priority ||
-                (subscription.priority === best.priority && lastServed < bestLastServed)
-            ) {
+                (owesKeepAlive && !bestOwesKeepAlive) ||
+                (owesKeepAlive === bestOwesKeepAlive &&
+                    (subscription.priority > best.priority ||
+                        (subscription.priority === best.priority && lastServed < bestLastServed)));
+            if (deservesMore) {
                 best = subscription;
+                bestOwesKeepAlive = owesKeepAlive;
                 bestLastServed = lastServed;
             }
         }
@@ -503,23 +534,31 @@ export class ServerSidePublishEngine extends EventEmitter implements IServerSide
     }
 
     /**
-     * Feed every queued PublishRequest to the most deserving ready subscription of this session
-     * (highest priority, then whoever has waited longest since its last turn), instead of letting
-     * a subscription serve itself from server_subscription.ts#_tick just because its own timer
-     * happened to fire first. See FEAT-24.
+     * Feed the queued PublishRequests to the most deserving subscriptions of this session -
+     * overdue keep-alives first, then the ready ones by priority, then whoever has waited longest
+     * since its last turn - instead of letting a subscription serve itself from
+     * server_subscription.ts#_tick just because its own timer happened to fire first (FEAT-24).
+     *
+     * One pass serves at most the requests queued when it starts: a client that re-sends its next
+     * Publish synchronously from the response callback must not keep this loop spinning. A
+     * subscription that cannot use a request right now (still inside its first publishing cycle,
+     * say) is set aside so the others still get their turn (FEAT-35).
      */
     public feedReadySubscriptions(): void {
-        while (this.pendingPublishRequestCount > 0) {
-            const subscription = this.#_pickMostDeservingReadySubscription();
+        let budget = this.pendingPublishRequestCount;
+        const exhausted = new Set<Subscription>();
+        while (budget > 0 && this.pendingPublishRequestCount > 0) {
+            const subscription = this.#_pickMostDeservingSubscription(exhausted);
             if (!subscription) {
                 break;
             }
-            const countBefore = this.pendingPublishRequestCount;
+            const responsesBefore = this.#responseCount;
             subscription.process_subscription();
-            if (this.pendingPublishRequestCount >= countBefore) {
-                // no progress: avoid spinning forever on a subscription that cannot actually consume a slot
-                break;
+            if (this.#responseCount === responsesBefore) {
+                exhausted.add(subscription);
+                continue;
             }
+            budget -= 1;
             this.#lastServedAt.set(subscription, ++this.#serveSequence);
         }
     }
@@ -680,8 +719,9 @@ export class ServerSidePublishEngine extends EventEmitter implements IServerSide
             traceLog("send_keep_alive_response  => invalid subscriptionId = ", subscriptionId);
             return false;
         }
-        // let check if we have available PublishRequest to send the keep alive
-        if (this.pendingPublishRequestCount === 0 || subscription.hasPendingNotifications) {
+        // let check if we have available PublishRequest to send the keep alive; a disabled
+        // subscription holds its pending notifications back, so they never stand in the way of its keep-alive
+        if (this.pendingPublishRequestCount === 0 || (subscription.publishingEnabled && subscription.hasPendingNotifications)) {
             // we cannot send the keep alive PublishResponse
             traceLog(
                 "send_keep_alive_response  => cannot send keep-alive  (no PublishRequest left) subscriptionId = ",
@@ -752,6 +792,7 @@ export class ServerSidePublishEngine extends EventEmitter implements IServerSide
         _assertValidPublishData(publishData);
         // xx assert(response.responseHeader.requestHandle !== 0,"expecting a valid requestHandle");
         response.results = publishData.results;
+        this.#responseCount += 1;
         this._send_response_for_request(publishData, response);
     }
 }

--- a/packages/node-opcua-server/source/server_subscription.ts
+++ b/packages/node-opcua-server/source/server_subscription.ts
@@ -1746,10 +1746,14 @@ export class Subscription extends EventEmitter {
         // c8 ignore next
         doDebug && debugLog("Subscription#_tick  self._pending_notifications= ", this._pending_notifications.size);
 
-        if (
-            publishEngine.pendingPublishRequestCount === 0 &&
-            (this.hasPendingNotifications || this.hasUncollectedMonitoredItemNotifications)
-        ) {
+        // A disabled subscription holds its notifications back (SetPublishingMode, Part 4 5.13.4)
+        // and owes nothing but its keep-alive, under its own id: what its monitored items have
+        // queued must neither make it LATE nor send it to the engine's arbitration, which only
+        // serves subscriptions that may publish (FEAT-35: CTT Subscription Basic 014/044/046/048).
+        const hasNotificationsToPublish =
+            this.publishingEnabled && (this.hasPendingNotifications || this.hasUncollectedMonitoredItemNotifications);
+
+        if (publishEngine.pendingPublishRequestCount === 0 && hasNotificationsToPublish) {
             // c8 ignore next
             doDebug &&
                 debugLog(
@@ -1764,7 +1768,7 @@ export class Subscription extends EventEmitter {
         }
 
         if (publishEngine.pendingPublishRequestCount > 0) {
-            if (this.hasPendingNotifications || this.hasUncollectedMonitoredItemNotifications) {
+            if (hasNotificationsToPublish) {
                 // A sibling subscription on this same session may deserve the next queued
                 // PublishRequest more (higher priority, or waited longer at equal priority).
                 // Let the engine arbitrate across every ready subscription it owns instead of

--- a/packages/node-opcua-server/test/test_publish_engine_keep_alive_arbitration.ts
+++ b/packages/node-opcua-server/test/test_publish_engine_keep_alive_arbitration.ts
@@ -1,0 +1,362 @@
+/**
+ * FEAT-35: a subscription that owes a keep-alive must still be served once the session's
+ * PublishRequests are arbitrated across subscriptions (FEAT-24, 963aa003).
+ *
+ * The OPC Foundation CTT scripts behind these tests (all pass on 2.181.1, all fail on master
+ * at 325ccdfbf): Subscription Basic 014 (PublishingEnabled=FALSE -> a keep-alive under that
+ * subscription's own id), 044 (SetPublishingMode re-enables -> the queued data change is
+ * delivered), 046/048 and Subscription Minimum 02 009/011/013/024/Err-003 (several
+ * subscriptions in one session -> Publish answered BadTimeout because nobody served it).
+ */
+import { SessionContext } from "node-opcua-address-space";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { StatusCodes } from "node-opcua-status-code";
+import { DataChangeNotification, PublishRequest, PublishResponse, type ServiceFault } from "node-opcua-types";
+import sinon from "sinon";
+import { ServerSidePublishEngine, Subscription, type SubscriptionOptions } from "../source/index.js";
+import { add_mock_monitored_item } from "./helper.js";
+
+const publishingInterval = 100;
+const maxKeepAliveCount = 3;
+
+function makeSubscription(engine: ServerSidePublishEngine, options: Partial<SubscriptionOptions> & { id: number }) {
+    const subscription = new Subscription({
+        publishingInterval,
+        lifeTimeCount: 1000,
+        maxKeepAliveCount,
+        priority: 0,
+        publishEngine: engine,
+        globalCounter: { totalMonitoredItemCount: 0 },
+        serverCapabilities: { maxMonitoredItems: 10000, maxMonitoredItemsPerSubscription: 1000 },
+        ...options
+    });
+    (subscription as unknown as { $session: { sessionContext: SessionContext } }).$session = {
+        sessionContext: SessionContext.defaultContext
+    };
+    engine.add_subscription(subscription);
+    return subscription;
+}
+
+interface Answer {
+    handle: number;
+    sentAt: number;
+    answeredAt: number;
+    response: PublishResponse | ServiceFault;
+}
+
+function isKeepAlive(response: PublishResponse | ServiceFault): boolean {
+    return (
+        response instanceof PublishResponse &&
+        response.responseHeader.serviceResult.equals(StatusCodes.Good) &&
+        (response.notificationMessage.notificationData?.length ?? 0) === 0
+    );
+}
+function isDataChange(response: PublishResponse | ServiceFault): boolean {
+    return (
+        response instanceof PublishResponse &&
+        (response.notificationMessage.notificationData ?? []).some((n) => n instanceof DataChangeNotification)
+    );
+}
+
+/**
+ * A client that keeps exactly one PublishRequest in flight, re-sending on every response after a
+ * setImmediate (the network round trip), which is how the CTT drives the Publish service.
+ */
+function makeClient(engine: ServerSidePublishEngine, timeoutHint: number) {
+    const answers: Answer[] = [];
+    const inFlight = new Map<number, number>();
+    let handle = 0;
+    let stopped = false;
+
+    function send(): number {
+        const requestHandle = ++handle;
+        inFlight.set(requestHandle, Date.now());
+        engine._on_PublishRequest(new PublishRequest({ requestHeader: { requestHandle, timeoutHint } }), (_request, response) => {
+            answers.push({
+                handle: requestHandle,
+                sentAt: inFlight.get(requestHandle) ?? Number.NaN,
+                answeredAt: Date.now(),
+                response
+            });
+            inFlight.delete(requestHandle);
+            if (!stopped) {
+                setImmediate(send);
+            }
+        });
+        return requestHandle;
+    }
+    return {
+        answers,
+        inFlight,
+        send,
+        stop() {
+            stopped = true;
+        }
+    };
+}
+
+describe("FEAT-35 keep-alives survive the per-session PublishRequest arbitration", function (this: Mocha.Suite) {
+    const test = this as unknown as { clock: sinon.SinonFakeTimers };
+
+    beforeEach(() => {
+        test.clock = sinon.useFakeTimers();
+    });
+    afterEach(() => {
+        test.clock.restore();
+    });
+
+    // the keep-alive deadline from the client's point of view: maxKeepAliveCount cycles, plus
+    // the cycle a request may have to wait for the subscription's next tick
+    const keepAliveDeadline = (maxKeepAliveCount + 1) * publishingInterval;
+
+    function cycles(n: number) {
+        for (let i = 0; i < n; i++) {
+            test.clock.tick(publishingInterval);
+        }
+    }
+
+    it("FEAT-35-A a subscription created with PublishingEnabled=false answers Publish with a keep-alive under its own id (CTT Subscription Basic 014)", () => {
+        const engine = new ServerSidePublishEngine();
+        const disabled = makeSubscription(engine, { id: 7, publishingEnabled: false });
+        // the CTT monitors a node on it: the item queues its initial value, which a disabled
+        // subscription must hold back
+        add_mock_monitored_item(disabled);
+        const client = makeClient(engine, 10 * keepAliveDeadline);
+        try {
+            client.send();
+            test.clock.tick(0);
+            // the first message goes out at the end of the first publishing cycle (Part 4 5.13.1)
+            cycles(1);
+            client.answers.length.should.eql(1);
+            client.answers[0].response.responseHeader.serviceResult.should.eql(StatusCodes.Good);
+            isKeepAlive(client.answers[0].response).should.eql(true);
+            (client.answers[0].response as PublishResponse).subscriptionId.should.eql(disabled.id);
+
+            // and then one keep-alive every maxKeepAliveCount cycles, never a data change,
+            // never a request left waiting beyond the keep-alive deadline
+            cycles(6 * maxKeepAliveCount);
+            client.stop();
+            client.answers.length.should.be.greaterThanOrEqual(6);
+            for (const answer of client.answers) {
+                isKeepAlive(answer.response).should.eql(true, `handle ${answer.handle}`);
+                (answer.response as PublishResponse).subscriptionId.should.eql(disabled.id);
+                (answer.answeredAt - answer.sentAt).should.be.lessThanOrEqual(keepAliveDeadline, `handle ${answer.handle}`);
+            }
+        } finally {
+            client.stop();
+            disabled.terminate();
+            disabled.dispose();
+            engine.shutdown();
+            engine.dispose();
+        }
+    });
+
+    it("FEAT-35-B a disabled subscription keeps sending keep-alives while a higher priority sibling publishes data every cycle", () => {
+        const engine = new ServerSidePublishEngine();
+        // registered first, so its timer fires first in every cycle: the worst case for the sibling
+        const busy = makeSubscription(engine, { id: 1, priority: 10 });
+        const idle = makeSubscription(engine, { id: 2, priority: 0, publishingEnabled: false });
+        const busyItem = add_mock_monitored_item(busy);
+        add_mock_monitored_item(idle);
+        const client = makeClient(engine, 10 * keepAliveDeadline);
+        try {
+            client.send();
+            test.clock.tick(0);
+            const nbCycles = 6 * maxKeepAliveCount;
+            for (let i = 0; i < nbCycles; i++) {
+                busyItem.simulateMonitoredItemAddingNotification();
+                test.clock.tick(publishingInterval);
+            }
+            client.stop();
+
+            const idleKeepAlives = client.answers.filter(
+                (a) => a.response instanceof PublishResponse && a.response.subscriptionId === idle.id
+            );
+            const busyData = client.answers.filter(
+                (a) => a.response instanceof PublishResponse && a.response.subscriptionId === busy.id
+            );
+            for (const answer of client.answers) {
+                answer.response.responseHeader.serviceResult.should.eql(StatusCodes.Good, `handle ${answer.handle}`);
+                (answer.answeredAt - answer.sentAt).should.be.lessThanOrEqual(keepAliveDeadline, `handle ${answer.handle}`);
+            }
+            for (const answer of idleKeepAlives) {
+                isKeepAlive(answer.response).should.eql(true, `handle ${answer.handle}`);
+            }
+            // one keep-alive per maxKeepAliveCount cycles, give or take the cycle lost to the sibling
+            idleKeepAlives.length.should.be.greaterThanOrEqual(nbCycles / maxKeepAliveCount - 2);
+            // ... and the busy subscription still gets the lion's share
+            busyData
+                .filter((a) => isDataChange(a.response))
+                .length.should.be.greaterThanOrEqual(nbCycles - idleKeepAlives.length - 2);
+        } finally {
+            client.stop();
+            busy.terminate();
+            busy.dispose();
+            idle.terminate();
+            idle.dispose();
+            engine.shutdown();
+            engine.dispose();
+        }
+    });
+
+    it("FEAT-35-C two disabled subscriptions in one session each answer Publish with their own keep-alive, none times out (CTT Subscription Basic 046/048)", () => {
+        const engine = new ServerSidePublishEngine();
+        const first = makeSubscription(engine, { id: 1, priority: 5, publishingEnabled: false });
+        const second = makeSubscription(engine, { id: 2, priority: 0, publishingEnabled: false });
+        add_mock_monitored_item(first);
+        add_mock_monitored_item(second);
+        // the CTT's default timeout is comfortably above one keep-alive interval
+        const client = makeClient(engine, 2 * keepAliveDeadline);
+        try {
+            client.send();
+            test.clock.tick(0);
+            cycles(8 * maxKeepAliveCount);
+            client.stop();
+
+            const byId = (id: number) =>
+                client.answers.filter((a) => a.response instanceof PublishResponse && a.response.subscriptionId === id);
+            for (const answer of client.answers) {
+                answer.response.responseHeader.serviceResult.should.eql(StatusCodes.Good, `handle ${answer.handle}`);
+                isKeepAlive(answer.response).should.eql(true, `handle ${answer.handle}`);
+                (answer.answeredAt - answer.sentAt).should.be.lessThanOrEqual(keepAliveDeadline, `handle ${answer.handle}`);
+            }
+            byId(first.id).length.should.be.greaterThanOrEqual(6);
+            byId(second.id).length.should.be.greaterThanOrEqual(6);
+            client.inFlight.size.should.eql(1);
+        } finally {
+            client.stop();
+            first.terminate();
+            first.dispose();
+            second.terminate();
+            second.dispose();
+            engine.shutdown();
+            engine.dispose();
+        }
+    });
+
+    it("FEAT-35-D SetPublishingMode(true) on a disabled subscription delivers the queued data change on the next Publish (CTT Subscription Basic 044)", () => {
+        const engine = new ServerSidePublishEngine();
+        const subscription = makeSubscription(engine, { id: 3, publishingEnabled: false });
+        const item = add_mock_monitored_item(subscription);
+        const client = makeClient(engine, 10 * keepAliveDeadline);
+        try {
+            client.send();
+            test.clock.tick(0);
+            cycles(1);
+            // while disabled: keep-alives only, whatever the item queues
+            item.simulateMonitoredItemAddingNotification();
+            cycles(maxKeepAliveCount);
+            client.answers.length.should.be.greaterThanOrEqual(2);
+            for (const answer of client.answers) {
+                isKeepAlive(answer.response).should.eql(true, `handle ${answer.handle}`);
+                (answer.response as PublishResponse).subscriptionId.should.eql(subscription.id);
+            }
+            const answeredWhileDisabled = client.answers.length;
+
+            // the client has one Publish in flight (re-sent after the last keep-alive; sinon puts a
+            // zero-delay timer created during a tick at now + 1, so tick(1) rather than tick(0))
+            test.clock.tick(1);
+            client.inFlight.size.should.eql(1);
+            subscription.setPublishingMode(true).should.eql(StatusCodes.Good);
+            cycles(1);
+            const afterEnable = client.answers.slice(answeredWhileDisabled);
+            afterEnable.length.should.be.greaterThanOrEqual(1);
+            isDataChange(afterEnable[0].response).should.eql(
+                true,
+                "expected the queued data change on the first Publish after enabling"
+            );
+            (afterEnable[0].response as PublishResponse).subscriptionId.should.eql(subscription.id);
+        } finally {
+            client.stop();
+            subscription.terminate();
+            subscription.dispose();
+            engine.shutdown();
+            engine.dispose();
+        }
+    });
+
+    it("FEAT-35-F a subscription disabled while it still holds harvested notifications is kept alive until it is enabled again", () => {
+        const engine = new ServerSidePublishEngine();
+        // one notification per Publish: a backlog of three leaves two harvested but unsent
+        const subscription = makeSubscription(engine, { id: 4, maxNotificationsPerPublish: 1 });
+        const item = add_mock_monitored_item(subscription);
+        const client = makeClient(engine, 10 * keepAliveDeadline);
+        try {
+            client.send();
+            test.clock.tick(0);
+            cycles(1);
+            item.simulateMonitoredItemAddingNotification();
+            item.simulateMonitoredItemAddingNotification();
+            item.simulateMonitoredItemAddingNotification();
+            cycles(1);
+            client.answers.filter((a) => isDataChange(a.response)).length.should.be.greaterThanOrEqual(2);
+            subscription.hasPendingNotifications.should.eql(true);
+
+            subscription.setPublishingMode(false).should.eql(StatusCodes.Good);
+            const answeredBefore = client.answers.length;
+            cycles(3 * maxKeepAliveCount);
+            const whileDisabled = client.answers.slice(answeredBefore);
+            whileDisabled.length.should.be.greaterThanOrEqual(2);
+            for (const answer of whileDisabled) {
+                isKeepAlive(answer.response).should.eql(true, `handle ${answer.handle}`);
+                (answer.response as PublishResponse).subscriptionId.should.eql(subscription.id);
+                (answer.answeredAt - answer.sentAt).should.be.lessThanOrEqual(keepAliveDeadline, `handle ${answer.handle}`);
+            }
+            subscription.hasPendingNotifications.should.eql(true);
+
+            test.clock.tick(1);
+            client.inFlight.size.should.eql(1);
+            subscription.setPublishingMode(true).should.eql(StatusCodes.Good);
+            const answeredWhileDisabled = client.answers.length;
+            cycles(1);
+            const afterEnable = client.answers.slice(answeredWhileDisabled);
+            afterEnable.length.should.be.greaterThanOrEqual(1);
+            isDataChange(afterEnable[0].response).should.eql(
+                true,
+                "the held-back notifications go out once publishing is enabled again"
+            );
+        } finally {
+            client.stop();
+            subscription.terminate();
+            subscription.dispose();
+            engine.shutdown();
+            engine.dispose();
+        }
+    });
+
+    it("FEAT-35-E an enabled but idle low-priority subscription is still kept alive beside a busy high-priority one", () => {
+        const engine = new ServerSidePublishEngine();
+        const busy = makeSubscription(engine, { id: 1, priority: 10 });
+        const idle = makeSubscription(engine, { id: 2, priority: 0 });
+        const busyItem = add_mock_monitored_item(busy);
+        const client = makeClient(engine, 10 * keepAliveDeadline);
+        try {
+            client.send();
+            test.clock.tick(0);
+            const nbCycles = 6 * maxKeepAliveCount;
+            for (let i = 0; i < nbCycles; i++) {
+                busyItem.simulateMonitoredItemAddingNotification();
+                test.clock.tick(publishingInterval);
+            }
+            client.stop();
+            const idleAnswers = client.answers.filter(
+                (a) => a.response instanceof PublishResponse && a.response.subscriptionId === idle.id
+            );
+            for (const answer of client.answers) {
+                answer.response.responseHeader.serviceResult.should.eql(StatusCodes.Good, `handle ${answer.handle}`);
+                (answer.answeredAt - answer.sentAt).should.be.lessThanOrEqual(keepAliveDeadline, `handle ${answer.handle}`);
+            }
+            idleAnswers
+                .filter((a) => isKeepAlive(a.response))
+                .length.should.be.greaterThanOrEqual(nbCycles / maxKeepAliveCount - 2);
+        } finally {
+            client.stop();
+            busy.terminate();
+            busy.dispose();
+            idle.terminate();
+            idle.dispose();
+            engine.shutdown();
+            engine.dispose();
+        }
+    });
+});


### PR DESCRIPTION
## Why

Regression on master versus 2.181.1, caught by the OPC Foundation CTT (1.05.513, Embedded selection) on 2026-09-07: nine Publish scripts that pass on 2.181.1 fail on master. Subscription Basic 014 ("PublishingEnabled=FALSE": the keep-alive came back under another subscription's id), 044 (re-enabling a subscription: "Expected DataChanges! got false"), 046, 048 and Subscription Minimum 02 009, 011, 013, 024, Err-003 (`Publish ... BadTimeout`).

Measured attribution with the new tests (A to F):

| build | outcome |
|---|---|
| origin/master 325ccdfb | A, B, C, D fail (C with the CTT's `BadTimeout`) |
| master minus 963aa003 | all pass |
| master minus 3b406eac and 8d9e1302, 963aa003 kept | A, B, C, D fail |

So 963aa003 ("serve the highest-priority ready subscription first") alone explains all nine scripts. Root cause in `server_subscription.ts#_tick`: since that commit any subscription with pending or uncollected notifications is sent to `feedReadySubscriptions`, whose picker skips `!publishingEnabled`. A disabled subscription with a monitored item always holds uncollected samples, so it was never processed: its keep-alive counter never advanced, no keep-alive under its id, its Publish waited until the client timeout, and on re-enable the held data went out on a stale request while the fresh Publish got a keep-alive. Before 963aa003, `_tick` called `process_subscription()`, whose first branch is `!publishingEnabled -> _process_keepAlive()`. An enabled idle subscription was never affected (test E passes on master).

Tracked as FEAT-35 on the CTT board (project 7).

## What

The design of 963aa003 is kept.

- `server_subscription.ts#_tick`: `hasNotificationsToPublish = publishingEnabled && (pending || uncollected)`. A disabled subscription is neither made LATE nor sent to the arbitration; it takes the `_process_keepAlive` route under its own id.
- `server_publish_engine.ts#feedReadySubscriptions`: overdue keep-alives first (nothing to publish and `keepAliveCounterHasExpired`), then ready subscriptions by priority, then longest-since-served. Progress is measured by a valid-response counter instead of queue length (a client re-sending synchronously from the callback made the old check see "no progress"); a subscription that cannot use a request is set aside instead of ending the pass; one pass serves at most the requests queued when it started.
- `send_keep_alive_response`: a disabled subscription's already-harvested notifications no longer block its keep-alive.
- New `test/test_publish_engine_keep_alive_arbitration.ts`: six tests (real engine, sinon fake timers, a client keeping one Publish in flight like the CTT): keep-alive for a disabled subscription under its own id; two subscriptions with one idle, no request left unanswered past the keep-alive deadline; re-enable then data change delivered; the BadTimeout scenario; enabled idle subscription unaffected; keep-alive not blocked by harvested notifications.

Deliberately not changed: `findLateSubscriptions` (request-arrival feeding) is not extended to disabled subscriptions, so an overdue keep-alive on an all-disabled session still waits for the next tick, at most one publishing interval, the same latency as 2.181.1.

## Verification

- `node-opcua-server` suite: 520 passing, 0 failing, the two FEAT-24 priority tests included.
- `tsc -b` for the package and the whole `packages` tree clean; test typecheck clean; biome, `check:shortcircuit`, `check-test-ports --summary` clean.
- e2e series E (SubscriptionUseCase): 69 passing, 1 failing, "should extend subscription lifetime", which fails 2 runs of 3 on master as well (a 100 ms real-clock margin), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
