### PR TITLE
docs(json, uanodeset-json): READMEs for the two new packages

### DIFF
--- a/packages/node-opcua-json/README.md
+++ b/packages/node-opcua-json/README.md
@@ -1,0 +1,147 @@
+# node-opcua-json
+
+The **OPC UA JSON encoding**, OPC 10000-6 clause 5.4: encoders and decoders for every built-in
+type, for `Variant`, `DataValue` and `ExtensionObject`, across all four encoding schemes the
+specification has defined.
+
+see http://node-opcua.github.io/
+
+```bash
+npm install node-opcua-json
+```
+
+## Why
+
+JSON is how OPC UA data leaves the OPC UA world. It is the wire form of PubSub over MQTT and
+AMQP (OPC 10000-14), the form a `PubSubConfigurationDataType` is exchanged in, and the form a
+`Variant` takes inside an Annex I JSON nodeset. Anywhere a value has to survive a hop through a
+broker, a database or another vendor's stack, this is the encoding it travels in.
+
+The details are easy to get subtly wrong: a `UInt64` is a string, not a number; a NodeId carries
+a namespace **URI**, not the index it had in the source document; and the field names changed
+between 1.04 and 1.05. This package is the single place the SDK implements clause 5.4, so every
+consumer agrees on those answers.
+
+## Quick start
+
+```ts
+import { DataType, Variant } from "node-opcua-variant";
+import { JsonEncodingScheme, opcuaJsonEncodeVariant } from "node-opcua-json";
+
+const namespaceArray = ["http://opcfoundation.org/UA/"];
+const v = new Variant({ dataType: DataType.Byte, value: 42 });
+
+opcuaJsonEncodeVariant(v, JsonEncodingScheme.Compact, namespaceArray);
+// { UaType: 3, Value: 42 }
+
+opcuaJsonEncodeVariant(v, JsonEncodingScheme.DeprecatedReversible, namespaceArray);
+// { Type: 3, Body: 42 }
+
+opcuaJsonEncodeVariant(v, JsonEncodingScheme.DeprecatedNonReversible, namespaceArray);
+// 42
+```
+
+The `namespaceArray` is not decoration. NodeIds and QualifiedNames encode with their namespace
+URI, so both directions need the document's namespace table to map an index to a URI and back.
+Pass the array the document declares, not the one your address space happens to have.
+
+## The four schemes
+
+Part 6 has changed JSON encoding once, and both generations are in the field, so both are here.
+
+| `JsonEncodingScheme` | version | a `Variant` looks like |
+|---|---|---|
+| `DeprecatedNonReversible` | 1.04 | the bare value, with no type at all |
+| `DeprecatedReversible` | 1.04 | `{ Type, Body, Dimensions? }` |
+| `Verbose` | 1.05 | `{ UaType, Value, UaDimensions? }`, every field written |
+| `Compact` | 1.05 | the same, with every field equal to its type's default omitted |
+
+`JsonEncoderMode104` (`Reversible` / `NonReversible`) and `JsonEncoderMode105` (`Verbose` /
+`Compact`) are aliases into that same enum, so a 1.05-only API can take a parameter that cannot
+express a 1.04 mode. `toJsonEncodingScheme()` widens either back.
+
+Two consequences worth knowing before you diff output against another stack:
+
+- The 1.05 field names are `UaType` / `Value` / `UaDimensions`. They changed with the encoding,
+  so a 1.05 reader will not find `Type` or `Body`.
+- `Compact` omits defaults, so a `Byte` of `0` encodes as `{ UaType: 3 }` with no `Value` at all,
+  while `Verbose` writes `{ UaType: 3, Value: 0 }`. Decoding is unaffected; byte-for-byte
+  comparison against a Verbose writer is not.
+
+When a PubSub subscriber has to work out which scheme it is being sent,
+`JsonDataSetMessageContentMaskToJsonEncodingScheme` reads the two `FieldEncoding` bits of
+OPC 10000-14 Table 112, and `JsonEncodingSchemeToJsonDataSetMessageContentMask` writes them.
+
+## Decoding structures
+
+Decoding a `Variant` that contains a structure means constructing that structure, and only the
+caller knows how to find its class. That is the whole of the `ExtensionObjectBuilder` interface:
+
+```ts
+interface ExtensionObjectBuilder {
+    getExtensionObjectConstructor(dataTypeNodeId: NodeId): ExtensionObjectConstructorFuncWithSchema;
+}
+```
+
+```ts
+import { opcuaJsonDecodeVariant, type VariantJSON105 } from "node-opcua-json";
+
+const variant = opcuaJsonDecodeVariant(json as VariantJSON105, builder, namespaceArray);
+```
+
+For a model with custom structures, `builder` resolves the DataType NodeId against a live
+address space or a dynamically built factory. For a model with only built-in types, a builder
+that throws is enough, because it is never reached.
+
+Handing the whole thing over at once, when you already know the type:
+
+```ts
+import { PubSubConnectionDataType } from "node-opcua-types";
+import { decodeOPCUA_JSON } from "node-opcua-json";
+
+const config = decodeOPCUA_JSON(PubSubConnectionDataType, JSON.parse(text));
+config.address; // a NetworkAddressUrlDataType, reconstructed from its UaTypeId
+```
+
+The test suite reads configuration files produced by the .NET stack, so this path is checked
+against another implementation rather than only against itself.
+
+## API
+
+Every built-in type has an `opcuaJsonEncodeX` / `opcuaJsonDecodeX` pair, and each takes the
+scheme, so one call site serves all four.
+
+| area | exports |
+|---|---|
+| Variant | `opcuaJsonEncodeVariant`, `opcuaJsonDecodeVariant`, the `104` / `105` pairs, `VariantJSON`, `VariantJSON104`, `VariantJSON105` |
+| DataValue | `opcuaJsonEncodeDataValue`, `opcuaJsonDecodeDataValue`, `opcuaJsonEncodeDataValueMQTT`, `DataValueJSON105` |
+| ExtensionObject | `opcuaJsonEncodeExtensionObject`, `opcuaJsonDecodeExtensionObject`, the `...Body` pair, `makeBody`, `ExtensionObjectJSON104`, `ExtensionObjectJSON105` |
+| NodeId | `opcuaJsonEncodeNodeId`, `opcuaJsonDecodeNodeId`, the `ExpandedNodeId` pair, `opcuaJsonEncodeNodeIdAsString` |
+| scalars | `Int64`, `UInt64`, `ByteString`, `DateTime`, `LocalizedText`, `QualifiedName`, `StatusCode` |
+| structures | `decodeOPCUA_JSON`, `decodeOPCUA_JSONOld` |
+| schemes | `JsonEncodingScheme`, `JsonEncoderMode104`, `JsonEncoderMode105`, `toJsonEncodingScheme`, `makeDataValueEncodingEnum`, the two `JsonDataSetMessageContentMask` converters |
+| dispatch | `bodyEncodeFunctor(dataType)`, `bodyDecodeFunctor(dataType)`, `EncoderFunc`, `DecoderFunc`, `ExtensionObjectBuilder` |
+
+`opcuaJsonEncodeVariant` and `opcuaJsonDecodeVariant` are overloaded across all four schemes and
+so cannot express the 1.05 object shape for Verbose alone. Where you need that exact type, reach
+for the explicit `opcuaJsonEncodeVariant105` / `opcuaJsonDecodeVariant105`, or the matching
+`...104` pair.
+
+## Position in the SDK
+
+This package sits **low in the dependency graph**, on the type and factory packages and nothing
+else. It does not depend on `node-opcua-address-space`, which is what allows the address space to
+depend on it, and in turn lets
+[`node-opcua-uanodeset-json`](../node-opcua-uanodeset-json) encode nodeset values with the same
+codec the PubSub layer uses.
+
+The `ExtensionObjectBuilder` parameter is the price of that position: rather than reaching for an
+address space itself, the package asks the caller to resolve structures.
+
+## Provenance and licence
+
+This code was written for `@sterfive/node-opcua-json`, part of the node-opcua-pubsub work, and is
+contributed here by its copyright holder under **MIT**, so that JSON encoding is not a licensing
+question for anyone building on the SDK.
+
+MIT

