### PR TITLE
fix(server): accept the event filter an alarm collector sends (FEAT-43)

### DIFF
--- a/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_SubscriptionUseCase_monitoring_events.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_SubscriptionUseCase_monitoring_events.ts
@@ -204,13 +204,13 @@ export function t(test: UmbrellaTestContext): void {
             });
         });
 
-        // A whereClause ContentFilter that exceeds the server's MaxWhereClauseParameters (default 100).
-        // Built as an InList carrying one SimpleAttributeOperand + 101 literal operands (102 operands).
+        // A whereClause ContentFilter that exceeds the server's MaxWhereClauseParameters (default 1000).
+        // Built as an InList carrying one SimpleAttributeOperand + 1001 literal operands (1002 operands).
         function makeOversizedWhereClause(): ContentFilter {
             const operands: (SimpleAttributeOperand | LiteralOperand)[] = [
                 new SimpleAttributeOperand({ attributeId: AttributeIds.Value, browsePath: ["EventType"] })
             ];
-            for (let i = 0; i < 101; i++) {
+            for (let i = 0; i < 1001; i++) {
                 operands.push(
                     new LiteralOperand({ value: new Variant({ dataType: DataType.NodeId, value: resolveNodeId("BaseEventType") }) })
                 );
@@ -315,6 +315,208 @@ export function t(test: UmbrellaTestContext): void {
                 should(res.results?.[0].statusCode).eql(StatusCodes.Good);
                 const filterResult = res.results![0].filterResult as EventFilterResult;
                 should(filterResult.selectClauseResults?.[0]).eql(StatusCodes.BadNodeIdUnknown);
+            });
+        });
+
+        // The event fields the OPC Foundation CTT's alarm collector selects (AlarmUtilities.CreateAllSelectFields
+        // over every condition type the server advertises), captured on the wire against a server exposing the
+        // standard alarm types: each one on BaseEventType with a single browse path, attribute Value.
+        const alarmCollectorFields = [
+            "EventId",
+            "EventType",
+            "SourceNode",
+            "SourceName",
+            "Time",
+            "ReceiveTime",
+            "LocalTime",
+            "Message",
+            "Severity",
+            "ConditionClassId",
+            "ConditionClassName",
+            "ConditionSubClassId",
+            "ConditionSubClassName",
+            "ConditionName",
+            "BranchId",
+            "Retain",
+            "SupportsFilteredRetain",
+            "EnabledState",
+            "Quality",
+            "LastSeverity",
+            "Comment",
+            "ClientUserId",
+            "EnabledState/Id",
+            "EnabledState/TransitionTime",
+            "EnabledState/EffectiveTransitionTime",
+            "EnabledState/TrueState",
+            "EnabledState/FalseState",
+            "Quality/SourceTimestamp",
+            "LastSeverity/SourceTimestamp",
+            "Comment/SourceTimestamp",
+            "DialogState",
+            "Prompt",
+            "ResponseOptionSet",
+            "DefaultResponse",
+            "OkResponse",
+            "CancelResponse",
+            "LastResponse",
+            "DialogState/Id",
+            "DialogState/TransitionTime",
+            "DialogState/TrueState",
+            "DialogState/FalseState",
+            "AckedState",
+            "ConfirmedState",
+            "AckedState/Id",
+            "AckedState/TransitionTime",
+            "AckedState/TrueState",
+            "AckedState/FalseState",
+            "ConfirmedState/Id",
+            "ConfirmedState/TransitionTime",
+            "ConfirmedState/TrueState",
+            "ConfirmedState/FalseState",
+            "ActiveState",
+            "InputNode",
+            "SuppressedState",
+            "OutOfServiceState",
+            "SuppressedOrShelved",
+            "MaxTimeShelved",
+            "AudibleEnabled",
+            "AudibleSound",
+            "SilenceState",
+            "OnDelay",
+            "OffDelay",
+            "FirstInGroupFlag",
+            "LatchedState",
+            "ReAlarmTime",
+            "ReAlarmRepeatCount",
+            "ActiveState/Id",
+            "ActiveState/TransitionTime",
+            "ActiveState/EffectiveTransitionTime",
+            "ActiveState/TrueState",
+            "ActiveState/FalseState",
+            "SuppressedState/Id",
+            "SuppressedState/TransitionTime",
+            "SuppressedState/TrueState",
+            "SuppressedState/FalseState",
+            "OutOfServiceState/Id",
+            "OutOfServiceState/TransitionTime",
+            "OutOfServiceState/TrueState",
+            "OutOfServiceState/FalseState",
+            "ShelvingState/CurrentState",
+            "ShelvingState/LastTransition",
+            "ShelvingState/UnshelveTime",
+            "ShelvingState/CurrentState/Id",
+            "ShelvingState/LastTransition/Id",
+            "ShelvingState/LastTransition/TransitionTime",
+            "SilenceState/Id",
+            "SilenceState/TransitionTime",
+            "SilenceState/TrueState",
+            "SilenceState/FalseState",
+            "LatchedState/Id",
+            "LatchedState/TransitionTime",
+            "LatchedState/TrueState",
+            "LatchedState/FalseState",
+            "HighHighLimit",
+            "HighLimit",
+            "LowLimit",
+            "LowLowLimit",
+            "BaseHighHighLimit",
+            "BaseHighLimit",
+            "BaseLowLimit",
+            "BaseLowLowLimit",
+            "SeverityHighHigh",
+            "SeverityHigh",
+            "SeverityLow",
+            "SeverityLowLow",
+            "HighHighDeadband",
+            "HighDeadband",
+            "LowDeadband",
+            "LowLowDeadband",
+            "LimitState/CurrentState",
+            "LimitState/LastTransition",
+            "LimitState/CurrentState/Id",
+            "LimitState/LastTransition/Id",
+            "LimitState/LastTransition/TransitionTime",
+            "SetpointNode",
+            "BaseSetpointNode",
+            "EngineeringUnits",
+            "HighHighState",
+            "HighState",
+            "LowState",
+            "LowLowState",
+            "HighHighState/Id",
+            "HighHighState/TransitionTime",
+            "HighHighState/TrueState",
+            "HighHighState/FalseState",
+            "HighState/Id",
+            "HighState/TransitionTime",
+            "HighState/TrueState",
+            "HighState/FalseState",
+            "LowState/Id",
+            "LowState/TransitionTime",
+            "LowState/TrueState",
+            "LowState/FalseState",
+            "LowLowState/Id",
+            "LowLowState/TransitionTime",
+            "LowLowState/TrueState",
+            "LowLowState/FalseState",
+            "NormalState",
+            "ExpirationDate",
+            "ExpirationLimit",
+            "CertificateType",
+            "Certificate",
+            "TrustListId",
+            "LastUpdateTime",
+            "UpdateFrequency",
+            "TargetValueNode",
+            "ExpectedTime",
+            "Tolerance"
+        ];
+
+        // The ConditionId operand: the NodeId attribute of the ConditionType instance itself.
+        function makeConditionIdOperand(): SimpleAttributeOperand {
+            return new SimpleAttributeOperand({
+                typeDefinitionId: resolveNodeId("ConditionType"),
+                browsePath: [],
+                attributeId: AttributeIds.NodeId
+            });
+        }
+
+        // The filter the alarm collector creates on the Server object: the 148 fields above plus ConditionId
+        // (149 select clauses), and a where clause of one InList over ConditionId with no list yet - the
+        // collector starts as "ConditionId in ()" and fills the list with ModifyMonitoredItems as conditions appear.
+        function makeAlarmCollectorFilter(): EventFilter {
+            const selectClauses = alarmCollectorFields.map(
+                (field) =>
+                    new SimpleAttributeOperand({
+                        typeDefinitionId: resolveNodeId("BaseEventType"),
+                        browsePath: field.split("/"),
+                        attributeId: AttributeIds.Value
+                    })
+            );
+            selectClauses.push(makeConditionIdOperand());
+            return new EventFilter({
+                selectClauses,
+                whereClause: new ContentFilter({
+                    elements: [{ filterOperator: FilterOperator.InList, filterOperands: [makeConditionIdOperand()] }]
+                })
+            });
+        }
+
+        it("ZZ2G server should accept the event filter an alarm collector sends: 149 select clauses and InList(ConditionId) with an empty list", async () => {
+            if (!client) throw new Error("client not initialized");
+            const eventFilter = makeAlarmCollectorFilter();
+            (eventFilter.selectClauses || []).length.should.eql(149);
+            await perform_operation_on_subscription(client, test.endpointUrl!, async (session, subscription) => {
+                const res = await (session as RawSession).createMonitoredItems(
+                    makeCreateRequest(subscription.subscriptionId, eventFilter)
+                );
+                res.responseHeader.serviceResult.should.eql(StatusCodes.Good);
+                // with the previous defaults this was BadEventFilterInvalid (149 > MaxSelectClauseParameters 100),
+                // and with the limit raised BadFilterOperandCountMismatch (InList declared 2..n operands)
+                should(res.results?.[0].statusCode).eql(StatusCodes.Good);
+                should(res.results?.[0].monitoredItemId).be.greaterThan(0);
+                const filterResult = res.results![0].filterResult as EventFilterResult;
+                should(filterResult.selectClauseResults?.length).eql(149);
             });
         });
 

