### PR TITLE
fix: a refused OpenSecureChannel answers a ServiceFault, and a legacy store lock no longer hangs certificate checks (FEAT-39, FEAT-40)

### DIFF
--- a/packages/node-opcua-certificate-manager/source/certificate_manager.ts
+++ b/packages/node-opcua-certificate-manager/source/certificate_manager.ts
@@ -7,7 +7,7 @@ import envPaths from "env-paths";
 import { assert } from "node-opcua-assert";
 import type { ICertificateStore } from "node-opcua-common";
 import { type Certificate, makeSHA1Thumbprint } from "node-opcua-crypto/web";
-import { checkDebugFlag, make_debugLog, make_errorLog } from "node-opcua-debug";
+import { checkDebugFlag, make_debugLog, make_errorLog, make_warningLog } from "node-opcua-debug";
 import { ObjectRegistry } from "node-opcua-object-registry";
 import {
     CertificateManager,
@@ -23,7 +23,54 @@ const paths = envPaths("node-opcua-default");
 
 const debugLog = make_debugLog("certificate_manager");
 const errorLog = make_errorLog("certificate_manager");
+const warningLog = make_warningLog("certificate_manager");
 const doDebug = checkDebugFlag("certificate_manager");
+
+/**
+ * Remove a lock file left in a PKI store by an older node-opcua, so that the
+ * current one can use the store at all.
+ *
+ * node-opcua-pki serialises every mutation of a store (`withLock2`) on
+ * `<rootFolder>/mutex.lock`. Today's global-mutex (3.x) takes that lock by
+ * creating a *directory* of that name; its predecessor (2.x, built on the
+ * `lockfile` package) created a plain *file* and left it behind when the
+ * process died holding it. Neither provider of the current library treats that
+ * file as the garbage it is: the native one only decides by mtime and waits
+ * until the file looks two minutes old, the proper-lockfile one calls rmdir on
+ * it, gets ENOTDIR and retries for hours. In both cases the first move into
+ * rejected/ or trusted/ never answers, and an OpenSecureChannel that waits on
+ * that verdict never answers either (FEAT-40, the CTT's Security Certificate
+ * Validation scripts timing out on Windows).
+ *
+ * A regular file at that path can never be a live lock of the current library,
+ * so it is removed before the store is first used. A directory is a real lock
+ * and is left alone.
+ *
+ * @returns `true` when a file was removed
+ */
+export function removeLegacyLockFile(rootFolder: string): boolean {
+    const legacyLockFile = path.join(rootFolder, "mutex.lock");
+    let stats: fs.Stats;
+    try {
+        stats = fs.statSync(legacyLockFile);
+    } catch {
+        return false;
+    }
+    if (stats.isDirectory()) {
+        return false;
+    }
+    try {
+        fs.unlinkSync(legacyLockFile);
+    } catch (err) {
+        errorLog(`cannot remove the legacy lock file ${legacyLockFile}: ${(err as Error).message}`);
+        return false;
+    }
+    warningLog(
+        `[NODE-OPCUA-W38] removed ${legacyLockFile}: a lock file left by an older node-opcua, ` +
+            "which would have stalled every update of this certificate store"
+    );
+    return true;
+}
 
 export interface ICertificateManager {
     getTrustStatus(certificate: Certificate): Promise<StatusCode>;
@@ -144,6 +191,20 @@ export interface OPCUACertificateManagerOptions {
 export class OPCUACertificateManager extends CertificateManager implements ICertificateManager, ICertificateStore {
     public static defaultCertificateSubject = "/O=Sterfive/L=Orleans/C=FR";
 
+    /**
+     * How long {@link checkCertificate} waits, in milliseconds, for the store
+     * to record its verdict (the move of the certificate into `rejected/` or
+     * `trusted/`) before answering with that verdict anyway.
+     *
+     * The verdict is known before the move starts: the move is bookkeeping.
+     * It takes the store's file lock, and a lock that is contended or stuck
+     * must not hold the OpenSecureChannel of the client being answered (the
+     * CTT gives up after 20 s and reports BadTimeout instead of the status the
+     * server had already decided on). On timeout the move carries on in the
+     * background and a warning is logged.
+     */
+    public static bookkeepingTimeout = 5000;
+
     public static registry = new ObjectRegistry();
     public referenceCounter: number;
     public automaticallyAcceptUnknownCertificate: boolean;
@@ -185,6 +246,9 @@ export class OPCUACertificateManager extends CertificateManager implements ICert
     public initialize(...args: unknown[]): unknown {
         const callback = args[0] as (err?: Error) => void;
         assert(callback && typeof callback === "function");
+        // before the first lock is taken: super.initialize() itself locks the store
+        // when it has a key or a configuration file to write
+        removeLegacyLockFile(this.rootDir);
         return super
             .initialize()
             .then(() => callback())
@@ -267,7 +331,7 @@ export class OPCUACertificateManager extends CertificateManager implements ICert
                     debugLog(`certificate with thumbprint ${thumbprint} is now trusted (was: ${statusCode.toString()})`);
                 }
                 try {
-                    await this.trustCertificate(topCertificateInChain);
+                    await this.#bookkeeping("trust", thumbprint, this.trustCertificate(topCertificateInChain));
                 } catch (err) {
                     if (err && (err as Error & { code: string }).code === "ENOENT") {
                         // Another concurrent caller already moved the certificate
@@ -288,7 +352,7 @@ export class OPCUACertificateManager extends CertificateManager implements ICert
                     debugLog("automaticallyAcceptUnknownCertificate = false");
                     debugLog(`certificate with thumbprint ${thumbprint} is now rejected`);
                 }
-                await this.rejectCertificate(topCertificateInChain);
+                await this.#bookkeeping("reject", thumbprint, this.rejectCertificate(topCertificateInChain));
                 return StatusCodes.BadCertificateUntrusted;
             }
         } else if (statusCode.equals(StatusCodes.BadCertificateRevocationUnknown)) {
@@ -315,10 +379,37 @@ export class OPCUACertificateManager extends CertificateManager implements ICert
                     await this.rejectCertificate(certificate);
                 }
             };
-            await rejectAll(certificates);
+            const thumbprint = makeSHA1Thumbprint(certificates[0]).toString("hex");
+            await this.#bookkeeping("reject chain", thumbprint, rejectAll(certificates));
             return statusCode;
         }
         return statusCode;
+    }
+
+    /**
+     * Wait for a store update, but not beyond {@link bookkeepingTimeout}: the
+     * caller already knows the verdict it will return. A rejection of the
+     * update propagates to the caller as before; a timeout is logged and the
+     * update is left to complete (or fail, logged) on its own.
+     */
+    async #bookkeeping(what: string, thumbprint: string, update: Promise<void>): Promise<void> {
+        let timer: NodeJS.Timeout | undefined;
+        const expired = new Promise<"timeout">((resolve) => {
+            timer = setTimeout(() => resolve("timeout"), OPCUACertificateManager.bookkeepingTimeout);
+        });
+        try {
+            const outcome = await Promise.race([update.then(() => "done" as const), expired]);
+            if (outcome === "timeout") {
+                warningLog(
+                    `[NODE-OPCUA-W39] the certificate store has not recorded the ${what} of ${thumbprint} ` +
+                        `after ${OPCUACertificateManager.bookkeepingTimeout} ms (store ${this.rootDir}): ` +
+                        "answering with the verdict already known; the store update goes on in the background"
+                );
+                update.catch((err: Error) => errorLog(`the ${what} of ${thumbprint} failed in the background: ${err.message}`));
+            }
+        } finally {
+            clearTimeout(timer);
+        }
     }
 
     public async getTrustStatus(certificate: Certificate): Promise<StatusCode>;

