### PR TITLE
fix(a&c): ConditionRefresh validates its SubscriptionId, and an 11th event listener no longer kills the server (FEAT-46)

### DIFF
--- a/packages/node-opcua-address-space-base/source/session_context.ts
+++ b/packages/node-opcua-address-space-base/source/session_context.ts
@@ -53,6 +53,16 @@ export interface IContinuationPointManager {
     dispose(): void;
 }
 
+/**
+ * What the address space needs to know about a Subscription when a Method takes a
+ * SubscriptionId / MonitoredItemId argument (ConditionRefresh, ConditionRefresh2).
+ */
+export interface ISubscriptionBase {
+    readonly id: number;
+    /** the MonitoredItem with that id in this Subscription, or `null` */
+    getMonitoredItem(monitoredItemId: number): object | null;
+}
+
 export interface ISessionBase {
     userIdentityToken?: UserIdentityToken;
     channel?: IChannelBase;
@@ -60,6 +70,15 @@ export interface ISessionBase {
     continuationPointManager: IContinuationPointManager;
     /** The URL of the Endpoint the Session was created on, if known. */
     getEndpointUrl?(): string | undefined;
+    /**
+     * The Subscription with that id **owned by this Session**, or `null`.
+     *
+     * A SubscriptionId is only meaningful inside the Session that created it (Part 4), so a
+     * Subscription of another Session is `null` here as much as one that never existed.
+     * Optional: an in-process caller (PseudoSession, tests) has no Subscriptions to check
+     * against, and a Method validating its SubscriptionId argument then lets it through.
+     */
+    getSubscription?(subscriptionId: number): ISubscriptionBase | null;
 }
 export interface ContinuationPointData {
     dataValues: DataValue[];

--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_condition_impl.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_condition_impl.ts
@@ -1075,9 +1075,11 @@ function _condition_refresh_method(
     }
     const subscriptionId = inputArguments[0].value;
 
+    // a rejected argument is answered in the Call result, never thrown: the Call service
+    // turns an exception into Bad_InternalError and the CTT reads that as a broken server
     let statusCode = _check_subscription_id_is_valid(subscriptionId, context);
     if (statusCode.isNotGood()) {
-        return statusCode;
+        return callback(null, { statusCode });
     }
 
     statusCode = _perform_condition_refresh(addressSpace, inputArguments, context);
@@ -1090,6 +1092,7 @@ function _perform_condition_refresh(addressSpace: AddressSpacePrivate, _inputArg
     // --- possible StatusCodes:
     //
     // Bad_SubscriptionIdInvalid  See Part 4 for the description of this result code
+    //                            (checked by the caller, before we get here)
     // Bad_RefreshInProgress      See Table 74 for the description of this result code
     // Bad_UserAccessDenied       The Method was not called in the context of the Session
     //                            that owns the Subscription
@@ -1101,8 +1104,6 @@ function _perform_condition_refresh(addressSpace: AddressSpacePrivate, _inputArg
         return StatusCodes.BadRefreshInProgress;
     }
 
-    addressSpace._condition_refresh_in_progress = true;
-
     const server = context.object?.addressSpace.rootFolder.objects.server;
     const refreshStartEventType = addressSpace.findEventType("RefreshStartEventType");
     if (!refreshStartEventType) {
@@ -1113,17 +1114,21 @@ function _perform_condition_refresh(addressSpace: AddressSpacePrivate, _inputArg
         throw new Error("cannot find RefreshEndEventType");
     }
 
-    server?.raiseEvent(refreshStartEventType, {});
-    // todo : resend retained conditions
+    addressSpace._condition_refresh_in_progress = true;
+    try {
+        server?.raiseEvent(refreshStartEventType, {});
 
-    const _server = server as unknown as { _conditionRefresh: () => void };
-    // starting from server object ..
-    // evaluated all --> hasNotifier/hasEventSource -> node
-    _server._conditionRefresh();
+        const _server = server as unknown as { _conditionRefresh: () => void };
+        // starting from server object ..
+        // evaluated all --> hasNotifier/hasEventSource -> node
+        _server._conditionRefresh();
 
-    server?.raiseEvent(refreshEndEventType, {});
-
-    addressSpace._condition_refresh_in_progress = false;
+        server?.raiseEvent(refreshEndEventType, {});
+    } finally {
+        // whatever a condition's event handler throws, the next refresh must not be
+        // answered Bad_RefreshInProgress for ever
+        addressSpace._condition_refresh_in_progress = false;
+    }
 
     return StatusCodes.Good;
 }
@@ -1146,10 +1151,19 @@ function _condition_refresh2_method(
         debugLog(chalk.cyan.bgWhite(" ConditionType.conditionRefresh2 !"));
     }
 
-    // xx var subscriptionId = inputArguments[0].value;
-    // xx var monitoredItemId = inputArguments[1].value;
+    const subscriptionId = inputArguments[0].value;
+    const monitoredItemId = inputArguments[1].value;
 
-    const statusCode = _perform_condition_refresh(addressSpace, inputArguments, context);
+    let statusCode = _check_subscription_id_is_valid(subscriptionId, context);
+    if (statusCode.isNotGood()) {
+        return callback(null, { statusCode });
+    }
+    statusCode = _check_monitored_item_id_is_valid(subscriptionId, monitoredItemId, context);
+    if (statusCode.isNotGood()) {
+        return callback(null, { statusCode });
+    }
+
+    statusCode = _perform_condition_refresh(addressSpace, inputArguments, context);
     return callback(null, {
         statusCode
     });
@@ -1280,7 +1294,33 @@ function _getCompositeKey(node: BaseNode, key: string): UAVariableImpl {
  * @param context {Object}
  * @private
  */
-function _check_subscription_id_is_valid(_subscriptionId: number, _context: ISessionContext) {
-    /// todo: return StatusCodes.BadSubscriptionIdInvalid; if subscriptionId doesn't belong to session...
-    return StatusCodes.Good;
+function _check_subscription_id_is_valid(subscriptionId: number, context: ISessionContext): StatusCode {
+    // Part 9 5.5.7: Bad_SubscriptionIdInvalid when the SubscriptionId is not one of the
+    // calling Session's. A Subscription of another Session is not reachable from this one
+    // (Part 4: SubscriptionIds are Session-scoped), so it gets the same answer.
+    const session = context.session;
+    if (!session || typeof session.getSubscription !== "function") {
+        // no Session behind the call (an in-process caller, a PseudoSession, a unit test):
+        // there is nothing to check the argument against
+        return StatusCodes.Good;
+    }
+    return session.getSubscription(subscriptionId) ? StatusCodes.Good : StatusCodes.BadSubscriptionIdInvalid;
+}
+
+/**
+ * ConditionRefresh2 (Part 9 5.5.8): the MonitoredItemId must name a MonitoredItem of the
+ * given Subscription, else Bad_MonitoredItemIdInvalid. Call after
+ * _check_subscription_id_is_valid, which has established that the Subscription is ours.
+ * @private
+ */
+function _check_monitored_item_id_is_valid(subscriptionId: number, monitoredItemId: number, context: ISessionContext): StatusCode {
+    const session = context.session;
+    if (!session || typeof session.getSubscription !== "function") {
+        return StatusCodes.Good;
+    }
+    const subscription = session.getSubscription(subscriptionId);
+    if (!subscription) {
+        return StatusCodes.BadSubscriptionIdInvalid;
+    }
+    return subscription.getMonitoredItem(monitoredItemId) ? StatusCodes.Good : StatusCodes.BadMonitoredItemIdInvalid;
 }

--- a/packages/node-opcua-address-space/impl/ua_object_impl.ts
+++ b/packages/node-opcua-address-space/impl/ua_object_impl.ts
@@ -77,6 +77,10 @@ export class UAObjectImpl<T extends UAObjectEvents & ListenerSignature<T> = UAOb
         this._eventNotifier = options.eventNotifier || EventNotifierFlags.None;
         assert(typeof this.eventNotifier === "number" && isValidByte(this.eventNotifier));
         this.symbolicName = options.symbolicName || null;
+        // every event MonitoredItem on this object is one "event" listener, and the Server
+        // object collects them for every Session: more than ten is the normal case, not a
+        // leak for Node to warn about (UAVariableImpl does the same for its "value_changed")
+        this.setMaxListeners(5000);
     }
 
     public readAttribute(
@@ -275,4 +279,12 @@ export class UAObjectImpl<T extends UAObjectEvents & ListenerSignature<T> = UAOb
     }
 }
 
-const plainChalk = new Proxy(chalk, { get: () => (s: string) => s }) as typeof chalk;
+// A colourless chalk for `inspect(node, { colors: false })`. Not a Proxy over `chalk`
+// returning the identity for every property: chalk 4 defines each style (`cyan`, ...)
+// on first use as a non-writable, non-configurable own data property, after which a
+// Proxy `get` trap returning anything else violates the Proxy invariant and throws a
+// TypeError. Node's own `warnMaxListenersExceeded` inspects the emitter without
+// colours, so that TypeError surfaced inside `node.on("event", ...)` when an eleventh
+// event MonitoredItem was created on the Server object, and killed the server process
+// (CTT A and C Refresh Err_004).
+const plainChalk = new chalk.Instance({ level: 0 });

--- a/packages/node-opcua-address-space/impl/ua_variable_impl.ts
+++ b/packages/node-opcua-address-space/impl/ua_variable_impl.ts
@@ -104,7 +104,8 @@ const warningLog = make_warningLog("ua_variable_impl");
 const doDebug = checkDebugFlag("ua_variable_impl");
 const errorLog = make_errorLog("ua_variable_impl");
 
-const plainChalk = new Proxy(chalk, { get: () => (s: string) => s }) as typeof chalk;
+// a colourless chalk; see ua_object_impl.ts for why it is not a Proxy over `chalk`
+const plainChalk = new chalk.Instance({ level: 0 });
 
 export function adjust_accessLevel(accessLevel: string | number | AccessLevelFlag | null | undefined): AccessLevelFlag {
     const flag = makeAccessLevelFlag(accessLevel ?? "CurrentRead | CurrentWrite");

--- a/packages/node-opcua-address-space/test/alarms_and_conditions/utest_condition.ts
+++ b/packages/node-opcua-address-space/test/alarms_and_conditions/utest_condition.ts
@@ -7,6 +7,7 @@ import should from "should";
 import sinon from "sinon";
 import {
     type AddressSpace,
+    type ISessionBase,
     SessionContext,
     type UACondition_Base,
     type UAConditionEx,
@@ -908,6 +909,88 @@ export function utest_condition(test: MochaSuiteEx): void {
                                     .should.eql("Variant(Scalar<NodeId>, value: RefreshEndEventType (ns=0;i=2788))");
                             }
                         );
+                });
+
+                // The Session of the CTT's "A and C Refresh" Err_003 / "A and C Refresh2" Err_002,
+                // Err_004: it owns Subscription 42, which holds MonitoredItem 7, and nothing else.
+                // A ServerSession answers getSubscription with its own Subscriptions only, so a
+                // Subscription of another Session looks exactly like one that never existed.
+                const sessionOwningSubscription42: ISessionBase = {
+                    ...mockSession,
+                    getSubscription(subscriptionId: number) {
+                        if (subscriptionId !== 42) return null;
+                        return {
+                            id: 42,
+                            getMonitoredItem: (monitoredItemId: number) => (monitoredItemId === 7 ? {} : null)
+                        };
+                    }
+                };
+                const uint32 = (value: number) => new Variant({ dataType: DataType.UInt32, value });
+
+                function callOnConditionType(methodName: string, inputArguments: Variant[], session: ISessionBase) {
+                    const conditionType = addressSpace.findObjectType("ConditionType")!;
+                    const context = new SessionContext({ object: conditionType, server: {}, session });
+                    const method = conditionType.getMethodByName(methodName)!;
+                    return method.execute(null, inputArguments, context);
+                }
+
+                it("ConditionRefresh answers BadSubscriptionIdInvalid in the Call result for a SubscriptionId the session does not own", async () => {
+                    const result = await callOnConditionType("ConditionRefresh", [uint32(12345)], sessionOwningSubscription42);
+                    should(result.statusCode).eql(StatusCodes.BadSubscriptionIdInvalid);
+                });
+
+                it("ConditionRefresh answers Good for a SubscriptionId the session owns, and the refresh runs", async () => {
+                    const serverObject = addressSpace.rootFolder.objects.server;
+                    const spy_on_event = sinon.spy();
+                    serverObject.on("event", spy_on_event);
+                    try {
+                        const result = await callOnConditionType("ConditionRefresh", [uint32(42)], sessionOwningSubscription42);
+                        should(result.statusCode).eql(StatusCodes.Good);
+                        const eventTypes = spy_on_event.getCalls().map((c) => c.args[0].eventType.value.toString());
+                        should(eventTypes[0]).eql("ns=0;i=2787"); // RefreshStartEventType
+                        should(eventTypes[eventTypes.length - 1]).eql("ns=0;i=2788"); // RefreshEndEventType
+                    } finally {
+                        serverObject.removeListener("event", spy_on_event);
+                    }
+                });
+
+                it("ConditionRefresh with a rejected SubscriptionId leaves the refresh available to the next caller", async () => {
+                    await callOnConditionType("ConditionRefresh", [uint32(12345)], sessionOwningSubscription42);
+                    const result = await callOnConditionType("ConditionRefresh", [uint32(42)], sessionOwningSubscription42);
+                    should(result.statusCode).eql(StatusCodes.Good);
+                });
+
+                it("ConditionRefresh still answers Good when the caller has no Session to check against", async () => {
+                    // an in-process caller (PseudoSession, SessionContext.defaultContext) has no Subscriptions
+                    const result = await callOnConditionType("ConditionRefresh", [uint32(12345)], mockSession);
+                    should(result.statusCode).eql(StatusCodes.Good);
+                });
+
+                it("ConditionRefresh2 answers BadSubscriptionIdInvalid before looking at the MonitoredItemId", async () => {
+                    const result = await callOnConditionType(
+                        "ConditionRefresh2",
+                        [uint32(12345), uint32(7)],
+                        sessionOwningSubscription42
+                    );
+                    should(result.statusCode).eql(StatusCodes.BadSubscriptionIdInvalid);
+                });
+
+                it("ConditionRefresh2 answers BadMonitoredItemIdInvalid for a MonitoredItemId that is not in the Subscription", async () => {
+                    const result = await callOnConditionType(
+                        "ConditionRefresh2",
+                        [uint32(42), uint32(0)],
+                        sessionOwningSubscription42
+                    );
+                    should(result.statusCode).eql(StatusCodes.BadMonitoredItemIdInvalid);
+                });
+
+                it("ConditionRefresh2 answers Good for a MonitoredItem of the session's own Subscription", async () => {
+                    const result = await callOnConditionType(
+                        "ConditionRefresh2",
+                        [uint32(42), uint32(7)],
+                        sessionOwningSubscription42
+                    );
+                    should(result.statusCode).eql(StatusCodes.Good);
                 });
             });
         });

