### PR TITLE
build: replace yargs with command-line-args

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "test:win": "cd packages && node --expose-gc --max-old-space-size=2048 run_all_mocha_tests.js",
     "test:per-package": "pnpm m run test",
     "test:per-package:dry-run": "pnpm m run test --dry-run",
-    "ncu": "ncu -u -x yargs,env-paths,long,@types/long,cli-truncate,chalk,case-anything,@types/node,typescript --target=latest && ncu --deep -u --timeout 400000  -x yargs,env-paths,cli-truncate,chalk,case-anything,long,@types/long,@types/node,typescript --target=latest ",
+    "ncu": "ncu -u -x env-paths,long,@types/long,cli-truncate,chalk,case-anything,@types/node,typescript --target=latest && ncu --deep -u --timeout 400000  -x env-paths,cli-truncate,chalk,case-anything,long,@types/long,@types/node,typescript --target=latest ",
     "ncu:minor": "npx npm-check-updates  -u  --deep --target=minor",
     "alex": "npx alex documentation/*.md",
     "cost-of-modules": "npx cost-of-modules",
@@ -136,10 +136,11 @@
     "@types/sinon": "22.0.0",
     "@types/underscore": "1.13.0",
     "@types/wordwrap": "^1.0.3",
-    "@types/yargs": "17.0.35",
+    "@types/command-line-args": "5.2.3",
     "backoff": "^2.5.0",
     "bomstrip": "^0.1.4",
     "chalk": "4.1.2",
+    "command-line-args": "6.0.2",
     "cli-table3": "0.6.5",
     "cli-truncate": "2.1.0",
     "csv-parse": "7.0.2",
@@ -166,8 +167,7 @@
     "tslib": "^2.8.1",
     "winston": "*",
     "wordwrap": "^1.0.0",
-    "xml-writer": "^1.7.0",
-    "yargs": "15.4.1"
+    "xml-writer": "^1.7.0"
   },
   "funding": {
     "url": "https://github.com/sponsors/erossignon"

--- a/packages/node-opcua-end2end-test/package.json
+++ b/packages/node-opcua-end2end-test/package.json
@@ -42,8 +42,8 @@
         "node-opcua-service-session": "2.182.0",
         "node-opcua-test-helpers": "2.181.0",
         "node-opcua-utils": "2.181.0",
-        "sterfive-bonjour-service": "1.1.4",
-        "yargs": "15.4.1"
+        "command-line-args": "6.0.2",
+        "sterfive-bonjour-service": "1.1.4"
     },
     "author": "Etienne Rossignon",
     "license": "MIT",

--- a/packages/node-opcua-end2end-test/test_helpers/bin/simple_server_that_fails_to_republish.js
+++ b/packages/node-opcua-end2end-test/test_helpers/bin/simple_server_that_fails_to_republish.js
@@ -5,13 +5,14 @@ const path = require("path");
 const fs = require("fs");
 // simulate kepware server that sometime shutdown session too early
 const chalk = require("chalk");
-const yargs = require("yargs");
+const commandLineArgs = require("command-line-args");
 
 const { OPCUAServer, nodesets, StatusCodes, DataType, RepublishResponse, Variant } = require("node-opcua");
 
 Error.stackTraceLimit = Infinity;
 
-const argv = yargs.wrap(132).string("port").describe("port").alias("p", "port").argv;
+// partial: this helper is spawned with extra flags it does not own
+const argv = commandLineArgs([{ name: "port", alias: "p", type: String }], { partial: true });
 
 const port = parseInt(argv.port) || 26555;
 

--- a/packages/node-opcua-end2end-test/test_helpers/bin/simple_server_that_terminate_session_too_early.js
+++ b/packages/node-opcua-end2end-test/test_helpers/bin/simple_server_that_terminate_session_too_early.js
@@ -6,13 +6,14 @@ const fs = require("fs");
 
 // simulate kepware server that sometime shutdown session too early
 const chalk = require("chalk");
-const yargs = require("yargs");
+const commandLineArgs = require("command-line-args");
 const { OPCUAServer, nodesets, StatusCodes, DataType } = require("node-opcua");
 
 Error.stackTraceLimit = Infinity;
 const doDebug = !!process.env.DEBUG;
 
-const argv = yargs.wrap(132).string("port").describe("port").alias("p", "port").argv;
+// partial: this helper is spawned with extra flags it does not own
+const argv = commandLineArgs([{ name: "port", alias: "p", type: String }], { partial: true });
 
 const packageFolder = path.join(__dirname, "../");
 

--- a/packages/node-opcua-end2end-test/test_helpers/bin/simple_server_with_custom_extension_objects.js
+++ b/packages/node-opcua-end2end-test/test_helpers/bin/simple_server_with_custom_extension_objects.js
@@ -2,11 +2,12 @@ const path = require("path");
 const fs = require("fs");
 const chalk = require("chalk");
 const { OPCUAServer, nodesets, Variant, DataType, MessageSecurityMode } = require("node-opcua");
-const yargs = require("yargs");
+const commandLineArgs = require("command-line-args");
 
 Error.stackTraceLimit = Infinity;
 
-const argv = yargs.wrap(132).string("port").describe("port").alias("p", "port").argv;
+// partial: this helper is spawned with extra flags it does not own
+const argv = commandLineArgs([{ name: "port", alias: "p", type: String }], { partial: true });
 
 const packageFolder = path.join(__dirname, "../");
 

--- a/packages/node-opcua-end2end-test/test_helpers/bin/simple_server_with_no_transferSubscription.js
+++ b/packages/node-opcua-end2end-test/test_helpers/bin/simple_server_with_no_transferSubscription.js
@@ -12,11 +12,12 @@ const {
     Variant,
     DataType
 } = require("node-opcua");
-const yargs = require("yargs");
+const commandLineArgs = require("command-line-args");
 
 Error.stackTraceLimit = Infinity;
 
-const argv = yargs.wrap(132).string("port").describe("port").alias("p", "port").argv;
+// partial: this helper is spawned with extra flags it does not own
+const argv = commandLineArgs([{ name: "port", alias: "p", type: String }], { partial: true });
 
 const packageFolder = path.join(__dirname, "../");
 

--- a/packages/node-opcua-local-discovery-server/bin/local-discovery-server.mjs
+++ b/packages/node-opcua-local-discovery-server/bin/local-discovery-server.mjs
@@ -10,7 +10,7 @@ import { make_debugLog } from "node-opcua-debug";
 
 const paths = envPaths("node-opcua-local-discovery-server");
 
