### PR TITLE
fix(alarms): a re-evaluated certificate alarm stays silent when nothing changed (Subscription Minimum 02)

### DIFF
--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_certificate_expiration_alarm_impl.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_certificate_expiration_alarm_impl.ts
@@ -72,6 +72,23 @@ class UACertificateExpirationAlarmImplBase extends UASystemOffNormalAlarmImpl im
     }
 
     public updateAlarmState2(isActive: boolean, severity: number, message: string) {
+        // A Condition reports its state *changes* (Part 9 5.5.2). This alarm is re-evaluated on
+        // timers - its own every half hour, push certificate management every minute - and a
+        // re-evaluation that finds the same verdict must stay silent: it used to raise a new
+        // "certificate ... is OK!" event on the Server object at every check, an unsolicited
+        // event every minute on any server with push certificate management installed (FEAT-24:
+        // CTT Subscription Minimum 02 020 subscribes to the Server events and expects none while
+        // it only writes to plain variables).
+        const branch = this.currentBranch();
+        if (
+            branch &&
+            branch.getActiveState() === isActive &&
+            branch.getSeverity() === severity &&
+            (branch.getMessage()?.text || "") === message
+        ) {
+            return;
+        }
+
         isActive ? this.activateAlarm() : this.deactivateAlarm();
 
         this.raiseNewCondition({

--- a/packages/node-opcua-address-space/test/alarms_and_conditions/test_certificate_alarm.ts
+++ b/packages/node-opcua-address-space/test/alarms_and_conditions/test_certificate_alarm.ts
@@ -135,6 +135,54 @@ describe("Test Certificate alarm", function (this: Mocha.Suite) {
         certificate1.currentBranch().getSeverity().should.eql(199);
     });
 
+    it("FEAT-24 should stay silent when a re-evaluation finds the certificate in the same state", () => {
+        // push certificate management re-evaluates the alarm every minute and the alarm itself
+        // every half hour: a server left running used to raise a "certificate is OK!" event on the
+        // Server object at each check, which CTT Subscription Minimum 02 020 picks up as an
+        // event nobody asked for.
+        const namespace = addressSpace.getOwnNamespace();
+        const certificate1: UACertificateExpirationAlarmEx = instantiateCertificateExpirationAlarm(
+            namespace,
+            "CertificateExpirationAlarmType",
+            {
+                browseName: "CertificateExpirySilent",
+                conditionName: "ExpirySilent",
+                inputNode: NodeId.nullNodeId,
+                normalState: NodeId.nullNodeId,
+                conditionSource: null,
+                organizedBy: addressSpace.rootFolder.objects,
+                conditionOf: addressSpace.rootFolder.objects
+            }
+        );
+        const raiseEventSpy = sinon.spy();
+        addressSpace.rootFolder.objects.server.on("event", raiseEventSpy);
+        try {
+            // the first verdict is news
+            certificate1.setCertificate(ok);
+            raiseEventSpy.callCount.should.eql(1);
+            raiseEventSpy.getCall(0).args[0].message.value.text.should.match(/is OK/);
+
+            // the same verdict again, however it is reached, is not
+            certificate1.update();
+            certificate1.update();
+            certificate1.setCertificate(ok);
+            raiseEventSpy.callCount.should.eql(1);
+
+            // a change of verdict is news again, once
+            certificate1.setCertificate(out_of_date);
+            raiseEventSpy.callCount.should.eql(2);
+            raiseEventSpy.getCall(1).args[0].message.value.text.should.match(/has expired/);
+            certificate1.update();
+            raiseEventSpy.callCount.should.eql(2);
+
+            certificate1.setCertificate(ok);
+            raiseEventSpy.callCount.should.eql(3);
+            raiseEventSpy.getCall(2).args[0].message.value.text.should.match(/is OK/);
+        } finally {
+            addressSpace.rootFolder.objects.server.removeListener("event", raiseEventSpy);
+        }
+    });
+
     it("should update the alarm on a regular basis", () => {
         const namespace = addressSpace.getOwnNamespace();
         const certificate1: UACertificateExpirationAlarmEx = instantiateCertificateExpirationAlarm(

--- a/packages/node-opcua-server/test/test_server_publish_engine.ts
+++ b/packages/node-opcua-server/test/test_server_publish_engine.ts
@@ -1118,6 +1118,77 @@ describe("Testing the server publish engine", function (this: Mocha.Suite) {
         }
     });
 
+    for (const highFirst of [true, false]) {
+        it(`FEAT-24 a Publish arriving while two subscriptions are late goes to the higher priority one, created ${highFirst ? "first" : "second"}`, () => {
+            // The CTT (Subscription Minimum 02 005/007/008) leaves no Publish in flight while it
+            // writes and waits a publishing interval, so both subscriptions are LATE when the next
+            // Publish lands and the engine picks one on arrival, through
+            // #_find_starving_subscription. Its comparator used to return 1 or 0, never a negative
+            // number: sorted that way, two subscriptions keep their registration order and the one
+            // created second was served first whatever the priorities (certification runs
+            // 11654/11656/11660: "Expected <N> but got <N+1>" in all four analyses).
+            const publish_server = new ServerSidePublishEngine();
+            const make = (id: number, priority: number) =>
+                makeSubscription({
+                    id,
+                    publishingInterval: 500,
+                    lifeTimeCount: 1000,
+                    maxKeepAliveCount: 3,
+                    priority,
+                    publishEngine: publish_server,
+                    globalCounter: { totalMonitoredItemCount: 0 },
+                    serverCapabilities: { maxMonitoredItems: 10000, maxMonitoredItemsPerSubscription: 1000 }
+                });
+            const high = make(highFirst ? 1 : 2, 100);
+            const low = make(highFirst ? 2 : 1, 0);
+            publish_server.add_subscription(highFirst ? high : low);
+            publish_server.add_subscription(highFirst ? low : high);
+            const highItem = add_mock_monitored_item(high);
+            const lowItem = add_mock_monitored_item(low);
+            const served: number[] = [];
+            const publish = () =>
+                publish_server._on_PublishRequest(new PublishRequest(), (_request, response) => {
+                    served.push((response as PublishResponse).subscriptionId);
+                });
+            try {
+                // the initial values: one Publish each, then a keep-alive
+                publish();
+                publish();
+                publish();
+                test.clock.tick(500 * (high.maxKeepAliveCount + 1));
+                flushPending();
+                served.length.should.eql(3);
+                publish_server.pendingPublishRequestCount.should.eql(0);
+
+                for (let iteration = 0; iteration < 3; iteration++) {
+                    served.length = 0;
+                    // no Publish in flight for a few cycles: both subscriptions owe a keep-alive
+                    test.clock.tick(500 * (high.maxKeepAliveCount + 2));
+                    high.state.should.eql(SubscriptionState.LATE);
+                    low.state.should.eql(SubscriptionState.LATE);
+                    // the write, sampled by both, then one publishing interval
+                    highItem.simulateMonitoredItemAddingNotification();
+                    lowItem.simulateMonitoredItemAddingNotification();
+                    test.clock.tick(550);
+                    // the Publish arrives: priority, not creation order, decides
+                    publish();
+                    flushPending();
+                    served.should.eql([high.id]);
+                    publish();
+                    flushPending();
+                    served.should.eql([high.id, low.id]);
+                }
+            } finally {
+                low.terminate();
+                low.dispose();
+                high.terminate();
+                high.dispose();
+                publish_server.shutdown();
+                publish_server.dispose();
+            }
+        });
+    }
+
     it("ZDZ-J PublishRequest timeout, the publish engine shall return a publish response with serviceResult = BadTimeout when Publish requests have timed out", () => {
         const publish_server = new ServerSidePublishEngine();
 


### PR DESCRIPTION
## Why

Two findings of the OPC Foundation CTT (1.05.513), Subscription Minimum 02, tracked as FEAT-24 on the CTT board (project 7).

**005 / 007 / 008** ("Expected subscriptionId N to be the dominant subscription that is received first, most of the time"): the certification runs were built from `1c144098`, before the comparator fix in `9f486d1d`. The CTT keeps no Publish in flight while it writes and waits, so both subscriptions are keep-alive-overdue LATE when the next Publish arrives and the choice is made on arrival: `_on_PublishRequest` → `#_feed_late_subscription` → `#_find_starving_subscription` → `sort(compare_subscriptions)` → last element. With `s1.priority > s2.priority ? 1 : 0` the sort kept registration order, so the subscription created second was always served first whatever its priority. Measured with a fake-timer simulation of the CTT choreography: 0/36 phase combinations honour priority with the old comparator, 36/36 with master's, and 10/10 with a real server and client over SignAndEncrypt. This PR adds the regression test on the arrival path (two late subscriptions, high priority created first, then second); it fails on the old comparator.

**020** ("Event data received; did not expect to receive any events"): an event subscription on the Server object with the CTT's select clauses logged, on a stock server with push certificate management, one `CertificateExpirationAlarmType` event per minute, source `DefaultApplicationGroup`, "certificate ... is OK": `push_certificate_manager_helpers.ts` re-evaluates the alarm every 60 s and `UACertificateExpirationAlarmImpl.updateAlarmState2` raised a new condition event unconditionally. Part 9 has a Condition report state changes; a re-evaluation that changes nothing must stay silent.

## What

- `ua_certificate_expiration_alarm_impl.ts`: `updateAlarmState2` returns when active state, severity and message are unchanged; the "back to normal" and "about to expire" severity steps still raise.
- `test_certificate_alarm.ts`: a re-evaluation with an unchanged certificate raises no event.
- `test_server_publish_engine.ts`: two tests for a Publish arriving while two subscriptions of different priority are late.

## Verification

`node-opcua-server` suite 525 passing; `alarms_and_conditions` 84 passing; e2e subscriptions 6 and umbrella series B+C (conditions, audit events) 84 passing; biome, `check:shortcircuit` (3208 files), `check-test-ports --summary` clean. FEAT-35 and FEAT-37 tests remain green.

Outside this repo: the certification server's demo tank alarm oscillates every 200 ms and raises limit events on the Server object, the remaining spontaneous source for 020; handled in server-for-ctt-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