--- a/packages/node-opcua-address-space/test/test_ua_object_inspect_and_event_listeners.ts
+++ b/packages/node-opcua-address-space/test/test_ua_object_inspect_and_event_listeners.ts
@@ -1,0 +1,68 @@
+import { inspect } from "node:util";
+import chalk from "chalk";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import should from "should";
+import type { AddressSpace } from "../dist/api/index.js";
+import { getMiniAddressSpace } from "../testHelpers.js";
+
+// The two halves of one server crash (certification run 11718, CTT "A and C Refresh"
+// Err_004): the eleventh event MonitoredItem on the Server object made Node emit its
+// MaxListenersExceededWarning, whose text inspects the emitter without colours, and that
+// inspection threw a TypeError out of `node.on("event", ...)` and out of the server process.
+describe("UAObject: inspect() and event listeners", () => {
+    let addressSpace: AddressSpace;
+    before(async () => {
+        addressSpace = await getMiniAddressSpace();
+    });
+    after(() => {
+        addressSpace.dispose();
+    });
+
+    it("inspect(object, { colors: false }) works after chalk has been used for real", () => {
+        // chalk 4 turns each style into a non-configurable own property on first use; a
+        // Proxy over chalk that returned something else for it threw from then on
+        chalk.cyan("x");
+        chalk.green("x");
+        const server = addressSpace.rootFolder.objects.server;
+        const text = inspect(server, { colors: false });
+        should(text).containEql("UAObject");
+        should(text).containEql("Server");
+        // and the colourless form is really colourless
+        should(text).not.containEql("\u001b"); // no ANSI escape
+        should(inspect(server, { colors: false, depth: 0 })).eql("UAObject<Server ns=0;i=2253>");
+    });
+
+    it("inspect(variable, { colors: false }) works after chalk has been used for real", () => {
+        chalk.cyan("x");
+        const serverStatus = addressSpace.rootFolder.objects.server.getChildByName("ServerStatus")!;
+        const text = inspect(serverStatus, { colors: false });
+        should(text).containEql("UAVariable");
+        should(text).not.containEql("\u001b"); // no ANSI escape
+    });
+
+    it("more than ten event listeners on an object is not a leak to warn about", async () => {
+        const server = addressSpace.rootFolder.objects.server;
+        // one listener per event MonitoredItem, and the Server object collects them for every Session
+        should(server.getMaxListeners()).be.greaterThan(10);
+
+        const warnings: Error[] = [];
+        const onWarning = (w: Error) => warnings.push(w);
+        process.on("warning", onWarning);
+        const listeners = Array.from({ length: 12 }, () => () => {
+            /* an event MonitoredItem */
+        });
+        try {
+            for (const listener of listeners) {
+                server.on("event", listener);
+            }
+            // process warnings are delivered on a later tick
+            await new Promise((resolve) => setImmediate(resolve));
+            should(warnings.filter((w) => w.name === "MaxListenersExceededWarning")).eql([]);
+        } finally {
+            process.removeListener("warning", onWarning);
+            for (const listener of listeners) {
+                server.removeListener("event", listener);
+            }
+        }
+    });
+});