-import yargs from "yargs/yargs.js";
+import commandLineArgs from "command-line-args";
 
 const configFolder = paths.config;
 const pkiFolder = path.join(configFolder, "PKI");
@@ -49,46 +49,30 @@ async function getIpAddresses() {
 }
 const applicationUri = "";
 
-const argv = yargs(process.argv)
-    .wrap(132)
+// `--tolerant` and `--force` default to true/false and both had a yargs `--no-x` form.
+// command-line-args has no negation, so they take an optional value instead: `--tolerant false`.
+const flag = () => (value) => (value === null || value === undefined ? true : value !== "false" && value !== "0");
 
-    .number("port")
-    .describe("port", "port to listen to (default: 4840)")
-    .default("port", 4840)
-
-    .boolean("tolerant")
-    .describe("tolerant", "automatically accept unknown registering server certificate")
-    .default("tolerant", true)
-
-    .boolean("force")
-    .describe("force", "force recreation of LDS self-signed certification (taking into account alternateHostname) ")
-    .default("force", false)
-
-    .string("alternateHostname")
-    .describe("alternateHostname ", "alternate hostname to use in certificate")
-    .string("hostname")
-    .describe("hostname", "the hostname")
-
-    .string("applicationName")
-    .describe("applicationName", "the application name")
-    .default("applicationName", "NodeOPCUA-DiscoveryServer")
-
-    .alias("a", "alternateHostname")
-    .alias("n", "applicationName")
-    .alias("p", "port")
-    .alias("h", "hostname")
-    .alias("f", "force")
-    .alias("t", "tolerant")
-
-    .help(true).argv/* as {
-        port: number,
-        tolerant: boolean,
-        force: boolean,
-        applicationName: string,
-        hostname?: string,
-        alternateHostname?: string
-    }*/
-   ;
+const argv = commandLineArgs([
+    { name: "port", alias: "p", type: Number, defaultValue: 4840, description: "port to listen to (default: 4840)" },
+    {
+        name: "tolerant",
+        alias: "t",
+        type: flag(),
+        defaultValue: true,
+        description: "automatically accept unknown registering server certificate"
+    },
+    {
+        name: "force",
+        alias: "f",
+        type: flag(),
+        defaultValue: false,
+        description: "force recreation of LDS self-signed certification (taking into account alternateHostname) "
+    },
+    { name: "alternateHostname", alias: "a", type: String, description: "alternate hostname to use in certificate" },
+    { name: "hostname", alias: "h", type: String, description: "the hostname" },
+    { name: "applicationName", alias: "n", type: String, defaultValue: "NodeOPCUA-DiscoveryServer", description: "the application name" }
+]);
 
 const port = argv.port;
 const automaticallyAcceptUnknownCertificate = argv.tolerant;

--- a/packages/node-opcua-local-discovery-server/package.json
+++ b/packages/node-opcua-local-discovery-server/package.json
@@ -32,10 +32,10 @@
     },
     "dependencies": {
         "@inquirer/prompts": "8.7.1",
+        "command-line-args": "6.0.2",
         "env-paths": "2.2.1",
         "node-opcua": "2.182.2",
-        "node-opcua-debug": "2.181.0",
-        "yargs": "15.4.1"
+        "node-opcua-debug": "2.181.0"
     },
     "homepage": "http://node-opcua.github.io/",
     "gitHead": "064029878247adf2fa5d14a8124e1930431e2428",

--- a/packages/node-opcua-model/bin/extract_schema.js
+++ b/packages/node-opcua-model/bin/extract_schema.js
@@ -1,27 +1,22 @@
 const { OPCUAClient } = require("node-opcua-client");
 const { parse_opcua_common } = require("..");
 
-const yargs = require("yargs/yargs");
+const commandLineArgs = require("command-line-args");
+const commandLineUsage = require("command-line-usage");
 
-const argv = yargs(process.argv)
-  .wrap(132)
-  .demand("endpoint")
-  .string("endpoint")
-  .describe("endpoint", "the end point to connect to ")
-  .string("securityMode")
-  .describe("securityMode", "the security mode")
-  .string("securityPolicy")
-  .describe("securityPolicy", "the policy mode")
-  .string("userName")
-  .describe("userName", "specify the user name of a UserNameIdentityToken ")
-  .string("password")
-  .describe("password", "specify the password of a UserNameIdentityToken")
-  .alias("e", "endpoint")
-  .alias("s", "securityMode")
-  .alias("P", "securityPolicy")
-  .alias("u", "userName")
-  .alias("p", "password")
-  .argv;
+const optionDefinitions = [
+  { name: "endpoint", alias: "e", type: String, description: "the end point to connect to " },
+  { name: "securityMode", alias: "s", type: String, description: "the security mode" },
+  { name: "securityPolicy", alias: "P", type: String, description: "the policy mode" },
+  { name: "userName", alias: "u", type: String, description: "specify the user name of a UserNameIdentityToken " },
+  { name: "password", alias: "p", type: String, description: "specify the password of a UserNameIdentityToken" }
+];
+const argv = commandLineArgs(optionDefinitions);
+if (!argv.endpoint) {
+  // was yargs .demand("endpoint"), which printed the usage and exited
+  console.log(commandLineUsage([{ header: "extract_schema", optionList: optionDefinitions }]));
+  process.exit(1);
+}
 
 const endpointUrl = argv.endpoint || "opc.tcp://localhost:48010";
 

--- a/packages/node-opcua-model/package.json
+++ b/packages/node-opcua-model/package.json
@@ -14,6 +14,8 @@
     "author": "Etienne Rossignon",
     "license": "MIT",
     "dependencies": {
+        "command-line-args": "6.0.2",
+        "command-line-usage": "7.0.4",
         "node-opcua-client-dynamic-extension-object": "2.182.1",
         "node-opcua-pseudo-session": "2.182.1"
     },

