### PR TITLE
fix(address-space): a mistyped Call argument answers BadInvalidArgument (Method Call Err-004)

### DIFF
--- a/packages/node-opcua-address-space/api/helpers/argument_list.ts
+++ b/packages/node-opcua-address-space/api/helpers/argument_list.ts
@@ -293,15 +293,14 @@ export function verifyArguments_ArgumentList(
         return { inputArgumentResults, statusCode: StatusCodes.BadTooManyArguments };
     }
 
-    const hasBadTypeMismatch = inputArgumentResults.includes(StatusCodes.BadTypeMismatch);
-    const hasBadOutOfRange = inputArgumentResults.includes(StatusCodes.BadOutOfRange);
-
-    const statusCode =
-        hasBadTypeMismatch || hasBadOutOfRange
-            ? hasBadTypeMismatch && !hasBadOutOfRange
-                ? StatusCodes.BadTypeMismatch
-                : StatusCodes.BadInvalidArgument
-            : StatusCodes.Good;
+    // Part 4 5.11.2 (Call): when one of the input arguments is not valid the
+    // operation statusCode is BadInvalidArgument and inputArgumentResults[i]
+    // carries the per-argument reason (BadTypeMismatch for a wrong DataType or
+    // ValueRank, BadOutOfRange for a value outside the range). A per-argument
+    // code is never promoted to the operation level (CTT Method Call Err-004,
+    // Subscription Durable Err-004).
+    const hasInvalidArgument = inputArgumentResults.some((s) => s.isNotGood());
+    const statusCode = hasInvalidArgument ? StatusCodes.BadInvalidArgument : StatusCodes.Good;
 
     return {
         inputArgumentResults,

--- a/packages/node-opcua-address-space/api/helpers/call_helpers.ts
+++ b/packages/node-opcua-address-space/api/helpers/call_helpers.ts
@@ -25,6 +25,8 @@ import { resolveOpaqueOnAddressSpace } from "./resolve_opaque_on_address_space.j
 //
 // BadMethodInvalid             The method id does not refer to a method for the specified object.
 // BadOutOfRange                Used to indicate that an input argument is outside the acceptable range.
+// BadInvalidArgument           One of the input arguments is not valid; inputArgumentResults[i] says why:
+// BadOutOfRange                Used to indicate that an input argument is outside the acceptable range.
 // BadTypeMismatch              Used to indicate that an input argument does not have the correct data type.
 //                               A ByteString is structurally the same as a one dimensional array of Byte.
 //                               A server shall accept a ByteString if an array of Byte is expected.

--- a/packages/node-opcua-address-space/test/test_argument_list.ts
+++ b/packages/node-opcua-address-space/test/test_argument_list.ts
@@ -122,13 +122,60 @@ describe("verifyArguments_ArgumentList", () => {
         });
     });
     it("verifyArguments_ArgumentList - One UInt32 - TypeMismatch", () => {
+        // Part 4 5.11.2: the operation code is BadInvalidArgument, the per-argument
+        // code says why (CTT Method Call Err-004)
         const argsBad = [new Variant({ dataType: DataType.String, value: "Bad" })];
         const result = verifyArguments_ArgumentList(addressSpace, methodInputArgumentsOneUInt32, argsBad);
         debugLog("inputArgumentResults[0]", result.inputArgumentResults?.[0].toString());
         debugLog("statusCode             ", result.statusCode.toString());
         result.should.eql({
             inputArgumentResults: [StatusCodes.BadTypeMismatch],
-            statusCode: StatusCodes.BadTypeMismatch
+            statusCode: StatusCodes.BadInvalidArgument
+        });
+    });
+
+    const methodInputArgumentsUInt32AndString: Argument[] = [
+        new Argument({
+            arrayDimensions: null,
+            dataType: resolveNodeId(DataType.UInt32),
+            description: "first",
+            name: "first",
+            valueRank: -1
+        }),
+        new Argument({
+            arrayDimensions: null,
+            dataType: resolveNodeId(DataType.String),
+            description: "second",
+            name: "second",
+            valueRank: -1
+        })
+    ];
+    it("verifyArguments_ArgumentList - UInt32 + String - only the mistyped argument is flagged", () => {
+        // CTT Subscription Durable Err-004: right count, one wrong DataType at a time,
+        // the other argument reports Good
+        const firstBad = [
+            new Variant({ dataType: DataType.String, value: "Bad" }),
+            new Variant({ dataType: DataType.String, value: "ok" })
+        ];
+        verifyArguments_ArgumentList(addressSpace, methodInputArgumentsUInt32AndString, firstBad).should.eql({
+            inputArgumentResults: [StatusCodes.BadTypeMismatch, StatusCodes.Good],
+            statusCode: StatusCodes.BadInvalidArgument
+        });
+        const secondBad = [
+            new Variant({ dataType: DataType.UInt32, value: 1 }),
+            new Variant({ dataType: DataType.UInt32, value: 2 })
+        ];
+        verifyArguments_ArgumentList(addressSpace, methodInputArgumentsUInt32AndString, secondBad).should.eql({
+            inputArgumentResults: [StatusCodes.Good, StatusCodes.BadTypeMismatch],
+            statusCode: StatusCodes.BadInvalidArgument
+        });
+        const bothGood = [
+            new Variant({ dataType: DataType.UInt32, value: 1 }),
+            new Variant({ dataType: DataType.String, value: "ok" })
+        ];
+        verifyArguments_ArgumentList(addressSpace, methodInputArgumentsUInt32AndString, bothGood).should.eql({
+            inputArgumentResults: [StatusCodes.Good, StatusCodes.Good],
+            statusCode: StatusCodes.Good
         });
     });
 