--- a/packages/node-opcua-certificate-manager/test/test_certificate_manager_store_lock.ts
+++ b/packages/node-opcua-certificate-manager/test/test_certificate_manager_store_lock.ts
@@ -1,0 +1,178 @@
+/**
+ * FEAT-40: a certificate check must answer even when the store's file lock is
+ * unavailable.
+ *
+ * node-opcua-pki serialises every store update on `<rootFolder>/mutex.lock`.
+ * The global-mutex node-opcua ships today takes it by creating a directory of
+ * that name; the one node-opcua shipped before 2.181 created a plain file and
+ * left it behind when the process died holding it. The current library never
+ * recognises that file as garbage - it waits until the file looks two minutes
+ * old (native provider) or retries an `rmdir` that fails with ENOTDIR for
+ * hours (proper-lockfile provider) - so on such a store the first
+ * rejectCertificate never answers and every OpenSecureChannel that waits on it
+ * times out. Seen on the certification server's store on Windows, CTT 1.05.513:
+ * Security Certificate Validation 005/009/033/045/046 reported BadTimeout.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import "mocha";
+import { readCertificate } from "node-opcua-crypto";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { CertificateManager } from "node-opcua-pki";
+import { StatusCodes } from "node-opcua-status-code";
+import should from "should";
+import { OPCUACertificateManager, removeLegacyLockFile } from "../source/index.js";
+import { scratch } from "./paths.js";
+
+const tmpFolder = scratch("temp", "store_lock");
+
+/** a self-signed certificate of its own, written under `folder` */
+async function makeCertificate(folder: string, name: string): Promise<Buffer> {
+    const pki = new CertificateManager({ keySize: 2048, location: path.join(folder, `${name}-pki`) });
+    await pki.initialize();
+    const certificateFile = path.join(folder, `${name}.pem`);
+    await pki.createSelfSignedCertificate({
+        applicationUri: `urn:${name}`,
+        dns: [],
+        ip: [],
+        validity: 100,
+        subject: `/CN=${name}`,
+        startDate: new Date(),
+        outputFile: certificateFile
+    });
+    await pki.dispose();
+    return readCertificate(certificateFile);
+}
+
+/**
+ * A store that has seen some use: a few trusted certificates, and the lock
+ * file an older node-opcua left behind. The file's mtime is now, as it is
+ * after a copy of the store, or after the older process touched it.
+ */
+async function populateStore(rootFolder: string, certificates: Buffer[]): Promise<void> {
+    const manager = new OPCUACertificateManager({ rootFolder, automaticallyAcceptUnknownCertificate: false });
+    await manager.initialize();
+    for (const certificate of certificates) {
+        await manager.trustCertificate(certificate);
+    }
+    await manager.dispose();
+    fs.writeFileSync(path.join(rootFolder, "mutex.lock"), "");
+}
+
+describe("OPCUACertificateManager and the store lock (FEAT-40)", function (this: Mocha.Suite) {
+    this.timeout(60_000);
+
+    let trusted: Buffer[];
+    let unknown: Buffer;
+
+    before(async () => {
+        fs.rmSync(tmpFolder, { recursive: true, force: true });
+        fs.mkdirSync(tmpFolder, { recursive: true });
+        trusted = [];
+        for (let i = 0; i < 3; i++) {
+            trusted.push(await makeCertificate(tmpFolder, `trusted${i}`));
+        }
+        unknown = await makeCertificate(tmpFolder, "unknown");
+    });
+
+    it("SL01 - removeLegacyLockFile removes a plain mutex.lock file and leaves a lock directory alone", () => {
+        const folder = path.join(tmpFolder, "sl01");
+        fs.mkdirSync(folder, { recursive: true });
+        removeLegacyLockFile(folder).should.eql(false, "nothing to remove");
+
+        fs.writeFileSync(path.join(folder, "mutex.lock"), "");
+        removeLegacyLockFile(folder).should.eql(true);
+        fs.existsSync(path.join(folder, "mutex.lock")).should.eql(false);
+
+        fs.mkdirSync(path.join(folder, "mutex.lock"));
+        removeLegacyLockFile(folder).should.eql(false, "a directory is a live lock");
+        fs.existsSync(path.join(folder, "mutex.lock")).should.eql(true);
+    });
+
+    it("SL02 - checkCertificate answers at once on a populated store that carries a legacy lock file", async () => {
+        const rootFolder = path.join(tmpFolder, "sl02");
+        await populateStore(rootFolder, trusted);
+        fs.existsSync(path.join(rootFolder, "mutex.lock")).should.eql(true);
+
+        const manager = new OPCUACertificateManager({ rootFolder, automaticallyAcceptUnknownCertificate: false });
+        await manager.initialize();
+        try {
+            // without the fix this waits for the lock file to look two minutes old
+            const started = Date.now();
+            const status = await manager.checkCertificate(unknown);
+            const elapsed = Date.now() - started;
+            status.should.eql(StatusCodes.BadCertificateUntrusted);
+            elapsed.should.be.lessThan(OPCUACertificateManager.bookkeepingTimeout, "answered before the bookkeeping bound");
+
+            // and the verdict was recorded: the certificate is in rejected/
+            fs.readdirSync(path.join(rootFolder, "rejected")).length.should.eql(1);
+            (await manager.getTrustStatus(unknown)).should.eql(StatusCodes.BadCertificateUntrusted);
+            // the trusted ones still are
+            for (const certificate of trusted) {
+                (await manager.checkCertificate(certificate)).should.eql(StatusCodes.Good);
+            }
+        } finally {
+            await manager.dispose();
+        }
+    });
+
+    it("SL03 - checkCertificate answers with the verdict it knows when the store update does not settle", async () => {
+        const rootFolder = path.join(tmpFolder, "sl03");
+        await populateStore(rootFolder, trusted);
+
+        // a store whose updates never complete: the lock is held elsewhere for good
+        class StuckStore extends OPCUACertificateManager {
+            public rejectCalls = 0;
+            public override rejectCertificate(certificate: Buffer): Promise<void>;
+            public override rejectCertificate(certificate: Buffer, callback: (err?: Error | null) => void): void;
+            public override rejectCertificate(_certificate: Buffer, callback?: (err?: Error | null) => void): Promise<void> | void {
+                this.rejectCalls++;
+                if (callback) {
+                    return;
+                }
+                return new Promise<void>(() => {
+                    /* never settles */
+                });
+            }
+        }
+        const manager = new StuckStore({ rootFolder, automaticallyAcceptUnknownCertificate: false });
+        await manager.initialize();
+
+        const bookkeepingTimeout = OPCUACertificateManager.bookkeepingTimeout;
+        OPCUACertificateManager.bookkeepingTimeout = 300;
+        try {
+            const started = Date.now();
+            const status = await manager.checkCertificate(unknown);
+            const elapsed = Date.now() - started;
+            status.should.eql(StatusCodes.BadCertificateUntrusted);
+            manager.rejectCalls.should.eql(1);
+            elapsed.should.be.within(250, 5000);
+        } finally {
+            OPCUACertificateManager.bookkeepingTimeout = bookkeepingTimeout;
+            await manager.dispose();
+        }
+    });
+
+    it("SL04 - a store update that fails still fails the check", async () => {
+        const rootFolder = path.join(tmpFolder, "sl04");
+        await populateStore(rootFolder, trusted);
+
+        class FailingStore extends OPCUACertificateManager {
+            public override rejectCertificate(certificate: Buffer): Promise<void>;
+            public override rejectCertificate(certificate: Buffer, callback: (err?: Error | null) => void): void;
+            public override rejectCertificate(_certificate: Buffer, callback?: (err?: Error | null) => void): Promise<void> | void {
+                if (callback) {
+                    return;
+                }
+                return Promise.reject(new Error("disk full"));
+            }
+        }
+        const manager = new FailingStore({ rootFolder, automaticallyAcceptUnknownCertificate: false });
+        await manager.initialize();
+        try {
+            await should(manager.checkCertificate(unknown)).be.rejectedWith(/disk full/);
+        } finally {
+            await manager.dispose();
+        }
+    });
+});