--- a/packages/node-opcua-samples/bin/client_example.js
+++ b/packages/node-opcua-samples/bin/client_example.js
@@ -34,57 +34,45 @@ const {
 const { toPem } = require("node-opcua-crypto");
 
 //node bin/client_example.js --endpoint  opc.tcp://localhost:53530/OPCUA/SimulationServer --node "ns=5;s=Sinusoid1"
-const yargs = require("yargs/yargs");
-const argv = yargs(process.argv)
-    .wrap(132)
-    
-    .option("endpoint", {
-        alias: "e",
-        demandOption: true,
-        describe: "the end point to connect to "
-    })
-    .option("securityMode", {
-        alias: "s",
-        default: "None",
-        describe: "the security mode (  None Sign SignAndEncrypt )"
-    })
-    .option("securityPolicy", {
+const commandLineArgs = require("command-line-args");
+const commandLineUsage = require("command-line-usage");
+
+const optionDefinitions = [
+    { name: "endpoint", alias: "e", type: String, description: "the end point to connect to " },
+    { name: "securityMode", alias: "s", type: String, defaultValue: "None", description: "the security mode (  None Sign SignAndEncrypt )" },
+    {
+        name: "securityPolicy",
         alias: "P",
-        default: "None",
-        describe: "the policy mode : (" + Object.keys(SecurityPolicy).join(" - ") + ")"
-    })
-    .option("userName", {
-        alias: "u",
-        describe: "specify the user name of a UserNameIdentityToken"
-    })
-    .option("password", {
-        alias: "p",
-        describe: "specify the password of a UserNameIdentityToken"
-    })
-    .option("node", {
-        alias: "n",
-        describe: "the nodeId of the value to monitor"
-    })
-    .option("timeout", {
-        alias: "t",
-        describe: " the timeout of the session in second =>  (-1 for infinity)"
-    })
-    .option("debug", {
-        alias: "d",
-        boolean: true,
-        describe: " display more verbose information"
-    })
-    .option("history", {
-        alias: "h",
-        describe: "make an historical read"
-    })
-    .option("discovery", {
+        type: String,
+        defaultValue: "None",
+        description: "the policy mode : (" + Object.keys(SecurityPolicy).join(" - ") + ")"
+    },
+    { name: "userName", alias: "u", type: String, description: "specify the user name of a UserNameIdentityToken" },
+    { name: "password", alias: "p", type: String, description: "specify the password of a UserNameIdentityToken" },
+    { name: "node", alias: "n", type: String, description: "the nodeId of the value to monitor" },
+    { name: "timeout", alias: "t", type: Number, description: " the timeout of the session in second =>  (-1 for infinity)" },
+    { name: "debug", alias: "d", type: Boolean, description: " display more verbose information" },
+    { name: "history", alias: "h", type: Boolean, description: "make an historical read" },
+    {
+        name: "discovery",
         alias: "D",
-        describe: "specify the endpoint uri of discovery server (by default same as server endpoint uri)"
-    })
-    .example("simple_client  --endpoint opc.tcp://localhost:49230 -P=Basic256Rsa256 -s=Sign", "")
-    .example("simple_client  -e opc.tcp://localhost:49230 -P=Basic256Sha256 -s=Sign -u JoeDoe -p P@338@rd ", "")
-    .example('simple_client  --endpoint opc.tcp://localhost:49230  -n="ns=0;i=2258"', "").argv;
+        type: String,
+        description: "specify the endpoint uri of discovery server (by default same as server endpoint uri)"
+    }
+];
+const sections = [
+    { header: "client_example", content: "connect to a server, browse it and monitor a node" },
+    { header: "Options", optionList: optionDefinitions },
+    {
+        header: "Examples",
+        content: [
+            "simple_client  --endpoint opc.tcp://localhost:49230 -P=Basic256Rsa256 -s=Sign",
+            "simple_client  -e opc.tcp://localhost:49230 -P=Basic256Sha256 -s=Sign -u JoeDoe -p P@338@rd ",
+            'simple_client  --endpoint opc.tcp://localhost:49230  -n="ns=0;i=2258"'
+        ]
+    }
+];
+const argv = commandLineArgs(optionDefinitions);
 
 const securityMode = coerceMessageSecurityMode(argv.securityMode);
 if (securityMode === MessageSecurityMode.Invalid) {
@@ -108,7 +96,7 @@ console.log(" monitoring node id = ", monitored_node);
 const endpointUrl = argv.endpoint;
 
 if (!endpointUrl) {
-    yargs.showHelp();
+    console.log(commandLineUsage(sections));
     process.exit(0);
 }
 const discoveryUrl = argv.discovery ? argv.discovery : endpointUrl;

--- a/packages/node-opcua-samples/bin/client_example_ts.ts
+++ b/packages/node-opcua-samples/bin/client_example_ts.ts
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 import util, { types } from "node:util";
 import chalk from "chalk";
+import commandLineArgs from "command-line-args";
+import commandLineUsage from "command-line-usage";
 import Table from "easy-table";
 import {
     ApplicationType,
@@ -40,7 +42,6 @@ import {
     type Variant
 } from "node-opcua";
 import { type Certificate, toPem } from "node-opcua-crypto";
-import yargs from "yargs/yargs";
 
 const { asTree } = require("treeify");
 
@@ -212,53 +213,40 @@ function getTick() {
 
 (async () => {
     // tsx bin/simple_client.ts --endpoint  opc.tcp://localhost:53530/OPCUA/SimulationServer --node "ns=5;s=Sinusoid1"
-    const argv = await yargs(process.argv.slice(2)).options({
-        endpoint: {
-            alias: "e",
-            demandOption: true,
-            string: true,
-            describe: "the end point to connect to "
-        },
-        securityMode: {
+    const optionDefinitions: commandLineUsage.OptionDefinition[] = [
+        { name: "endpoint", alias: "e", type: String, description: "the end point to connect to " },
+        {
+            name: "securityMode",
             alias: "s",
-            default: "None",
-            describe: "the security mode (  None Sign SignAndEncrypt )"
+            type: String,
+            defaultValue: "None",
+            description: "the security mode (  None Sign SignAndEncrypt )"
         },
-        securityPolicy: {
+        {
+            name: "securityPolicy",
             alias: "P",
-            default: "None",
-            describe: `the policy mode : (${Object.keys(SecurityPolicy).join(" - ")})`
+            type: String,
+            defaultValue: "None",
+            description: `the policy mode : (${Object.keys(SecurityPolicy).join(" - ")})`
         },
-        userName: {
-            alias: "u",
-            describe: "specify the user name of a UserNameIdentityToken"
-        },
-        password: {
-            alias: "p",
-            describe: "specify the password of a UserNameIdentityToken"
-        },
-        node: {
-            alias: "n",
-            describe: "the nodeId of the value to monitor"
-        },
-        timeout: {
-            alias: "t",
-            describe: " the timeout of the session in second =>  (-1 for infinity)"
-        },
-        debug: {
-            alias: "d",
-            boolean: true,
-            describe: " display more verbose information"
-        },
-        history: {
-            alias: "h",
-            describe: "make an historical read"
-        },
-        discovery: {
+        { name: "userName", alias: "u", type: String, description: "specify the user name of a UserNameIdentityToken" },
+        { name: "password", alias: "p", type: String, description: "specify the password of a UserNameIdentityToken" },
+        { name: "node", alias: "n", type: String, description: "the nodeId of the value to monitor" },
+        { name: "timeout", alias: "t", type: Number, description: " the timeout of the session in second =>  (-1 for infinity)" },
+        { name: "debug", alias: "d", type: Boolean, description: " display more verbose information" },
+        { name: "history", alias: "h", type: Boolean, description: "make an historical read" },
+        {
+            name: "discovery",
             alias: "D",
-            describe: "specify the endpoint uri of discovery server (by default same as server endpoint uri)"
+            type: String,
+            description: "specify the endpoint uri of discovery server (by default same as server endpoint uri)"
         }
-    }).argv;
+    ];
+    const sections: commandLineUsage.Section[] = [
+        { header: "client_example", content: "connect to a server, browse it and monitor a node" },
+        { header: "Options", optionList: optionDefinitions }
+    ];
+    const argv = commandLineArgs(optionDefinitions);
 
     const securityMode = coerceMessageSecurityMode(argv.securityMode);
     if (securityMode === MessageSecurityMode.Invalid) {
@@ -280,7 +268,7 @@ function getTick() {
     console.log(" monitoring node id = ", monitored_node);
 
     if (!argv.endpoint) {
-        // y.showHelp();
+        console.log(commandLineUsage(sections));
         process.exit(0);
     }
     const discoveryUrl: string = argv.discovery ? (argv.discovery as string) : argv.endpoint || "";

--- a/packages/node-opcua-samples/bin/di_server.js
+++ b/packages/node-opcua-samples/bin/di_server.js
@@ -17,26 +17,20 @@ const { makeBoiler, createBoilerType } = require("node-opcua-address-space/testH
 Error.stackTraceLimit = Infinity;
 
 const { assert } = require("node-opcua-assert");
-const argv = require("yargs")
-    .wrap(132)
+const commandLineArgs = require("command-line-args");
 
-    .string("alternateHostname")
-    .describe("alternateHostname")
-    .alias("a", "alternateHostname")
-
-    .string("port")
-    .describe("port")
-    .alias("p", "port")
-
-    .number("keySize")
-    .describe("keySize", "certificate keySize [1024|2048|3072|4096]")
-    .default("keySize", 2048)
-    .alias("k", "keySize")
-
-    .string("discoveryServerEndpointUrl")
-    .describe("discoveryServerEndpointUrl", " end point of the discovery server to register to")
-    .default("discoveryServerEndpointUrl", "opc.tcp://localhost:4840")
-    .alias("d", "discoveryServerEndpointUrl").argv;
+const argv = commandLineArgs([
+    { name: "alternateHostname", alias: "a", type: String },
+    { name: "port", alias: "p", type: String },
+    { name: "keySize", alias: "k", type: Number, defaultValue: 2048, description: "certificate keySize [1024|2048|3072|4096]" },
+    {
+        name: "discoveryServerEndpointUrl",
+        alias: "d",
+        type: String,
+        defaultValue: "opc.tcp://localhost:4840",
+        description: " end point of the discovery server to register to"
+    }
+]);
 
 const port = parseInt(argv.port) || 26543;
 

--- a/packages/node-opcua-samples/bin/findServersOnNetwork.js
+++ b/packages/node-opcua-samples/bin/findServersOnNetwork.js
@@ -1,20 +1,12 @@
 const opcua = require("node-opcua");
 
 
-const yargs = require("yargs/yargs");
+const commandLineArgs = require("command-line-args");
 
-const argv = yargs(process.argv)
-    .wrap(132)
-    .string("capabilities")
-    .default("capabilities","DA")
-    .alias("c","capabilities")
-
-    .string("discoveryServerURI")
-    .default("discoveryServerURI","opc.tcp://localhost:4840")
-    .alias("d","discoveryServerURI")
-
-    .help(true)
-    .argv;
+const argv = commandLineArgs([
+    { name: "capabilities", alias: "c", type: String, defaultValue: "DA" },
+    { name: "discoveryServerURI", alias: "d", type: String, defaultValue: "opc.tcp://localhost:4840" }
+]);
 
 const capabilities = argv.capabilities || "LDS";
 

--- a/packages/node-opcua-samples/bin/get_endpoints.ts
+++ b/packages/node-opcua-samples/bin/get_endpoints.ts
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { types } from "node:util";
 import chalk from "chalk";
+import commandLineArgs from "command-line-args";
+import commandLineUsage from "command-line-usage";
 import {
     ApplicationType,
     coerceMessageSecurityMode,
@@ -14,36 +16,41 @@ import {
     UserTokenType
 } from "node-opcua";
 import { type Certificate, toPem } from "node-opcua-crypto";
-import yargs from "yargs";
 
 const Table = require("easy-table");
 const treeify = require("treeify");
 
 async function main() {
     // tsx bin/simple_client.ts --endpoint  opc.tcp://localhost:53530/OPCUA/SimulationServer --node "ns=5;s=Sinusoid1"
-    const argv = await yargs(process.argv)
-        .wrap(132)
-
-        .option("endpoint", {
-            alias: "e",
-            demandOption: true,
-            describe: "the end point to connect to "
-        })
-        .option("securityMode", {
+    const optionDefinitions: commandLineUsage.OptionDefinition[] = [
+        { name: "endpoint", alias: "e", type: String, description: "the end point to connect to " },
+        {
+            name: "securityMode",
             alias: "s",
-            default: "None",
-            describe: "the security mode (  None Sign SignAndEncrypt )"
-        })
-        .option("securityPolicy", {
+            type: String,
+            defaultValue: "None",
+            description: "the security mode (  None Sign SignAndEncrypt )"
+        },
+        {
+            name: "securityPolicy",
             alias: "P",
-            default: "None",
-            describe: `the policy mode : (${Object.keys(SecurityPolicy).join(" - ")})`
-        })
-        .option("discovery", {
+            type: String,
+            defaultValue: "None",
+            description: `the policy mode : (${Object.keys(SecurityPolicy).join(" - ")})`
+        },
+        {
+            name: "discovery",
             alias: "D",
-            describe: "specify the endpoint uri of discovery server (by default same as server endpoint uri)"
-        })
-        .example("get_endpoints  --endpoint opc.tcp://localhost:49230", "").argv;
+            type: String,
+            description: "specify the endpoint uri of discovery server (by default same as server endpoint uri)"
+        }
+    ];
+    const sections: commandLineUsage.Section[] = [
+        { header: "get_endpoints", content: "list the endpoints a server offers" },
+        { header: "Options", optionList: optionDefinitions },
+        { header: "Examples", content: ["get_endpoints  --endpoint opc.tcp://localhost:49230"] }
+    ];
+    const argv = commandLineArgs(optionDefinitions);
 
     const securityMode = coerceMessageSecurityMode(argv.securityMode);
     if (securityMode === MessageSecurityMode.Invalid) {
@@ -61,7 +68,7 @@ async function main() {
     const endpointUrl = argv.endpoint as string;
 
     if (!endpointUrl) {
-        yargs.showHelp();
+        console.log(commandLineUsage(sections));
         process.exit(0);
     }
     const discoveryUrl = argv.discovery ? (argv.discovery as string) : endpointUrl;

--- a/packages/node-opcua-samples/bin/more.js
+++ b/packages/node-opcua-samples/bin/more.js
@@ -3,9 +3,15 @@
 /*
  * write a file to the console, preserving the Ansi color decoration
  */
-const argv = require("yargs")
-    .usage("Usage: $0 <file>")
-    .argv;
+const commandLineArgs = require("command-line-args");
+const commandLineUsage = require("command-line-usage");
+
+const optionDefinitions = [{ name: "file", defaultOption: true, type: String, description: "the file to write out" }];
+const argv = commandLineArgs(optionDefinitions);
+if (!argv.file) {
+    console.log(commandLineUsage([{ header: "more", content: "Usage: more <file>" }, { header: "Options", optionList: optionDefinitions }]));
+    process.exit(1);
+}
 
 const fs = require("fs");
 
@@ -35,6 +41,6 @@ function func(data) {
     console.log(data);
 }
 
-const input = fs.createReadStream(argv._[0]);
+const input = fs.createReadStream(argv.file);
 
 readLines(input, func);

--- a/packages/node-opcua-samples/bin/opcua_interceptor.js
+++ b/packages/node-opcua-samples/bin/opcua_interceptor.js
@@ -3,8 +3,14 @@
 const net = require("net");
 
 const chalk = require("chalk");
-const yargs = require("yargs");
-const argv =  yargs.usage("Usage: $0 --portServer [num] --port [num]  --hostname <hostname> -block").argv;
+const commandLineArgs = require("command-line-args");
+
+const argv = commandLineArgs([
+    { name: "port", type: Number, description: "the port of the server to intercept" },
+    { name: "portServer", type: Number, description: "the port this interceptor listens on" },
+    { name: "hostname", type: String, description: "the host of the server to intercept" },
+    { name: "block", type: Boolean, description: "drop the intercepted traffic instead of forwarding it" }
+]);
 
 const opcua = require("node-opcua");
 

--- a/packages/node-opcua-samples/bin/server_with_push_certificate.ts
+++ b/packages/node-opcua-samples/bin/server_with_push_certificate.ts
@@ -3,11 +3,12 @@
 import path from "node:path";
 import bcrypt from "bcryptjs";
 import chalk from "chalk";
+import commandLineArgs from "command-line-args";
+import type commandLineUsage from "command-line-usage";
 import envPaths from "env-paths";
 import { makeRoles, nodesets, OPCUACertificateManager, OPCUAServer, type OPCUAServerOptions, WellKnownRoles } from "node-opcua";
 import { CertificateManager } from "node-opcua-pki";
 import { installPushCertificateManagement } from "node-opcua-server-configuration";
-import yargs from "yargs";
 
 const config = envPaths("node-opcua-default").config;
 const pkiFolder = path.join(config, "PKI");
@@ -54,11 +55,10 @@ const userManager = {
 };
 
 async function main() {
-    const argv = await yargs.wrap(132).option("port", {
-        alias: "p",
-        default: "26543",
-        describe: "port to listen"
-    }).argv;
+    const optionDefinitions: commandLineUsage.OptionDefinition[] = [
+        { name: "port", alias: "p", type: String, defaultValue: "26543", description: "port to listen" }
+    ];
+    const argv = commandLineArgs(optionDefinitions);
 
     const port = parseInt(argv.port, 10) || 26555;
 

--- a/packages/node-opcua-samples/bin/simple_secure_server.ts
+++ b/packages/node-opcua-samples/bin/simple_secure_server.ts
@@ -3,6 +3,8 @@
 import os from "node:os";
 
 import chalk from "chalk";
+import commandLineArgs from "command-line-args";
+import type commandLineUsage from "command-line-usage";
 import {
     MessageSecurityMode,
     makeApplicationUrn,
@@ -12,7 +14,6 @@ import {
     SecurityPolicy,
     type ServerSession
 } from "node-opcua";
-import yargs from "yargs";
 
 Error.stackTraceLimit = Infinity;
 
@@ -29,29 +30,13 @@ const userManager = {
 };
 
 async function main() {
-    const argv = await yargs(process.argv)
-        .wrap(132)
-
-        .option("alternateHostname", {
-            alias: "a",
-            describe: "alternateHostname"
-        })
-
-        .option("port", {
-            alias: "p",
-            default: 26543
-        })
-
-        .option("silent", {
-            alias: "s",
-            default: false,
-            describe: "silent - no trace"
-        })
-        .option("maxSessions", {
-            alias: "m",
-            default: 10
-        })
-        .help(true).argv;
+    const optionDefinitions: commandLineUsage.OptionDefinition[] = [
+        { name: "alternateHostname", alias: "a", type: String, description: "alternateHostname" },
+        { name: "port", alias: "p", type: Number, defaultValue: 26543 },
+        { name: "silent", alias: "s", type: Boolean, defaultValue: false, description: "silent - no trace" },
+        { name: "maxSessions", alias: "m", type: Number, defaultValue: 10 }
+    ];
+    const argv = commandLineArgs(optionDefinitions);
 
     const port = argv.port || 26543;
     // server_options.alternateHostname = argv.alternateHostname;

--- a/packages/node-opcua-samples/bin/simple_server.js
+++ b/packages/node-opcua-samples/bin/simple_server.js
@@ -6,7 +6,7 @@ const fs = require("fs");
 const os = require("os");
 const assert = require("assert");
 const chalk = require("chalk");
-const yargs = require("yargs/yargs");
+const commandLineArgs = require("command-line-args");
 const envPaths = require("env-paths");
 const bcrypt = require("bcryptjs");
 
@@ -32,44 +32,25 @@ const { build_address_space_for_conformance_testing } = require("node-opcua-addr
 
 Error.stackTraceLimit = Infinity;
 
-const argv = yargs(process.argv)
-    .wrap(132)
-
-    .string("alternateHostname")
-    .describe("alternateHostname")
-
-    .number("port")
-    .default("port", 26543)
-
-    .number("maxSessions")
-    .describe("maxSessions", "the maximum number of concurrent client session that the server will accept")
-    .default("maxSessions", 500)
-
-    .number("maxSubscriptionsPerSession")
-    .describe("maxSubscriptionsPerSession", "the maximum number of concurrent subscriptions per session")
-
-    .boolean("silent")
-    .default("silent", false)
-    .describe("silent", "no trace")
-
-    .string("alternateHostname")
-    .default("alternateHostname", null)
-
-    .number("keySize")
-    .describe("keySize", "certificate keySize [1024|2048|3072|4096]")
-    .default("keySize", 2048)
-    .alias("k", "keySize")
-
-    .string("applicationName")
-    .describe("applicationName", "the application name")
-    .default("applicationName", "NodeOPCUA-Server")
-
-    .alias("a", "alternateHostname")
-    .alias("m", "maxSessions")
-    .alias("n", "applicationName")
-    .alias("p", "port")
-
-    .help(true).argv;
+const argv = commandLineArgs([
+    { name: "alternateHostname", alias: "a", type: String, defaultValue: null },
+    { name: "port", alias: "p", type: Number, defaultValue: 26543 },
+    {
+        name: "maxSessions",
+        alias: "m",
+        type: Number,
+        defaultValue: 500,
+        description: "the maximum number of concurrent client session that the server will accept"
+    },
+    {
+        name: "maxSubscriptionsPerSession",
+        type: Number,
+        description: "the maximum number of concurrent subscriptions per session"
+    },
+    { name: "silent", type: Boolean, defaultValue: false, description: "no trace" },
+    { name: "keySize", alias: "k", type: Number, defaultValue: 2048, description: "certificate keySize [1024|2048|3072|4096]" },
+    { name: "applicationName", alias: "n", type: String, defaultValue: "NodeOPCUA-Server", description: "the application name" }
+]);
 
 const port = argv.port;
 const maxSessions = argv.maxSessions;

--- a/packages/node-opcua-samples/bin/simple_server_with_custom_extension_objects.ts
+++ b/packages/node-opcua-samples/bin/simple_server_with_custom_extension_objects.ts
@@ -2,8 +2,9 @@
 /* eslint no-process-exit: 0 */
 import path from "node:path";
 import chalk from "chalk";
+import commandLineArgs from "command-line-args";
+import type commandLineUsage from "command-line-usage";
 import { nodesets, OPCUAServer } from "node-opcua";
-import yargs from "yargs";
 
 Error.stackTraceLimit = Infinity;
 
@@ -14,11 +15,10 @@ function constructFilename(filename: string): string {
 const rootFolder = path.join(__dirname, "../../..");
 
 async function main() {
-    const argv = await yargs.wrap(132).option("port", {
-        alias: "p",
-        default: "26543",
-        describe: "port to listen"
-    }).argv;
+    const optionDefinitions: commandLineUsage.OptionDefinition[] = [
+        { name: "port", alias: "p", type: String, defaultValue: "26543", description: "port to listen" }
+    ];
+    const argv = commandLineArgs(optionDefinitions);
     const port = parseInt(argv.port, 10) || 26555;
     const server_certificate_file = constructFilename("certificates/server_cert_2048.pem");
     const server_certificate_privatekey_file = constructFilename("certificates/server_key_2048.pem");

--- a/packages/node-opcua-samples/package.json
+++ b/packages/node-opcua-samples/package.json
@@ -20,9 +20,12 @@
     },
     "dependencies": {
         "@types/underscore": "1.13.0",
-        "@types/yargs": "17.0.35",
+        "@types/command-line-args": "5.2.3",
+        "@types/command-line-usage": "5.0.4",
         "bcryptjs": "3.0.3",
         "chalk": "4.1.2",
+        "command-line-args": "6.0.2",
+        "command-line-usage": "7.0.4",
         "easy-table": "^1.2.0",
         "env-paths": "2.2.1",
         "node-opcua": "2.182.2",
@@ -37,8 +40,7 @@
         "node-opcua-utils": "2.181.0",
         "node-opcua-vendor-diagnostic": "2.182.2",
         "sprintf-js": "^1.1.3",
-        "treeify": "^1.1.0",
-        "yargs": "15.4.1"
+        "treeify": "^1.1.0"
     },
     "author": "Etienne Rossignon",
     "license": "MIT",

--- a/packages/parallel_test.js
+++ b/packages/parallel_test.js
@@ -40,7 +40,7 @@ require("should");
 const chalk = require("chalk");
 
 const { Mocha } = require("mocha");
-const yargs = require("yargs");
+const commandLineArgs = require("command-line-args");
 
 function durationToString(milliseconds) {
     const seconds = Math.floor(milliseconds / 1000);
@@ -341,20 +341,15 @@ function dumpRunningTests() {
 }
 
 if (isMainThread) {
-    const argv = yargs
-        .option("fileFilter", {
-            describe: "file filter",
-            default: null,
-            alias: "f"
-        })
-        .option("testFilter", {
-            alias: "t",
-            default: null
-        })
-        .options("verbose", {
-            alias: "v",
-            default: false
-        }).argv;
+    // partial: mocha flags reach this runner too, and an unknown one used to be ignored
+    const argv = commandLineArgs(
+        [
+            { name: "fileFilter", alias: "f", type: String, defaultValue: null, description: "file filter" },
+            { name: "testFilter", alias: "t", type: String, defaultValue: null },
+            { name: "verbose", alias: "v", type: Boolean, defaultValue: false }
+        ],
+        { partial: true }
+    );
 
     if (argv.verbose) {
         console.info("Verbose mode on.");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@types/bonjour':
         specifier: ^3.5.13
         version: 3.5.13
+      '@types/command-line-args':
+        specifier: 5.2.3
+        version: 5.2.3
       '@types/lodash.partition':
         specifier: ^4.6.9
         version: 4.6.9
@@ -45,9 +48,6 @@ importers:
       '@types/wordwrap':
         specifier: ^1.0.3
         version: 1.0.3
-      '@types/yargs':
-        specifier: 17.0.35
-        version: 17.0.35
       backoff:
         specifier: ^2.5.0
         version: 2.5.0
@@ -63,6 +63,9 @@ importers:
       cli-truncate:
         specifier: 2.1.0
         version: 2.1.0
+      command-line-args:
+        specifier: 6.0.2
+        version: 6.0.2
       csv-parse:
         specifier: 7.0.2
         version: 7.0.2
@@ -138,9 +141,6 @@ importers:
       xml-writer:
         specifier: ^1.7.0
         version: 1.7.0
-      yargs:
-        specifier: 15.4.1
-        version: 15.4.1
     dependenciesMeta:
       '*':
         injected: true
@@ -1548,6 +1548,9 @@ importers:
       cli-truncate:
         specifier: 2.1.0
         version: 2.1.0
+      command-line-args:
+        specifier: 6.0.2
+        version: 6.0.2
       node-opcua:
         specifier: 2.182.2
         version: link:../node-opcua
@@ -1638,9 +1641,6 @@ importers:
       sterfive-bonjour-service:
         specifier: 1.1.4
         version: 1.1.4
-      yargs:
-        specifier: 15.4.1
-        version: 15.4.1
 
   packages/node-opcua-enum:
     devDependencies:
@@ -1924,6 +1924,9 @@ importers:
       '@inquirer/prompts':
         specifier: 8.7.1
         version: 8.7.1(@types/node@24.13.3)
+      command-line-args:
+        specifier: 6.0.2
+        version: 6.0.2
       env-paths:
         specifier: 2.2.1
         version: 2.2.1
@@ -1933,12 +1936,15 @@ importers:
       node-opcua-debug:
         specifier: 2.181.0
         version: link:../node-opcua-debug
-      yargs:
-        specifier: 15.4.1
-        version: 15.4.1
 
   packages/node-opcua-model:
     dependencies:
+      command-line-args:
+        specifier: 6.0.2
+        version: 6.0.2
+      command-line-usage:
+        specifier: 7.0.4
+        version: 7.0.4
       node-opcua-client-dynamic-extension-object:
         specifier: 2.182.1
         version: link:../node-opcua-client-dynamic-extension-object
@@ -3343,18 +3349,27 @@ importers:
 
   packages/node-opcua-samples:
     dependencies:
+      '@types/command-line-args':
+        specifier: 5.2.3
+        version: 5.2.3
+      '@types/command-line-usage':
+        specifier: 5.0.4
+        version: 5.0.4
       '@types/underscore':
         specifier: 1.13.0
         version: 1.13.0
-      '@types/yargs':
-        specifier: 17.0.35
-        version: 17.0.35
       bcryptjs:
         specifier: 3.0.3
         version: 3.0.3
       chalk:
         specifier: 4.1.2
         version: 4.1.2
+      command-line-args:
+        specifier: 6.0.2
+        version: 6.0.2
+      command-line-usage:
+        specifier: 7.0.4
+        version: 7.0.4
       easy-table:
         specifier: ^1.2.0
         version: 1.2.0
@@ -3400,9 +3415,6 @@ importers:
       treeify:
         specifier: ^1.1.0
         version: 1.1.0
-      yargs:
-        specifier: 15.4.1
-        version: 15.4.1
 
   packages/node-opcua-schemas:
     dependencies:
@@ -5157,6 +5169,12 @@ packages:
   '@types/bonjour@3.5.13':
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
 
+  '@types/command-line-args@5.2.3':
+    resolution: {integrity: sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==}
+
+  '@types/command-line-usage@5.0.4':
+    resolution: {integrity: sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==}
+
   '@types/dns-packet@5.6.5':
     resolution: {integrity: sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==}
 
@@ -5207,12 +5225,6 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
-
-  '@types/yargs-parser@21.0.3':
-    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
-
-  '@types/yargs@17.0.35':
-    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -5310,10 +5322,6 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
-  camelcase@5.3.1:
-    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
-    engines: {node: '>=6'}
-
   case-anything@1.1.5:
     resolution: {integrity: sha512-UsoMDAMnOaD3mkNmbRg7WoCi6tViuqCihsUCVvHojgsVYJ6kcDjhrvzNwv8nZqjqatYTeQbfoDlJ+2xJVWwp4A==}
 
@@ -5347,9 +5355,6 @@ packages:
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
-
-  cliui@6.0.0:
-    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -5422,10 +5427,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  decamelize@1.2.0:
-    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
-    engines: {node: '>=0.10.0'}
 
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
@@ -5537,10 +5538,6 @@ packages:
       '@75lb/nature':
         optional: true
 
-  find-up@4.1.0:
-    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
-    engines: {node: '>=8'}
-
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -5563,10 +5560,6 @@ packages:
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
-
-  get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -5696,10 +5689,6 @@ packages:
   linkify-it@5.0.2:
     resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
-  locate-path@5.0.0:
-    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
-    engines: {node: '>=8'}
-
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -5794,25 +5783,13 @@ packages:
   one-time@1.0.0:
     resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
 
-  p-limit@2.3.0:
-    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
-    engines: {node: '>=6'}
-
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
-  p-locate@4.1.0:
-    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
-    engines: {node: '>=8'}
-
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
-
-  p-try@2.2.0:
-    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
-    engines: {node: '>=6'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -5889,13 +5866,6 @@ packages:
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
-  require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-
-  require-main-filename@2.0.0:
-    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
-
   rimraf@6.1.3:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
@@ -5923,9 +5893,6 @@ packages:
   serialize-javascript@7.0.5:
     resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
     engines: {node: '>=20.0.0'}
-
-  set-blocking@2.0.0:
-    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -6118,9 +6085,6 @@ packages:
   webcrypto-core@1.9.2:
     resolution: {integrity: sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==}
 
-  which-module@2.0.1:
-    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
-
   which-typed-array@1.1.20:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
     engines: {node: '>= 0.4'}
@@ -6143,10 +6107,6 @@ packages:
   workerpool@10.0.1:
     resolution: {integrity: sha512-NAnKwZJxWlj/U1cp6ZkEtPE+GQY1S6KtOS3AlCiPfPFLxV3m64giSp7g2LsNJxzYCocDT7TSl+7T0sgrDp3KoQ==}
 
-  wrap-ansi@6.2.0:
-    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
-    engines: {node: '>=8'}
-
   ws@8.21.3:
     resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
@@ -6168,21 +6128,10 @@ packages:
     resolution: {integrity: sha512-elFVMRiV5jb59fbc87zzVa0C01QLBEWP909mRuWqFqrYC5wNTH5QW4AaKMNv7d6zAsuOulkD7wnztZNLQW0Nfg==}
     engines: {node: '>=0.4.0'}
 
-  y18n@4.0.3:
-    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
-
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
-
-  yargs-parser@18.1.3:
-    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
-    engines: {node: '>=6'}
-
-  yargs@15.4.1:
-    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
-    engines: {node: '>=8'}
 
   yauzl@3.4.0:
     resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
@@ -6770,6 +6719,10 @@ snapshots:
     dependencies:
       '@types/node': 24.13.3
 
+  '@types/command-line-args@5.2.3': {}
+
+  '@types/command-line-usage@5.0.4': {}
+
   '@types/dns-packet@5.6.5':
     dependencies:
       '@types/node': 24.13.3
@@ -6820,12 +6773,6 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 24.13.3
-
-  '@types/yargs-parser@21.0.3': {}
-
-  '@types/yargs@17.0.35':
-    dependencies:
-      '@types/yargs-parser': 21.0.3
 
   ansi-regex@5.0.1: {}
 
@@ -6911,8 +6858,6 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
-  camelcase@5.3.1: {}
-
   case-anything@1.1.5: {}
 
   chalk-template@0.4.0:
@@ -6946,12 +6891,6 @@ snapshots:
       string-width: 4.2.3
 
   cli-width@4.1.0: {}
-
-  cliui@6.0.0:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 6.2.0
 
   clone@1.0.4:
     optional: true
@@ -7023,8 +6962,6 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
-
-  decamelize@1.2.0: {}
 
   defaults@1.0.4:
     dependencies:
@@ -7140,11 +7077,6 @@ snapshots:
 
   find-replace@5.0.2: {}
 
-  find-up@4.1.0:
-    dependencies:
-      locate-path: 5.0.0
-      path-exists: 4.0.0
-
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -7162,8 +7094,6 @@ snapshots:
   function-bind@1.1.2: {}
 
   generator-function@2.0.1: {}
-
-  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -7280,10 +7210,6 @@ snapshots:
   linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
-
-  locate-path@5.0.0:
-    dependencies:
-      p-locate: 4.1.0
 
   locate-path@6.0.0:
     dependencies:
@@ -7415,23 +7341,13 @@ snapshots:
     dependencies:
       fn.name: 1.1.0
 
-  p-limit@2.3.0:
-    dependencies:
-      p-try: 2.2.0
-
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
 
-  p-locate@4.1.0:
-    dependencies:
-      p-limit: 2.3.0
-
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
-
-  p-try@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
 
@@ -7484,10 +7400,6 @@ snapshots:
 
   reflect-metadata@0.2.2: {}
 
-  require-directory@2.1.1: {}
-
-  require-main-filename@2.0.0: {}
-
   rimraf@6.1.3:
     dependencies:
       glob: 13.0.6
@@ -7508,8 +7420,6 @@ snapshots:
   semver@7.8.5: {}
 
   serialize-javascript@7.0.5: {}
-
-  set-blocking@2.0.0: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -7723,8 +7633,6 @@ snapshots:
       asn1js: 3.0.10
       tslib: 2.8.1
 
-  which-module@2.0.1: {}
-
   which-typed-array@1.1.20:
     dependencies:
       available-typed-arrays: 1.0.7
@@ -7761,40 +7669,13 @@ snapshots:
 
   workerpool@10.0.1: {}
 
-  wrap-ansi@6.2.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
   ws@8.21.3: {}
 
   wtfnode@0.10.1: {}
 
   xml-writer@1.7.0: {}
 
-  y18n@4.0.3: {}
-
   yaml@2.9.0: {}
-
-  yargs-parser@18.1.3:
-    dependencies:
-      camelcase: 5.3.1
-      decamelize: 1.2.0
-
-  yargs@15.4.1:
-    dependencies:
-      cliui: 6.0.0
-      decamelize: 1.2.0
-      find-up: 4.1.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      require-main-filename: 2.0.0
-      set-blocking: 2.0.0
-      string-width: 4.2.3
-      which-module: 2.0.1
-      y18n: 4.0.3
-      yargs-parser: 18.1.3
 
   yauzl@3.4.0:
     dependencies:


### PR DESCRIPTION
## Why

`yargs` was pinned at **15.4.1** (2020) while `@types/yargs` sat at **17**, so the types never
described the runtime. The root `ncu` script excluded `yargs` from upgrades outright, which is
how the two drifted that far apart.

It also blocks the ESM work. Under `"type": "module"` the default export is the *factory*, not
a ready-made instance, so `yargs.wrap(132)` and `yargs.showHelp()` stop type-checking and stop
working. The all-packages ESM probe ended with exactly three residual errors, all of them this.

`command-line-args` / `command-line-usage` are ESM-native (`"type": "module"` with dual
`exports`), and are already the house choice in the toolbox repo, so the shape here follows
that one: an `optionDefinitions` array, a `sections` array for usage, and
`commandLineUsage.OptionDefinition[]` as the type where a description is rendered.

## What changed

18 files across 5 packages:

| package | files |
|---|---|
| `node-opcua-samples` | 10 bins |
| `node-opcua-end2end-test` | 4 test-server helpers |
| `node-opcua-local-discovery-server` | the published LDS bin |
| `node-opcua-model` | `extract_schema.js` |
| root | `packages/parallel_test.js`, the CI runner |

`node-opcua-model` used yargs in `bin/` without ever declaring it, resolving by hoisting; it now
declares what it uses.

## Behaviour changes, both on published CLIs

1. **No `--no-x` negation.** LDS's `--tolerant` (default true) and `--force` had a yargs `--no-`
   form. They now take an optional value instead: `--tolerant false`. Implemented with a small
   custom type so nothing is lost, only respelled.
2. **No automatic `--help`.** `demandOption` / `demand` became an explicit check that prints
   `commandLineUsage(sections)` and exits, which is what yargs did on a missing required option.

Unknown flags still do not throw: the four end2end helpers and `parallel_test.js` pass
`{ partial: true }`, because they are spawned with flags they do not own.

## Verification

```
npx tsc -b packages --force              0
pnpm run lint:ci                         0
pnpm run check:testtypes                 0
pnpm run check:consumers                 0
node packages/parallel_test.js -f zzz -v honours -f and -v, 0 files, clean exit
LDS bin -p 4850 --tolerant false         starts on 4850
end2end helper -p 26601                  parses, unknown flags land in _unknown
more.js with no argument                 prints the usage guide
```

## Found but not fixed

Neither is yargs-related, so neither is in scope here:

- `node-opcua-model/bin/extract_schema.js` requires `node-opcua-client`, which that package does
  not declare. The script does not run today.
- `node-opcua-samples/bin/opcua_interceptor.js` requires `../lib/misc/message_builder`, a path
  from the v1 layout that no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