--- a/packages/node-opcua-address-space/test/test_ua_object_inspect_and_event_listeners.ts
+++ b/packages/node-opcua-address-space/test/test_ua_object_inspect_and_event_listeners.ts
@@ -1,3 +1,4 @@
+import type { EventEmitter } from "node:events";
 import { inspect } from "node:util";
 import chalk from "chalk";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
@@ -43,7 +44,8 @@ describe("UAObject: inspect() and event listeners", () => {
     it("more than ten event listeners on an object is not a leak to warn about", async () => {
         const server = addressSpace.rootFolder.objects.server;
         // one listener per event MonitoredItem, and the Server object collects them for every Session
-        should(server.getMaxListeners()).be.greaterThan(10);
+        // (the public UAObject interface exposes on/once/removeListener only; the cap is the emitter's)
+        should((server as unknown as EventEmitter).getMaxListeners()).be.greaterThan(10);
 
         const warnings: Error[] = [];
         const onWarning = (w: Error) => warnings.push(w);

--- a/packages/node-opcua-end2end-test/test/end_to_end/alarms_and_conditions/u_test_e2e_conditions.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/alarms_and_conditions/u_test_e2e_conditions.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import {
     AttributeIds,
     type ClientMonitoredItemBase,
+    type ClientSession,
     type ClientSubscription,
     callConditionRefresh,
     coerceNodeId,
@@ -351,6 +352,110 @@ export function t(umbrellaTest: UmbrellaTestContext) {
                     const tankLevelCondition = test.tankLevelCondition;
                     tankLevelCondition.currentBranch().setRetain(false);
                     tankLevelCondition.raiseNewCondition({});
+                }
+            });
+        });
+
+        // CTT 1.05.513 "A and C Refresh" Err_003 and "A and C Refresh2" Err_002 / Err_004
+        // (certification run 11718, FEAT-46): the argument checks of Part 9 5.5.7 / 5.5.8,
+        // answered in the Call result, with the Session intact afterwards.
+        it("A&C-02b - ConditionRefresh / ConditionRefresh2 validate their SubscriptionId and MonitoredItemId arguments", async () => {
+            const conditionTypeId = resolveNodeId("ConditionType");
+            const uint32 = (value: number) => new Variant({ dataType: DataType.UInt32, value });
+            const callRefresh = async (session: ClientSession, subscriptionId: number) =>
+                (
+                    await session.call({
+                        objectId: conditionTypeId,
+                        methodId: resolveNodeId("ConditionType_ConditionRefresh"),
+                        inputArguments: [uint32(subscriptionId)]
+                    })
+                ).statusCode;
+            const callRefresh2 = async (session: ClientSession, subscriptionId: number, monitoredItemId: number) =>
+                (
+                    await session.call({
+                        objectId: conditionTypeId,
+                        methodId: resolveNodeId("ConditionType_ConditionRefresh2"),
+                        inputArguments: [uint32(subscriptionId), uint32(monitoredItemId)]
+                    })
+                ).statusCode;
+            const sessionStillWorks = async (session: ClientSession) => {
+                const dataValue = await session.read({
+                    nodeId: resolveNodeId("Server_ServerStatus_State"),
+                    attributeId: AttributeIds.Value
+                });
+                should(dataValue.statusCode).eql(StatusCodes.Good);
+            };
+
+            await perform_operation_on_subscription(client, test.endpointUrl!, async (session, subscription) => {
+                await given_an_installed_event_monitored_item(test, subscription);
+
+                stepInfo("ConditionRefresh with a SubscriptionId that does not exist");
+                should(await callRefresh(session, 12345)).eql(StatusCodes.BadSubscriptionIdInvalid);
+                await sessionStillWorks(session);
+
+                stepInfo("ConditionRefresh with the session's own subscription");
+                test.spy_monitored_item1_changes.resetHistory();
+                should(await callRefresh(session, subscription.subscriptionId)).eql(StatusCodes.Good);
+                await waitUntilCondition(
+                    async () => test.spy_monitored_item1_changes.callCount >= 2,
+                    5000,
+                    "RefreshStart + RefreshEnd"
+                );
+                const eventTypes = test.spy_monitored_item1_changes
+                    .getCalls()
+                    .map((c) => extract_value_for_field("EventType", c.args[0]).value.toString());
+                should(eventTypes[0]).eql("ns=0;i=2787"); // RefreshStartEventType
+                should(eventTypes[eventTypes.length - 1]).eql("ns=0;i=2788"); // RefreshEndEventType
+
+                stepInfo("ConditionRefresh2 with a MonitoredItemId that is not in the subscription");
+                should(await callRefresh2(session, subscription.subscriptionId, 0)).eql(StatusCodes.BadMonitoredItemIdInvalid);
+                await sessionStillWorks(session);
+
+                stepInfo("ConditionRefresh2 with a SubscriptionId that does not exist");
+                should(await callRefresh2(session, 12345, test.monitoredItem1.monitoredItemId!)).eql(
+                    StatusCodes.BadSubscriptionIdInvalid
+                );
+
+                stepInfo("ConditionRefresh2 with the session's own subscription and monitored item");
+                should(await callRefresh2(session, subscription.subscriptionId, test.monitoredItem1.monitoredItemId!)).eql(
+                    StatusCodes.Good
+                );
+                await sessionStillWorks(session);
+            });
+
+            stepInfo("ConditionRefresh with a SubscriptionId that belongs to another session");
+            await perform_operation_on_subscription(client, test.endpointUrl!, async (_session, otherSubscription) => {
+                const otherClient = OPCUAClient.create({ clientName: "u_test_e2e_conditions-other" });
+                await perform_operation_on_subscription(otherClient, test.endpointUrl!, async (session) => {
+                    should(await callRefresh(session, otherSubscription.subscriptionId)).eql(StatusCodes.BadSubscriptionIdInvalid);
+                    await sessionStillWorks(session);
+                });
+            });
+        });
+
+        // CTT "A and C Refresh" Err_004 creates ten more event monitored items on the Server
+        // object; the eleventh "event" listener made Node warn, the warning's inspect() of the
+        // node threw, and the server process died with it (run 11718).
+        it("A&C-02c - the server survives more than ten event monitored items on the Server object", async () => {
+            await perform_operation_on_subscription(client, test.endpointUrl!, async (session, subscription) => {
+                const items = [];
+                for (let i = 0; i < 12; i++) {
+                    items.push(
+                        await subscription.monitor(
+                            { attributeId: AttributeIds.EventNotifier, nodeId: resolveNodeId("Server") },
+                            { discardOldest: true, filter: eventFilter, queueSize: 10, samplingInterval: 10 },
+                            TimestampsToReturn.Both
+                        )
+                    );
+                }
+                should(items.length).eql(12);
+                const dataValue = await session.read({
+                    nodeId: resolveNodeId("Server_ServerStatus_State"),
+                    attributeId: AttributeIds.Value
+                });
+                should(dataValue.statusCode).eql(StatusCodes.Good);
+                for (const item of items) {
+                    await item.terminate();
                 }
             });
         });


### PR DESCRIPTION
## Why

FEAT-46 on the CTT board (project 7): run 11718, A and C Refresh. Two defects, one script apart.

**ConditionRefresh answered Good for any SubscriptionId.** `ua_condition_impl.ts` had `_check_subscription_id_is_valid` as a stub returning Good, and the branch meant to return a bad code returned without calling the callback, so the Call would never have been answered once implemented; ConditionRefresh2 looked at neither argument. Part 9 5.5.7 wants Bad_SubscriptionIdInvalid (and Bad_MonitoredItemIdInvalid for ConditionRefresh2).

**The channel dropped right after.** Not the refresh path: the shard's server log ends with a stack, the server process died. Err_004 creates ten more event monitored items on the Server object; the eleventh "event" listener trips Node's MaxListenersExceededWarning, whose text runs `util.inspect(emitter)` without colours. `UAObjectImpl[inspect.custom]` used `new Proxy(chalk, { get: () => (s) => s })`; chalk 4 defines its colour properties on first use as non-writable, non-configurable own properties, after which that trap violates the Proxy invariant: a TypeError thrown synchronously inside `MonitoredItem.setNode -> node.on("event")`, uncaught, process exit. Proven with a six-line probe. Two causes: the Proxy (also in `ua_variable_impl.ts`), and `UAObjectImpl` never raising its listener cap although the Server object legitimately gets one listener per event monitored item (`UAVariableImpl` already sets 5000).

## What

- `node-opcua-address-space-base`: `ISubscriptionBase`, optional `ISessionBase.getSubscription()` (ServerSession already has it).
- `ua_condition_impl.ts`: ConditionRefresh answers Bad_SubscriptionIdInvalid when the calling session does not own the subscription (another session's is unreachable, same answer, as CTT Err_005 accepts); ConditionRefresh2 also Bad_MonitoredItemIdInvalid; both through the callback; `_condition_refresh_in_progress` reset in a `finally`. No session behind the call (PseudoSession, tests): Good as before.
- `ua_object_impl.ts` / `ua_variable_impl.ts`: `plainChalk = new chalk.Instance({ level: 0 })`; `UAObjectImpl` sets `setMaxListeners(5000)`.
- Tests: 7 in `utest_condition.ts`, `test_ua_object_inspect_and_event_listeners.ts` (3), e2e A&C-02b (invalid id refused and the session still reads; valid refresh with RefreshStart/End; Refresh2 bad item; another session's subscription) and A&C-02c (12 event items on the Server object, the server survives).

## Verification

Before, on the parent commit with the new tests: inspect/listeners 0/3, ConditionRefresh 5/8. After: 3/3, 8/8, e2e 3/3; address-space 1336 passing, server 530; `lint:ci`, `check:shortcircuit`, `test:check`, `check-test-ports --summary` green.

CTT 1.05.513 replay of A and C Refresh against a server built from this branch:

| script | run 11718 | after |
|---|---|---|
| Err_003 | error, got Good | ok |
| Err_004 | error, BadDisconnect | ok (50 calls Good, refresh pairs received) |
| Err_005 | not run, server dead | ok |
| cleanup | error, BadDisconnect | ok |
| Test_002 / Test_003 | skipped, no alarm (FEAT-45) | same, expected |

Pre-existing and left alone: refresh events are broadcast to every event monitored item rather than the named subscription; Err_004 and Test_003 tolerate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