--- a/packages/node-opcua-client/source/private/client_base_impl.ts
+++ b/packages/node-opcua-client/source/private/client_base_impl.ts
@@ -33,7 +33,8 @@ import {
     type PerformTransactionCallback,
     type Request as Request1,
     type Response as Response1,
-    type SecurityPolicy
+    type SecurityPolicy,
+    type ServiceFaultAnnotatedError
 } from "node-opcua-secure-channel";
 import {
     FindServersOnNetworkRequest,
@@ -49,9 +50,14 @@ import {
     GetEndpointsRequest,
     GetEndpointsResponse
 } from "node-opcua-service-endpoints";
-import { type ChannelSecurityToken, coerceMessageSecurityMode, MessageSecurityMode } from "node-opcua-service-secure-channel";
+import {
+    type ChannelSecurityToken,
+    coerceMessageSecurityMode,
+    MessageSecurityMode,
+    ServiceFault
+} from "node-opcua-service-secure-channel";
 import { CloseSessionRequest, type CloseSessionResponse } from "node-opcua-service-session";
-import { type ErrorCallback, StatusCodes } from "node-opcua-status-code";
+import { type ErrorCallback, type StatusCode, StatusCodes } from "node-opcua-status-code";
 import {
     type IAcceptedReverseConnection,
     type IClientTransportFactory,
@@ -1230,7 +1236,21 @@ export class ClientBaseImpl<Events extends OPCUAClientBaseEvents = OPCUAClientBa
                     /* */
                     this._handleDisconnectionWhileConnecting(err, callback);
                 } else {
-                    err = new Error(`The connection may have been rejected by server,\n Err = (${err.message})`);
+                    const fault = (err as ServiceFaultAnnotatedError).response;
+                    if (fault instanceof ServiceFault) {
+                        // the server answered the OpenSecureChannel with a ServiceFault (Part 6 6.7.4):
+                        // it refused the connection and said why - typically a client certificate it
+                        // does not trust (BadSecurityChecksFailed) or that is out of date
+                        const statusCode = fault.responseHeader.serviceResult;
+                        const rejected = new Error(
+                            `The connection has been rejected by server: ${statusCode.toString()}`
+                        ) as ServiceFaultAnnotatedError & { statusCode: StatusCode };
+                        rejected.statusCode = statusCode;
+                        rejected.response = fault;
+                        err = rejected;
+                    } else {
+                        err = new Error(`The connection may have been rejected by server,\n Err = (${err.message})`);
+                    }
                     this._handleUnrecoverableConnectionFailure(err, callback);
                 }
             }