--- a/packages/node-opcua-uanodeset-json/README.md
+++ b/packages/node-opcua-uanodeset-json/README.md
@@ -29,7 +29,8 @@ The annex specifies three shapes of the same model, and this package implements 
 Importing the package registers all three with the address-space loader, so a path is enough:
 
 ```ts
-import { AddressSpace, generateAddressSpace } from "node-opcua-address-space";
+import { AddressSpace } from "node-opcua-address-space";
+import { generateAddressSpace } from "node-opcua-address-space/nodeJS";
 import "node-opcua-uanodeset-json";
 
 const addressSpace = AddressSpace.create();

--- a/packages/node-opcua-uanodeset-json/README.md
+++ b/packages/node-opcua-uanodeset-json/README.md
@@ -1,0 +1,148 @@
+# node-opcua-uanodeset-json
+
+The **JSON NodeSet** of OPC 10000-6 Annex I, in all three of its serialisations, readable and
+writable by node-opcua.
+
+see http://node-opcua.github.io/
+
+```bash
+npm install node-opcua-uanodeset-json
+```
+
+## Why
+
+An information model has been a NodeSet2 XML document for as long as OPC UA has had one. Annex I
+is the normative JSON form of the same thing, and it is what you want when the consumer is not an
+OPC UA stack: a browser, a `jq` pipeline, a document database, a diff in a code review, or a
+build step that has to add one node to a companion specification without a full XML toolchain.
+
+The annex specifies three shapes of the same model, and this package implements all three:
+
+| extension | Annex | what it is | reach for it when |
+|---|---|---|---|
+| `.jsonl` | I.4 | one JSON object per line, header first | you want to stream, `grep`, or diff a model line by line |
+| `.json` | I.1 | one document, children nested inside their parent | you want to read it, or hand it to a JSON API |
+| `.uanodeset` | I.3 | a TAR.GZ of a manifest and numbered members | the model is large enough that one file is unwieldy |
+
+## Reading: nothing to call
+
+Importing the package registers all three with the address-space loader, so a path is enough:
+
+```ts
+import { AddressSpace, generateAddressSpace } from "node-opcua-address-space";
+import "node-opcua-uanodeset-json";
+
+const addressSpace = AddressSpace.create();
+await generateAddressSpace(addressSpace, [
+    "Opc.Ua.NodeSet2.xml",     // still XML
+    "Opc.Ua.Di.jsonl",         // Annex I line form
+    "MyCompanionSpec.uanodeset" // Annex I archive
+]);
+```
+
+`node-opcua-server` already imports it, so a server gets this for free. Formats are chosen by
+**sniffing the content**, not the extension, and the head a sniffer is shown is already inflated,
+so `.jsonl.gz` and `.json.gz` work as well and a misnamed file still loads.
+
+To register only one form, import only that subpath. It is the point of the subpaths:
+
+```ts
+import "node-opcua-uanodeset-json/jsonl";
+```
+
+Reading is **exact**, and that claim is tested rather than asserted. The DI nodeset loaded from
+`.jsonl`, `.json` and `.uanodeset` produces an address space with the same digest as the one
+loaded from its NodeSet2 XML, where the digest hashes every node's id, browse name, class,
+reference count and, for variables, status code and value. Agreeing node counts would not be that
+claim.
+
+## Writing
+
+The writers take a stream of `NodesetRecord`, the intermediate form the loader produces, so
+converting between any two formats is reading one and writing the other:
+
+```ts
+import { writeFile } from "node:fs/promises";
+import { recordsToAnnexIJson } from "node-opcua-uanodeset-json";
+
+await writeFile("Opc.Ua.Di.json", recordsToAnnexIJson(records), "utf8");
+```
+
+```ts
+import zlib from "node:zlib";
+import { recordsToAnnexIArchiveTar } from "node-opcua-uanodeset-json";
+
+const tar = recordsToAnnexIArchiveTar(records, { maxNodesPerFile: 1000 });
+await writeFile("Opc.Ua.Di.uanodeset", zlib.gzipSync(Buffer.from(tar)));
+```
+
+Writing is a **fixpoint**: `write(read(write(read(x))))` is byte-identical to `write(read(x))`,
+for the document form and for the archive down to the tar bytes. Splitting an archive never
+divides a subtree across two members, and the members carry no `Models`, because I.3 says the
+manifest specifies them.
+
+Cross-implementation, which is the check that actually matters: the OPC Foundation's
+`UA-NodeSetTool` reads what this writes and its `compare` reports the result identical to the
+original XML.
+
+## What the annex does differently
+
+Three decisions in I.1 will surprise a reader who knows NodeSet2 XML, and each one is why a
+naive translation does not work:
+
+- **No namespace table.** A NodeId embeds its namespace URI: `nsu=http://…/DI/;i=1002`, and a
+  QualifiedName likewise. Nothing is relative to a document-scoped index, so a node can be moved
+  between documents unchanged. `parseAnnexINodeId` and `formatAnnexINodeId` are the conversion,
+  and they split on the **first** semicolon, since a URI may contain one.
+- **No aliases.** Reference types are written out.
+- **Three references are not references.** `HasTypeDefinition` becomes the `TypeId` field,
+  `HasModellingRule` becomes `ModellingRuleId`, and the forward edge from a parent to its child
+  is implied by `ParentId`. A reader that only walks `References` silently loses all three; this
+  package puts them back.
+
+The document form adds two more:
+
+- Nodes are partitioned into **eight containers** by NodeClass, and children nest inside their
+  parent's `ChildList` rather than sitting at the top level.
+- `Ordered` and `Declarations` handle cycles. I.2 makes reading order normative so a decoder
+  reading forwards never meets a NodeId it has not already seen, and `Declarations` carries stubs
+  for the ones that cannot be ordered. A test model exists specifically to exercise this, because
+  it is what breaks a naive reader.
+
+## API
+
+Most callers need only the side-effect import. The rest is for building tools.
+
+| export | what it is |
+|---|---|
+| `recordsToAnnexIJson(records)` | records as an Annex I document, serialised |
+| `recordsToAnnexIDocument(records)` | the same as an `AnnexIUANodeSet` object |
+| `recordsToAnnexIArchiveTar(records, options?)` | records as the tar bytes of an archive, before gzip |
+| `flattenAnnexIDocument(nodeSet)` | a document's nodes in I.2 reading order, un-nested, with `ParentId` filled in |
+| `annexIHeaderRecord` / `annexINodeRecord` | the codec: Annex I to `NodesetRecord` |
+| `decodeAnnexIVariant`, `AnnexIValueError` | a Part 6 1.05 JSON Variant, as Annex I carries it |
+| `parseAnnexINodeId`, `formatAnnexINodeId`, and the `QualifiedName` pair | the `nsu=` canonical forms |
+| `annexINamespaceTable`, `OPCUA_CORE_NAMESPACE` | namespace resolution |
+| `isAnnexIHeaderLine`, `isAnnexIDocumentHead`, `isAnnexIArchiveHead` | the three sniffers, usable directly |
+| `readTar`, `writeTar`, `isTar`, `TarEntry` | the tar layer |
+| `ANNEX_I_JSONL_FORMAT`, `ANNEX_I_JSON_FORMAT`, `ANNEX_I_ARCHIVE_FORMAT` | format names, for `nodesetFormatByName` |
+| `registerAnnexIJsonlFormat()` and friends | explicit registration; idempotent, and the imports already call them |
+| `AnnexINode`, `AnnexIUANodeSet`, `AnnexIReference`, … | the model types |
+
+### The tar layer
+
+`.uanodeset` is a TAR.GZ, and the monorepo has no tar dependency. This should not be the package
+that adds one, so `readTar` / `writeTar` are about 150 lines here: they read both the original V7
+layout and ustar, and write ustar.
+
+`isTar` recognises an archive by its **header checksum** rather than by a magic string, because
+V7 leaves the magic empty and that is what the reference implementation writes. A checksum is the
+only structural test that works on both.
+
+Archives are validated against I.3 rather than read optimistically. A manifest naming a file the
+archive lacks, and a file the archive holds that the manifest does not name, are both refused:
+either one silently changes which nodes get loaded.
+
+## License
+
+MIT


