### PR TITLE
build: scan the source behind an emitted directory

### DIFF
--- a/packages/node-opcua-address-space/test_helpers/get_address_space_fixture.ts
+++ b/packages/node-opcua-address-space/test_helpers/get_address_space_fixture.ts
@@ -12,7 +12,8 @@ import path from "node:path";
  * behind it. Anchoring on the package root removes the question, and at the ESM flip
  * `__dirname` becomes `import.meta.dirname` here and nowhere else.
  */
-const packageRoot = findPackageRoot(__dirname);
+const here = __dirname;
+const packageRoot = findPackageRoot(here);
 
 /**
  * The nearest ancestor holding a package.json. Kept local on purpose: this file

--- a/packages/node-opcua-samples/bin/client_example_ts.ts
+++ b/packages/node-opcua-samples/bin/client_example_ts.ts
@@ -45,6 +45,11 @@ import { type Certificate, toPem } from "node-opcua-crypto";
 
 const { asTree } = require("treeify");
 
+// The one place this module learns where it sits on disk. `import.meta.dirname`
+// cannot be used while this package emits CommonJS (TS1470), so the ESM migration
+// has this single line to change rather than several scattered uses.
+const here = __dirname;
+
 function w(str: string, l: number): string {
     return str.padEnd(l).substring(0, l);
 }
@@ -338,7 +343,7 @@ function getTick() {
 
             serverCertificate = endpoint.serverCertificate;
 
-            const certificate_filename = path.join(__dirname, `../certificates/PKI/server_certificate${i}.pem`);
+            const certificate_filename = path.join(here, `../certificates/PKI/server_certificate${i}.pem`);
 
             if (serverCertificate) {
                 fs.writeFile(certificate_filename, toPem(serverCertificate, "CERTIFICATE"), () => {

--- a/packages/node-opcua-samples/bin/get_endpoints.ts
+++ b/packages/node-opcua-samples/bin/get_endpoints.ts
@@ -20,6 +20,11 @@ import { type Certificate, toPem } from "node-opcua-crypto";
 const Table = require("easy-table");
 const treeify = require("treeify");
 
+// The one place this module learns where it sits on disk. `import.meta.dirname`
+// cannot be used while this package emits CommonJS (TS1470), so the ESM migration
+// has this single line to change rather than several scattered uses.
+const here = __dirname;
+
 async function main() {
     // tsx bin/simple_client.ts --endpoint  opc.tcp://localhost:53530/OPCUA/SimulationServer --node "ns=5;s=Sinusoid1"
     const optionDefinitions: commandLineUsage.OptionDefinition[] = [
@@ -133,7 +138,7 @@ async function main() {
 
         serverCertificate = endpoint.serverCertificate;
 
-        const certificate_filename = path.join(__dirname, `../certificates/PKI/server_certificate${i}.pem`);
+        const certificate_filename = path.join(here, `../certificates/PKI/server_certificate${i}.pem`);
 
         if (serverCertificate) {
             fs.writeFile(certificate_filename, toPem(serverCertificate, "CERTIFICATE"), () => {

--- a/packages/node-opcua-samples/bin/server_with_push_certificate.ts
+++ b/packages/node-opcua-samples/bin/server_with_push_certificate.ts
@@ -11,6 +11,11 @@ import { CertificateManager } from "node-opcua-pki";
 import { installPushCertificateManagement } from "node-opcua-server-configuration";
 
 const config = envPaths("node-opcua-default").config;
+// The one place this module learns where it sits on disk. `import.meta.dirname`
+// cannot be used while this package emits CommonJS (TS1470), so the ESM migration
+// has this single line to change rather than several scattered uses.
+const here = __dirname;
+
 const pkiFolder = path.join(config, "PKI");
 
 const certificateManager = new OPCUACertificateManager({
@@ -74,7 +79,7 @@ async function main() {
     };
 
     process.title = `Node OPCUA Server on port : ${serverOptions.port}`;
-    const tmpFolder = path.join(__dirname, "../certificates/myApp");
+    const tmpFolder = path.join(here, "../certificates/myApp");
 
     const applicationGroup = new CertificateManager({
         location: tmpFolder

--- a/packages/node-opcua-samples/bin/simple_server_with_custom_extension_objects.ts
+++ b/packages/node-opcua-samples/bin/simple_server_with_custom_extension_objects.ts
@@ -8,11 +8,16 @@ import { nodesets, OPCUAServer } from "node-opcua";
 
 Error.stackTraceLimit = Infinity;
 
+// The one place this module learns where it sits on disk. `import.meta.dirname`
+// cannot be used while this package emits CommonJS (TS1470), so the ESM migration
+// has this single line to change rather than several scattered uses.
+const here = __dirname;
+
 function constructFilename(filename: string): string {
-    return path.join(__dirname, "../", filename);
+    return path.join(here, "../", filename);
 }
 
-const rootFolder = path.join(__dirname, "../../..");
+const rootFolder = path.join(here, "../../..");
 
 async function main() {
     const optionDefinitions: commandLineUsage.OptionDefinition[] = [

--- a/packages/node-opcua-utils/source/buffer_ellipsis.ts
+++ b/packages/node-opcua-utils/source/buffer_ellipsis.ts
@@ -9,5 +9,3 @@ export function buffer_ellipsis(buffer: Buffer, start?: number, end?: number): s
     }
     return `${buffer.subarray(start, start + 10).toString("hex")} ... ${buffer.subarray(end - 10, end).toString("hex")}`;
 }
-
-exports.buffer_ellipsis = buffer_ellipsis;

--- a/tools/esm-convert/src/rule.js
+++ b/tools/esm-convert/src/rule.js
@@ -37,7 +37,6 @@ import { TEST_DIRS } from "../../shared/test_dirs.mjs";
 const SKIP_DIRS = new Set(["node_modules", "dist", "dist-esm", "distNodeJS", "distHelpers", "coverage", "build"]);
 
 /** the anchor FEAT-1 established, and the comment that goes with it */