--- a/packages/node-opcua-end2end-test/test/secure_connection/test_e2e_open_secure_channel_refused_certificate.ts
+++ b/packages/node-opcua-end2end-test/test/secure_connection/test_e2e_open_secure_channel_refused_certificate.ts
@@ -1,0 +1,148 @@
+/**
+ * FEAT-39: a server that refuses the client certificate answers the
+ * OpenSecureChannel with a ServiceFault carrying the status code.
+ *
+ * Part 6 6.7.4: once the security of the request is verified, an error is
+ * answered with a ServiceFault in place of the OpenSecureChannel response,
+ * secured like that response. Answered with a transport-level ERR message
+ * instead, the refusal told nothing: the CTT read the connect as Good and its
+ * Security Certificate Validation scripts failed with "the connection was
+ * granted", and node-opcua's own client only reported a closed socket.
+ *
+ * Status codes, as the server maps them: an untrusted or badly signed or
+ * revoked certificate is BadSecurityChecksFailed (the client learns nothing
+ * about the trust list); a certificate out of its validity period is
+ * BadCertificateTimeInvalid, passed through, so that a client can tell what to
+ * fix.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import {
+    get_empty_nodeset_filename,
+    MessageSecurityMode,
+    OPCUACertificateManager,
+    OPCUAClient,
+    OPCUAServer,
+    SecurityPolicy,
+    ServiceFault,
+    type StatusCode,
+    StatusCodes
+} from "node-opcua";
+import { readCertificate, readCertificateChain, readCertificateRevocationList } from "node-opcua-crypto";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import should from "should";
+import { certificateFolder, tmpFolderFor } from "../../test_helpers/paths.js";
+
+type RejectedConnection = Error & { statusCode?: StatusCode; response?: unknown };
+
+const port = 5800;
+
+describe("OpenSecureChannel refused because of the client certificate (FEAT-39)", function (this: Mocha.Suite) {
+    this.timeout(Math.max(60_000, this.timeout()));
+
+    const tmpFolder = tmpFolderFor("feat39");
+    let server: OPCUAServer;
+    let endpointUrl: string;
+    let serverCertificateManager: OPCUACertificateManager;
+    let clientCertificateManager: OPCUACertificateManager;
+
+    before(async () => {
+        fs.rmSync(tmpFolder, { recursive: true, force: true });
+        serverCertificateManager = new OPCUACertificateManager({
+            rootFolder: path.join(tmpFolder, "server-pki"),
+            automaticallyAcceptUnknownCertificate: false
+        });
+        await serverCertificateManager.initialize();
+        // the client trusts the server; the server decides about the client
+        clientCertificateManager = new OPCUACertificateManager({
+            rootFolder: path.join(tmpFolder, "client-pki"),
+            automaticallyAcceptUnknownCertificate: true
+        });
+        await clientCertificateManager.initialize();
+
+        server = new OPCUAServer({
+            port,
+            serverCertificateManager,
+            nodeset_filename: get_empty_nodeset_filename(),
+            securityPolicies: [SecurityPolicy.Basic256Sha256],
+            securityModes: [MessageSecurityMode.SignAndEncrypt]
+        });
+        await server.start();
+        endpointUrl = server.getEndpointUrl();
+    });
+
+    after(async () => {
+        await server.shutdown();
+        await serverCertificateManager.dispose();
+        await clientCertificateManager.dispose();
+    });
+
+    async function connectAndExpectRefusal(client: OPCUAClient): Promise<RejectedConnection> {
+        let error: RejectedConnection | undefined;
+        try {
+            await client.connect(endpointUrl);
+            await client.disconnect();
+        } catch (err) {
+            error = err as RejectedConnection;
+        }
+        should.exist(error, "expecting the OpenSecureChannel to be refused");
+        return error as RejectedConnection;
+    }
+
+    function secureClient(extra: Record<string, unknown> = {}): OPCUAClient {
+        return OPCUAClient.create({
+            clientCertificateManager,
+            securityMode: MessageSecurityMode.SignAndEncrypt,
+            securityPolicy: SecurityPolicy.Basic256Sha256,
+            endpointMustExist: false,
+            connectionStrategy: { maxRetry: 0 },
+            ...extra
+        });
+    }
+
+    it("FEAT39-1 an untrusted client certificate is refused with BadSecurityChecksFailed, said in a ServiceFault", async () => {
+        const client = secureClient();
+        const error = await connectAndExpectRefusal(client);
+
+        error.message.should.match(/rejected by server/);
+        error.message.should.match(/BadSecurityChecksFailed/);
+        should(error.statusCode).eql(StatusCodes.BadSecurityChecksFailed);
+        // a decoded ServiceFault on the error is what tells a secured refusal from a dropped socket
+        should(error.response).be.instanceOf(ServiceFault);
+        (error.response as ServiceFault).responseHeader.serviceResult.should.eql(StatusCodes.BadSecurityChecksFailed);
+
+        // and the server has recorded the refusal
+        const clientCertificate = readCertificate(client.certificateFile);
+        (await serverCertificateManager.getTrustStatus(clientCertificate)).should.eql(StatusCodes.BadCertificateUntrusted);
+        fs.readdirSync(path.join(serverCertificateManager.rootDir, "rejected")).length.should.be.greaterThan(0);
+    });
+
+    it("FEAT39-2 the same certificate connects once the server trusts it", async () => {
+        const client = secureClient();
+        await serverCertificateManager.trustCertificate(readCertificate(client.certificateFile));
+        await client.connect(endpointUrl);
+        const session = await client.createSession();
+        await session.close();
+        await client.disconnect();
+    });
+
+    it("FEAT39-3 a trusted certificate that is out of date is refused with BadCertificateTimeInvalid", async () => {
+        const certificateFile = path.join(certificateFolder, "client_cert_2048_outofdate.pem");
+        const privateKeyFile = path.join(certificateFolder, "client_key_2048.pem");
+        const chain = readCertificateChain(certificateFile);
+        chain.length.should.eql(2, "the sample certificate comes with its issuer");
+        // trusted, issuer known with its revocation list: only the validity period is wrong
+        await serverCertificateManager.trustCertificate(chain[0]);
+        await serverCertificateManager.addIssuer(chain[1]);
+        await serverCertificateManager.addRevocationList(
+            await readCertificateRevocationList(path.join(certificateFolder, "CA", "crl", "revocation_list.crl"))
+        );
+
+        const client = secureClient({ certificateFile, privateKeyFile });
+        const error = await connectAndExpectRefusal(client);
+
+        error.message.should.match(/BadCertificateTimeInvalid/);
+        should(error.statusCode).eql(StatusCodes.BadCertificateTimeInvalid);
+        should(error.response).be.instanceOf(ServiceFault);
+    });
+});

--- a/packages/node-opcua-end2end-test/test/secure_connection/test_e2e_secure_server_with_restricted_security_mode.ts
+++ b/packages/node-opcua-end2end-test/test/secure_connection/test_e2e_secure_server_with_restricted_security_mode.ts
@@ -48,7 +48,9 @@ describe("testing server with restricted securityModes - Given a server with a s
 
     it("should not connect with SecurityMode==None", async () => {
         const err = await attemptConnection();
-        should(err?.message).match(/The connection may have been rejected by server/);
+        // no None endpoint: the server refuses the OpenSecureChannel with a ServiceFault that
+        // says so - a None request asks for no security, so the fault needs none either
+        should(err?.message).match(/The connection has been rejected by server: BadSecurityPolicyRejected/);
     });
 
     it("should not connect with SecurityMode==Sign/Basic256Sha256", async () => {

--- a/packages/node-opcua-secure-channel/source/server/server_secure_channel_layer.ts
+++ b/packages/node-opcua-secure-channel/source/server/server_secure_channel_layer.ts
@@ -184,6 +184,12 @@ export interface IServerSessionBase {
  */
 export class ServerSecureChannelLayer extends EventEmitter {
     public static throttleTime = 100;
+    /**
+     * how long a refused channel stays open after the ServiceFault (or ERR
+     * message) has been sent, so that the peer reads it before the socket
+     * closes, in milliseconds
+     */
+    public static closeDelayAfterRefusal = 1000;
 
     /**
      * @private
@@ -322,6 +328,8 @@ export class ServerSecureChannelLayer extends EventEmitter {
     readonly #messageChunker: MessageChunker;
 
     #timeoutId: NodeJS.Timeout | null;
+    /** the close scheduled after a refused OpenSecureChannel has been answered */
+    #refusalCloseTimer: NodeJS.Timeout | null = null;
     #open_secure_channel_onceClose: ((err: Error | null) => void) | null = null;
     #securityTokenTimeout: NodeJS.Timeout | null;
     #transactionsCount: number;
@@ -1033,6 +1041,10 @@ export class ServerSecureChannelLayer extends EventEmitter {
         // there is no need for the security token expiration event to trigger anymore
         this.#_stop_security_token_watch_dog();
         this.#_stop_open_channel_watch_dog();
+        if (this.#refusalCloseTimer) {
+            clearTimeout(this.#refusalCloseTimer);
+            this.#refusalCloseTimer = null;
+        }
     }
 
     #_cancel_wait_for_open_secure_channel_request_timeout() {
@@ -1797,28 +1809,91 @@ export class ServerSecureChannelLayer extends EventEmitter {
     // Bad_SecureChannelIdInvalid
     // Bad_NonceInvalid
 
+    /**
+     * Refuse the OpenSecureChannel.
+     *
+     * Part 6 6.7.4: once the Server has verified the security of the request,
+     * an error is answered with a ServiceFault in place of the
+     * OpenSecureChannel response, secured as that response would be: signed
+     * with the server key and encrypted for the public key of the
+     * SenderCertificate, which is there and usable even when the certificate
+     * itself is refused. The client then reads the status the server decided
+     * on. Answered with a transport-level ERR message instead (Part 6 7.1.3,
+     * meant for faults of the transport itself) the refusal said nothing: the
+     * CTT's stack reported the connect as Good and its Security Certificate
+     * Validation scripts failed with "the connection was granted", and
+     * node-opcua's own client only saw a closed socket (FEAT-39).
+     *
+     * The ERR message remains for the errors found before the security of the
+     * request could be established - unknown policy, no such endpoint, no
+     * usable client key - where nothing can be secured.
+     */
     #_on_OpenSecureChannelRequestError(serviceResult: StatusCode, description: string, message: Message) {
         warningLog("ServerSecureChannel sendError: ", serviceResult.toString(), { description }, message.request.constructor.name);
-        this.securityMode = MessageSecurityMode.None;
         this.#status = "closing";
 
+        const serviceFault = new ServiceFault({
+            responseHeader: {
+                serviceResult,
+                timestamp: new Date(),
+                stringTable: [description, serviceResult.toString()]
+            }
+        });
+        // the client reads the fault before the socket goes; the delay also keeps
+        // a rejected peer from hammering the server with new connections
+        const closeAfterwards = () => {
+            this.#refusalCloseTimer = setTimeout(() => {
+                this.#refusalCloseTimer = null;
+                this.close();
+            }, ServerSecureChannelLayer.closeDelayAfterRefusal);
+        };
+
         setTimeout(() => {
-            this.send_response(
-                "ERR",
-                new ServiceFault({
-                    responseHeader: {
-                        serviceResult,
-                        timestamp: new Date(),
-                        stringTable: [description, serviceResult.toString()]
-                    }
-                }),
-                message,
-                () => {
-                    setTimeout(() => {
-                        this.close();
-                    }, 1000);
+            const securedMessage = this.#_prepare_refusal_message(message);
+            if (securedMessage) {
+                try {
+                    this.send_response("OPN", serviceFault, securedMessage, closeAfterwards);
+                    return;
+                } catch (err) {
+                    warningLog(
+                        "ServerSecureChannel: cannot secure the ServiceFault, falling back to ERR: ",
+                        (err as Error).message
+                    );
                 }
-            );
+            }
+            this.securityMode = MessageSecurityMode.None;
+            this.send_response("ERR", serviceFault, message, closeAfterwards);
         }, ServerSecureChannelLayer.throttleTime); // Throttling keep connection on hold for a while.
+    }
+
+    /**
+     * The message to answer a refused OpenSecureChannelRequest with, when the
+     * refusal can be secured as the request asked: the response security
+     * header (server certificate, thumbprint of the client certificate), for
+     * `send_response("OPN", ...)` to sign and encrypt. `null` when it cannot:
+     * no OpenSecureChannelRequest yet, a security mode this channel cannot
+     * sign for, or no public key extracted from the client certificate.
+     */
+    #_prepare_refusal_message(message: Message): Message | null {
+        const request = message.request;
+        if (!(request instanceof OpenSecureChannelRequest) || !message.securityHeader) {
+            return null;
+        }
+        switch (this.securityMode) {
+            case MessageSecurityMode.None:
+                break;
+            case MessageSecurityMode.Sign:
+            case MessageSecurityMode.SignAndEncrypt:
+                if (!this.#clientPublicKey || !this.#messageBuilder || !getCryptoFactory(this.#messageBuilder.securityPolicy)) {
+                    return null;
+                }
+                break;
+            default:
+                return null;
+        }
+        return {
+            ...message,
+            securityHeader: this.#_prepare_response_security_header(request, message)
+        };
     }
 }

