### PR TITLE
fix(secure-channel): an issuer without a revocation list refuses with BadSecurityChecksFailed (FEAT-44)

### DIFF
--- a/packages/node-opcua-end2end-test/test/secure_connection/test_e2e_open_secure_channel_refused_certificate.ts
+++ b/packages/node-opcua-end2end-test/test/secure_connection/test_e2e_open_secure_channel_refused_certificate.ts
@@ -14,6 +14,13 @@
  * about the trust list); a certificate out of its validity period is
  * BadCertificateTimeInvalid, passed through, so that a client can tell what to
  * fix.
+ *
+ * FEAT-44: a CA without a revocation list. When it is the certificate's own
+ * CA the answer is BadCertificateRevocationUnknown, which the CTT accepts
+ * (Security Certificate Validation 042/043); when it is an issuer higher in
+ * the chain the certificate manager says BadCertificateIssuerRevocationUnknown
+ * but the wire says BadSecurityChecksFailed, as Errata 1.04.12 asks (002
+ * warned about the precise code).
  */
 import fs from "node:fs";
 import path from "node:path";
@@ -30,6 +37,7 @@ import {
 } from "node-opcua";
 import { readCertificate, readCertificateChain, readCertificateRevocationList } from "node-opcua-crypto";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { CertificateAuthority } from "node-opcua-pki";
 import should from "should";
 import { certificateFolder, tmpFolderFor } from "../../test_helpers/paths.js";
 
@@ -144,5 +152,88 @@ describe("OpenSecureChannel refused because of the client certificate (FEAT-39)"
         error.message.should.match(/BadCertificateTimeInvalid/);
         should(error.statusCode).eql(StatusCodes.BadCertificateTimeInvalid);
         should(error.response).be.instanceOf(ServiceFault);
+    });
+
+    describe("a CA without a revocation list (FEAT-44)", () => {
+        // the CTT's own PKI: ctt_ca1TC, a trusted root whose revocation list is
+        // not available, and ctt_ca1TC_ca2I, an intermediate under it, known
+        // (issuers/) with its revocation list
+        let root: CertificateAuthority;
+        let intermediate: CertificateAuthority;
+
+        before(async () => {
+            // distinct subjects: the certificate manager files a revocation list
+            // under its issuer's subject name, so two CAs called NodeOPCUA-CA (the
+            // default, also the samples CA of FEAT39-3) would share their lists
+            root = new CertificateAuthority({
+                keySize: 2048,
+                location: path.join(tmpFolder, "root-ca"),
+                subject: "/CN=FEAT-44 root CA"
+            });
+            await root.initialize();
+            intermediate = new CertificateAuthority({
+                keySize: 2048,
+                location: path.join(tmpFolder, "intermediate-ca"),
+                subject: "/CN=FEAT-44 intermediate CA",
+                issuerCA: root
+            });
+            await intermediate.initialize();
+
+            await serverCertificateManager.trustCertificate(readCertificateChain(root.caCertificate)[0]);
+            // and no root.revocationList
+            await serverCertificateManager.addIssuer(readCertificateChain(intermediate.caCertificate)[0]);
+            await serverCertificateManager.addRevocationList(await readCertificateRevocationList(intermediate.revocationList));
+        });
+
+        /** a certificate for the client, issued by `ca`, trusted by the server (the CTT's *_appT) */
+        async function issueTrustedClientCertificate(ca: CertificateAuthority, name: string): Promise<string> {
+            const applicationUri = `urn:localhost:${name}`;
+            const csrFile = await clientCertificateManager.createCertificateRequest({
+                applicationUri,
+                dns: ["localhost"],
+                subject: `/CN=${name}`,
+                validity: 365
+            });
+            const certificateFile = path.join(tmpFolder, `${name}.pem`);
+            await ca.signCertificateRequest(certificateFile, csrFile, { applicationUri, dns: ["localhost"] });
+            // the file holds the chain (leaf, then its issuer): only the leaf is trusted
+            await serverCertificateManager.trustCertificate(readCertificateChain(certificateFile)[0]);
+            return certificateFile;
+        }
+
+        it("FEAT44-1 an issuer that cannot be checked for revocation is refused with BadSecurityChecksFailed (Errata 1.04.12)", async () => {
+            // CTT Security Certificate Validation 002: ctt_ca1TC_ca2I_appT. Nothing
+            // is wrong with the certificate or the intermediate itself; the root
+            // has no revocation list, so the intermediate cannot be checked.
+            const certificateFile = await issueTrustedClientCertificate(intermediate, "feat44-issuer-revocation-unknown");
+            const chain = readCertificateChain(certificateFile);
+            chain.length.should.eql(2, "the leaf and the intermediate");
+            // the certificate manager keeps the precise verdict
+            (await serverCertificateManager.checkCertificate(chain)).should.eql(StatusCodes.BadCertificateIssuerRevocationUnknown);
+
+            const client = secureClient({ certificateFile, privateKeyFile: clientCertificateManager.privateKey });
+            const error = await connectAndExpectRefusal(client);
+
+            // but the wire does not say more than "security checks failed"
+            error.message.should.match(/BadSecurityChecksFailed/);
+            should(error.statusCode).eql(StatusCodes.BadSecurityChecksFailed);
+            should(error.response).be.instanceOf(ServiceFault);
+            (error.response as ServiceFault).responseHeader.serviceResult.should.eql(StatusCodes.BadSecurityChecksFailed);
+        });
+
+        it("FEAT44-2 a certificate whose own CA has no revocation list is still refused with BadCertificateRevocationUnknown", async () => {
+            // CTT Security Certificate Validation 042: ctt_ca1TC_appT
+            const certificateFile = await issueTrustedClientCertificate(root, "feat44-revocation-unknown");
+            (await serverCertificateManager.checkCertificate(readCertificateChain(certificateFile))).should.eql(
+                StatusCodes.BadCertificateRevocationUnknown
+            );
+
+            const client = secureClient({ certificateFile, privateKeyFile: clientCertificateManager.privateKey });
+            const error = await connectAndExpectRefusal(client);
+
+            error.message.should.match(/BadCertificateRevocationUnknown/);
+            should(error.statusCode).eql(StatusCodes.BadCertificateRevocationUnknown);
+            should(error.response).be.instanceOf(ServiceFault);
+        });
     });
 });