--- a/packages/node-opcua-server/source/server_capabilities.ts
+++ b/packages/node-opcua-server/source/server_capabilities.ts
@@ -134,6 +134,10 @@ export interface IServerCapabilities {
      * The value specifies the maximum the Server can support under normal circumstances,
      * therefore there is no guarantee the Server can always support
      * the maximum.
+     *
+     * An EventFilter with more select clauses than this is refused with BadEventFilterInvalid.
+     * Default 1000: a client that selects every field of every standard condition type
+     * (what the OPC Foundation CTT's alarm collector does) sends 149 of them.
      */
     maxSelectClauseParameters: UInt32;
 
@@ -142,6 +146,10 @@ export interface IServerCapabilities {
      * EventField WhereClause Parameters the Server can support for an EventFilter.
      * The value specifies the maximum the Server can support under normal circumstances,
      * therefore there is no guarantee the Server can always support the maximum
+     *
+     * Counted as the operands of every element of the whereClause; more than this is refused
+     * with BadEventFilterInvalid. Default 1000: an alarm collector's "InList(ConditionId, ...)"
+     * grows by one operand per condition it tracks.
      */
     maxWhereClauseParameters: UInt32;
 
@@ -212,8 +220,11 @@ export const defaultServerCapabilities: IServerCapabilities = {
     maxMonitoredItems: 1000000, // 1 million
     maxSubscriptionsPerSession: 10,
     maxMonitoredItemsPerSubscription: 100000, // one hundred thousand
-    maxSelectClauseParameters: 100,
-    maxWhereClauseParameters: 100,
+    // 100 was below what any server exposing the standard alarm types receives from a client
+    // that selects every event field (the CTT's alarm collector: 149 select clauses over the
+    // 33 standard condition types), and its where clause grows with the conditions tracked.
+    maxSelectClauseParameters: 1000,
+    maxWhereClauseParameters: 1000,
     maxMonitoredItemsQueueSize: 60000,
 
     conformanceUnits: []

--- a/packages/node-opcua-server/test/test_server_engine.ts
+++ b/packages/node-opcua-server/test/test_server_engine.ts
@@ -2412,3 +2412,62 @@ describe("FEAT-29: ServerEngine ServerCapabilities.ConformanceUnits (i=24101)", 
         });
     });
 });