--- a/packages/node-opcua-secure-channel/source/server/server_secure_channel_layer.ts
+++ b/packages/node-opcua-secure-channel/source/server/server_secure_channel_layer.ts
@@ -1824,9 +1824,12 @@ export class ServerSecureChannelLayer extends EventEmitter {
      * Validation scripts failed with "the connection was granted", and
      * node-opcua's own client only saw a closed socket (FEAT-39).
      *
-     * The ERR message remains for the errors found before the security of the
-     * request could be established - unknown policy, no such endpoint, no
-     * usable client key - where nothing can be secured.
+     * The ERR message remains where nothing can be secured: a signed request
+     * whose policy is unknown, whose endpoint does not exist, or whose
+     * certificate yields no usable key. A request in mode None asks for no
+     * security and is answered with a plain ServiceFault whatever the error
+     * (a None request refused because the server has no None endpoint reads
+     * BadSecurityPolicyRejected at the client).
      */
     #_on_OpenSecureChannelRequestError(serviceResult: StatusCode, description: string, message: Message) {
         warningLog("ServerSecureChannel sendError: ", serviceResult.toString(), { description }, message.request.constructor.name);


### PR DESCRIPTION
## Why

Two findings of the OPC Foundation CTT 1.05.513, Security Certificate Validation, tracked as FEAT-40 and FEAT-39 on the CTT board (project 7). Together they block the three secure SecurityPolicy profiles (Basic256Sha256, Aes128-Sha256-RsaOaep, Aes256-Sha256-RsaPss) in the certification runs: 14 scripts of that unit failed on every run.

**FEAT-40 (first commit).** `OPCUACertificateManager.checkCertificate` never resolved on a store that carried a zero-byte *file* named `mutex.lock`, left behind by the pre-3.x, lockfile-based global-mutex. node-opcua-pki serialises every store mutation with a lock on `<root>/mutex`; global-mutex 3.3.0 takes it by `mkdir(mutex.lock)` and never recognises a foreign file there: the native provider decides by mtime alone (a fresh copy of the store blocks until the file is two minutes old), the proper-lockfile provider (the variant the certification server resolves) retries `rmdir` on the file for hours. Every untrusted client then hangs its OpenSecureChannel. `removeLegacyLockFile()` unlinks a plain-file `mutex.lock` at `initialize()`, and the reject/trust bookkeeping in `#checkCertificate` is bounded (`bookkeepingTimeout`, 5 s): the verdict is answered, the move finishes in the background, warning `[NODE-OPCUA-W39]`.

**FEAT-39 (second commit).** A refused OpenSecureChannel was answered by `send_response("ERR", ServiceFault, message)`: an `ERR` chunk carrying the request's asymmetric security header plus a ServiceFault body. A Part 6 ERR message is header + StatusCode + Reason, so every conformant reader (node-opcua's own message builder included) read the securityPolicyUri length as the status, a Good-severity value. The CTT reported "connection was granted" / "received Good, expected BadSecurityChecksFailed"; node-opcua's client only saw "socket has been disconnected by third party". The refusal is now an OPN response carrying the ServiceFault, secured as the request asked (server key, client public key from the SenderCertificate), with an ERR fallback only when nothing can be secured (unknown policy, no endpoint for a signed request). The status mapping is unchanged. The client reports `The connection has been rejected by server: <status>` with `err.statusCode` and the decoded fault.

