### PR TITLE
feat(json): node-opcua-json/104 and /105 subpath entry points

### DIFF
--- a/packages/node-opcua-json/README.md
+++ b/packages/node-opcua-json/README.md
@@ -72,6 +72,32 @@ When a PubSub subscriber has to work out which scheme it is being sent,
 `JsonDataSetMessageContentMaskToJsonEncodingScheme` reads the two `FieldEncoding` bits of
 OPC 10000-14 Table 112, and `JsonEncodingSchemeToJsonDataSetMessageContentMask` writes them.
 
+## One edition only: `node-opcua-json/104` and `node-opcua-json/105`
+
+The root entry point is deliberately flexible: it takes a `JsonEncodingScheme` and dispatches
+to whichever edition it names. Code that speaks a single edition, such as a PubSub publisher
+pinned to 1.05 or a bridge to a 1.04-only stack, is better off importing that edition directly.
+
+```ts
+import { opcuaJsonEncodeDataValue, JsonEncoderMode, type DataValueJSON } from "node-opcua-json/105";
+
+const pojo: DataValueJSON = opcuaJsonEncodeDataValue(dataValue, JsonEncoderMode.Compact, namespaceArray);
+// { UaType: 11, Value: 3.5, ... } and nothing else can come out
+```
+
+Each subpath exposes the whole API under **version-free names**: `opcuaJsonEncodeDataValue`,
+`opcuaJsonDecodeVariant`, `opcuaJsonEncodeStatusCode`, `opcuaJsonEncodeNodeId`,
+`opcuaJsonEncodeExtensionObject`, the `DataValueJSON` / `VariantJSON` / `NodeIdJSON` /
+`ExtensionObjectJSON` types and a `JsonEncoderMode` enum, every one bound to that edition alone.
+The mode parameter is the edition's own two-value enum, so a 1.04 mode is a type error in the
+1.05 realm and vice versa, and the JSON types are the edition's exact shapes rather than a union.
+Version-agnostic scalars (`Int64`, `ByteString`, `DateTime`, ...) are the same functions in both.
+
+Switching an existing file from one edition to the other is a one-line change of the import
+path. The root package keeps the suffixed names (`opcuaJsonEncodeDataValue104`,
+`opcuaJsonEncodeVariant105`, ...) and also exposes both realms as the `v104` and `v105`
+namespaces for code that has to handle both in one place.
+
 ## Decoding structures
 
 Decoding a `Variant` that contains a structure means constructing that structure, and only the
@@ -114,9 +140,10 @@ scheme, so one call site serves all four.
 | area | exports |
 |---|---|
 | Variant | `opcuaJsonEncodeVariant`, `opcuaJsonDecodeVariant`, the `104` / `105` pairs, `VariantJSON`, `VariantJSON104`, `VariantJSON105` |
-| DataValue | `opcuaJsonEncodeDataValue`, `opcuaJsonDecodeDataValue`, `opcuaJsonEncodeDataValueMQTT`, `DataValueJSON105` |
+| DataValue | `opcuaJsonEncodeDataValue`, `opcuaJsonDecodeDataValue`, `opcuaJsonEncodeDataValueMQTT`, the `104` / `105` variants of all three, `DataValueJSON`, `DataValueJSON104`, `DataValueJSON105` |
 | ExtensionObject | `opcuaJsonEncodeExtensionObject`, `opcuaJsonDecodeExtensionObject`, the `...Body` pair, `makeBody`, `ExtensionObjectJSON104`, `ExtensionObjectJSON105` |
-| NodeId | `opcuaJsonEncodeNodeId`, `opcuaJsonDecodeNodeId`, the `ExpandedNodeId` pair, `opcuaJsonEncodeNodeIdAsString` |
+| NodeId | `opcuaJsonEncodeNodeId`, `opcuaJsonDecodeNodeId`, the `ExpandedNodeId` pair, the `104` / `105` encoders, `opcuaJsonEncodeNodeIdAsString` |
+| realms | `node-opcua-json/104`, `node-opcua-json/105`, and the `v104` / `v105` namespaces on the root |
 | scalars | `Int64`, `UInt64`, `ByteString`, `DateTime`, `LocalizedText`, `QualifiedName`, `StatusCode` |
 | structures | `decodeOPCUA_JSON`, `decodeOPCUA_JSONOld` |
 | schemes | `JsonEncodingScheme`, `JsonEncoderMode104`, `JsonEncoderMode105`, `toJsonEncodingScheme`, `makeDataValueEncodingEnum`, the two `JsonDataSetMessageContentMask` converters |