-const ANCHOR = /^(\s*(?:export\s+)?const\s+[A-Za-z_$][\w$]*\s*=\s*)(__dirname|__filename)(\s*;)/gm;
 
 /** the comment above an anchor, which says the opposite once the package is ESM */
 const ANCHOR_COMMENT =
@@ -145,23 +144,50 @@ export function mocharcRename(pkgDir) {
     return { from, to };
 }
 
-/** `const here = __dirname;` -> `const here = import.meta.dirname;`, and drop the stale note */
+/**
+ * `__dirname` -> `import.meta.dirname`, everywhere it appears as code.
+ *
+ * FEAT-1 concentrated these into one anchor per module, because `import.meta` is illegal
+ * while a package emits CommonJS (TS1470) and one line is easier to change than several.
+ * That was an ergonomic choice, not a correctness one: in an ES module the substitution is
+ * exact wherever it sits, so once a package is being flipped there is nothing left to
+ * decide and the tool does all of them. `check-dirname` still keeps shipped source on the
+ * anchor; the scattered uses this converts are in test trees, which that gate does not cover.
+ *
+ * A `typeof __filename` is left alone: it is asking whether the global exists, and the
+ * answer under ESM is meant to be "no". Identifiers are found through the AST rather than a
+ * regex so that prose mentioning `__dirname` in a comment is not rewritten.
+ */
 export function convertAnchors(text) {
-    if (!ANCHOR.test(text)) {
-        ANCHOR.lastIndex = 0;
-        return null;
+    if (!text.includes("__dirname") && !text.includes("__filename")) return null;
+    const sf = ts.createSourceFile("anchor.ts", text, ts.ScriptTarget.ESNext, true, ts.ScriptKind.TS);
+    const hits = [];
+    const visit = (node) => {
+        if (ts.isIdentifier(node) && (node.text === "__dirname" || node.text === "__filename") && !ts.isTypeOfExpression(node.parent)) {
+            hits.push({ start: node.getStart(sf), end: node.getEnd(), name: node.text });
+        }
+        ts.forEachChild(node, visit);
+    };
+    visit(sf);
+    if (hits.length === 0) return null;
+
+    let out = text;
+    // back to front, so earlier offsets stay valid
+    for (const h of hits.reverse()) {
+        out = out.slice(0, h.start) + `import.meta.${h.name === "__dirname" ? "dirname" : "filename"}` + out.slice(h.end);
     }
-    ANCHOR.lastIndex = 0;
-    let out = text.replace(ANCHOR, (_m, head, name, tail) => `${head}import.meta.${name === "__dirname" ? "dirname" : "filename"}${tail}`);
-    out = out.replace(ANCHOR_COMMENT, "");
-    return out;
+    return out.replace(ANCHOR_COMMENT, "");
 }
 
 // ── the half that needs a person ────────────────────────────────────────────────
 
 /** things whose ESM form changes behaviour, so the tool reports rather than rewrites */
 export function findManualWork(text, filePath = "file.ts") {
-    if (!text.includes("require") && !text.includes("await") && !text.includes("module.exports")) return [];
+    // `exports` and `__dirname` belong here as well as `module.exports`: a lone
+    // `exports.foo = foo` beside an `export function` is a no-op under CJS emit and a
+    // ReferenceError under ESM, and this guard is what let one sit in node-opcua-utils
+    // while the survey called the package fully mechanical.
+    if (!/\brequire\b|\bawait\b|\bexports\b|__dirname|__filename/.test(text)) return [];
     const sf = ts.createSourceFile(filePath, text, ts.ScriptTarget.ESNext, true, ts.ScriptKind.TS);
     const lines = text.split("\n");
     const out = [];
@@ -185,6 +211,16 @@ export function findManualWork(text, filePath = "file.ts") {
         }
         if (ts.isPropertyAccessExpression(node) && node.expression.getText(sf) === "module" && node.name.text === "exports") {
             note(node, "module-exports", "replace with a named or default export");
+        }
+        // `exports.foo = ...`, which is neither `module.exports` nor an ES export
+        if (
+            ts.isBinaryExpression(node) &&
+            node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+            ts.isPropertyAccessExpression(node.left) &&
+            ts.isIdentifier(node.left.expression) &&
+            node.left.expression.text === "exports"
+        ) {
+            note(node, "cjs-exports", "`exports` does not exist in an ES module; use an export declaration");
         }
         if (ts.isAwaitExpression(node)) {
             // module scope only: a await inside a function is fine

--- a/tools/esm-convert/test/test_rule.js
+++ b/tools/esm-convert/test/test_rule.js
@@ -101,9 +101,19 @@ test("converts an exported anchor", () => {
     assert.equal(convertAnchors("export const here = __dirname;\n"), "export const here = import.meta.dirname;\n");
 });
 
-test("leaves a scattered use alone: only the anchor shape is mechanical", () => {
-    // check-dirname keeps these out of shipped source; if one appears, a person decides
-    assert.equal(convertAnchors('const p = path.join(__dirname, "x");\n'), null);
+test("converts a scattered use too: in an ES module the substitution is exact anywhere", () => {
+    // FEAT-1's single anchor was for the CJS period, when import.meta was illegal (TS1470).
+    // Once a package is being flipped there is nothing left to decide, and test trees - which
+    // check-dirname does not cover - are full of these.
+    assert.equal(convertAnchors('const p = path.join(__dirname, "x");'), 'const p = path.join(import.meta.dirname, "x");');
+});
+
+test("leaves a typeof guard alone: it is asking whether the global exists", () => {
+    assert.equal(convertAnchors('const isBrowser = typeof __filename === "undefined";'), null);
+});
+
+test("does not rewrite prose: a comment mentioning __dirname is not code", () => {
+    assert.equal(convertAnchors('// path.join(__dirname, "x") is the intended use'), null);
 });
 
 // ── what needs a person ─────────────────────────────────────────────────────────
@@ -151,6 +161,17 @@ test("await inside a function is fine and is not reported", () => {
 
 test("require in a comment is not code", () => {
     assert.equal(findManualWork('// const x = require("y");\nconst a = 1;\n').length, 0);
+});
+
+test("reports `exports.foo`, which is neither module.exports nor an ES export", () => {
+    // this is what node-opcua-utils carried: a no-op duplicate under CJS emit, and a
+    // ReferenceError the moment the package became a module
+    const found = findManualWork("export function f() {}\nexports.f = f;");
+    assert.equal(found[0].kind, "cjs-exports");
+});
+
+test("an export declaration is not an `exports` assignment", () => {
+    assert.equal(findManualWork("export const exports2 = 1;").length, 0);
 });
 
 test("an ordinary import is not manual work", () => {

--- a/tools/shared/shipped_dirs.mjs
+++ b/tools/shared/shipped_dirs.mjs
@@ -7,7 +7,11 @@
  * gate's coverage, which none of them noticed because they all still reported "clean".
  *
  * A package's `files` array is the list of what it publishes, so it is the honest source for
- * this. Build output is excluded: `dist` is emitted, not authored.
+ * this. Build output is excluded: `dist` is emitted, not authored - but excluding it is not
+ * enough on its own. node-opcua-address-space ships `distHelpers`, and the tree that produces
+ * it, `test_helpers`, appears nowhere in `files`; every gate therefore skipped it while
+ * reporting a clean scan. So an emitted directory is resolved back through the package's
+ * tsconfigs to the source it is compiled from.
  */
 import fs from "node:fs";
 import path from "node:path";
@@ -40,6 +44,41 @@ const holdsTypeScript = (dir) => {
 };
 
 /**
+ * outDir -> the source directories compiled into it, read from the package's tsconfigs.
+ *
+ * The `include` globs are used rather than `rootDir`, because a rootDir of "" or "." names the
+ * package itself and would widen a scan to everything; `include: ["api/**", "impl/**"]` says
+ * precisely which trees feed that output.
+ */
+function emittedFrom(packageDir) {
+    const map = new Map();
+    let names;
+    try {
+        names = fs.readdirSync(packageDir).filter((n) => /^tsconfig.*\.json$/.test(n));
+    } catch {
+        return map;
+    }
+    for (const name of names) {
+        let config;
+        try {
+            config = JSON.parse(stripJsonComments(fs.readFileSync(path.join(packageDir, name), "utf8")));
+        } catch {
+            continue;
+        }
+        const outDir = config.compilerOptions?.outDir?.replace(/^\.\//, "").replace(/\/$/, "");
+        if (!outDir) continue;
+        const roots = (config.include ?? [])
+            .map((g) => g.replace(/^\.\//, "").split("/")[0])
+            .filter((r) => r && r !== "**" && !r.includes("*") && !r.includes("."));
+        if (roots.length) map.set(outDir, [...new Set([...(map.get(outDir) ?? []), ...roots])]);
+    }
+    return map;
+}
+
+/** tsconfigs are JSONC; only line comments appear in this repo's */
+const stripJsonComments = (text) => text.replace(/^\s*\/\/.*$/gm, "");
+
+/**
  * The source directories one package ships, from its `files` array.
  *
  * `fallback` is used when a package declares no `files`, which npm reads as "publish
@@ -60,9 +99,15 @@ export function shippedDirsOf(packageDir, fallback = ["source", "src"]) {
         return onlyExisting();
     }
     const listed = pj.files ?? null;
-    const candidates = listed
-        ? listed.map((f) => f.replace(/^\.\//, "").replace(/\/$/, "")).filter((f) => !NOT_SOURCE.test(f))
-        : fallback;
+    let candidates;
+    if (listed) {
+        const entries = listed.map((f) => f.replace(/^\.\//, "").replace(/\/$/, ""));
+        const emitted = entries.filter((f) => NOT_SOURCE.test(f));
+        const sources = emitted.length ? emittedFrom(packageDir) : new Map();
+        candidates = [...new Set([...entries.filter((f) => !NOT_SOURCE.test(f)), ...emitted.flatMap((f) => sources.get(f) ?? [])])];
+    } else {
+        candidates = fallback;
+    }
 
     const dirs = [];
     for (const c of candidates) {

--- a/tools/shared/test/test_shipped_dirs.js
+++ b/tools/shared/test/test_shipped_dirs.js
@@ -192,3 +192,53 @@ test("every directory this repository uses for tests is in the list", () => {
         assert.deepEqual(missing, [], `test directories no gate scans: ${missing.join(", ")}`);
     });
 });
+
+// ── source behind an emitted directory ──────────────────────────────────────────
+//
+// The third way this has failed. node-opcua-address-space ships `distHelpers`, and the tree
+// that compiles into it, `test_helpers`, is named nowhere in `files`. Excluding build output
+// was right; stopping there meant every gate skipped an entire published tree and still
+// reported a clean scan. Six raw uses of __dirname were sitting in the gap.
+
+test("an emitted directory in `files` resolves back to the source it is compiled from", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "shipped-dirs-"));
+    try {
+        const pkg = path.join(root, "p");
+        fs.mkdirSync(path.join(pkg, "helpers"), { recursive: true });
+        fs.writeFileSync(path.join(pkg, "helpers", "a.ts"), "export const x = 1;");
+        fs.writeFileSync(path.join(pkg, "package.json"), JSON.stringify({ name: "p", files: ["distHelpers"] }));
+        fs.writeFileSync(
+            path.join(pkg, "tsconfig_helpers.json"),
+            JSON.stringify({ compilerOptions: { rootDir: "helpers", outDir: "distHelpers" }, include: ["helpers/**/*.ts"] })
+        );
+        assert.deepEqual(shippedDirsOf(pkg), ["helpers"]);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test("a rootDir naming the package itself does not widen the scan to everything", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "shipped-dirs-"));
+    try {
+        const pkg = path.join(root, "p");
+        for (const d of ["api", "impl", "scratch"]) {
+            fs.mkdirSync(path.join(pkg, d), { recursive: true });
+            fs.writeFileSync(path.join(pkg, d, "a.ts"), "export const x = 1;");
+        }
+        fs.writeFileSync(path.join(pkg, "package.json"), JSON.stringify({ name: "p", files: ["dist"] }));
+        // rootDir "" is what node-opcua-address-space declares; the include globs are the answer
+        fs.writeFileSync(
+            path.join(pkg, "tsconfig.json"),
+            JSON.stringify({ compilerOptions: { rootDir: "", outDir: "dist" }, include: ["api/**/*.ts", "impl/**/*.ts"] })
+        );
+        assert.deepEqual(shippedDirsOf(pkg).sort(), ["api", "impl"]);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test("node-opcua-address-space's test_helpers tree is in scope", () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const dirs = shippedDirsOf(path.join(repoRoot, "packages", "node-opcua-address-space"));
+    assert.ok(dirs.includes("test_helpers"), `found: ${dirs.join(", ")}`);
+});


### PR DESCRIPTION
Closes the gaps the all-packages ESM probe found. Each one was a gate reporting a clean scan
over something it had never opened.

## 1. A published source tree no gate could see

`node-opcua-address-space` ships `distHelpers`. The tree that compiles into it, `test_helpers`,
appears nowhere in `files`, so `shippedDirsOf` never returned it and every gate built on it
skipped the tree while reporting success. Excluding build output was right; stopping there was
the bug.

The tsconfigs already hold the mapping:

```json
// tsconfig_helpers.json
{ "compilerOptions": { "rootDir": "test_helpers", "outDir": "distHelpers" } }
```

So an emitted directory named in `files` is now resolved back through the package's tsconfigs
to the source it is compiled from. The `include` globs are used rather than `rootDir`, because
address-space declares `rootDir: ""` for its `dist` and that would widen a scan to the whole
package.

Five packages gained scope, every one of them genuinely publishing that source:

| package | gained |
|---|---|
| `node-opcua-address-space` | `test_helpers` |
| `node-opcua-packet-analyzer` | `test_helpers` |
| `node-opcua-secure-channel` | `test_helpers` |
| `node-opcua-transport` | `test_helpers`, `test-fixtures` |
| `node-opcua-samples` | `bin` |

`node-opcua-transport/dist/test_helpers` is a declared `exports` subpath, so other packages
import it by name: this is shipped API, not scratch.

`check-dirname` immediately found **six raw `__dirname` uses** in the newly covered trees, all
converted here to the single-anchor pattern. The other three gates stayed clean.

This is the third time hardcoded scope has failed, after `source_nodejs` and the `api`/`impl`
rename, so it is pinned by tests.

## 2. `exports.foo` in a TypeScript source

`node-opcua-utils/source/buffer_ellipsis.ts` carried this under its `export function`:

```ts
exports.buffer_ellipsis = buffer_ellipsis;
```

A harmless duplicate assignment under CJS emit, and `ReferenceError: exports is not defined`
the moment the package becomes a module. `esm-convert` missed it because its early-out tested
for `module.exports` and this is not that, so the survey called the package fully mechanical.
Guard widened, `cjs-exports` reported, line removed.

## 3. `__dirname` was never a decision

The converter refused every use that was not the exact `const here = __dirname;` shape, on the
grounds that a person should decide. That was wrong. FEAT-1 concentrated these into one anchor
because `import.meta` is illegal while a package emits CommonJS (TS1470) - an ergonomic choice
for the CJS period, not a correctness one. In an ES module the substitution is exact wherever
it sits.

`convertAnchors` now converts all of them, through the AST rather than a regex so that prose
mentioning `__dirname` in a comment is left alone, and a `typeof __filename` guard is skipped
because it is asking whether the global exists.

That matters for the flip: 20 packages have these in test trees, which `check-dirname` does not
cover. They were being classified as needing a decision and would otherwise have been
hand-edited 20 times.

## Survey

Before: `2 already ESM, 101 mechanical, 20 need a decision` - and wrong, because the
`buffer_ellipsis` line was invisible.

After: `2 already ESM, 121 mechanical, 0 need a decision` - and now true, because the tool does
the dirname work rather than skipping it.

## Verification

```
node --test tools/shared/test/test_shipped_dirs.js      20 pass (3 new)
node --test tools/esm-convert/test/test_rule.js         29 pass (4 new)
node tools/check-dirname.mjs                            2439 files, clean
node tools/check-debug-name.mjs                         3267 files, clean
node tools/check-import-extension.mjs                   3234 files, clean
node tools/check-no-tla.mjs                             2451 files, clean
pnpm run lint:ci                                        0
pnpm run check:testtypes                                0
pnpm run check:consumers                                0
node-opcua-utils                                        35 passing
node-opcua-address-space                                1336 passing
```

## One note for anyone with a warm build tree

`check:consumers` failed here until `npx tsc -b packages/node-opcua-transport --force`. Since
transport became ESM, an existing `dist` holds its old CommonJS emit and `tsc -b` does not
re-emit on a `type` change - its incremental state does not track that field. CI builds from
clean and is unaffected, but a local tree from before that merge needs the `--force` once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
