### PR TITLE
test(discovery): generate DISCO1-9's certificate every run

### DIFF
--- a/packages/node-opcua-end2end-test/test/discovery/u_test_discovery_server.ts
+++ b/packages/node-opcua-end2end-test/test/discovery/u_test_discovery_server.ts
@@ -407,16 +407,23 @@ export function t(test: TestHarness) {
             const unknownCertificateManager = await createServerCertificateManager(port5);
             const unknownApplicationUri = makeApplicationUrn(os.hostname(), "UnknownRegistrant");
             const unknownCertificateFile = path.join(unknownCertificateManager.rootDir, "certificate_unknown_registrant.pem");
-            if (!fs.existsSync(unknownCertificateFile)) {
-                await unknownCertificateManager.createSelfSignedCertificate({
-                    applicationUri: unknownApplicationUri,
-                    dns: [os.hostname(), "localhost"],
-                    outputFile: unknownCertificateFile,
-                    subject: "/CN=UnknownRegistrant",
-                    startDate: new Date(),
-                    validity: 365
-                });
+            // Generated every run, never reused. The PKI lives under the OS temp directory and
+            // outlives the suite, so a certificate kept from an earlier run goes on being read
+            // after the private key beside it has been regenerated - and the two no longer
+            // match. That failed as "the certificate and the private key do not match", which
+            // reads like a configuration fault rather than stale scratch state. CI never saw
+            // it because every run starts from an empty machine.
+            if (fs.existsSync(unknownCertificateFile)) {
+                fs.rmSync(unknownCertificateFile);
             }
+            await unknownCertificateManager.createSelfSignedCertificate({
+                applicationUri: unknownApplicationUri,
+                dns: [os.hostname(), "localhost"],
+                outputFile: unknownCertificateFile,
+                subject: "/CN=UnknownRegistrant",
+                startDate: new Date(),
+                validity: 365
+            });
             const unknownCertificate = readCertificate(unknownCertificateFile);
             const unknownIdentity: RegistrantIdentity = {
                 certificateFile: unknownCertificateFile,


### PR DESCRIPTION
`DISCO1-9` failed on any machine that had run the suite before:

```
AssertionError: expected '[NODE-OPCUA-E01] Configuration error : the certificate and
the private key do not match ! please fix your configuration'
  to match /BadSecurityChecksFailed|BadCertificateUntrusted|rejected by server/
```

## Why

The test cached the certificate it generates, but not the private key that certificate was
signed with:

```ts
const unknownCertificateFile = path.join(unknownCertificateManager.rootDir, "certificate_unknown_registrant.pem");
if (!fs.existsSync(unknownCertificateFile)) {
    await unknownCertificateManager.createSelfSignedCertificate({ ... });
}
```

`createServerCertificateManager` roots its PKI at `os.tmpdir()/node-opcua-tmp/server<port>`,
which outlives the suite. Once that key is regenerated, the cached certificate no longer
matches it, and the test gets a configuration error instead of the rejection it asserts.

Caught on 2026-09-10 while running the full suite locally: the cached certificate was dated
**2026-09-07 11:26**, the private key beside it **2026-09-09 22:42**.

CI starts from a clean machine every run, so it never sees this. It only costs developers, and
it reads like a real fault rather than stale scratch state, which is what makes it worth
fixing rather than documenting.

## The change

Generate the certificate every run. The cache saved one self-signed certificate per run, and
in exchange coupled the test to leftover state; the `rejectCertificate` call just below it
exists for the same reason, because a cached certificate leaks trust state across runs too.

Verified rather than reasoned about, by planting the exact bad state (a certificate from
another port's PKI, so it cannot match the key):

| | |
|---|---|
| before the change, mismatched certificate planted | **fails**, with the original error verbatim |
| after the change, same certificate planted | **passes**, file regenerated (1554 -> 1399 bytes) |
| twice in a row | passes, passes |
| after deleting `os.tmpdir()/node-opcua-tmp` entirely | passes |

`pnpm run lint:ci` is clean.

## Note for anyone running the discovery tests locally

Three other tests in this file fail on a machine with something already answering on port
4840 - a container publishing an OPC UA server, say - because the test counts the servers it
can discover:

```
AssertionError: found 7 server running instead of 6: may be you have a LDS
running on your system. please make sure to shut it down before running the tests
```

That is environmental and untouched here. `DISCO1-9` is not among those three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