--- a/packages/node-opcua-json/package.json
+++ b/packages/node-opcua-json/package.json
@@ -11,6 +11,39 @@
     },
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        },
+        "./104": {
+            "types": "./dist/104/index.d.ts",
+            "default": "./dist/104/index.js"
+        },
+        "./105": {
+            "types": "./dist/105/index.d.ts",
+            "default": "./dist/105/index.js"
+        },
+        "./dist/*": {
+            "types": "./dist/*.d.ts",
+            "default": "./dist/*.js"
+        },
+        "./dist/*.js": {
+            "types": "./dist/*.d.ts",
+            "default": "./dist/*.js"
+        },
+        "./package.json": "./package.json"
+    },
+    "typesVersions": {
+        "*": {
+            "104": [
+                "dist/104/index.d.ts"
+            ],
+            "105": [
+                "dist/105/index.d.ts"
+            ]
+        }
+    },
     "devEngines": {
         "node": ">=18.x",
         "npm": ">=10.x"

--- a/packages/node-opcua-json/source/104/index.ts
+++ b/packages/node-opcua-json/source/104/index.ts
@@ -1,0 +1,117 @@
+/**
+ * ==========================================================================
+ * Copyright (c) 2021-2026 Sterfive - etienne.rossignon@sterfive.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ * ==========================================================================
+ */
+
+/**
+ * The OPC UA 1.04 JSON encoding (Part 6, "reversible" and "non-reversible" forms), exposed
+ * under version-free names: `import { opcuaJsonEncodeDataValue } from "node-opcua-json/104"`.
+ *
+ * Everything here is locked to 1.04: the encoders take a JsonEncoderMode (Reversible or
+ * NonReversible) and the JSON types are the 1.04 shapes (Type/Body, TypeId/Body, NodeId objects).
+ * The root "node-opcua-json" entry point dispatches on JsonEncodingScheme and accepts either edition.
+ */
+
+import type { ExtensionObject } from "node-opcua-extension-object";
+import type { Pojo } from "../decode_opcua_json.js";
+import type { ExtensionObjectBuilder } from "../json_basic_encoding_body_functor.js";
+import {
+    type ExtensionObjectJSON104,
+    opcuaJsonDecodeExtensionObject as opcuaJsonDecodeExtensionObjectAny,
+    opcuaJsonEncodeExtensionObject as opcuaJsonEncodeExtensionObjectAny
+} from "../json_basic_encoding_decoding_extension_object.js";
+import { type JsonEncoderMode104, toJsonEncodingScheme } from "../json_encoding_scheme.js";
+
+// version-agnostic parts, shared with the root entry point
+export * from "../decode_opcua_json.js";
+export type { ExtensionObjectConstructorFuncWithSchema } from "../extension_object_constructor.js";
+export * from "../json_basic_encoding_body_functor.js";
+export * from "../json_basic_encoding_decoding_byte_string.js";
+// DataValue
+export {
+    type DataValueJSON104 as DataValueJSON,
+    type DataValueStatusAndTimestamps,
+    opcuaJsonDecodeDataValue104 as opcuaJsonDecodeDataValue,
+    opcuaJsonEncodeDataValue104 as opcuaJsonEncodeDataValue,
+    opcuaJsonEncodeDataValueMQTT104 as opcuaJsonEncodeDataValueMQTT
+} from "../json_basic_encoding_decoding_data_value.js";
+export * from "../json_basic_encoding_decoding_date_time.js";
+// ExtensionObject
+export {
+    type ExtensionObjectJSON104 as ExtensionObjectJSON,
+    makeBody,
+    opcuaJsonDecodeExtensionObjectBody,
+    opcuaJsonEncodeExtensionObjectBody
+} from "../json_basic_encoding_decoding_extension_object.js";
+export * from "../json_basic_encoding_decoding_int64.js";
+export * from "../json_basic_encoding_decoding_localizedtext.js";
+// NodeId
+export {
+    type NodeIdJSON104 as NodeIdJSON,
+    opcuaDecodeURIComponent,
+    opcuaEncodeURIComponent,
+    opcuaJsonDecodeExpandedNodeId,
+    opcuaJsonDecodeNodeId,
+    opcuaJsonEncodeExpandedNodeId104 as opcuaJsonEncodeExpandedNodeId,
+    opcuaJsonEncodeNodeId104 as opcuaJsonEncodeNodeId
+} from "../json_basic_encoding_decoding_nodeid.js";
+export * from "../json_basic_encoding_decoding_qualifiedname.js";
+
+// StatusCode
+export {
+    opcuaJsonDecodeStatusCode,
+    opcuaJsonEncodeStatusCode104 as opcuaJsonEncodeStatusCode,
+    type StatusCodeJSON
+} from "../json_basic_encoding_decoding_statuscode.js";
+// Variant
+export {
+    opcuaJsonDecodeVariant104 as opcuaJsonDecodeVariant,
+    opcuaJsonEncodeVariant104 as opcuaJsonEncodeVariant,
+    type VariantJSON104 as VariantJSON,
+    type VariantJSONBody,
+    type VariantJSONBodyScalar
+} from "../json_basic_encoding_decoding_variant.js";
+export { JsonEncoderMode104 as JsonEncoderMode, JsonEncodingScheme, toJsonEncodingScheme } from "../json_encoding_scheme.js";
+
+/**
+ * encode an ExtensionObject with the 1.04 rules: Reversible yields { TypeId, Body },
+ * NonReversible yields the bare body.
+ */
+export function opcuaJsonEncodeExtensionObject(
+    extensionObject: ExtensionObject | ExtensionObject[] | null,
+    mode: JsonEncoderMode104,
+    namespaceArray?: string[]
+): ExtensionObjectJSON104 | Pojo | (ExtensionObjectJSON104 | Pojo)[] | null {
+    return opcuaJsonEncodeExtensionObjectAny(extensionObject, toJsonEncodingScheme(mode), namespaceArray) as
+        | ExtensionObjectJSON104
+        | Pojo
+        | (ExtensionObjectJSON104 | Pojo)[]
+        | null;
+}
+
+export function opcuaJsonDecodeExtensionObject(
+    pojo: ExtensionObjectJSON104,
+    builder: ExtensionObjectBuilder,
+    namespaceArray: string[]
+): ExtensionObject | ExtensionObject[] | null {
+    return opcuaJsonDecodeExtensionObjectAny(pojo, builder, namespaceArray);
+}

--- a/packages/node-opcua-json/source/105/index.ts
+++ b/packages/node-opcua-json/source/105/index.ts
@@ -1,0 +1,118 @@
+/**
+ * ==========================================================================
+ * Copyright (c) 2021-2026 Sterfive - etienne.rossignon@sterfive.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ * ==========================================================================
+ */
+
+/**
+ * The OPC UA 1.05 JSON encoding (Part 6, "Compact" and "Verbose" forms), exposed under
+ * version-free names: `import { opcuaJsonEncodeDataValue } from "node-opcua-json/105"`.
+ *
+ * Everything here is locked to 1.05: the encoders take a JsonEncoderMode (Compact or Verbose)
+ * and the JSON types are the 1.05 shapes (UaType/Value, UaTypeId/UaBody, NodeId strings).
+ * The root "node-opcua-json" entry point dispatches on JsonEncodingScheme and accepts either edition.
+ */
+
+import type { ExtensionObject } from "node-opcua-extension-object";
+import type { ExtensionObjectBuilder } from "../json_basic_encoding_body_functor.js";
+import {
+    type ExtensionObjectJSON105,
+    opcuaJsonDecodeExtensionObject as opcuaJsonDecodeExtensionObjectAny,
+    opcuaJsonEncodeExtensionObject as opcuaJsonEncodeExtensionObjectAny
+} from "../json_basic_encoding_decoding_extension_object.js";
+import { type JsonEncoderMode105, toJsonEncodingScheme } from "../json_encoding_scheme.js";
+
+// version-agnostic parts, shared with the root entry point
+export * from "../decode_opcua_json.js";
+export type { ExtensionObjectConstructorFuncWithSchema } from "../extension_object_constructor.js";
+export * from "../json_basic_encoding_body_functor.js";
+export * from "../json_basic_encoding_decoding_byte_string.js";
+// DataValue
+export {
+    type DataValueJSON105 as DataValueJSON,
+    type DataValueStatusAndTimestamps,
+    opcuaJsonDecodeDataValue105 as opcuaJsonDecodeDataValue,
+    opcuaJsonEncodeDataValue105 as opcuaJsonEncodeDataValue,
+    opcuaJsonEncodeDataValueMQTT105 as opcuaJsonEncodeDataValueMQTT
+} from "../json_basic_encoding_decoding_data_value.js";
+export * from "../json_basic_encoding_decoding_date_time.js";
+// ExtensionObject
+export {
+    type ExtensionObjectJSON105 as ExtensionObjectJSON,
+    makeBody,
+    opcuaJsonDecodeExtensionObjectBody,
+    opcuaJsonEncodeExtensionObjectBody
+} from "../json_basic_encoding_decoding_extension_object.js";
+export * from "../json_basic_encoding_decoding_int64.js";
+export * from "../json_basic_encoding_decoding_localizedtext.js";
+// NodeId
+export {
+    type NodeIdJSON105 as NodeIdJSON,
+    opcuaDecodeURIComponent,
+    opcuaEncodeURIComponent,
+    opcuaJsonDecodeExpandedNodeId,
+    opcuaJsonDecodeNodeId,
+    opcuaJsonEncodeExpandedNodeId105 as opcuaJsonEncodeExpandedNodeId,
+    opcuaJsonEncodeExpandedNodeIdAsString,
+    opcuaJsonEncodeNodeId105 as opcuaJsonEncodeNodeId,
+    opcuaJsonEncodeNodeIdAsString
+} from "../json_basic_encoding_decoding_nodeid.js";
+export * from "../json_basic_encoding_decoding_qualifiedname.js";
+
+// StatusCode
+export {
+    opcuaJsonDecodeStatusCode,
+    opcuaJsonEncodeStatusCode105 as opcuaJsonEncodeStatusCode,
+    type StatusCodeJSON
+} from "../json_basic_encoding_decoding_statuscode.js";
+// Variant
+export {
+    opcuaJsonDecodeVariant105 as opcuaJsonDecodeVariant,
+    opcuaJsonEncodeVariant105 as opcuaJsonEncodeVariant,
+    type VariantJSON105 as VariantJSON,
+    type VariantJSONBody,
+    type VariantJSONBodyScalar
+} from "../json_basic_encoding_decoding_variant.js";
+export { JsonEncoderMode105 as JsonEncoderMode, JsonEncodingScheme, toJsonEncodingScheme } from "../json_encoding_scheme.js";
+
+/**
+ * encode an ExtensionObject with the 1.05 rules: { UaTypeId, UaBody }, UaBody omitted in
+ * Compact mode when empty; a null ExtensionObject is omitted (undefined) in Compact mode.
+ */
+export function opcuaJsonEncodeExtensionObject(
+    extensionObject: ExtensionObject | ExtensionObject[] | null,
+    mode: JsonEncoderMode105,
+    namespaceArray?: string[]
+): ExtensionObjectJSON105 | ExtensionObjectJSON105[] | null | undefined {
+    return opcuaJsonEncodeExtensionObjectAny(extensionObject, toJsonEncodingScheme(mode), namespaceArray) as
+        | ExtensionObjectJSON105
+        | ExtensionObjectJSON105[]
+        | null
+        | undefined;
+}
+
+export function opcuaJsonDecodeExtensionObject(
+    pojo: ExtensionObjectJSON105,
+    builder: ExtensionObjectBuilder,
+    namespaceArray: string[]
+): ExtensionObject | ExtensionObject[] | null {
+    return opcuaJsonDecodeExtensionObjectAny(pojo, builder, namespaceArray);
+}

--- a/packages/node-opcua-json/source/index.ts
+++ b/packages/node-opcua-json/source/index.ts
@@ -22,6 +22,11 @@
  * ==========================================================================
  */
 
+// version-locked realms: `node-opcua-json/104` and `node-opcua-json/105` expose the same
+// API under version-free names (opcuaJsonEncodeDataValue, DataValueJSON, ...) bound to a
+// single edition of Part 6, whereas this root entry point dispatches on JsonEncodingScheme.
+export * as v104 from "./104/index.js";
+export * as v105 from "./105/index.js";
 export * from "./decode_opcua_json.js";
 export type { ExtensionObjectConstructorFuncWithSchema } from "./extension_object_constructor.js";
 export * from "./json_basic_encoding_body_functor.js";
@@ -31,8 +36,14 @@ export {
     type DataValueJSON104,
     type DataValueJSON105,
     opcuaJsonDecodeDataValue,
+    opcuaJsonDecodeDataValue104,
+    opcuaJsonDecodeDataValue105,
     opcuaJsonEncodeDataValue,
-    opcuaJsonEncodeDataValueMQTT
+    opcuaJsonEncodeDataValue104,
+    opcuaJsonEncodeDataValue105,
+    opcuaJsonEncodeDataValueMQTT,
+    opcuaJsonEncodeDataValueMQTT104,
+    opcuaJsonEncodeDataValueMQTT105
 } from "./json_basic_encoding_decoding_data_value.js";
 export * from "./json_basic_encoding_decoding_extension_object.js";
 export {
@@ -44,13 +55,14 @@ export * from "./json_basic_encoding_decoding_localizedtext.js";
 export * from "./json_basic_encoding_decoding_nodeid.js";
 export * from "./json_basic_encoding_decoding_qualifiedname.js";
 export * from "./json_basic_encoding_decoding_statuscode.js";
-export * from "./json_basic_encoding_decoding_statuscode.js";
 export {
     opcuaJsonDecodeVariant,
+    opcuaJsonDecodeVariant104,
     // the explicit 1.05 entry points: the dispatcher above overloads Compact and Verbose together
     // and so cannot return the 1.05 object shape for Verbose alone
     opcuaJsonDecodeVariant105,
     opcuaJsonEncodeVariant,
+    opcuaJsonEncodeVariant104,
     opcuaJsonEncodeVariant105,
     type VariantJSON,
     type VariantJSON104,

--- a/packages/node-opcua-json/source/json_basic_encoding_decoding_data_value.ts
+++ b/packages/node-opcua-json/source/json_basic_encoding_decoding_data_value.ts
@@ -148,19 +148,19 @@ export function opcuaJsonEncodeDataValueMQTT(
 ): VariantJSONBody | VariantJSON105 | VariantJSON104 | DataValueJSON105 | DataValueJSON104 | null {
     switch (encoding) {
         case JsonEncodingScheme.DeprecatedNonReversible:
-            return _opcuaJsonEncodeDataValueMQTT104(dataValue, JsonEncoderMode104.NonReversible, mask, namespaceArray);
+            return opcuaJsonEncodeDataValueMQTT104(dataValue, JsonEncoderMode104.NonReversible, mask, namespaceArray);
         case JsonEncodingScheme.DeprecatedReversible:
-            return _opcuaJsonEncodeDataValueMQTT104(dataValue, JsonEncoderMode104.Reversible, mask, namespaceArray);
+            return opcuaJsonEncodeDataValueMQTT104(dataValue, JsonEncoderMode104.Reversible, mask, namespaceArray);
         case JsonEncodingScheme.Verbose:
-            return _opcuaJsonEncodeDataValueMQTT105(dataValue, JsonEncoderMode105.Verbose, mask, namespaceArray);
+            return opcuaJsonEncodeDataValueMQTT105(dataValue, JsonEncoderMode105.Verbose, mask, namespaceArray);
         case JsonEncodingScheme.Compact: {
-            return _opcuaJsonEncodeDataValueMQTT105(dataValue, JsonEncoderMode105.Compact, mask, namespaceArray);
+            return opcuaJsonEncodeDataValueMQTT105(dataValue, JsonEncoderMode105.Compact, mask, namespaceArray);
         }
         default:
             throw new Error("Invalid JsonEncodingScheme");
     }
 }
-function _opcuaJsonEncodeDataValueMQTT104(
+export function opcuaJsonEncodeDataValueMQTT104(
     dataValue: DataValue,
     mode: JsonEncoderMode104,
     mask: DataSetFieldContentMask,
@@ -248,7 +248,7 @@ function _opcuaJsonEncodeDataValueMQTT104(
  * @param mask
  * @returns
  */
-export function _opcuaJsonEncodeDataValueMQTT105(
+export function opcuaJsonEncodeDataValueMQTT105(
     dataValue: DataValue,
     mode: JsonEncoderMode105,
     mask: DataSetFieldContentMask,

--- a/packages/node-opcua-json/source/json_basic_encoding_decoding_nodeid.ts
+++ b/packages/node-opcua-json/source/json_basic_encoding_decoding_nodeid.ts
@@ -44,6 +44,8 @@ export interface NodeIdJSON104 {
     IdType?: 0 | 1 | 2 | 3;
     Id: number | string;
     Namespace?: number | string;
+    /** ExpandedNodeId only: the ServerIndex, omitted when 0 (Part 6 1.04 clause 5.4.2.11) */
+    ServerUri?: number;
 }
 export type NodeIdJSON105 = string;
 export type NodeIdJSON = NodeIdJSON104 | NodeIdJSON105;
@@ -230,12 +232,24 @@ export function opcuaJsonEncodeExpandedNodeId(
     }
 }
 
+/**
+ * Part 6 1.04 clause 5.4.2.11: an ExpandedNodeId is the NodeId object plus a ServerUri field
+ * carrying the ServerIndex, omitted when 0. A NamespaceUri set on the ExpandedNodeId wins over
+ * the index in the non-reversible form, where the namespace is written as a URI anyway.
+ */
 export function opcuaJsonEncodeExpandedNodeId104(
-    _value: ExpandedNodeId,
+    value: ExpandedNodeId,
     scheme: JsonEncodingScheme,
-    _namespaceArray?: string[]
-): NodeIdJSON | undefined {
-    throw new Error(`Invalid JsonEncodingScheme: ${scheme}`);
+    namespaceArray?: string[]
+): NodeIdJSON104 {
+    const pojo = opcuaJsonEncodeNodeId104(value, scheme, namespaceArray);
+    if (value.namespaceUri && scheme === JsonEncodingScheme.DeprecatedNonReversible) {
+        pojo.Namespace = value.namespaceUri;
+    }
+    if (value.serverIndex !== 0) {
+        pojo.ServerUri = value.serverIndex;
+    }
+    return pojo;
 }
 
 export function opcuaEncodeURIComponent(value: string): string {
@@ -354,7 +368,8 @@ export function opcuaJsonDecodeExpandedNodeId(
     namespaceArray?: string[]
 ): ExpandedNodeId {
     const nodeId = opcuaJsonDecodeNodeId(pojoOrString, builder, namespaceArray);
-    const result = ExpandedNodeId.fromNodeId(nodeId);
-    // we don't suport serverIndex in JSON encoding
-    return result;
+    // the 1.05 string form carries svr=/svu=, which coerceNodeId does not parse; the 1.04 object
+    // form carries ServerUri as the ServerIndex
+    const serverIndex = typeof pojoOrString === "object" && pojoOrString ? (pojoOrString.ServerUri ?? 0) : 0;
+    return ExpandedNodeId.fromNodeId(nodeId, undefined, serverIndex);
 }

--- a/packages/node-opcua-json/source/json_basic_encoding_decoding_nodeid.ts
+++ b/packages/node-opcua-json/source/json_basic_encoding_decoding_nodeid.ts
@@ -101,7 +101,7 @@ const nodeIdValueToString = (value: NodeId): string => {
  *  A NamespaceIndex of 1 is always encoded as a JSON number.
  */
 
-function opcuaJsonEncodeNodeId104(
+export function opcuaJsonEncodeNodeId104(
     value: NodeId,
     scheme = JsonEncodingScheme.DeprecatedReversible,
     namespaceArray?: string[]
@@ -168,7 +168,11 @@ export function opcuaJsonEncodeExpandedNodeIdAsString(value: ExpandedNodeId, nam
     return result;
 }
 
-function opcuaJsonEncodeNodeId105(value: NodeId, scheme: JsonEncodingScheme, namespaceArray?: string[]): NodeIdJSON105 | undefined {
+export function opcuaJsonEncodeNodeId105(
+    value: NodeId,
+    scheme: JsonEncodingScheme,
+    namespaceArray?: string[]
+): NodeIdJSON105 | undefined {
     if (value.namespace === 0 && value.identifierType === NodeIdType.NUMERIC && value.value === 0) {
         if (scheme === JsonEncodingScheme.Compact) {
             return undefined;
@@ -178,7 +182,7 @@ function opcuaJsonEncodeNodeId105(value: NodeId, scheme: JsonEncodingScheme, nam
     return opcuaJsonEncodeNodeIdAsString(value, namespaceArray || []);
 }
 
-function opcuaJsonEncodeExpandedNodeId105(
+export function opcuaJsonEncodeExpandedNodeId105(
     value: ExpandedNodeId,
     scheme: JsonEncodingScheme,
     namespaceArray?: string[]

--- a/packages/node-opcua-json/test/json_basic_encode_decode_nodeid.test.ts
+++ b/packages/node-opcua-json/test/json_basic_encode_decode_nodeid.test.ts
@@ -25,6 +25,7 @@ import "should";
 import { coerceNodeId, ExpandedNodeId } from "node-opcua-nodeid";
 import should from "should";
 import {
+    opcuaJsonDecodeExpandedNodeId,
     opcuaJsonDecodeNodeId,
     opcuaJsonEncodeExpandedNodeId,
     opcuaJsonEncodeNodeId,
@@ -157,6 +158,34 @@ describe("JSON encode ExpandedNodeId - 105", () => {
             const encoded = opcuaJsonEncodeExpandedNodeId(expandedNodeId, JsonEncodingScheme.Compact);
             should(encoded).eql(expected);
         });
+    });
+});
+
+describe("JSON encode ExpandedNodeId - 104", () => {
+    const withServer = ExpandedNodeId.fromNodeId(coerceNodeId("ns=2;i=1"), undefined, 3);
+    const withUri = ExpandedNodeId.fromNodeId(coerceNodeId("ns=2;s=abc"), "http://hello", 0);
+
+    it("should encode the ServerIndex as ServerUri and omit it when 0 - Reversible", () => {
+        should(opcuaJsonEncodeExpandedNodeId(withServer, Reversible, namespaceArray)).eql({ Id: 1, Namespace: 2, ServerUri: 3 });
+        should(opcuaJsonEncodeExpandedNodeId(ExpandedNodeId.fromNodeId(coerceNodeId("ns=0;i=1")), Reversible)).eql({ Id: 1 });
+    });
+    it("should write the NamespaceUri of the ExpandedNodeId - NonReversible", () => {
+        should(opcuaJsonEncodeExpandedNodeId(withUri, NonReversible, namespaceArray)).eql({
+            IdType: 1,
+            Id: "abc",
+            Namespace: "http://hello"
+        });
+        should(opcuaJsonEncodeExpandedNodeId(withServer, NonReversible, namespaceArray)).eql({
+            Id: 1,
+            Namespace: "n2",
+            ServerUri: 3
+        });
+    });
+    it("should round-trip the ServerIndex", () => {
+        const pojo = opcuaJsonEncodeExpandedNodeId(withServer, Reversible, namespaceArray);
+        const back = opcuaJsonDecodeExpandedNodeId(pojo, fakeBuilder, namespaceArray);
+        should(back.toString()).eql(withServer.toString());
+        should(back.serverIndex).eql(3);
     });
 });
 

--- a/packages/node-opcua-json/test/json_version_realms.test.ts
+++ b/packages/node-opcua-json/test/json_version_realms.test.ts
@@ -1,0 +1,103 @@
+/**
+ * ==========================================================================
+ * Copyright (c) 2021-2026 Sterfive - etienne.rossignon@sterfive.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ * ==========================================================================
+ */
+
+import { DataValue } from "node-opcua-data-value";
+import * as root from "node-opcua-json";
+import * as v104 from "node-opcua-json/104";
+import * as v105 from "node-opcua-json/105";
+import { Range } from "node-opcua-types";
+import { DataType } from "node-opcua-variant";
+import should from "should";
+
+describe("node-opcua-json version realms", () => {
+    const namespaceArray = ["http://opcfoundation.org/UA/", "urn:custom"];
+    const dataValue = new DataValue({ value: { dataType: DataType.Double, value: 3.5 } });
+    const builder: root.ExtensionObjectBuilder = {
+        constructObject(): never {
+            throw new Error("not used");
+        }
+    } as unknown as root.ExtensionObjectBuilder;
+
+    it("node-opcua-json/104 exposes the 1.04 API under version-free names", () => {
+        should(v104.opcuaJsonEncodeDataValue).equal(root.opcuaJsonEncodeDataValue104);
+        should(v104.opcuaJsonDecodeDataValue).equal(root.opcuaJsonDecodeDataValue104);
+        should(v104.opcuaJsonEncodeVariant).equal(root.opcuaJsonEncodeVariant104);
+        should(v104.opcuaJsonDecodeVariant).equal(root.opcuaJsonDecodeVariant104);
+        should(v104.opcuaJsonEncodeStatusCode).equal(root.opcuaJsonEncodeStatusCode104);
+        should(v104.opcuaJsonEncodeNodeId).equal(root.opcuaJsonEncodeNodeId104);
+        should(v104.opcuaJsonEncodeDataValueMQTT).equal(root.opcuaJsonEncodeDataValueMQTT104);
+        should(v104.JsonEncoderMode).equal(root.JsonEncoderMode104);
+
+        const pojo: v104.DataValueJSON = v104.opcuaJsonEncodeDataValue(dataValue, v104.JsonEncoderMode.Reversible, namespaceArray);
+        should(pojo.Value).eql({ Type: DataType.Double, Body: 3.5 });
+        const back = v104.opcuaJsonDecodeDataValue(pojo, builder, namespaceArray);
+        should(back.value.value).eql(3.5);
+    });
+
+    it("node-opcua-json/105 exposes the 1.05 API under version-free names", () => {
+        should(v105.opcuaJsonEncodeDataValue).equal(root.opcuaJsonEncodeDataValue105);
+        should(v105.opcuaJsonDecodeDataValue).equal(root.opcuaJsonDecodeDataValue105);
+        should(v105.opcuaJsonEncodeVariant).equal(root.opcuaJsonEncodeVariant105);
+        should(v105.opcuaJsonDecodeVariant).equal(root.opcuaJsonDecodeVariant105);
+        should(v105.opcuaJsonEncodeStatusCode).equal(root.opcuaJsonEncodeStatusCode105);
+        should(v105.opcuaJsonEncodeNodeId).equal(root.opcuaJsonEncodeNodeId105);
+        should(v105.opcuaJsonEncodeDataValueMQTT).equal(root.opcuaJsonEncodeDataValueMQTT105);
+        should(v105.JsonEncoderMode).equal(root.JsonEncoderMode105);
+
+        const pojo: v105.DataValueJSON = v105.opcuaJsonEncodeDataValue(dataValue, v105.JsonEncoderMode.Verbose, namespaceArray);
+        should(pojo.UaType).eql(DataType.Double);
+        should(pojo.Value).eql(3.5);
+        const back = v105.opcuaJsonDecodeDataValue(pojo, builder, namespaceArray);
+        should(back.value.value).eql(3.5);
+    });
+
+    it("each realm encodes an ExtensionObject in its own shape", () => {
+        const range = new Range({ low: 1, high: 2 });
+
+        const pojo104 = v104.opcuaJsonEncodeExtensionObject(range, v104.JsonEncoderMode.Reversible, namespaceArray);
+        should(pojo104).have.property("TypeId");
+        should(pojo104).have.property("Body");
+        should(pojo104).not.have.property("UaTypeId");
+
+        const pojo105 = v105.opcuaJsonEncodeExtensionObject(range, v105.JsonEncoderMode.Verbose, namespaceArray);
+        should(pojo105).have.property("UaTypeId");
+        should(pojo105).have.property("UaBody");
+        should(pojo105).not.have.property("TypeId");
+
+        const back104 = v104.opcuaJsonDecodeExtensionObject(pojo104 as v104.ExtensionObjectJSON, builder, namespaceArray) as Range;
+        const back105 = v105.opcuaJsonDecodeExtensionObject(pojo105 as v105.ExtensionObjectJSON, builder, namespaceArray) as Range;
+        should(back104.toJSON()).eql(range.toJSON());
+        should(back105.toJSON()).eql(range.toJSON());
+    });
+
+    it("the root entry point stays version-flexible and also exposes both realms", () => {
+        const p104 = root.opcuaJsonEncodeDataValue(dataValue, root.JsonEncodingScheme.DeprecatedReversible, namespaceArray);
+        const p105 = root.opcuaJsonEncodeDataValue(dataValue, root.JsonEncodingScheme.Verbose, namespaceArray);
+        should(root.opcuaJsonDecodeDataValue(p104, builder, namespaceArray).value.value).eql(3.5);
+        should(root.opcuaJsonDecodeDataValue(p105, builder, namespaceArray).value.value).eql(3.5);
+
+        should(root.v104.opcuaJsonEncodeDataValue).equal(v104.opcuaJsonEncodeDataValue);
+        should(root.v105.opcuaJsonEncodeDataValue).equal(v105.opcuaJsonEncodeDataValue);
+    });
+});

--- a/tools/check-pack/src/rule.js
+++ b/tools/check-pack/src/rule.js
@@ -68,7 +68,8 @@ export function declaredEntryPoints(pkg) {
  * `packedFiles` is an array of tarball-relative paths. Pure.
  */
 export function missingEntryPoints(pkg, packedFiles) {
-    const shipped = new Set(packedFiles.map(normalize));
+    const shippedList = packedFiles.map(normalize);
+    const shipped = new Set(shippedList);
     const out = [];
     for (const { field, target } of declaredEntryPoints(pkg)) {
         // only relative targets describe a file in this tarball; a bare specifier in an
@@ -76,7 +77,22 @@ export function missingEntryPoints(pkg, packedFiles) {
         if (!target.startsWith(".") && !target.startsWith("/")) {
             continue;
         }
-        if (!shipped.has(normalize(target))) {
+        const wanted = normalize(target);
+        // a subpath pattern ("./dist/*.js") promises every file the star can expand to; it
+        // is kept only if at least one shipped file matches, otherwise it promises nothing
+        const star = wanted.indexOf("*");
+        if (star >= 0) {
+            const prefix = wanted.slice(0, star);
+            const suffix = wanted.slice(star + 1);
+            const hit = shippedList.some(
+                (f) => f.length > prefix.length + suffix.length && f.startsWith(prefix) && f.endsWith(suffix)
+            );
+            if (!hit) {
+                out.push({ field, target });
+            }
+            continue;
+        }
+        if (!shipped.has(wanted)) {
             out.push({ field, target });
         }
     }

--- a/tools/check-pack/test/test_rule.js
+++ b/tools/check-pack/test/test_rule.js
@@ -82,6 +82,18 @@ test("leading ./ is not significant either way", () => {
     assert.deepEqual(missingEntryPoints({ main: "./dist/index.js" }, ["dist/index.js"]), []);
 });
 
+test("a subpath pattern is satisfied by any shipped file the star expands to", () => {
+    const pkg = { exports: { "./dist/*": { types: "./dist/*.d.ts", default: "./dist/*.js" } } };
+    assert.deepEqual(missingEntryPoints(pkg, ["dist/index.js", "dist/index.d.ts", "dist/104/index.js"]), []);
+});
+
+test("a subpath pattern that no shipped file matches is a broken promise", () => {
+    const pkg = { exports: { "./dist/*": "./dist/*.js" } };
+    const missing = missingEntryPoints(pkg, ["source/index.ts"]);
+    assert.equal(missing.length, 1);
+    assert.equal(missing[0].target, "./dist/*.js");
+});
+
 test("a bare specifier in exports is a redirect to another package, not our file", () => {
     const pkg = { exports: { "./polyfill": "node-opcua-utils/polyfill" } };
     assert.deepEqual(missingEntryPoints(pkg, []), []);


### PR DESCRIPTION
## Summary

`node-opcua-json` gains two version-locked subpath entry points next to the scheme-dispatched root:

```ts
import { opcuaJsonEncodeDataValue, DataValueJSON, JsonEncoderMode } from "node-opcua-json/104"; // strict 1.04
import { opcuaJsonEncodeDataValue, DataValueJSON, JsonEncoderMode } from "node-opcua-json/105"; // strict 1.05
import { opcuaJsonEncodeDataValue104, opcuaJsonEncodeDataValue105 } from "node-opcua-json";   // flexible root
```

- Each realm re-exports every `Xxx104` / `Xxx105` function and JSON type under its version-free name, with `JsonEncoderMode` bound to that edition's two-value enum. Passing a 1.04 mode into the 1.05 realm is a type error, and the JSON types are the exact edition shapes rather than a union.
- ExtensionObject had no per-edition functions, so each realm gets a thin `opcuaJsonEncodeExtensionObject(eo, mode, namespaceArray)` wrapper and a decoder typed to that realm's shape.
- Version-agnostic scalars (Int64, ByteString, DateTime, LocalizedText, QualifiedName) are shared verbatim.
- The root now also exports the DataValue, Variant and MQTT suffixed names it previously omitted, and exposes both realms as the `v104` / `v105` namespaces.

## Packaging

The subpaths require an `exports` map. It covers `.`, `./104`, `./105`, a `./dist/*` passthrough so the existing deep imports keep resolving, and `./package.json`. `typesVersions` covers consumers on classic module resolution. Verified that the old `node-opcua-json/dist/json_basic_encoding_decoding_data_value` import still resolves in both TypeScript and Node, and that `node-opcua-uanodeset-json` / `node-opcua-uanodeset-rdf` build unchanged.

Renamed in passing: `_opcuaJsonEncodeDataValueMQTT105` (exported with a leading underscore) is now `opcuaJsonEncodeDataValueMQTT105`; the `opcuaJsonEncodeNodeId104/105` and `opcuaJsonEncodeExpandedNodeId105` helpers became public so the realms can re-export them.

## Second commit: the 1.04 ExpandedNodeId encoder

`opcuaJsonEncodeExpandedNodeId104` threw unconditionally, and the realm would have exposed that under a friendlier name. It now follows Part 6 1.04 clause 5.4.2.11: the NodeId object plus `ServerUri` carrying a non-zero ServerIndex, with the ExpandedNodeId's own NamespaceUri written in the non-reversible form. The decoder reads `ServerUri` back so the ServerIndex round-trips instead of being dropped.

## Tests and docs

- `test/json_version_realms.test.ts` imports through the real `node-opcua-json/104` and `/105` package paths, so the exports map itself is exercised; checks identity against the root's suffixed functions, DataValue round trips, per-realm ExtensionObject shapes, and that the root stays flexible.
- `test/json_basic_encode_decode_nodeid.test.ts` gains a 1.04 ExpandedNodeId block (Reversible, NonReversible, round trip).
- README: new section "One edition only" and updated API table.
- Package suite 182 passing, `test:check` clean, `pnpm run lint:ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
