### PR TITLE
fix(address-space): narrow an instance DataType to the one its type declares

### DIFF
--- a/packages/node-opcua-address-space/api/index.ts
+++ b/packages/node-opcua-address-space/api/index.ts
@@ -156,6 +156,7 @@ export * from "./interfaces/state_machine/ua_transition_ex.js";
 export * from "./interfaces/ua_subscription_diagnostics_variable_ex.js";
 export { ensureDatatypeExtracted, ensureDatatypeExtractedWithCallback } from "./loader/ensure_datatype_extracted.js";
 export * from "./loader/generateAddressSpaceRaw.js";
+export { type NarrowedDataType, narrowInstanceDataTypes } from "./loader/narrow_instance_datatypes.js";
 export {
     isNdjsonHeaderLine,
     NDJSON_IMAGE_FORMAT,

--- a/packages/node-opcua-address-space/api/loader/load_nodeset2.ts
+++ b/packages/node-opcua-address-space/api/loader/load_nodeset2.ts
@@ -15,6 +15,7 @@ import type { NamespacePrivate } from "../../impl/namespace_private.js";
 import type { NodeSetLoaderOptions } from "../interfaces/nodeset_loader_options.js";
 import { ensureDatatypeExtracted } from "./ensure_datatype_extracted.js";
 import { promoteObjectsAndVariables } from "./namespace_post_step.js";
+import { narrowInstanceDataTypes } from "./narrow_instance_datatypes.js";
 import { type NodesetRecord, type NodesetRecordProducer, type NodesetRecordWithBytes, recordBytes } from "./nodeset_record.js";
 import type { PendingBackReferences } from "./nodeset_record_applier.js";
 import { type LoaderTaskQueues, makeLoaderTaskQueues, NodesetRecordApplier, type Task } from "./nodeset_record_applier.js";
@@ -256,6 +257,10 @@ export class NodeSetLoader {
                 "assigning extension objects to variables",
                 queues.postTasks2_AssignedExtensionObjectToDataValue
             );
+
+            doDebug && debugLog(chalk.bgGreenBright("Narrowing instance DataTypes to their declaration ---------------------"));
+            // after the values are in: a value that would not fit the declared type keeps the variable as it is
+            narrowInstanceDataTypes(addressSpace1);
 
             doDebug && debugLog(chalk.bgGreenBright("Performing post variable initialization ---------------------"));
             // awaited: a promoter that throws must reject generateAddressSpace, not surface later

--- a/packages/node-opcua-address-space/api/loader/narrow_instance_datatypes.ts
+++ b/packages/node-opcua-address-space/api/loader/narrow_instance_datatypes.ts
@@ -1,0 +1,264 @@
+/**
+ * @module node-opcua-address-space
+ */
+import type {
+    BaseNode,
+    IAddressSpace,
+    UADataType,
+    UAObject,
+    UAObjectType,
+    UAReferenceType,
+    UAVariable,
+    UAVariableType
+} from "node-opcua-address-space-base";
+import { BrowseDirection, NodeClass, type QualifiedName } from "node-opcua-data-model";
+import { checkDebugFlag, make_debugLog } from "node-opcua-debug";
+import { type NodeId, sameNodeId } from "node-opcua-nodeid";
+import { DataType } from "node-opcua-variant";
+import type { NamespacePrivate } from "../../impl/namespace_private.js";
+
+const doDebug = checkDebugFlag("narrow_instance_datatypes");
+const debugLog = make_debugLog("narrow_instance_datatypes");
+
+type UAType = UAObjectType | UAVariableType;
+type UAInstance = UAObject | UAVariable;
+
+function isType(node: BaseNode): node is UAType {
+    return node.nodeClass === NodeClass.ObjectType || node.nodeClass === NodeClass.VariableType;
+}
+function isInstance(node: BaseNode): node is UAInstance {
+    return node.nodeClass === NodeClass.Object || node.nodeClass === NodeClass.Variable;
+}
+
+/**
+ * the type definition of an instance, resolved without the ObjectType/VariableType guards of the
+ * typed getters: a companion nodeset with a wrong type definition must not abort the sweep
+ */
+function typeDefinitionOf(addressSpace: IAddressSpace, node: UAInstance): UAType | null {
+    const typeDefinition: NodeId | undefined = node.typeDefinition;
+    if (!typeDefinition || typeDefinition.isEmpty()) {
+        return null;
+    }
+    const typeNode = addressSpace.findNode(typeDefinition);
+    return typeNode && isType(typeNode) ? typeNode : null;
+}
+
+/**
+ * the members a type declares, by browse name, looked up along its supertype chain and its
+ * interfaces the way `instantiate` collects them (see impl/_instantiate_helpers.ts); the answer
+ * is cached per (type, browse name) so a sweep over thousands of instances of the same type
+ * walks the chain once per member
+ */
+class DeclarationIndex {
+    private readonly cache = new Map<string, BaseNode | null>();
+    /** absent from a standard nodeset older than 1.04: then no type has interfaces to look into */
+    private readonly hasInterface: UAReferenceType | null;
+    private readonly hasModellingRule: UAReferenceType;
+
+    constructor(
+        private readonly addressSpace: IAddressSpace,
+        hasModellingRule: UAReferenceType
+    ) {
+        this.hasInterface = addressSpace.findReferenceType("HasInterface") ?? null;
+        this.hasModellingRule = hasModellingRule;
+    }
+
+    /**
+     * whether `declared` is a member declaration a variable instance must honour: a variable with
+     * a modelling rule (Mandatory, Optional, ...). A type child without one is not instantiated by
+     * Part 3 and is left alone.
+     */
+    public isVariableDeclaration(declared: BaseNode): declared is UAVariable {
+        return (
+            declared.nodeClass === NodeClass.Variable &&
+            declared.findReferencesEx(this.hasModellingRule, BrowseDirection.Forward).length > 0
+        );
+    }
+
+    public find(type: UAType, browseName: QualifiedName): BaseNode | null {
+        const key = `${type.nodeId.toString()}|${browseName.toString()}`;
+        const cached = this.cache.get(key);
+        if (cached !== undefined) {
+            return cached;
+        }
+        const found = this.walk(type, browseName, new Set<string>());
+        this.cache.set(key, found);
+        return found;
+    }
+
+    private walk(type: UAType, browseName: QualifiedName, visited: Set<string>): BaseNode | null {
+        const typeKey = type.nodeId.toString();
+        if (visited.has(typeKey)) {
+            return null;
+        }
+        visited.add(typeKey);
+        const child = type.getChildByName(browseName);
+        if (child) {
+            return child;
+        }
+        const interfaces = this.hasInterface ? type.findReferencesEx(this.hasInterface, BrowseDirection.Forward) : [];
+        for (const reference of interfaces) {
+            const interfaceType = reference.node ?? this.addressSpace.findNode(reference.nodeId);
+            if (interfaceType && isType(interfaceType)) {
+                const declared = this.walk(interfaceType, browseName, visited);
+                if (declared) {
+                    return declared;
+                }
+            }
+        }
+        const superType = type.subtypeOfObj as UAType | null;
+        return superType ? this.walk(superType, browseName, visited) : null;
+    }
+}
+
+// a parent chain deeper than this is a cycle in a broken nodeset, not a model
+const MAX_DEPTH = 64;
+
+/**
+ * the node of a type definition that declares this instance member, or null when no type in
+ * the instance's ancestry declares one under its browse name.
+ *
+ * The declaration is looked up in the type definition of the containing instance first; a
+ * member nested below a declared member (an object declared by the type with children of its
+ * own, whose own type definition says nothing about them) is found through the declaration of
+ * its container instead.
+ */
+function declarationOf(addressSpace: IAddressSpace, index: DeclarationIndex, node: UAInstance, depth: number): BaseNode | null {
+    if (depth > MAX_DEPTH) {
+        return null;
+    }
+    const parent = node.parent;
+    // a node under a type is a declaration itself, never an instance to narrow
+    if (!parent || isType(parent)) {
+        return null;
+    }
+    const parentIsInstance = isInstance(parent);
+    if (parentIsInstance) {
+        const parentType = typeDefinitionOf(addressSpace, parent);
+        if (parentType) {
+            const declared = index.find(parentType, node.browseName);
+            if (declared) {
+                return declared;
+            }
+        }
+    }
+    // the container may itself be a declared member (an instance, or a method) whose declaration
+    // carries the member; a method has no type definition and is resolved the same way
+    if (parentIsInstance || parent.nodeClass === NodeClass.Method) {
+        const parentDeclaration = declarationOf(addressSpace, index, parent as UAInstance, depth + 1);
+        if (parentDeclaration) {
+            return parentDeclaration.getChildByName(node.browseName);
+        }
+    }
+    return null;
+}
+
+function findDataTypeNode(addressSpace: IAddressSpace, nodeId: NodeId): UADataType | null {
+    if (!nodeId || nodeId.isEmpty()) {
+        return null;
+    }
+    return addressSpace.findDataType(nodeId) ?? null;
+}
+
+/** where a variable keeps the built-in type it derived from its DataType (see impl/get_basic_datatype.ts) */
+interface VariableWithBasicDataTypeCache {
+    _basicDataType?: DataType | null;
+}
+
+export interface NarrowedDataType {
+    node: UAVariable;
+    from: NodeId;
+    to: NodeId;
+}
+
+/**
+ * make every instance variable's DataType at least as narrow as its declaration.
+ *
+ * OPC 10000-3 lets an instance use the DataType its type definition declares for the member, or
+ * a subtype of it; a supertype is not conformant. Companion nodesets that predate a narrowing
+ * of the standard types carry the supertype anyway (every NamespaceMetadata object written
+ * against UA 1.04 declares `ModelVersion` as String, which UA 1.05 narrowed to
+ * SemanticVersionString), so every server loading them fails the type-conformance check of
+ * the CTT (Base Info Core Structure) and no server can fix it per nodeset. The declared type is
+ * what the model means: an instance whose DataType is a strict supertype of the declared one is
+ * moved to the declared one.
+ *
+ * Nothing else moves: an instance whose DataType is the declared one, a subtype of it, or
+ * unrelated is left alone, values are never touched, and the children of types are declarations,
+ * not instances. A variable whose current value would not fit the declared built-in type is
+ * left alone as well, and reported: narrowing it would make the value lie about its type.
+ *
+ * @returns the variables that were narrowed
+ */
+export function narrowInstanceDataTypes(addressSpace: IAddressSpace): NarrowedDataType[] {
+    const narrowed: NarrowedDataType[] = [];
+    // a nodeset without these cannot declare a member, let alone the DataType of one: a
+    // minimal fixture, or a standard nodeset still to come. Nothing to narrow, and the lookups
+    // below would throw on the first missing reference type.
+    const hasModellingRule = addressSpace.findReferenceType("HasModellingRule");
+    if (
+        !hasModellingRule ||
+        !addressSpace.findReferenceType("HasSubtype") ||
+        !addressSpace.findReferenceType("HasChild") ||
+        !addressSpace.findReferenceType("HierarchicalReferences")
+    ) {
+        return narrowed;
+    }
+    const index = new DeclarationIndex(addressSpace, hasModellingRule);
+
+    for (const namespace of addressSpace.getNamespaceArray()) {
+        for (const node of (namespace as NamespacePrivate).nodeIterator()) {
+            if (node.nodeClass !== NodeClass.Variable) {
+                continue;
+            }
+            const variable = node as UAVariable;
+            const declared = declarationOf(addressSpace, index, variable, 0);
+            if (!declared || !index.isVariableDeclaration(declared)) {
+                continue;
+            }
+            if (sameNodeId(variable.dataType, declared.dataType)) {
+                continue;
+            }
+            const instanceDataType = findDataTypeNode(addressSpace, variable.dataType);
+            const declaredDataType = findDataTypeNode(addressSpace, declared.dataType);
+            if (!instanceDataType || !declaredDataType) {
+                continue;
+            }
+            // a subtype of the declaration, or an unrelated type: not this sweep's business
+            if (!declaredDataType.isSubtypeOf(instanceDataType)) {
+                continue;
+            }
+            const value = variable.readValue().value;
+            const declaredBuiltInType = declaredDataType.basicDataType;
+            const valueFits =
+                value.dataType === DataType.Null ||
+                declaredBuiltInType === DataType.Variant ||
+                value.dataType === declaredBuiltInType;
+            if (!valueFits) {
+                debugLog(
+                    `not narrowing ${variable.nodeId.toString()} ${variable.browseName.toString()}: ` +
+                        `its value is a ${DataType[value.dataType]}, the declared ${declaredDataType.browseName.toString()} ` +
+                        `is a ${DataType[declaredBuiltInType]}`
+                );
+                continue;
+            }
+            const from = variable.dataType;
+            variable.dataType = declaredDataType.nodeId;
+            (variable as unknown as VariableWithBasicDataTypeCache)._basicDataType = null;
+            narrowed.push({ node: variable, from, to: declaredDataType.nodeId });
+            // c8 ignore next
+            if (doDebug) {
+                debugLog(
+                    `narrowed the DataType of ${variable.nodeId.toString()} ${variable.browseName.toString()} ` +
+                        `from ${instanceDataType.browseName.toString()} (${from.toString()}) ` +
+                        `to the declared ${declaredDataType.browseName.toString()} (${declaredDataType.nodeId.toString()})`
+                );
+            }
+        }
+    }
+    // c8 ignore next
+    if (doDebug && narrowed.length > 0) {
+        debugLog(`narrowed the DataType of ${narrowed.length} instance variable(s) to the one their type declares`);
+    }
+    return narrowed;
+}

--- a/packages/node-opcua-address-space/test/fixtures/nodeset_catalog_xml_digests.json
+++ b/packages/node-opcua-address-space/test/fixtures/nodeset_catalog_xml_digests.json
@@ -6,8 +6,8 @@
   },
   "di": {
     "uri": "http://opcfoundation.org/UA/DI/",
-    "length": 299604,
-    "sha1": "38772a7a9d56c702fadae32f449d342ad3ea0a60"
+    "length": 299680,
+    "sha1": "ff730d196bc29100df4d2c9c8703b0345a39097a"
   },
   "adi": {
     "uri": "http://opcfoundation.org/UA/ADI/",

--- a/packages/node-opcua-address-space/test/test_narrow_instance_datatypes.ts
+++ b/packages/node-opcua-address-space/test/test_narrow_instance_datatypes.ts
@@ -1,0 +1,254 @@
+import { AttributeIds, NodeClass } from "node-opcua-data-model";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { resolveNodeId, sameNodeId } from "node-opcua-nodeid";
+import { nodesets } from "node-opcua-nodesets";
+import { DataType } from "node-opcua-variant";
+import should from "should";
+import {
+    AddressSpace,
+    narrowInstanceDataTypes,
+    type UADataType,
+    type UAObject,
+    type UAObjectType,
+    type UAVariable
+} from "../dist/api/index.js";
+import { generateAddressSpace } from "../nodeJS.js";
+
+const SemanticVersionString = resolveNodeId("i=24263");
+const String_ = resolveNodeId("i=12");
+const DI_URI = "http://opcfoundation.org/UA/DI/";
+
+function dataTypeAttribute(variable: UAVariable) {
+    const dataValue = variable.readAttribute(null, AttributeIds.DataType);
+    dataValue.value.dataType.should.eql(DataType.NodeId);
+    return dataValue.value.value;
+}
+
+/**
+ * every member of the NamespaceMetadata objects whose DataType is a strict supertype of what
+ * NamespaceMetadataType declares for it: what OPC 10000-3 forbids and the CTT reports
+ */
+function namespaceMetadataMembersWiderThanDeclared(addressSpace: AddressSpace): string[] {
+    const metadataType = addressSpace.findObjectType("NamespaceMetadataType");
+    should.exist(metadataType);
+    const namespaces = addressSpace.findNode("i=11715") as UAObject;
+    should.exist(namespaces);
+    const offenders: string[] = [];
+    for (const namespaceObject of namespaces.getComponents()) {
+        for (const member of namespaceObject.findReferencesExAsObject("Aggregates")) {
+            if (member.nodeClass !== NodeClass.Variable) {
+                continue;
+            }
+            const declared = metadataType!.getChildByName(member.browseName) as UAVariable | null;
+            if (!declared || declared.nodeClass !== NodeClass.Variable) {
+                continue;
+            }
+            const instanceDataType = addressSpace.findDataType((member as UAVariable).dataType) as UADataType;
+            const declaredDataType = addressSpace.findDataType(declared.dataType) as UADataType;
+            if (sameNodeId(instanceDataType.nodeId, declaredDataType.nodeId)) {
+                continue;
+            }
+            if (declaredDataType.isSubtypeOf(instanceDataType)) {
+                offenders.push(
+                    `${namespaceObject.browseName.toString()}/${member.browseName.toString()}: ` +
+                        `${instanceDataType.browseName.toString()} wider than ${declaredDataType.browseName.toString()}`
+                );
+            }
+        }
+    }
+    return offenders;
+}
+
+describe("narrowing instance DataTypes to their declaration at load", function (this: Mocha.Suite) {
+    this.timeout(200000);
+
+    describe("the DI nodeset over the standard one", () => {
+        let addressSpace: AddressSpace;
+        before(async () => {
+            addressSpace = AddressSpace.create();
+            await generateAddressSpace(addressSpace, [nodesets.standard, nodesets.di]);
+        });
+        after(() => {
+            addressSpace.dispose();
+        });
+
+        it("NamespaceMetadataType still declares ModelVersion as SemanticVersionString", () => {
+            const metadataType = addressSpace.findObjectType("NamespaceMetadataType")!;
+            const declared = metadataType.getChildByName("ModelVersion") as UAVariable;
+            should.exist(declared);
+            declared.dataType.toString().should.eql(SemanticVersionString.toString());
+        });
+
+        it("the DI namespace ModelVersion, declared String by the DI nodeset, reads SemanticVersionString", () => {
+            const di = addressSpace.getNamespaceIndex(DI_URI);
+            di.should.be.greaterThan(0);
+            const modelVersion = addressSpace.findNode(`ns=${di};i=489`) as UAVariable;
+            should.exist(modelVersion);
+            should(modelVersion.browseName.name).eql("ModelVersion");
+            modelVersion.dataType.toString().should.eql(SemanticVersionString.toString());
+            dataTypeAttribute(modelVersion).toString().should.eql(SemanticVersionString.toString());
+        });
+
+        it("its value is untouched: still the String 1.5.0", () => {
+            const di = addressSpace.getNamespaceIndex(DI_URI);
+            const modelVersion = addressSpace.findNode(`ns=${di};i=489`) as UAVariable;
+            const dataValue = modelVersion.readValue();
+            dataValue.statusCode.isGood().should.eql(true);
+            dataValue.value.dataType.should.eql(DataType.String);
+            dataValue.value.value.should.eql("1.5.0");
+        });
+
+        it("a second sweep finds nothing left to narrow", () => {
+            narrowInstanceDataTypes(addressSpace).should.eql([]);
+        });
+    });
+
+    describe("what the sweep leaves alone", () => {
+        let addressSpace: AddressSpace;
+        let objectType: UAObjectType;
+        let instance: UAObject;
+        before(async () => {
+            addressSpace = AddressSpace.create();
+            await generateAddressSpace(addressSpace, [nodesets.standard]);
+            const namespace = addressSpace.registerNamespace("urn:feat32");
+
+            objectType = namespace.addObjectType({ browseName: "Feat32Type" });
+            namespace.addVariable({
+                browseName: "Version",
+                dataType: "SemanticVersionString",
+                modellingRule: "Mandatory",
+                propertyOf: objectType
+            });
+            namespace.addVariable({
+                browseName: "Measure",
+                dataType: "Double",
+                modellingRule: "Optional",
+                propertyOf: objectType
+            });
+            namespace.addVariable({
+                browseName: "Anything",
+                dataType: "Number",
+                modellingRule: "Optional",
+                propertyOf: objectType
+            });
+            namespace.addVariable({
+                browseName: "Tag",
+                dataType: "SemanticVersionString",
+                modellingRule: "Optional",
+                propertyOf: objectType
+            });
+            // a member nested below a declared member whose own type says nothing about it
+            const group = namespace.addObject({
+                browseName: "Group",
+                componentOf: objectType,
+                modellingRule: "Mandatory",
+                typeDefinition: "FolderType"
+            });
+            namespace.addVariable({
+                browseName: "GroupVersion",
+                dataType: "SemanticVersionString",
+                modellingRule: "Mandatory",
+                propertyOf: group
+            });
+
+            // the instance is assembled by hand, with the DataTypes a companion nodeset could carry
+            instance = namespace.addObject({
+                browseName: "Feat32Instance",
+                organizedBy: addressSpace.rootFolder.objects,
+                typeDefinition: objectType
+            });
+            const add = (browseName: string, dataType: string, value?: { dataType: DataType; value: unknown }) =>
+                namespace.addVariable({ browseName, dataType, propertyOf: instance, value });
+            add("Version", "String", { dataType: DataType.String, value: "1.0.0" });
+            add("Measure", "Number", { dataType: DataType.Int32, value: 42 });
+            add("Anything", "Double", { dataType: DataType.Double, value: 1.5 });
+            add("Tag", "Int32", { dataType: DataType.Int32, value: 7 });
+            const instanceGroup = namespace.addObject({ browseName: "Group", componentOf: instance, typeDefinition: "FolderType" });
+            namespace.addVariable({
+                browseName: "GroupVersion",
+                dataType: "String",
+                propertyOf: instanceGroup,
+                value: { dataType: DataType.String, value: "2.0.0" }
+            });
+        });
+        after(() => {
+            addressSpace.dispose();
+        });
+
+        let narrowed: ReturnType<typeof narrowInstanceDataTypes>;
+        before(() => {
+            narrowed = narrowInstanceDataTypes(addressSpace);
+        });
+
+        it("narrows a member whose DataType is a strict supertype of the declared one", () => {
+            const version = instance.getPropertyByName("Version") as UAVariable;
+            version.dataType.toString().should.eql(SemanticVersionString.toString());
+            version.readValue().value.value.should.eql("1.0.0");
+        });
+
+        it("narrows a member nested below a declared member, through the container's declaration", () => {
+            const group = instance.getComponentByName("Group") as UAObject;
+            const version = group.getPropertyByName("GroupVersion") as UAVariable;
+            version.dataType.toString().should.eql(SemanticVersionString.toString());
+        });
+
+        it("leaves a member whose DataType is a subtype of the declared one", () => {
+            const anything = instance.getPropertyByName("Anything") as UAVariable;
+            anything.dataType.toString().should.eql(resolveNodeId("Double").toString());
+        });
+
+        it("leaves a member whose DataType is unrelated to the declared one", () => {
+            const tag = instance.getPropertyByName("Tag") as UAVariable;
+            tag.dataType.toString().should.eql(resolveNodeId("Int32").toString());
+            tag.readValue().value.value.should.eql(7);
+        });
+
+        it("leaves a member whose value would not fit the declared built-in type", () => {
+            const measure = instance.getPropertyByName("Measure") as UAVariable;
+            measure.dataType.toString().should.eql(resolveNodeId("Number").toString());
+            measure.readValue().value.dataType.should.eql(DataType.Int32);
+        });
+
+        it("leaves the declarations of the type itself", () => {
+            const declared = objectType.getPropertyByName("Version") as UAVariable;
+            declared.dataType.toString().should.eql(SemanticVersionString.toString());
+            const measure = objectType.getPropertyByName("Measure") as UAVariable;
+            measure.dataType.toString().should.eql(resolveNodeId("Double").toString());
+        });
+
+        it("reports exactly the nodes it moved", () => {
+            narrowed
+                .map((n) => `${n.node.browseName.name}:${n.from.toString()}->${n.to.toString()}`)
+                .sort()
+                .should.eql([
+                    `GroupVersion:${String_.toString()}->${SemanticVersionString.toString()}`,
+                    `Version:${String_.toString()}->${SemanticVersionString.toString()}`
+                ]);
+        });
+
+        it("has nothing left to do on a second pass", () => {
+            narrowInstanceDataTypes(addressSpace).should.eql([]);
+        });
+    });
+
+    describe("the companion nodesets", () => {
+        it("no NamespaceMetadata member is wider than NamespaceMetadataType declares, after loading standard + DI + ADI + more", async () => {
+            const addressSpace = AddressSpace.create();
+            try {
+                await generateAddressSpace(addressSpace, [
+                    nodesets.standard,
+                    nodesets.di,
+                    nodesets.adi,
+                    nodesets.autoId,
+                    nodesets.ia,
+                    nodesets.machinery,
+                    nodesets.gds
+                ]);
+                namespaceMetadataMembersWiderThanDeclared(addressSpace).should.eql([]);
+                narrowInstanceDataTypes(addressSpace).should.eql([]);
+            } finally {
+                addressSpace.dispose();
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Why

The OPC Foundation CTT (1.05.513, Base Info Core Structure 2 / 001.js) reports on a server that loads the DI companion nodeset over UA 1.05.07:

```
ERROR: Attribute.DataType (i=12) or the DataType of the Value (Value: 1.5.0 ...) of current Instance (ns=2;i=489)
doesn't match the expectation (BuiltInType.i=24263)
```

`ns=2;i=489` is `Server/Namespaces/http://opcfoundation.org/UA/DI/` → `ModelVersion`, declared `DataType="String"` in Opc.Ua.Di.NodeSet2.xml 1.05.0, while UA 1.05.07 declares `NamespaceMetadataType.ModelVersion` as `SemanticVersionString` (i=24263), a subtype of String. Part 3 requires an instance's DataType to be the declared one or a subtype; a supertype is not conformant, and every companion nodeset written before that change carries the same String declaration, so a server cannot fix it per nodeset.

Tracked as FEAT-32 on the CTT board (project 7).

## What

`packages/node-opcua-address-space/api/loader/narrow_instance_datatypes.ts` (new), run once by `generateAddressSpace` after the variable-initialisation tasks and before `promoteObjectsAndVariables`:

- For every Variable of every namespace, find its declaration: the containing instance's type definition first (cached per type and browse name, walking supertypes and `HasInterface` the way `_instantiate_helpers.ts` does), else the container's own declaration's child for nested members. A declaration must be a Variable with a modelling rule.
- Narrow only when the declared DataType is a strict subtype of the instance's, and only when the current value's built-in type already matches the declared one (a value that would then lie about its type is left alone and logged at debug level). Same or subtype DataTypes, unrelated ones, values and type nodes are never touched. Sets `variable.dataType` and clears the basic-data-type cache, the two writes `changeDataType` does minus its value rewrite.
- On standard 1.05.07 + DI + ADI + AutoID + IA + Machinery + Robotics + MachineVision + GDS exactly one node moves: DI `ModelVersion`. The others predate `ModelVersion`, GDS already uses i=24263, `NamespaceVersion` is still String in the type. Nothing in ns=0 moves. Cost: 15 to 60 ms.
- Skips cleanly on nodesets without `HasModellingRule`, `HasSubtype`, `HasChild` or `HierarchicalReferences` (pre-1.04 or minimal fixtures), which the suite exercised.
- `toNodeset2XML()` of a loaded DI now writes `DataType="SemanticVersionString"` with its alias; the golden-digest fixture is regenerated (only the `di` entry changed).

## Tests

`test/test_narrow_instance_datatypes.ts`, 13 tests: DI ModelVersion's DataType attribute is i=24263 and its value still reads as String "1.5.0"; synthetic type with declared members (direct and nested); untouched subtype, unrelated and type-declaration cases; the value guard; the exact narrowed list; idempotence; and a sweep over standard + DI + ADI + AutoID + IA + Machinery + GDS asserting no NamespaceMetadata member is wider than the type declares. Full `node-opcua-address-space` suite: 1307 passing, 1 pending, 0 failing. Build green, biome clean.

Note: `check:shortcircuit` reports 8 pre-existing hits in `test_nodeset_format_registry.ts` on master; #1639 fixes them, this branch does not touch that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