+
+describe("FEAT-43: ServerEngine advertises MaxSelectClauseParameters and MaxWhereClauseParameters (i=24099, i=24100)", () => {
+    const maxSelectClauseParametersId = makeNodeId(VariableIds.Server_ServerCapabilities_MaxSelectClauseParameters);
+    const maxWhereClauseParametersId = makeNodeId(VariableIds.Server_ServerCapabilities_MaxWhereClauseParameters);
+
+    async function readLimits(engine: ServerEngine): Promise<[number, number]> {
+        const dataValues = await engine.read(
+            context,
+            new ReadRequest({
+                nodesToRead: [
+                    { nodeId: maxSelectClauseParametersId, attributeId: AttributeIds.Value },
+                    { nodeId: maxWhereClauseParametersId, attributeId: AttributeIds.Value }
+                ]
+            })
+        );
+        for (const dataValue of dataValues) {
+            dataValue.statusCode.should.eql(StatusCodes.Good);
+            dataValue.value.dataType.should.eql(DataType.UInt32);
+        }
+        return [dataValues[0].value.value as number, dataValues[1].value.value as number];
+    }
+
+    function makeEngine(serverCapabilities?: {
+        maxSelectClauseParameters: number;
+        maxWhereClauseParameters: number;
+    }): Promise<ServerEngine> {
+        const engine = new ServerEngine({
+            applicationUri: "URI:NODEOPCUA-EVENT-FILTER-LIMITS-TEST",
+            buildInfo: { productName: "EVENT-FILTER-LIMITS-TEST", productUri: "URI:EVENT-FILTER-LIMITS-TEST" },
+            serverCapabilities
+        });
+        return new Promise((resolve) => engine.initialize({ nodeset_filename: nodesets.standard }, () => resolve(engine)));
+    }
+
+    it("should advertise the defaults, large enough for an alarm collector selecting every field of the standard condition types (149)", async function (this: Mocha.Context) {
+        this.timeout(30000);
+        const engine = await makeEngine();
+        try {
+            const [maxSelect, maxWhere] = await readLimits(engine);
+            maxSelect.should.eql(1000);
+            maxWhere.should.eql(1000);
+            maxSelect.should.be.greaterThanOrEqual(149);
+        } finally {
+            await engine.shutdown();
+        }
+    });
+
+    it("should advertise the configured values", async function (this: Mocha.Context) {
+        this.timeout(30000);
+        const engine = await makeEngine({ maxSelectClauseParameters: 250, maxWhereClauseParameters: 50 });
+        try {
+            const [maxSelect, maxWhere] = await readLimits(engine);
+            maxSelect.should.eql(250);
+            maxWhere.should.eql(50);
+        } finally {
+            await engine.shutdown();
+        }
+    });
+});