## What

- `node-opcua-certificate-manager`: `removeLegacyLockFile()`, `bookkeepingTimeout`, `#bookkeeping`; tests `test_certificate_manager_store_lock.ts` SL01-SL04 (a populated temp store with the legacy file: fail before, pass after).
- `node-opcua-secure-channel`: `#_on_OpenSecureChannelRequestError` and `#_prepare_refusal_message` in `server_secure_channel_layer.ts`; close timer tracked with the others.
- `node-opcua-client`: `client_base_impl.ts` surfaces the fault's status.
- e2e tests `test_e2e_open_secure_channel_refused_certificate.ts` FEAT39-1..3: untrusted certificate -> BadSecurityChecksFailed, expired trusted -> BadCertificateTimeInvalid; one existing test now reads BadSecurityPolicyRejected instead of "may have been rejected".

## Verification

certificate-manager 25/25, secure-channel 269/269, client 77/77, e2e secure_connection + discovery + secure_server 125/125; biome, `check:shortcircuit`, `check-test-ports --summary` clean.

CTT 1.05.513 replay of Security Certificate Validation against a server built from this branch (Windows): 52 scripts, **24 ok, 0 errors, 1 warning**, baseline 14 errors. 007/008/029/038 pass on their own criteria (BadCertificateTimeInvalid, BadCertificateUseNotAllowed, BadSecurityChecksFailed were read as such). The remaining warning is 002: the CTT cites Errata 1.04.12, servers should answer BadSecurityChecksFailed rather than BadCertificateIssuerRevocationUnknown; that mapping decision is left for a follow-up.

A patch for global-mutex 3.3.0 (`removeForeignLockFile()` in both providers) is attached to FEAT-40 on the board; the fix here does not wait for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