--- a/packages/node-opcua-secure-channel/source/server/server_secure_channel_layer.ts
+++ b/packages/node-opcua-secure-channel/source/server/server_secure_channel_layer.ts
@@ -181,6 +181,39 @@ export interface IServerSessionBase {
 }
 
 /**
+ * The status code a refused OpenSecureChannel carries on the wire, given the
+ * certificate manager's verdict on the client certificate.
+ *
+ * Part 4 Table 104 (OpenSecureChannel service result codes) lists what a
+ * client may be told. A client can act on these, so they pass through:
+ *
+ * - BadCertificateTimeInvalid: the certificate is out of its validity period,
+ * - BadCertificateUseNotAllowed: the certificate is not an application
+ *   instance certificate,
+ * - BadCertificateRevocationUnknown: the certificate's own CA has no
+ *   revocation list; the CTT accepts it (Security Certificate Validation
+ *   042 and 043).
+ *
+ * Everything else is BadSecurityChecksFailed: an untrusted, revoked or badly
+ * signed certificate must not learn from the answer what the server's trust
+ * list holds. That includes BadCertificateIssuerRevocationUnknown, the
+ * verdict when an *issuer* of the chain cannot be checked for revocation:
+ * Errata 1.04.12 says a server should answer BadSecurityChecksFailed there,
+ * and the CTT (Security Certificate Validation 002) warns about the precise
+ * code (FEAT-44).
+ */
+export function openSecureChannelRefusalStatus(certificateStatus: StatusCode): StatusCode {
+    if (
+        certificateStatus.equals(StatusCodes.BadCertificateTimeInvalid) ||
+        certificateStatus.equals(StatusCodes.BadCertificateUseNotAllowed) ||
+        certificateStatus.equals(StatusCodes.BadCertificateRevocationUnknown)
+    ) {
+        return certificateStatus;
+    }
+    return StatusCodes.BadSecurityChecksFailed;
+}
+
+/**
  */
 export class ServerSecureChannelLayer extends EventEmitter {
     public static throttleTime = 100;
@@ -1209,22 +1242,14 @@ export class ServerSecureChannelLayer extends EventEmitter {
                 // OPCUA specification v1.02 part 6 page 42 $6.7.4
                 // If an error occurs after the  Server  has verified  Message  security  it  shall  return a  ServiceFault  instead
                 // of a OpenSecureChannel  response. The  ServiceFault  Message  is described in  Part  4,   7.28.
-                if (
-                    statusCode.isNot(StatusCodes.BadCertificateIssuerRevocationUnknown) &&
-                    statusCode.isNot(StatusCodes.BadCertificateRevocationUnknown) &&
-                    statusCode.isNot(StatusCodes.BadCertificateTimeInvalid) &&
-                    statusCode.isNot(StatusCodes.BadCertificateUseNotAllowed)
-                ) {
-                    statusCode = StatusCodes.BadSecurityChecksFailed;
-                }
-                // Those are not considered as error but as a warning
-                //    BadCertificateIssuerRevocationUnknown,
-                //    BadCertificateRevocationUnknown,
-                //    BadCertificateTimeInvalid,
-                //    BadCertificateUseNotAllowed
                 //
-                // the client will decided what to do next
-                return this.#_on_OpenSecureChannelRequestError(statusCode, "certificate invalid", message);
+                // The certificate manager's verdict stays as it is (rejected folder,
+                // audit events, diagnostics); only what goes on the wire is narrowed.
+                return this.#_on_OpenSecureChannelRequestError(
+                    openSecureChannelRefusalStatus(statusCode),
+                    "certificate invalid",
+                    message
+                );
             }
             this.#_handle_OpenSecureChannelRequest(message);
         });