--- a/packages/node-opcua-server/test/test_validate_filter.ts
+++ b/packages/node-opcua-server/test/test_validate_filter.ts
@@ -1,6 +1,7 @@
 import "should";
 import type { BaseNode } from "node-opcua-address-space";
 import { AttributeIds } from "node-opcua-data-model";
+import { resolveNodeId } from "node-opcua-nodeid";
 import {
     ContentFilter,
     ElementOperand,
@@ -12,6 +13,7 @@ import {
 import { StatusCodes } from "node-opcua-status-code";
 import type { ReadValueIdOptions } from "node-opcua-types";
 
+import { defaultServerCapabilities } from "../source/server_capabilities.js";
 import { validateFilter } from "../source/validate_filter.js";
 
 // The EventFilter branch of validateFilter does not dereference the node, so a stub is sufficient.
@@ -153,6 +155,71 @@ describe("validateFilter - EventFilter whereClause conformance (OPC UA Part 4 - 
             StatusCodes.BadEventFilterInvalid
         );
         validateFilter(filter, onEventNotifier, dummyNode, { maxSelectClauseParameters: 2 }).should.eql(StatusCodes.Good);
+    });
+
+    // The ConditionId operand of an alarm collector: the NodeId attribute of the ConditionType instance itself.
+    const conditionIdOperand = () =>
+        new SimpleAttributeOperand({
+            typeDefinitionId: resolveNodeId("ConditionType"),
+            browsePath: [],
+            attributeId: AttributeIds.NodeId
+        });
+
+    // The filter the OPC Foundation CTT's alarm collector creates on the Server object (captured on the
+    // wire): every event field of every standard condition type the server advertises, 148 of them, each
+    // on BaseEventType with one browse path, plus the ConditionId operand; and a where clause of one
+    // InList over ConditionId with no list yet (the collector fills it with ModifyMonitoredItems).
+    function alarmCollectorFilter(): EventFilter {
+        const selectClauses: SimpleAttributeOperand[] = [];
+        for (let i = 0; i < 148; i++) {
+            selectClauses.push(
+                new SimpleAttributeOperand({
+                    typeDefinitionId: resolveNodeId("BaseEventType"),
+                    browsePath: [`Field${i}`],
+                    attributeId: AttributeIds.Value
+                })
+            );
+        }
+        selectClauses.push(conditionIdOperand());
+        return new EventFilter({
+            selectClauses,
+            whereClause: new ContentFilter({
+                elements: [{ filterOperator: FilterOperator.InList, filterOperands: [conditionIdOperand()] }]
+            })
+        });
+    }
+
+    it("VF11 - the default server capabilities accept the 149 select clauses an alarm collector sends", () => {
+        const filter = alarmCollectorFilter();
+        (filter.selectClauses || []).length.should.eql(149);
+        const defaults = {
+            maxSelectClauseParameters: defaultServerCapabilities.maxSelectClauseParameters,
+            maxWhereClauseParameters: defaultServerCapabilities.maxWhereClauseParameters
+        };
+        validateFilter(filter, onEventNotifier, dummyNode, defaults).should.eql(StatusCodes.Good);
+        // the previous default, 100, is what refused it: Part 5 leaves the value to the server, and any
+        // server exposing the standard alarm types receives more than that from a client selecting every field
+        validateFilter(filter, onEventNotifier, dummyNode, { maxSelectClauseParameters: 100 }).should.eql(
+            StatusCodes.BadEventFilterInvalid
+        );
+    });
+
+    it("VF12 - accepts an InList with only its left operand: Part 4 7.7.4 makes it FALSE, not malformed", () => {
+        const filter = new EventFilter({
+            selectClauses: [],
+            whereClause: new ContentFilter({
+                elements: [{ filterOperator: FilterOperator.InList, filterOperands: [conditionIdOperand()] }]
+            })
+        });
+        validateFilter(filter, onEventNotifier, dummyNode).should.eql(StatusCodes.Good);
+    });
+
+    it("VF13 - still rejects an InList with no operand at all with BadFilterOperandCountMismatch", () => {
+        const filter = new EventFilter({
+            selectClauses: [],
+            whereClause: new ContentFilter({ elements: [{ filterOperator: FilterOperator.InList, filterOperands: [] }] })
+        });
+        validateFilter(filter, onEventNotifier, dummyNode).should.eql(StatusCodes.BadFilterOperandCountMismatch);
     });
 
     it("VF10 - still rejects an EventFilter applied to a non-EventNotifier attribute", () => {

--- a/packages/node-opcua-service-filter/source/check_where_clause.ts
+++ b/packages/node-opcua-service-filter/source/check_where_clause.ts
@@ -249,13 +249,20 @@ function checkBetween(filterContext: FilterContext, filter: ContentFilter, filte
 }
 
 /**
- * 
- * InList
+ * InList (OPC UA Part 4 - 7.7.4)
  * TRUE if operand[0] is equal to one or more of the remaining operands.
  * The Equals Operator is evaluated for operand[0] and each remaining operand in the
- * list. If any Equals evaluation is TRUE, InList returns TRUE
- x*/
+ * list. If any Equals evaluation is TRUE, InList returns TRUE.
+ *
+ * With no remaining operand there is nothing operand[0] can equal, so the result is
+ * FALSE: an "InList(ConditionId)" with an empty list is how an alarm collector starts
+ * (the OPC Foundation CTT creates it that way and fills the list with
+ * ModifyMonitoredItems), not a malformed element.
+ */
 function checkInList(context: FilterContext, filterOperands: FilterOperand[]): boolean {
+    if (filterOperands.length < 2) {
+        return false;
+    }
     const operand0 = filterOperands[0];
 
     // c8 ignore next
@@ -346,8 +353,15 @@ function checkFilterAtIndex(filterContext: FilterContext, filter: ContentFilter,
 }
 
 // Number of operands each FilterOperator expects, as per OPC UA Part 4 - Table 118 / Table 119.
-// `max = Infinity` is used for the variadic InList operator (2..n). Operators not listed here are
+// `max = Infinity` is used for the variadic InList operator. Operators not listed here are
 // not subject to an operand-count check.
+//
+// InList is 1..n, not 2..n: Part 4 7.7.4 defines it by its evaluation ("TRUE if operand[0] is
+// equal to one or more of the remaining operands"), which with no remaining operand is FALSE,
+// not an error. The OPC Foundation CTT's alarm collector monitors the Server object with
+// "InList(ConditionId)" and no list, then grows the list with ModifyMonitoredItems; refusing
+// the element with BadFilterOperandCountMismatch failed every Alarms and Conditions unit at
+// its initialize step. An InList with no operand at all is still malformed.
 const operandCountByOperator: { [operator: number]: { min: number; max: number } } = {
     [FilterOperator.Equals]: { min: 2, max: 2 },
     [FilterOperator.IsNull]: { min: 1, max: 1 },
@@ -358,7 +372,7 @@ const operandCountByOperator: { [operator: number]: { min: number; max: number }
     [FilterOperator.Like]: { min: 2, max: 2 },
     [FilterOperator.Not]: { min: 1, max: 1 },
     [FilterOperator.Between]: { min: 3, max: 3 },
-    [FilterOperator.InList]: { min: 2, max: Number.POSITIVE_INFINITY },
+    [FilterOperator.InList]: { min: 1, max: Number.POSITIVE_INFINITY },
     [FilterOperator.And]: { min: 2, max: 2 },
     [FilterOperator.Or]: { min: 2, max: 2 },
     [FilterOperator.Cast]: { min: 2, max: 2 },

--- a/packages/node-opcua-service-filter/test/test_check.ts
+++ b/packages/node-opcua-service-filter/test/test_check.ts
@@ -1,6 +1,7 @@
 import "should";
 import { AttributeIds } from "node-opcua-data-model";
 import { NodeId, resolveNodeId } from "node-opcua-nodeid";
+import { StatusCodes } from "node-opcua-status-code";
 import {
     ContentFilter,
     ElementOperand,
@@ -11,7 +12,7 @@ import {
 } from "node-opcua-types";
 import { DataType, Variant, type VariantOptionsT } from "node-opcua-variant";
 
-import { checkFilter, extractEventFieldsBase, ofType } from "../dist/index.js";
+import { checkFilter, extractEventFieldsBase, ofType, validateContentFilter } from "../dist/index.js";
 import { alarmNode, FilterContextMock, variableWithAlarm } from "./filter_context_mock.js";
 
 // https://reference.opcfoundation.org/v105/Core/docs/Part4/7.7.3/
@@ -739,10 +740,13 @@ describe("Testing extract EventField", function (this: Mocha.Suite) {
         checkFilter(filterContext, contentFilter).should.eql(false);
     });
 
-    it("EV35 - checkFilter rejects a variadic InList carrying fewer than the minimum operands", () => {
+    it("EV35 - checkFilter evaluates an InList with only its left operand to false (Part 4 7.7.4)", () => {
         filterContext.eventSource = filterContext.findNodeByName("RootFolder.Objects.Server.AuditCertificateExpiredEvent");
 
-        // InList expects 2..n operands; provide only 1
+        // "TRUE if operand[0] is equal to one or more of the remaining operands": with no remaining
+        // operand nothing can match, so the element is FALSE rather than malformed. This is how an
+        // alarm collector starts (the OPC Foundation CTT monitors the Server object with
+        // "InList(ConditionId)" and fills the list later with ModifyMonitoredItems).
         const contentFilter = new ContentFilter({
             elements: [
                 {
@@ -752,6 +756,24 @@ describe("Testing extract EventField", function (this: Mocha.Suite) {
             ]
         });
         checkFilter(filterContext, contentFilter).should.eql(false);
+    });
+
+    it("EV35b - validateContentFilter accepts an InList with 1..n operands and refuses one with none", () => {
+        const conditionId = () =>
+            new SimpleAttributeOperand({
+                typeDefinitionId: resolveNodeId("ConditionType"),
+                browsePath: [],
+                attributeId: AttributeIds.NodeId
+            });
+        const literal = () =>
+            new LiteralOperand({ value: new Variant({ dataType: DataType.NodeId, value: resolveNodeId("BaseEventType") }) });
+        const inList = (filterOperands: (SimpleAttributeOperand | LiteralOperand)[]) =>
+            new ContentFilter({ elements: [{ filterOperator: FilterOperator.InList, filterOperands }] });
+
+        validateContentFilter(inList([conditionId()])).should.eql(StatusCodes.Good);
+        validateContentFilter(inList([conditionId(), literal()])).should.eql(StatusCodes.Good);
+        validateContentFilter(inList([conditionId(), literal(), literal()])).should.eql(StatusCodes.Good);
+        validateContentFilter(inList([])).should.eql(StatusCodes.BadFilterOperandCountMismatch);
     });
 
     it("EV32 - checkFilter ignores an unreachable element, even a cyclic one (Part 4 7.7.1)", () => {


### PR DESCRIPTION
## Why

FEAT-43 on the CTT board (project 7). Every Alarms and Conditions unit of the certification run fails at its initialize step: the CTT's alarm collector creates one monitored item on the Server object with an EventFilter of **149 select clauses** (every event field of the 33 condition types the server advertises) and a where clause of one **InList element with a single operand**, "ConditionId in ()", which it fills later with ModifyMonitoredItems. The request was read off the wire (server-side capture, OPC UA JSON) and the server's answer measured with a probe on `validateFilter`:

    default capabilities (MaxSelectClauseParameters 100)  -> BadEventFilterInvalid
    limits raised to 1000                                  -> BadFilterOperandCountMismatch (InList declared 2..n, got 1)

Part 5 leaves MaxSelectClauseParameters to the server, and 100 is below what a conformant client sends to any server exposing the standard alarm types. Part 4 7.7.4 defines InList by its evaluation, "TRUE if operand[0] is equal to one or more of the remaining operands": with no remaining operand it is FALSE, not malformed, and the Foundation's own tool relies on that.

## What

- `server_capabilities.ts`: default `maxSelectClauseParameters` and `maxWhereClauseParameters` 100 -> 1000, reason in the interface docs; the advertised ServerCapabilities values already follow the option (engine test added).
- `check_where_clause.ts`: InList accepts 1..n operands (0 still `BadFilterOperandCountMismatch`); `checkInList` evaluates the single-operand case to false.
- Tests: service-filter EV35/EV35b, server VF11-VF13 (the 149-clause collector filter accepted by default and refused with the old 100), engine FEAT-43 block, e2e ZZ2G with the captured filter shape (the oversized fixture of ZZ2D/ZZ2E grows to 1002 operands so it keeps testing the limit).

## Verification

service-filter 67 passing, server validate-filter 15, engine/configuration 133, e2e event-monitoring 12; biome, `check:shortcircuit`, `check-test-ports --summary` clean.

CTT 1.05.513 replay of A and C Basic against a server built from this branch: initialize.js and cleanup.js pass (baseline: BadEventFilterInvalid, then BadNothingToDo), 5 ok / 0 errors / 3 skipped. The two skipped test cases now report "No Alarms received from the server": with the collector finally running, the next blocker for the facet is on the certification server's side (no active condition reaches the collector), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
