### PR TITLE
feat(address-space): instantiate() honours options.references

### DIFF
--- a/packages/node-opcua-address-space-base/source/instantiate_options.ts
+++ b/packages/node-opcua-address-space-base/source/instantiate_options.ts
@@ -1,6 +1,6 @@
 import type { LocalizedTextLike, QualifiedNameLike } from "node-opcua-data-model";
 import type { NodeIdLike } from "node-opcua-nodeid";
-import type { BaseNode } from "./base_node.js";
+import type { AddReferenceOpts, BaseNode } from "./base_node.js";
 import type { ModellingRuleType } from "./modelling_rule_type.js";
 import type { INamespace } from "./namespace.js";
 
@@ -67,6 +67,24 @@ export interface InstantiateOptions {
      * @default: []
      */
     optionals?: string[];
+    /**
+     * additional references to create on the new node at construction time.
+     *
+     * Use it to link the instance to a parent through an aggregate reference
+     * that has no dedicated option (HasOrderedComponent, HasPhysicalComponent,
+     * HasContainedComponent, HasAttachedComponent ...):
+     *
+     * ```javascript
+     *   references: [{ referenceType: "HasOrderedComponent", isForward: false, nodeId: listNode }]
+     * ```
+     *
+     * Because the reference exists when the node is created, the NodeIdManager
+     * derives the symbolic name from that parent (`List_First`), exactly as it
+     * does for `componentOf`; adding the reference afterwards would leave the
+     * node named without its parent. Such a parent also counts when deciding
+     * whether modelling rules are copied (an instance declared inside a type).
+     */
+    references?: AddReferenceOpts[];
     /**
      * modellingRule
      */

--- a/packages/node-opcua-address-space/impl/ua_object_type_impl.ts
+++ b/packages/node-opcua-address-space/impl/ua_object_type_impl.ts
@@ -4,12 +4,12 @@
 
 import type {
     AddObjectOptions,
+    AddReferenceOpts,
     BaseNodeEvents,
     InstantiateObjectOptions,
     ISessionContext,
     UAObject,
-    UAObjectType,
-    UAReference
+    UAObjectType
 } from "node-opcua-address-space-base";
 import { assert } from "node-opcua-assert";
 import { AttributeIds, type LocalizedTextLike, NodeClass } from "node-opcua-data-model";
@@ -128,7 +128,10 @@ export class UAObjectTypeImpl extends BaseNodeImpl<BaseNodeEvents> implements UA
         const baseObjectType = addressSpace.findObjectType("BaseObjectType") as UAObjectType;
         assert(baseObjectType, "BaseObjectType must be defined in the address space");
 
-        const references: UAReference[] = [];
+        // caller-supplied references (typically an inverse aggregate reference to a
+        // parent that has no dedicated option, e.g. HasOrderedComponent) are created
+        // with the node, so the NodeIdManager sees the parent when naming it.
+        const references: AddReferenceOpts[] = options.references ? [...options.references] : [];
 
         const copyAlsoModellingRules = topMostParentIsObjectTypeOrVariableType(addressSpace, options);
 

--- a/packages/node-opcua-address-space/impl/ua_variable_type_impl.ts
+++ b/packages/node-opcua-address-space/impl/ua_variable_type_impl.ts
@@ -2,6 +2,7 @@
  * @module node-opcua-address-space
  */
 import type {
+    AddReferenceOpts,
     AddVariableOptions,
     BaseNode,
     BaseNodeEvents,
@@ -12,6 +13,7 @@ import type {
     UAMethod,
     UAObject,
     UAObjectType,
+    UAReferenceType,
     UAVariable,
     UAVariableType
 } from "node-opcua-address-space-base";
@@ -48,10 +50,47 @@ const errorLog = make_errorLog("ua_variable_type_impl");
 interface InstantiateS {
     propertyOf?: NodeIdLike | UAObject | UAObjectType | UAVariable | UAVariableType | UAMethod;
     componentOf?: NodeIdLike | BaseNode;
+    references?: AddReferenceOpts[];
     modellingRule?: ModellingRuleType;
     copyAlsoModellingRules?: boolean;
     copyAlsoAllOptionals?: boolean;
 }
+
+/**
+ * the parent given through `options.references` as an inverse aggregate
+ * reference (HasOrderedComponent, HasPhysicalComponent ...), if any.
+ * See InstantiateOptions.references.
+ */
+export function findAggregateParentInReferences(
+    addressSpace: AddressSpacePrivate,
+    references: AddReferenceOpts[] | undefined
+): BaseNode | null {
+    if (!references || references.length === 0) {
+        return null;
+    }
+    const aggregates = addressSpace.findReferenceType("Aggregates");
+    if (!aggregates) {
+        return null;
+    }
+    for (const ref of references) {
+        if (ref.isForward !== false) {
+            continue;
+        }
+        const referenceType =
+            typeof ref.referenceType === "object" && "nodeClass" in (ref.referenceType as object)
+                ? (ref.referenceType as UAReferenceType)
+                : addressSpace.findReferenceType(ref.referenceType as NodeIdLike);
+        if (!referenceType?.isSubtypeOf(aggregates)) {
+            continue;
+        }
+        const parent = addressSpace._coerceNode(ref.nodeId as BaseNode | NodeIdLike);
+        if (parent) {
+            return parent;
+        }
+    }
+    return null;
+}
+
 export function topMostParentIsObjectTypeOrVariableType(addressSpace: AddressSpacePrivate, options: InstantiateS): boolean {
     if (options.copyAlsoModellingRules) {
         return true;
@@ -60,7 +99,7 @@ export function topMostParentIsObjectTypeOrVariableType(addressSpace: AddressSpa
         return true;
     }
 
-    const parent = options.propertyOf || options.componentOf;
+    const parent = options.propertyOf || options.componentOf || findAggregateParentInReferences(addressSpace, options.references);
     if (!parent) {
         return false;
     }
@@ -292,6 +331,9 @@ export class UAVariableTypeImpl extends BaseNodeImpl<BaseNodeEvents> implements 
             nodeId: options.nodeId,
             notifierOf: options.notifierOf,
             organizedBy: options.organizedBy,
+            // see InstantiateOptions.references: created with the node so the
+            // NodeIdManager derives the symbolic name from that parent
+            references: options.references,
             typeDefinition: this.nodeId,
             value: options.value || defaultValue,
             valueRank
@@ -353,7 +395,11 @@ function hasChildWithBrowseName(parent: BaseNode, childBrowseName: QualifiedName
 }
 
 function getParent(addressSpace: IAddressSpace, options: InstantiateVariableOptions) {
-    const parent = options.componentOf || options.organizedBy;
+    const parent =
+        options.componentOf ||
+        options.organizedBy ||
+        findAggregateParentInReferences(addressSpace as AddressSpacePrivate, options.references) ||
+        undefined;
     if (parent instanceof NodeId) {
         return addressSpace.findNode(parent as NodeId);
     }

--- a/packages/node-opcua-address-space/test/test_instantiate_with_references.ts
+++ b/packages/node-opcua-address-space/test/test_instantiate_with_references.ts
@@ -1,0 +1,110 @@
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { nodesets } from "node-opcua-nodesets";
+import should from "should";
+import { AddressSpace, getSymbols, setSymbols, type UAObjectType, type UAVariableType } from "../dist/api/index.js";
+import { generateAddressSpace } from "../distNodeJS/index.js";
+
+/**
+ * instantiate() with `options.references`
+ *
+ * A child linked to its parent through an aggregate reference that has no
+ * dedicated option (HasOrderedComponent ...) must get that link at
+ * construction, so that:
+ *   - the NodeIdManager names it after its parent (`ListType_First`),
+ *   - modelling rules are copied when the parent lives inside a type.
+ * Before, instantiate() discarded a caller-supplied `references` array.
+ */
+describe("UAObjectType/UAVariableType instantiate with options.references", () => {
+    let addressSpace: AddressSpace;
+    let listType: UAObjectType;
+    let itemType: UAObjectType;
+    let sampleType: UAVariableType;
+
+    beforeEach(async () => {
+        addressSpace = AddressSpace.create();
+        addressSpace.registerNamespace("Private");
+        await generateAddressSpace(addressSpace, [nodesets.standard]);
+        const ns = addressSpace.getOwnNamespace();
+        setSymbols(ns, []);
+
+        listType = ns.addObjectType({ browseName: "ListType" });
+        itemType = ns.addObjectType({ browseName: "ItemType" });
+        ns.addVariable({
+            browseName: "Level",
+            dataType: "Double",
+            modellingRule: "Mandatory",
+            propertyOf: itemType
+        });
+        sampleType = ns.addVariableType({ browseName: "SampleType", dataType: "Double" });
+    });
+    afterEach(() => {
+        addressSpace.dispose();
+    });
+
+    it("UAObjectType.instantiate creates the HasOrderedComponent link and names the node after its parent", () => {
+        const first = itemType.instantiate({
+            browseName: "First",
+            modellingRule: "Mandatory",
+            references: [{ referenceType: "HasOrderedComponent", isForward: false, nodeId: listType.nodeId }]
+        });
+
+        const ordered = listType.findReferencesEx("HasOrderedComponent");
+        ordered.length.should.eql(1);
+        ordered[0].nodeId.toString().should.eql(first.nodeId.toString());
+        first.parentNodeId?.toString().should.eql(listType.nodeId.toString());
+
+        // the mandatory property was instantiated with its modelling rule copied
+        const level = first.getPropertyByName("Level");
+        should.exist(level);
+        level!.modellingRule!.should.eql("Mandatory");
+
+        const symbols = getSymbols(addressSpace.getOwnNamespace());
+        const names = symbols.map((s) => s[0]);
+        names.should.containEql("ListType_First");
+        names.should.containEql("ListType_First_Level");
+        names.should.not.containEql("First");
+    });
+
+    it("UAVariableType.instantiate creates the HasOrderedComponent link and names the node after its parent", () => {
+        const first = sampleType.instantiate({
+            browseName: "FirstSample",
+            dataType: "Double",
+            modellingRule: "Optional",
+            references: [{ referenceType: "HasOrderedComponent", isForward: false, nodeId: listType.nodeId }]
+        });
+
+        const ordered = listType.findReferencesEx("HasOrderedComponent");
+        ordered.length.should.eql(1);
+        ordered[0].nodeId.toString().should.eql(first.nodeId.toString());
+        first.parentNodeId?.toString().should.eql(listType.nodeId.toString());
+
+        const names = getSymbols(addressSpace.getOwnNamespace()).map((s) => s[0]);
+        names.should.containEql("ListType_FirstSample");
+        names.should.not.containEql("FirstSample");
+    });
+
+    it("a duplicate browseName under the ordered parent is rejected", () => {
+        itemType.instantiate({
+            browseName: "First",
+            references: [{ referenceType: "HasOrderedComponent", isForward: false, nodeId: listType.nodeId }]
+        });
+        // the second node resolves to the same symbolic name, hence the same
+        // NodeId, and the namespace refuses to register it twice
+        should.throws(() => {
+            itemType.instantiate({
+                browseName: "First",
+                references: [{ referenceType: "HasOrderedComponent", isForward: false, nodeId: listType.nodeId }]
+            });
+        }, /already registered|already a child with browseName/);
+    });
+
+    it("instantiate without references behaves as before (componentOf)", () => {
+        const holder = addressSpace
+            .getOwnNamespace()
+            .addObject({ browseName: "Holder", organizedBy: addressSpace.rootFolder.objects });
+        const first = itemType.instantiate({ browseName: "First", componentOf: holder });
+        first.parentNodeId?.toString().should.eql(holder.nodeId.toString());
+        const names = getSymbols(addressSpace.getOwnNamespace()).map((s) => s[0]);
+        names.should.containEql("Holder_First");
+    });
+});

--- a/packages/node-opcua-address-space/test/test_instantiate_with_references.ts
+++ b/packages/node-opcua-address-space/test/test_instantiate_with_references.ts
@@ -51,12 +51,14 @@ describe("UAObjectType/UAVariableType instantiate with options.references", () =
         const ordered = listType.findReferencesEx("HasOrderedComponent");
         ordered.length.should.eql(1);
         ordered[0].nodeId.toString().should.eql(first.nodeId.toString());
-        first.parentNodeId?.toString().should.eql(listType.nodeId.toString());
+        if (!first.parentNodeId) throw new Error("parentNodeId was not set");
+        first.parentNodeId.toString().should.eql(listType.nodeId.toString());
 
         // the mandatory property was instantiated with its modelling rule copied
         const level = first.getPropertyByName("Level");
-        should.exist(level);
-        level!.modellingRule!.should.eql("Mandatory");
+        if (!level) throw new Error("Level property was not instantiated");
+        if (!level.modellingRule) throw new Error("modelling rule was not copied");
+        level.modellingRule.should.eql("Mandatory");
 
         const symbols = getSymbols(addressSpace.getOwnNamespace());
         const names = symbols.map((s) => s[0]);
@@ -76,7 +78,8 @@ describe("UAObjectType/UAVariableType instantiate with options.references", () =
         const ordered = listType.findReferencesEx("HasOrderedComponent");
         ordered.length.should.eql(1);
         ordered[0].nodeId.toString().should.eql(first.nodeId.toString());
-        first.parentNodeId?.toString().should.eql(listType.nodeId.toString());
+        if (!first.parentNodeId) throw new Error("parentNodeId was not set");
+        first.parentNodeId.toString().should.eql(listType.nodeId.toString());
 
         const names = getSymbols(addressSpace.getOwnNamespace()).map((s) => s[0]);
         names.should.containEql("ListType_FirstSample");
@@ -103,7 +106,8 @@ describe("UAObjectType/UAVariableType instantiate with options.references", () =
             .getOwnNamespace()
             .addObject({ browseName: "Holder", organizedBy: addressSpace.rootFolder.objects });
         const first = itemType.instantiate({ browseName: "First", componentOf: holder });
-        first.parentNodeId?.toString().should.eql(holder.nodeId.toString());
+        if (!first.parentNodeId) throw new Error("parentNodeId was not set");
+        first.parentNodeId.toString().should.eql(holder.nodeId.toString());
         const names = getSymbols(addressSpace.getOwnNamespace()).map((s) => s[0]);
         names.should.containEql("Holder_First");
     });


### PR DESCRIPTION
## Summary

`UAObjectType.instantiate()` and `UAVariableType.instantiate()` now honour a caller-supplied `options.references`.

A child that must be linked to its parent through an aggregate reference with no dedicated option (`HasOrderedComponent`, `HasPhysicalComponent`, `HasContainedComponent`, `HasAttachedComponent`) could only be linked *after* construction. By then the `NodeIdManager` had already named the node without its parent chain (`First` instead of `ListType_First`), so a seeded symbol table could never match it and NodeIds churned on every regeneration. `instantiate()` built its own `references` array and silently discarded the one passed in.

## Changes

- `node-opcua-address-space-base`: `InstantiateOptions.references?: AddReferenceOpts[]`, documented as the way to give such a parent at construction.
- `ua_object_type_impl.ts`: the caller's references seed the array passed to `addObject`.
- `ua_variable_type_impl.ts`: `references` is passed to `addVariable` (it was not passed at all); `findAggregateParentInReferences()` lets `topMostParentIsObjectTypeOrVariableType()` and the duplicate-browse-name check see a parent given this way, so a child instantiated inside a type through `HasOrderedComponent` still copies its modelling rules.
- Test `test_instantiate_with_references.ts`: ordered object and variable children get the link at construction (`ParentNodeId` set, `listType.findReferencesEx("HasOrderedComponent")` sees them), the mandatory property is instantiated with its modelling rule, symbolic names are `ListType_First` / `ListType_First_Level`, a duplicate is rejected, and the `componentOf` path is unchanged.

No behaviour change for callers that do not pass `references`.

## Verification

- `pnpm run generate && pnpm run build`: clean.
- `node-opcua-address-space` mocha suite: 1325 passing, 1 pending, 0 failing (with the sample certificates generated by `npx pki demo --dev`).

## Noted, not changed

`hasChildWithBrowseName()` in `ua_variable_type_impl.ts` calls `findReferencesAsObject("HasChild", true)`, an exact match on the abstract `HasChild` type, so it never finds anything and the duplicate-child assertion in `assertUnusedChildBrowseName()` never fires. Switching it to `findReferencesExAsObject` makes it work, but an alarm-condition test then fails because its fixture instantiates a second `AlarmCondition1` on `Motor.RPM`. Left as is; worth a separate decision.

## Context

Found while round-tripping OPC 40501-1 (MachineTools) through the Sterfive OPC UA modeler, whose YAML loader creates ordered/physical/contained/attached components and seeds NodeIds from the working group's `NodeIds.csv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
