### PR TITLE
fix(json): add DiagnosticInfo and XmlElement codecs

### DIFF
--- a/packages/node-opcua-json/source/104/index.ts
+++ b/packages/node-opcua-json/source/104/index.ts
@@ -55,6 +55,7 @@ export {
     opcuaJsonEncodeDataValueMQTT104 as opcuaJsonEncodeDataValueMQTT
 } from "../json_basic_encoding_decoding_data_value.js";
 export * from "../json_basic_encoding_decoding_date_time.js";
+export * from "../json_basic_encoding_decoding_diagnosticinfo.js";
 // ExtensionObject
 export {
     type ExtensionObjectJSON104 as ExtensionObjectJSON,

--- a/packages/node-opcua-json/source/105/index.ts
+++ b/packages/node-opcua-json/source/105/index.ts
@@ -54,6 +54,7 @@ export {
     opcuaJsonEncodeDataValueMQTT105 as opcuaJsonEncodeDataValueMQTT
 } from "../json_basic_encoding_decoding_data_value.js";
 export * from "../json_basic_encoding_decoding_date_time.js";
+export * from "../json_basic_encoding_decoding_diagnosticinfo.js";
 // ExtensionObject
 export {
     type ExtensionObjectJSON105 as ExtensionObjectJSON,

--- a/packages/node-opcua-json/source/index.ts
+++ b/packages/node-opcua-json/source/index.ts
@@ -45,6 +45,7 @@ export {
     opcuaJsonEncodeDataValueMQTT104,
     opcuaJsonEncodeDataValueMQTT105
 } from "./json_basic_encoding_decoding_data_value.js";
+export * from "./json_basic_encoding_decoding_diagnosticinfo.js";
 export * from "./json_basic_encoding_decoding_extension_object.js";
 export {
     opcuaJsonDecodeExtensionObject,

--- a/packages/node-opcua-json/source/json_basic_encoding_body_functor.ts
+++ b/packages/node-opcua-json/source/json_basic_encoding_body_functor.ts
@@ -29,6 +29,7 @@ import type { ExtensionObjectConstructorFuncWithSchema } from "./extension_objec
 import { opcuaJsonDecodeByteString, opcuaJsonEncodeByteString } from "./json_basic_encoding_decoding_byte_string.js";
 import { opcuaJsonDecodeDataValue, opcuaJsonEncodeDataValue } from "./json_basic_encoding_decoding_data_value.js";
 import { opcuaJsonDecodeDateTime, opcuaJsonEncodeDateTime } from "./json_basic_encoding_decoding_date_time.js";
+import { opcuaJsonDecodeDiagnosticInfo, opcuaJsonEncodeDiagnosticInfo } from "./json_basic_encoding_decoding_diagnosticinfo.js";
 import { opcuaJsonDecodeExtensionObject, opcuaJsonEncodeExtensionObject } from "./json_basic_encoding_decoding_extension_object.js";
 import {
     opcuaJsonDecodeInt64,
@@ -108,6 +109,8 @@ export function bodyEncodeFunctor(dataType: DataType): EncoderFunc<unknown> {
         case DataType.Guid:
             return opcuaJsonEncodeGuid as EncoderFunc<unknown>;
         case DataType.String:
+        case DataType.XmlElement:
+            // XmlElement values are encoded as a JSON string holding the XML text (Part 6, 5.4.2.9)
             return opcuaJsonEncodeString as EncoderFunc<unknown>;
         case DataType.ByteString:
             return opcuaJsonEncodeByteString as EncoderFunc<unknown>;
@@ -134,8 +137,7 @@ export function bodyEncodeFunctor(dataType: DataType): EncoderFunc<unknown> {
         case DataType.DataValue:
             return opcuaJsonEncodeDataValue as EncoderFunc<unknown>;
         case DataType.DiagnosticInfo:
-        case DataType.XmlElement:
-            throw new Error(`Unsupported yet ${DataType[dataType]}`);
+            return opcuaJsonEncodeDiagnosticInfo as EncoderFunc<unknown>;
         default:
             return () => null;
     }
@@ -156,6 +158,7 @@ export function bodyDecodeFunctor(dataType: DataType): DecoderFunc<unknown> {
         case DataType.String:
         case DataType.UInt16:
         case DataType.UInt32:
+        case DataType.XmlElement:
             return ((a: boolean | number | string) => a) as DecoderFunc<unknown>;
         case DataType.ByteString:
             return opcuaJsonDecodeByteString as DecoderFunc<unknown>;
@@ -182,8 +185,7 @@ export function bodyDecodeFunctor(dataType: DataType): DecoderFunc<unknown> {
         case DataType.DataValue:
             return opcuaJsonDecodeDataValue as DecoderFunc<unknown>;
         case DataType.DiagnosticInfo:
-        case DataType.XmlElement:
-            throw new Error(`Unsupported yet ${DataType[dataType]}`);
+            return opcuaJsonDecodeDiagnosticInfo as DecoderFunc<unknown>;
         default:
             return () => null;
     }

--- a/packages/node-opcua-json/source/json_basic_encoding_decoding_diagnosticinfo.ts
+++ b/packages/node-opcua-json/source/json_basic_encoding_decoding_diagnosticinfo.ts
@@ -1,0 +1,129 @@
+/**
+ * ==========================================================================
+ * Copyright (c) 2021-2026 Sterfive - etienne.rossignon@sterfive.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ * ==========================================================================
+ */
+import { DiagnosticInfo } from "node-opcua-data-model";
+import type { StatusCode } from "node-opcua-status-code";
+import type { ExtensionObjectBuilder } from "./json_basic_encoding_body_functor.js";
+import {
+    opcuaJsonDecodeStatusCode,
+    opcuaJsonEncodeStatusCode,
+    type StatusCodeJSON
+} from "./json_basic_encoding_decoding_statuscode.js";
+import { JsonEncodingScheme } from "./json_encoding_scheme.js";
+
+/**
+ * JSON form of a DiagnosticInfo
+ *
+ * reference: https://reference.opcfoundation.org/Core/Part6/v105/docs/5.4.2.13
+ *
+ * Each field is omitted when it holds its default value (-1 for the string
+ * table indexes, null for AdditionalInfo, Good for InnerStatusCode and null for
+ * InnerDiagnosticInfo), except in the Verbose encoding where every field is present.
+ */
+export interface DiagnosticInfoJSON {
+    /** index into the string table of the response header, -1 when not set */
+    SymbolicId?: number;
+    /** index into the string table of the response header, -1 when not set */
+    NamespaceUri?: number;
+    /** index into the string table of the response header, -1 when not set */
+    Locale?: number;
+    /** index into the string table of the response header, -1 when not set */
+    LocalizedText?: number;
+    AdditionalInfo?: string | null;
+    InnerStatusCode?: StatusCodeJSON | number | null;
+    InnerDiagnosticInfo?: DiagnosticInfoJSON | null;
+}
+
+function isEmptyDiagnosticInfo(d: DiagnosticInfo): boolean {
+    return (
+        d.symbolicId === -1 &&
+        d.namespaceURI === -1 &&
+        d.locale === -1 &&
+        d.localizedText === -1 &&
+        !d.additionalInfo &&
+        (!d.innerStatusCode || d.innerStatusCode.value === 0) &&
+        (!d.innerDiagnosticInfo || isEmptyDiagnosticInfo(d.innerDiagnosticInfo))
+    );
+}
+
+export function opcuaJsonEncodeDiagnosticInfo(
+    diagnosticInfo: DiagnosticInfo | null | undefined,
+    scheme = JsonEncodingScheme.Compact,
+    namespaceArray?: string[]
+): DiagnosticInfoJSON | null | undefined {
+    const verbose = scheme === JsonEncodingScheme.Verbose;
+
+    if (!diagnosticInfo || (!verbose && isEmptyDiagnosticInfo(diagnosticInfo))) {
+        // an empty DiagnosticInfo is treated like a null value:
+        // omitted in the Compact encoding, encoded as null in the deprecated encodings
+        return scheme === JsonEncodingScheme.Compact ? undefined : null;
+    }
+    const d = diagnosticInfo;
+    const pojo: DiagnosticInfoJSON = {};
+
+    const setIndex = (key: "SymbolicId" | "NamespaceUri" | "Locale" | "LocalizedText", value: number) => {
+        if (verbose || value !== -1) {
+            pojo[key] = value;
+        }
+    };
+    setIndex("SymbolicId", d.symbolicId);
+    setIndex("NamespaceUri", d.namespaceURI);
+    setIndex("Locale", d.locale);
+    setIndex("LocalizedText", d.localizedText);
+
+    if (verbose || d.additionalInfo) {
+        pojo.AdditionalInfo = d.additionalInfo ?? null;
+    }
+    const innerStatusCode: StatusCode | null = d.innerStatusCode ?? null;
+    if (verbose || (innerStatusCode && innerStatusCode.value !== 0)) {
+        const encoded = innerStatusCode ? opcuaJsonEncodeStatusCode(innerStatusCode, scheme) : null;
+        pojo.InnerStatusCode = encoded === undefined ? null : encoded;
+    }
+    if (verbose || d.innerDiagnosticInfo) {
+        const inner = opcuaJsonEncodeDiagnosticInfo(d.innerDiagnosticInfo ?? null, scheme, namespaceArray);
+        if (verbose || inner) {
+            pojo.InnerDiagnosticInfo = inner === undefined ? null : inner;
+        }
+    }
+    return pojo;
+}
+
+export function opcuaJsonDecodeDiagnosticInfo(
+    pojo: DiagnosticInfoJSON | null | undefined,
+    _builder?: ExtensionObjectBuilder,
+    _namespaceArray?: string[]
+): DiagnosticInfo {
+    if (!pojo || typeof pojo !== "object") {
+        return new DiagnosticInfo();
+    }
+    const index = (value: number | undefined | null): number => (typeof value === "number" ? value : -1);
+    return new DiagnosticInfo({
+        symbolicId: index(pojo.SymbolicId),
+        namespaceURI: index(pojo.NamespaceUri),
+        locale: index(pojo.Locale),
+        localizedText: index(pojo.LocalizedText),
+        additionalInfo: pojo.AdditionalInfo ?? null,
+        innerStatusCode: opcuaJsonDecodeStatusCode(pojo.InnerStatusCode),
+        innerDiagnosticInfo: pojo.InnerDiagnosticInfo ? opcuaJsonDecodeDiagnosticInfo(pojo.InnerDiagnosticInfo) : undefined
+    });
+}

--- a/packages/node-opcua-json/source/json_basic_encoding_decoding_extension_object.ts
+++ b/packages/node-opcua-json/source/json_basic_encoding_decoding_extension_object.ts
@@ -310,12 +310,12 @@ function isDefault(field: FieldType, value: unknown): boolean {
             // DiagnosticInfo is default if it has no body
             const valueAsDiag = value as DiagnosticInfoOptions;
             return (
-                valueAsDiag.symbolicId === 0 &&
-                valueAsDiag.namespaceURI === 0 &&
-                valueAsDiag.locale === 0 &&
-                valueAsDiag.localizedText === 0 &&
+                (valueAsDiag.symbolicId ?? -1) === -1 &&
+                (valueAsDiag.namespaceURI ?? -1) === -1 &&
+                (valueAsDiag.locale ?? -1) === -1 &&
+                (valueAsDiag.localizedText ?? -1) === -1 &&
                 !valueAsDiag.additionalInfo &&
-                !valueAsDiag.innerStatusCode &&
+                (!valueAsDiag.innerStatusCode || valueAsDiag.innerStatusCode.value === 0) &&
                 !valueAsDiag.innerDiagnosticInfo
             );
         }

--- a/packages/node-opcua-json/source/json_basic_encoding_decoding_variant.ts
+++ b/packages/node-opcua-json/source/json_basic_encoding_decoding_variant.ts
@@ -181,6 +181,7 @@ export function opcuaJsonEncodeVariant105(variant: Variant, mode: JsonEncoderMod
             case DataType.LocalizedText:
             case DataType.ExtensionObject:
             case DataType.StatusCode:
+            case DataType.DiagnosticInfo:
                 // these are all scalar types, so we can remove the UaType
                 // delete pojo.UaType;
                 break;

--- a/packages/node-opcua-json/test/json_basic_encode_decode_diagnosticinfo.test.ts
+++ b/packages/node-opcua-json/test/json_basic_encode_decode_diagnosticinfo.test.ts
@@ -1,0 +1,138 @@
+/**
+ * ==========================================================================
+ * Copyright (c) 2021-2026 Sterfive - etienne.rossignon@sterfive.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ * ==========================================================================
+ */
+import { DiagnosticInfo } from "node-opcua-data-model";
+import { StatusCodes } from "node-opcua-status-code";
+import { DataType, Variant } from "node-opcua-variant";
+import should from "should";
+import {
+    opcuaJsonDecodeDiagnosticInfo,
+    opcuaJsonDecodeVariant,
+    opcuaJsonEncodeDiagnosticInfo,
+    opcuaJsonEncodeVariant,
+    type VariantJSON105
+} from "../source/index.js";
+import { JsonEncodingScheme } from "../source/json_encoding_scheme.js";
+import { fakeBuilder } from "./helper.js";
+
+// https://reference.opcfoundation.org/Core/Part6/v105/docs/5.4.2.13
+
+const { Compact, Verbose, DeprecatedReversible, DeprecatedNonReversible } = JsonEncodingScheme;
+
+const full = new DiagnosticInfo({
+    symbolicId: 1,
+    namespaceURI: 2,
+    locale: 3,
+    localizedText: 4,
+    additionalInfo: "more",
+    innerStatusCode: StatusCodes.BadInternalError,
+    innerDiagnosticInfo: new DiagnosticInfo({ symbolicId: 5, additionalInfo: "inner" })
+});
+
+describe("JSON encode DiagnosticInfo", () => {
+    it("empty - compact is omitted", () => {
+        should(opcuaJsonEncodeDiagnosticInfo(new DiagnosticInfo(), Compact)).eql(undefined);
+        should(opcuaJsonEncodeDiagnosticInfo(null, Compact)).eql(undefined);
+    });
+    it("empty - deprecated encodings are null", () => {
+        should(opcuaJsonEncodeDiagnosticInfo(new DiagnosticInfo(), DeprecatedReversible)).eql(null);
+        should(opcuaJsonEncodeDiagnosticInfo(new DiagnosticInfo(), DeprecatedNonReversible)).eql(null);
+    });
+    it("empty - verbose keeps every field", () => {
+        should(opcuaJsonEncodeDiagnosticInfo(new DiagnosticInfo(), Verbose)).eql({
+            SymbolicId: -1,
+            NamespaceUri: -1,
+            Locale: -1,
+            LocalizedText: -1,
+            AdditionalInfo: null,
+            InnerStatusCode: {},
+            InnerDiagnosticInfo: null
+        });
+    });
+    it("partial - compact omits default fields", () => {
+        should(opcuaJsonEncodeDiagnosticInfo(new DiagnosticInfo({ symbolicId: 3, additionalInfo: "x" }), Compact)).eql({
+            SymbolicId: 3,
+            AdditionalInfo: "x"
+        });
+    });
+    it("full - compact", () => {
+        should(opcuaJsonEncodeDiagnosticInfo(full, Compact)).eql({
+            SymbolicId: 1,
+            NamespaceUri: 2,
+            Locale: 3,
+            LocalizedText: 4,
+            AdditionalInfo: "more",
+            InnerStatusCode: { Code: StatusCodes.BadInternalError.value },
+            InnerDiagnosticInfo: { SymbolicId: 5, AdditionalInfo: "inner" }
+        });
+    });
+    it("full - deprecated reversible encodes the inner status code as a number", () => {
+        should(opcuaJsonEncodeDiagnosticInfo(full, DeprecatedReversible)).eql({
+            SymbolicId: 1,
+            NamespaceUri: 2,
+            Locale: 3,
+            LocalizedText: 4,
+            AdditionalInfo: "more",
+            InnerStatusCode: StatusCodes.BadInternalError.value,
+            InnerDiagnosticInfo: { SymbolicId: 5, AdditionalInfo: "inner" }
+        });
+    });
+    it("full - verbose adds the status code symbol", () => {
+        const pojo = opcuaJsonEncodeDiagnosticInfo(full, Verbose);
+        should(pojo?.InnerStatusCode).eql({ Code: StatusCodes.BadInternalError.value, Symbol: "BadInternalError" });
+        should(pojo?.InnerDiagnosticInfo).eql({
+            SymbolicId: 5,
+            NamespaceUri: -1,
+            Locale: -1,
+            LocalizedText: -1,
+            AdditionalInfo: "inner",
+            InnerStatusCode: {},
+            InnerDiagnosticInfo: null
+        });
+    });
+});
+
+describe("JSON decode DiagnosticInfo", () => {
+    it("decodes null as an empty DiagnosticInfo", () => {
+        should(opcuaJsonDecodeDiagnosticInfo(null)).eql(new DiagnosticInfo());
+        should(opcuaJsonDecodeDiagnosticInfo(undefined)).eql(new DiagnosticInfo());
+    });
+    it("round trips through every scheme", () => {
+        for (const scheme of [Compact, Verbose, DeprecatedReversible, DeprecatedNonReversible]) {
+            const pojo = opcuaJsonEncodeDiagnosticInfo(full, scheme);
+            const back = opcuaJsonDecodeDiagnosticInfo(pojo);
+            should(back.toJSON()).eql(full.toJSON());
+        }
+    });
+});
+
+describe("JSON Variant with DiagnosticInfo", () => {
+    it("encodes and decodes a DiagnosticInfo scalar variant", () => {
+        const variant = new Variant({ dataType: DataType.DiagnosticInfo, value: full });
+        const pojo = opcuaJsonEncodeVariant(variant, Verbose, []) as unknown as VariantJSON105;
+        should(pojo).have.property("UaType", DataType.DiagnosticInfo);
+        const back = opcuaJsonDecodeVariant(pojo, fakeBuilder, []);
+        should(back.dataType).eql(DataType.DiagnosticInfo);
+        should((back.value as DiagnosticInfo).toJSON()).eql(full.toJSON());
+    });
+});

--- a/packages/node-opcua-json/test/json_basic_encode_decode_xml_element.test.ts
+++ b/packages/node-opcua-json/test/json_basic_encode_decode_xml_element.test.ts
@@ -1,0 +1,64 @@
+/**
+ * ==========================================================================
+ * Copyright (c) 2021-2026 Sterfive - etienne.rossignon@sterfive.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ * ==========================================================================
+ */
+import { DataType, Variant } from "node-opcua-variant";
+import should from "should";
+import {
+    bodyDecodeFunctor,
+    bodyEncodeFunctor,
+    opcuaJsonDecodeVariant,
+    opcuaJsonEncodeVariant,
+    type VariantJSON105
+} from "../source/index.js";
+import { JsonEncodingScheme } from "../source/json_encoding_scheme.js";
+import { fakeBuilder } from "./helper.js";
+
+// https://reference.opcfoundation.org/Core/Part6/v105/docs/5.4.2.9
+
+const { Compact, Verbose, DeprecatedReversible, DeprecatedNonReversible } = JsonEncodingScheme;
+const xml = "<a><b>1</b></a>";
+
+describe("JSON encode/decode XmlElement", () => {
+    it("encodes the XML text as a JSON string in every scheme", () => {
+        const encode = bodyEncodeFunctor(DataType.XmlElement);
+        for (const scheme of [Compact, Verbose, DeprecatedReversible, DeprecatedNonReversible]) {
+            should(encode(xml, scheme)).eql(xml);
+        }
+    });
+    it("omits an empty XmlElement in the compact encoding only", () => {
+        const encode = bodyEncodeFunctor(DataType.XmlElement);
+        should(encode("", Compact)).eql(undefined);
+        should(encode("", Verbose)).eql("");
+    });
+    it("decodes a JSON string back to the XML text", () => {
+        should(bodyDecodeFunctor(DataType.XmlElement)(xml, fakeBuilder, [])).eql(xml);
+    });
+    it("round trips an XmlElement variant", () => {
+        const variant = new Variant({ dataType: DataType.XmlElement, value: xml });
+        const pojo = opcuaJsonEncodeVariant(variant, Verbose, []) as unknown as VariantJSON105;
+        should(pojo).have.property("UaType", DataType.XmlElement);
+        const back = opcuaJsonDecodeVariant(pojo, fakeBuilder, []);
+        should(back.dataType).eql(DataType.XmlElement);
+        should(back.value).eql(xml);
+    });
+});

--- a/packages/node-opcua-json/test/json_ua_encode_decode.test.ts
+++ b/packages/node-opcua-json/test/json_ua_encode_decode.test.ts
@@ -36,7 +36,7 @@ describe("JSON UA encode/decode", () => {
         indexRange: numericRange
     });
     const builder: ExtensionObjectBuilder = {
-        getExtensionObjectConstructor(dataTypeNodeId: NodeId): ExtensionObjectConstructorFuncWithSchema {
+        getExtensionObjectConstructor(_dataTypeNodeId: NodeId): ExtensionObjectConstructorFuncWithSchema {
             // This is a mock implementation, replace with actual logic to get the constructor
             return null as unknown as ExtensionObjectConstructorFuncWithSchema;
         }


### PR DESCRIPTION
DiagnosticInfo and XmlElement threw "Unsupported yet" in the JSON body functor while LocalizedText, QualifiedName and StatusCode were already supported.

- DiagnosticInfo: new codec following Part 6 5.4.2.13. Default fields (-1 indexes, empty AdditionalInfo, Good InnerStatusCode, null InnerDiagnosticInfo) are omitted in Compact and the deprecated schemes, kept in Verbose. InnerStatusCode reuses the StatusCode codec of the same scheme; InnerDiagnosticInfo recurses.
- XmlElement: shares the String codec (JSON string holding the XML text, Part 6 5.4.2.9).
- Fixed the extension-object "is default" check for DiagnosticInfo, which compared string-table indexes to 0 instead of their actual default of -1, so a default DiagnosticInfo was never recognized as default.
- Exported from the root entry point and both `/104` and `/105` realm entry points.
- Added tests covering all four encoding schemes, empty/partial/full values, round trips, and Variant round trips.

Package `tsc -b`, mocha (196 passing) and `pnpm run lint:ci` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)