@@ -200,9 +247,10 @@ describe("verifyArguments_ArgumentList", () => {
         const result = verifyArguments_ArgumentList(addressSpace, methodInputArgumentsOneArrayOfAny, argsBad);
         debugLog("inputArgumentResults[0]", result.inputArgumentResults?.[0].toString());
         debugLog("statusCode             ", result.statusCode.toString());
+        // a wrong ValueRank is a type mismatch of the argument, the operation is BadInvalidArgument
         result.should.eql({
             inputArgumentResults: [StatusCodes.BadTypeMismatch],
-            statusCode: StatusCodes.BadTypeMismatch
+            statusCode: StatusCodes.BadInvalidArgument
         });
     });
 

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_UaMethodInputArgsResult.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_UaMethodInputArgsResult.ts
@@ -70,13 +70,14 @@ describe("list status codes for input arguments", () => {
         should(result.inputArgumentResults?.[0]).eql(StatusCodes.Good);
     });
 
-    it("should return lib generated BadTypeMismatch if argument type is wrong", async () => {
+    it("should return BadInvalidArgument with a lib generated BadTypeMismatch on the argument if its type is wrong", async () => {
         const result = await clientSession.call({
             objectId: "ns=1;s=e2e",
             methodId: "ns=1;s=RingDoor",
             inputArguments: [{ dataType: DataType.UInt32, value: 1 }]
         });
-        result.statusCode.should.eql(StatusCodes.BadTypeMismatch);
+        // Part 4 5.11.2: the operation reports BadInvalidArgument, inputArgumentResults says why
+        result.statusCode.should.eql(StatusCodes.BadInvalidArgument);
         should(result.inputArgumentResults?.[0]).eql(StatusCodes.BadTypeMismatch);
     });
 

--- a/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_call_service.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_call_service.ts
@@ -128,7 +128,9 @@ export function t(test: UmbrellaTestContext) {
 
             await perform_operation_on_client_session(client, endpointUrl, async (session) => {
                 const results = await session.call(methodsToCall);
-                results[0].statusCode.should.eql(StatusCodes.BadTypeMismatch);
+                // Part 4 5.11.2 (CTT Method Call Err-004): BadInvalidArgument at the operation level,
+                // BadTypeMismatch on the argument
+                results[0].statusCode.should.eql(StatusCodes.BadInvalidArgument);
                 should(results[0].inputArgumentResults?.length).eql(1);
                 should(results[0].inputArgumentResults?.[0]).eql(StatusCodes.BadTypeMismatch);
             });
@@ -147,7 +149,9 @@ export function t(test: UmbrellaTestContext) {
 
             await perform_operation_on_client_session(client, endpointUrl, async (session) => {
                 const results = await session.call(methodsToCall);
-                results[0].statusCode.should.eql(StatusCodes.BadTypeMismatch);
+                // Part 4 5.11.2 (CTT Method Call Err-004): BadInvalidArgument at the operation level,
+                // BadTypeMismatch on the argument
+                results[0].statusCode.should.eql(StatusCodes.BadInvalidArgument);
                 should(results[0].inputArgumentResults?.length).eql(1);
                 should(results[0].inputArgumentResults?.[0]).eql(StatusCodes.BadTypeMismatch);
             });
@@ -268,7 +272,7 @@ export function t(test: UmbrellaTestContext) {
             });
         });
 
-        it("Q8 should succeed and return BadTypeMismatch when CallRequest is GetMonitoredItem and has the argument with a wrong dataType ", async () => {
+        it("Q8 should succeed and return BadInvalidArgument / BadTypeMismatch when CallRequest is GetMonitoredItem and has the argument with a wrong dataType ", async () => {
             const methodsToCall = [
                 {
                     objectId: coerceNodeId("ns=0;i=2253"), // SERVER
@@ -283,7 +287,7 @@ export function t(test: UmbrellaTestContext) {
                 const results = await session.call(methodsToCall);
 
                 results.length.should.eql(1);
-                results[0].statusCode.should.equalOneOf(StatusCodes.BadTypeMismatch, StatusCodes.BadInvalidArgument);
+                results[0].statusCode.should.eql(StatusCodes.BadInvalidArgument);
 
                 should(results[0].inputArgumentResults).be.instanceOf(Array);
                 should(results[0].inputArgumentResults?.length).eql(1);


### PR DESCRIPTION
## Why

CTT 1.05.513, Method Services / Method Call / Err-004 and Subscription Services / Subscription Durable / Err-004, on every certification run:

    Call.Results[0].StatusCode incorrect. Received: BadTypeMismatch (0x80740000). Expected: BadInvalidArgument (0x80ab0000)

Part 4 5.11.2: when an input argument is not valid, the CallMethodResult's statusCode is Bad_InvalidArgument and inputArgumentResults[i] carries the reason (Bad_TypeMismatch, Bad_OutOfRange). `verifyArguments_ArgumentList` promoted Bad_TypeMismatch itself to the operation level whenever no argument was out of range.

## What

- `argument_list.ts`: a mistyped or out-of-range argument gives Bad_InvalidArgument at the operation level, the per-argument code in inputArgumentResults; the count cases (Bad_ArgumentsMissing, Bad_TooManyArguments) are unchanged.
- `call_helpers.ts`: the results are carried through as computed.
- Tests: unit cases per argument outcome in `test_argument_list.ts`; the two end-to-end Call tests assert the operation code and the per-argument reason together.

## Verification

address-space 1337 passing, role-set-server 73, `lint:ci`, `check:shortcircuit`, `check-test-ports --summary` clean.

CTT replay of the Method Call and Subscription Durable units against a server built from this branch: in progress at the time of opening; the per-script table follows in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