### PR DESCRIPTION
READMEs for the two packages added in https://github.com/node-opcua/node-opcua/pull/1642, which
landed without any. Documentation only, no code touched.

Each leads with the job the package does and a snippet that runs, then the one thing a reader
will otherwise get wrong.

### `node-opcua-json`

The trap is version drift. The 1.05 field names are `UaType` / `Value` / `UaDimensions`, not
`Type` / `Body` / `Dimensions`, and `Compact` omits every field equal to its type's default, so a
`Byte` of `0` encodes as `{ UaType: 3 }` with no `Value` at all. Someone diffing this package's
output against a Verbose writer from another stack will think it is broken. The four schemes get
a table, and the `ExtensionObjectBuilder` parameter is explained as what it is: the price of
sitting below `node-opcua-address-space` in the dependency graph.

### `node-opcua-uanodeset-json`

The trap is that Annex I turns three references into fields. `HasTypeDefinition` becomes
`TypeId`, `HasModellingRule` becomes `ModellingRuleId`, and the parent-to-child forward edge is
implied by `ParentId`. A reader walking only `References` silently loses all three and produces a
plausible, wrong address space.

Reading needs no API call at all, which is worth saying plainly: the import registers the
formats, `node-opcua-server` already does it, and sniffing is on content rather than extension so
`.jsonl.gz` and misnamed files both work.

The equivalence and fixpoint claims are stated with what backs them. "Round trips" without
saying against what is not a claim, so the README says the DI nodeset read from all three forms
produces the digest its NodeSet2 XML produces, that the digest covers every node's id, browse
name, class, reference count and variable value, and that agreeing node counts would not have
been that claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