--- a/packages/node-opcua-secure-channel/test/22-test_open_secure_channel_refusal_status.ts
+++ b/packages/node-opcua-secure-channel/test/22-test_open_secure_channel_refusal_status.ts
@@ -1,0 +1,46 @@
+import { StatusCodes } from "node-opcua-status-code";
+import "should";
+import { openSecureChannelRefusalStatus } from "../source/server/server_secure_channel_layer.js";
+
+/**
+ * What a refused OpenSecureChannel says on the wire, given the certificate
+ * manager's verdict (FEAT-39, FEAT-44).
+ */
+describe("openSecureChannelRefusalStatus - the status a refused OpenSecureChannel carries", () => {
+    it("REF1 passes BadCertificateTimeInvalid through: the client can fix an out-of-date certificate", () => {
+        openSecureChannelRefusalStatus(StatusCodes.BadCertificateTimeInvalid).should.eql(StatusCodes.BadCertificateTimeInvalid);
+    });
+
+    it("REF2 passes BadCertificateUseNotAllowed through", () => {
+        openSecureChannelRefusalStatus(StatusCodes.BadCertificateUseNotAllowed).should.eql(StatusCodes.BadCertificateUseNotAllowed);
+    });
+
+    it("REF3 passes BadCertificateRevocationUnknown through: the certificate's own CA has no revocation list (CTT 042/043)", () => {
+        openSecureChannelRefusalStatus(StatusCodes.BadCertificateRevocationUnknown).should.eql(
+            StatusCodes.BadCertificateRevocationUnknown
+        );
+    });
+
+    it("REF4 turns BadCertificateIssuerRevocationUnknown into BadSecurityChecksFailed, as Errata 1.04.12 asks (CTT 002)", () => {
+        openSecureChannelRefusalStatus(StatusCodes.BadCertificateIssuerRevocationUnknown).should.eql(
+            StatusCodes.BadSecurityChecksFailed
+        );
+    });
+
+    it("REF5 turns every other verdict into BadSecurityChecksFailed: the answer must not describe the trust list", () => {
+        for (const verdict of [
+            StatusCodes.BadCertificateUntrusted,
+            StatusCodes.BadCertificateRevoked,
+            StatusCodes.BadCertificateIssuerRevoked,
+            StatusCodes.BadCertificateIssuerTimeInvalid,
+            StatusCodes.BadCertificateIssuerUseNotAllowed,
+            StatusCodes.BadCertificateChainIncomplete,
+            StatusCodes.BadCertificateInvalid,
+            StatusCodes.BadCertificateUriInvalid,
+            StatusCodes.BadCertificateHostNameInvalid,
+            StatusCodes.BadSecurityChecksFailed
+        ]) {
+            openSecureChannelRefusalStatus(verdict).should.eql(StatusCodes.BadSecurityChecksFailed, verdict.toString());
+        }
+    });
+});


### PR DESCRIPTION
## Why

FEAT-44 on the CTT board (project 7), follow-up of PR 1650. Since a refused OpenSecureChannel is answered with a ServiceFault, the CTT's Security Certificate Validation 002.js (client certificate issued by a known but untrusted CA without a revocation list) records one warning:

    As per Errata 1.04.12, servers should return BadSecurityChecksFailed instead of BadCertificateIssuerRevocationUnknown

It is the last mark on the three secure SecurityPolicy cards of the certification report. Scripts 042 and 043 (trusted CA without CRL, BadCertificateRevocationUnknown) pass without remark, so only the issuer form changes.

## What

- `server_secure_channel_layer.ts`: the mapping of the certificate manager's verdict to the OpenSecureChannel refusal is now `openSecureChannelRefusalStatus()`, with the table and the errata in its doc. BadCertificateIssuerRevocationUnknown joins the BadSecurityChecksFailed side; BadCertificateTimeInvalid, BadCertificateUseNotAllowed and BadCertificateRevocationUnknown are passed through as before. The certificate manager's own verdict, the rejected folder, audit and diagnostics keep the precise code; only the wire answer narrows.
- Unit test `22-test_open_secure_channel_refusal_status.ts` (the table, one case per reason).
- e2e `test_e2e_open_secure_channel_refused_certificate.ts`: a nested suite builds the CTT's own shape with node-opcua-pki (trusted root without CRL, intermediate in issuers/ with its CRL, trusted leaf). FEAT44-1: the manager still says BadCertificateIssuerRevocationUnknown, the wire says BadSecurityChecksFailed. FEAT44-2: a leaf issued directly by the CRL-less root is still refused with BadCertificateRevocationUnknown. Note in the test: node-opcua-pki files CRLs under the issuer's subject fingerprint, so the CAs need distinct subjects or they share revocation lists.

## Verification

Old mapping: FEAT44-1 fails with the CTT's exact complaint. With the fix: e2e 5 passing (FEAT39-1..3, FEAT44-1..2), unit 5 passing, whole secure-channel suite 274 passing; biome (pre-existing warning in node-opcua-json only), `check:shortcircuit`, `test:check`, `check-test-ports --summary` clean.

CTT 1.05.513 replay of Security Certificate Validation against a server built from this branch: 002 ok (was a warning), 042 and 043 ok, unit 21 ok / 0 warnings / 0 errors, the rest not supported by the CTT's own stack or manual. The three secure SecurityPolicy cards should read "fulfilled" on the next full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
