### PR TITLE
fix(server): enforce the anonymous TransferSubscriptions rule by default (Part 4 5.13.7)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,21 @@
 
+TransferSubscriptions: the anonymous rule is now enforced by default (OPC UA Part 4 §5.13.7)
+============================================================================================
+
+  - **behaviour change** `OPCUAServerOptions.allowAnonymousSubscriptionTransferOnUnsecuredChannel`
+    now defaults to `false` (it used to default to `true`). As required by Part 4 §5.13.7, a
+    Subscription created by an anonymous Session is only transferred to another Session when the
+    SecureChannel MessageSecurityMode is `Sign` or `SignAndEncrypt` **and** the client certificate's
+    ApplicationUri is the one of the original Session; otherwise the transfer is refused with
+    `Bad_UserAccessDenied`. A stock server used to accept the transfer over a `None` endpoint and
+    failed the CTT 1.05 script *Subscription Services / Subscription Transfer / Err-017*.
+  - migration: an anonymous client that reconnects over a `None` endpoint and expects to keep its
+    subscriptionId now rebuilds its subscription instead. Set
+    `allowAnonymousSubscriptionTransferOnUnsecuredChannel: true` on the server to restore the previous
+    behaviour; the option is documented as an explicit relaxation of the specification.
+  - unchanged: the cross-user ownership check (a transfer is refused unless the destination Session
+    operates on behalf of the same user as the Subscription owner) is always enforced.
+
 Local Discovery Server: registration conformance (OPC UA Part 4 §5.5.5 / §5.5.6)
 ================================================================================
 

--- a/packages/node-opcua-client/source/private/reconnection/reconnection.ts
+++ b/packages/node-opcua-client/source/private/reconnection/reconnection.ts
@@ -338,7 +338,7 @@ function attempt_subscription_transfer(
                     if (statusCode.isNotGood()) {
                         // the subscription could not be transferred (BadSubscriptionIdInvalid when the
                         // subscription no longer exists, BadUserAccessDenied when the server refuses the
-                        // transfer per OPC UA Part 4 §5.14.7, ...). Whatever the reason, recreate it here
+                        // transfer per OPC UA Part 4 §5.13.7, ...). Whatever the reason, recreate it here
                         // directly on the new session instead of relying on the subsequent Republish step
                         // to notice and repair it (which would otherwise cost an extra failed round-trip).
                         doDebug &&

--- a/packages/node-opcua-end2end-test/test/end_to_end/_helper_umbrella.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/_helper_umbrella.ts
@@ -128,6 +128,11 @@ export async function beforeTest(test: UmbrellaTestContext) {
             // monitor ~5000 nodes in one call, so the server must allow that
             operationLimits: { maxMonitoredItemsPerCall: 10000 }
         },
+        // the umbrella suites exercise the transfer mechanics (TSS, SubscriptionDiagnostics-5, 195-B)
+        // with anonymous clients over a None endpoint, which Part 4 5.13.7 refuses by default: keep the
+        // pre-2.183 relaxation here; the rule itself is covered by
+        // test_e2e_transfer_subscription_anonymous_secured_channel.ts
+        allowAnonymousSubscriptionTransferOnUnsecuredChannel: true,
         server_sourcefile: ""
     };
     console.log(

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_subscription_survives_refused_transfer_on_reconnection.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_subscription_survives_refused_transfer_on_reconnection.ts
@@ -24,7 +24,7 @@ const doDebug = checkDebugFlag("TEST");
 // -------------------------------------------------------------------------------------------------
 // When the client reconnects and can no longer reactivate its previous session, it creates a NEW
 // session and asks the server to TransferSubscriptions. Depending on whether the server authorises the
-// transfer (OPC UA Part 4 §5.14.7), one of two things happens - both observable client-side through
+// transfer (OPC UA Part 4 §5.13.7), one of two things happens - both observable client-side through
 // the subscriptionId:
 //
 //   * transfer ACCEPTED  -> the subscription keeps its original server-assigned subscriptionId;
@@ -74,7 +74,7 @@ async function startServer(port: number, allowAnonymousSubscriptionTransferOnUns
     }, 100);
 
     // capture the StatusCode returned for every TransferSubscriptions operation so the test can assert
-    // that the §5.14.7 authorisation actually behaved as expected.
+    // that the §5.13.7 authorisation actually behaved as expected.
     const transferStatuses: string[] = [];
     const engine = server.engine as unknown as {
         transferSubscription: (...args: unknown[]) => Promise<TransferResult>;
@@ -236,7 +236,7 @@ function assertCommonRecoveryGuarantees(result: ScenarioResult): void {
     maxAfter.should.be.greaterThan(minAfter, "several distinct fresh values should be received after recovery");
 }
 
-describe("GHTR1 - transferred-vs-rebuilt subscription after reconnection (OPC UA Part 4 §5.14.7)", function (this: Mocha.Context) {
+describe("GHTR1 - transferred-vs-rebuilt subscription after reconnection (OPC UA Part 4 §5.13.7)", function (this: Mocha.Context) {
     this.timeout(60_000);
 
     it("GHTR1-A should REBUILD the subscription (new subscriptionId) when the server refuses the transfer", async () => {

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_transfer_subscription_anonymous_secured_channel.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_transfer_subscription_anonymous_secured_channel.ts
@@ -1,0 +1,178 @@
+import {
+    type ClientSession,
+    type ClientSessionRawSubscriptionService,
+    MessageSecurityMode,
+    OPCUAClient,
+    type OPCUAServer,
+    SecurityPolicy,
+    StatusCodes,
+    type TransferSubscriptionsRequestLike,
+    type TransferSubscriptionsResponse
+} from "node-opcua";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import should from "should";
+import { build_server_with_temperature_device } from "../../test_helpers/build_server_with_temperature_device.js";
+
+// transferSubscriptions() is declared on the raw subscription service, deliberately
+// excluded from the public ClientSession interface. Its optional-callback overload
+// wins resolution for a single-arg call, so re-declare the Promise-only form.
+type RawSession = Omit<ClientSession & ClientSessionRawSubscriptionService, "transferSubscriptions"> & {
+    transferSubscriptions(options: TransferSubscriptionsRequestLike): Promise<TransferSubscriptionsResponse>;
+};
+
+// -------------------------------------------------------------------------------------------------
+// OPC UA Part 4 5.13.7 (TransferSubscriptions) - the anonymous-session rule.
+//
+// A Subscription created by an anonymous session may only be transferred to another session when the
+// SecureChannel MessageSecurityMode is Sign or SignAndEncrypt and the client certificate's
+// ApplicationUri is the one of the original session. The CTT (1.05.513, Subscription Transfer
+// Err-017) expects a server to refuse the transfer over a None channel.
+//
+// node-opcua enforces the rule by default (allowAnonymousSubscriptionTransferOnUnsecuredChannel:
+// false) and refuses with Bad_UserAccessDenied; the option set to true restores the relaxed
+// behaviour (anonymous transfer accepted over a None endpoint).
+// -------------------------------------------------------------------------------------------------
+
+const port = 5801;
+
+interface Security {
+    securityMode: MessageSecurityMode;
+    securityPolicy: SecurityPolicy;
+}
+const none: Security = { securityMode: MessageSecurityMode.None, securityPolicy: SecurityPolicy.None };
+const sign: Security = { securityMode: MessageSecurityMode.Sign, securityPolicy: SecurityPolicy.Basic256Sha256 };
+const signAndEncrypt: Security = {
+    securityMode: MessageSecurityMode.SignAndEncrypt,
+    securityPolicy: SecurityPolicy.Basic256Sha256
+};
+
+async function orphanAnonymousSubscription(endpointUrl: string, security: Security): Promise<number> {
+    // an anonymous session creates a subscription, then closes WITHOUT deleting it: the subscription
+    // stays on the server, orphaned, the way a reconnecting client leaves it.
+    const client = OPCUAClient.create({ endpointMustExist: false, ...security });
+    await client.connect(endpointUrl);
+    try {
+        const session = await client.createSession();
+        const subscription = await session.createSubscription2({
+            requestedPublishingInterval: 100,
+            requestedLifetimeCount: 10 * 60,
+            requestedMaxKeepAliveCount: 5,
+            maxNotificationsPerPublish: 2,
+            publishingEnabled: true,
+            priority: 6
+        });
+        const subscriptionId = subscription.subscriptionId;
+        await session.close(/* deleteSubscriptions */ false);
+        return subscriptionId;
+    } finally {
+        await client.disconnect();
+    }
+}
+
+async function transferAnonymously(endpointUrl: string, security: Security, subscriptionId: number): Promise<StatusCodes> {
+    // the same client certificate (the OPCUAClient default) so the ApplicationUri matches the original
+    // session: only the channel security mode varies between the scenarios.
+    const client = OPCUAClient.create({ endpointMustExist: false, ...security });
+    await client.connect(endpointUrl);
+    try {
+        const session = await client.createSession();
+        try {
+            const response = await (session as RawSession).transferSubscriptions({
+                subscriptionIds: [subscriptionId],
+                sendInitialValues: false
+            });
+            should(response.results).be.an.Array().and.have.length(1);
+            const statusCode = response.results?.[0].statusCode ?? StatusCodes.BadInternalError;
+            if (statusCode.equals(StatusCodes.Good)) {
+                await (session as RawSession).deleteSubscriptions({ subscriptionIds: [subscriptionId] });
+            }
+            return statusCode;
+        } finally {
+            await session.close(true);
+        }
+    } finally {
+        await client.disconnect();
+    }
+}
+
+async function startServer(allowAnonymousSubscriptionTransferOnUnsecuredChannel?: boolean): Promise<OPCUAServer> {
+    return await build_server_with_temperature_device({
+        port,
+        allowAnonymous: true,
+        ...(allowAnonymousSubscriptionTransferOnUnsecuredChannel === undefined
+            ? {}
+            : { allowAnonymousSubscriptionTransferOnUnsecuredChannel })
+    });
+}
+
+describe("GHTR3 - anonymous TransferSubscriptions and the channel security mode (Part 4 5.13.7)", function (this: Mocha.Context) {
+    this.timeout(60_000);
+
+    describe("GHTR3-default - the rule is enforced when the option is not set", () => {
+        let server: OPCUAServer;
+        let endpointUrl: string;
+
+        before(async () => {
+            server = await startServer();
+            endpointUrl = server.getEndpointUrl();
+        });
+
+        after(async () => {
+            await server.shutdown();
+        });
+
+        it("GHTR3-A the default is the conformant one", () => {
+            should(server.engine.allowAnonymousSubscriptionTransferOnUnsecuredChannel).eql(false);
+        });
+
+        it("GHTR3-B an anonymous session on a None endpoint cannot take over an anonymous subscription", async () => {
+            const subscriptionId = await orphanAnonymousSubscription(endpointUrl, none);
+            const statusCode = await transferAnonymously(endpointUrl, none, subscriptionId);
+            should(statusCode).eql(
+                StatusCodes.BadUserAccessDenied,
+                `the transfer over a None channel must be refused, got ${statusCode.toString()}`
+            );
+        });
+
+        it("GHTR3-C the transfer succeeds over Sign with the same client certificate", async () => {
+            const subscriptionId = await orphanAnonymousSubscription(endpointUrl, sign);
+            const statusCode = await transferAnonymously(endpointUrl, sign, subscriptionId);
+            should(statusCode).eql(StatusCodes.Good, `the transfer over Sign must succeed, got ${statusCode.toString()}`);
+        });
+
+        it("GHTR3-D the transfer succeeds over SignAndEncrypt with the same client certificate", async () => {
+            const subscriptionId = await orphanAnonymousSubscription(endpointUrl, signAndEncrypt);
+            const statusCode = await transferAnonymously(endpointUrl, signAndEncrypt, subscriptionId);
+            should(statusCode).eql(StatusCodes.Good, `the transfer over SignAndEncrypt must succeed, got ${statusCode.toString()}`);
+        });
+
+        it("GHTR3-E a subscription created over SignAndEncrypt cannot be taken over from a None channel", async () => {
+            const subscriptionId = await orphanAnonymousSubscription(endpointUrl, signAndEncrypt);
+            const statusCode = await transferAnonymously(endpointUrl, none, subscriptionId);
+            should(statusCode).eql(
+                StatusCodes.BadUserAccessDenied,
+                `the transfer from a None channel must be refused, got ${statusCode.toString()}`
+            );
+        });
+    });
+
+    describe("GHTR3-relaxed - allowAnonymousSubscriptionTransferOnUnsecuredChannel: true", () => {
+        let server: OPCUAServer;
+        let endpointUrl: string;
+
+        before(async () => {
+            server = await startServer(true);
+            endpointUrl = server.getEndpointUrl();
+        });
+
+        after(async () => {
+            await server.shutdown();
+        });
+
+        it("GHTR3-F an anonymous session on a None endpoint takes over an anonymous subscription (pre-2.183 behaviour)", async () => {
+            const subscriptionId = await orphanAnonymousSubscription(endpointUrl, none);
+            const statusCode = await transferAnonymously(endpointUrl, none, subscriptionId);
+            should(statusCode).eql(StatusCodes.Good, `the relaxed server must accept the transfer, got ${statusCode.toString()}`);
+        });
+    });
+});

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_transfer_subscription_cross_user_denied.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_transfer_subscription_cross_user_denied.ts
@@ -24,7 +24,7 @@ type RawSession = Omit<ClientSession & ClientSessionRawSubscriptionService, "tra
 };
 
 // -------------------------------------------------------------------------------------------------
-// OPC UA Part 4 §5.14.7 - ownership check for TransferSubscriptions.
+// OPC UA Part 4 §5.13.7 - ownership check for TransferSubscriptions.
 //
 // A Subscription may only be transferred to a Session operating on behalf of the SAME user as the
 // session that owns it. This must hold even after the owning session is gone (the subscription has
@@ -93,7 +93,7 @@ async function transferAs(endpointUrl: string, userName: string, password: strin
     }
 }
 
-describe("GHTR2 - cross-user TransferSubscriptions is denied over an unsecured channel (Part 4 §5.14.7)", function (this: Mocha.Context) {
+describe("GHTR2 - cross-user TransferSubscriptions is denied over an unsecured channel (Part 4 §5.13.7)", function (this: Mocha.Context) {
     this.timeout(60_000);
 
     let server: OPCUAServer;

--- a/packages/node-opcua-end2end-test/test_helpers/external_server_fixture.ts
+++ b/packages/node-opcua-end2end-test/test_helpers/external_server_fixture.ts
@@ -26,6 +26,7 @@ export interface IStartServerOptions {
     maxConnectionsPerEndpoint?: number;
     nodeset_filename?: string[];
     serverCapabilities?: ServerCapabilitiesOptions;
+    allowAnonymousSubscriptionTransferOnUnsecuredChannel?: boolean;
 }
 export async function start_simple_server(options: IStartServerOptions): Promise<ServerHandle> {
     const maxRetries = 5;

--- a/packages/node-opcua-server/source/opcua_server.ts
+++ b/packages/node-opcua-server/source/opcua_server.ts
@@ -990,17 +990,18 @@ export interface OPCUAServerOptions extends OPCUABaseServerOptions, OPCUAServerE
     isAuditing?: boolean;
 
     /**
-     * OPC UA Part 4 §5.14.7 defines a stricter rule for transferring a Subscription between anonymous
-     * sessions: the old and new session must share the same ApplicationUri and the channel
-     * MessageSecurityMode must be Sign or SignAndEncrypt. Over an unsecured channel that rule protects
-     * little (anonymous identities are indistinguishable and the ApplicationUri is unauthenticated), so
-     * it is opt-in: this flag defaults to `true` (anonymous transfer accepted on any channel). Set it to
-     * `false` to enforce the strict rule.
+     * OPC UA Part 4 §5.13.7 (TransferSubscriptions) rules that a Subscription created by an anonymous
+     * session may only be transferred to another session when the SecureChannel MessageSecurityMode is
+     * Sign or SignAndEncrypt and the client certificate's ApplicationUri is the one of the original
+     * session. The conformant behaviour is the default: with `false`, an anonymous transfer over a
+     * `MessageSecurityMode.None` channel is refused with `Bad_UserAccessDenied` (the CTT 1.05 script
+     * "Subscription Transfer / Err-017" checks exactly this).
      *
-     * Note: this only affects anonymous-to-anonymous transfers. The cross-user ownership check (a
-     * transfer is refused unless the destination session operates on behalf of the same user as the
-     * subscription owner) is always enforced.
-     * @default true
+     * Set it to `true` to relax the rule and accept anonymous-to-anonymous transfers over an unsecured
+     * channel, the behaviour of node-opcua before 2.183.0. The relaxation only affects anonymous
+     * sessions: the cross-user ownership check (a transfer is refused unless the destination session
+     * operates on behalf of the same user as the subscription owner) is always enforced.
+     * @default false
      */
     allowAnonymousSubscriptionTransferOnUnsecuredChannel?: boolean;
 

--- a/packages/node-opcua-server/source/server_engine.ts
+++ b/packages/node-opcua-server/source/server_engine.ts
@@ -357,17 +357,11 @@ export interface ServerEngineOptions {
     historyServerCapabilities?: HistoryServerCapabilitiesOptions;
     serverConfiguration?: ServerConfigurationOptions;
     /**
-     * OPC UA Part 4 §5.14.7 defines a stricter rule for transferring a Subscription between anonymous
-     * sessions: the old and new session must share the same ApplicationUri and the channel
-     * MessageSecurityMode must be Sign or SignAndEncrypt. Over an unsecured channel that rule protects
-     * little (anonymous identities are indistinguishable and the ApplicationUri is unauthenticated), so
-     * it is opt-in: this flag defaults to `true` (anonymous transfer accepted on any channel). Set it to
-     * `false` to enforce the strict rule.
-     *
-     * Note: this only affects anonymous-to-anonymous transfers. The cross-user ownership check (a
-     * transfer is refused unless the destination session operates on behalf of the same user as the
-     * subscription owner) is always enforced.
-     * @default true
+     * OPC UA Part 4 §5.13.7 (TransferSubscriptions): an anonymous session's Subscription may only be
+     * transferred over a Sign or SignAndEncrypt channel to a client with the same ApplicationUri.
+     * `false` (the default) enforces the rule; `true` relaxes it and accepts anonymous-to-anonymous
+     * transfers over an unsecured channel (the behaviour before 2.183.0). See OPCUAServerOptions.
+     * @default false
      */
     allowAnonymousSubscriptionTransferOnUnsecuredChannel?: boolean;
 }
@@ -426,13 +420,13 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
         this._orphanPublishEngine = undefined; // will be constructed on demand
 
         this.isAuditing = typeof options.isAuditing === "boolean" ? options.isAuditing : false;
-        // OPC UA Part 4 §5.14.7 defines a stricter rule for anonymous transfers (same ApplicationUri +
-        // Sign/SignAndEncrypt). Over an unsecured channel that rule protects little - anonymous identities
-        // are indistinguishable and the ApplicationUri is unauthenticated - and enforcing it would break
-        // the common anonymous reconnection/transfer flow, so it is OPT-IN. The cross-user ownership check
-        // (see transferSubscription) is always enforced regardless of this flag.
+        // OPC UA Part 4 §5.13.7: an anonymous Subscription is only transferred over a Sign/SignAndEncrypt
+        // channel to a client with the same ApplicationUri. Enforced by default (CTT Subscription Transfer
+        // Err-017); the flag is an explicit relaxation for anonymous clients that reconnect over a None
+        // endpoint and expect to keep their subscriptionId. The cross-user ownership check (see
+        // transferSubscription) is always enforced regardless of this flag.
         this.allowAnonymousSubscriptionTransferOnUnsecuredChannel =
-            options.allowAnonymousSubscriptionTransferOnUnsecuredChannel !== false;
+            options.allowAnonymousSubscriptionTransferOnUnsecuredChannel === true;
 
         options.buildInfo.buildDate = options.buildInfo.buildDate || new Date();
         // ---------------------------------------------------- ServerStatusDataType
@@ -1914,7 +1908,7 @@ export class ServerEngine extends EventEmitter implements IAddressSpaceAccessor 
         }
 
         // check that the destination session is operating on behalf of the same user as the session
-        // that owns the subscription (OPC UA Part 4 §5.14.7). When the subscription has been orphaned
+        // that owns the subscription (OPC UA Part 4 §5.13.7). When the subscription has been orphaned
         // its owning session is gone, so we rely on the identity snapshot retained at orphaning time.
         const sourceIdentity = subscription.$session
             ? getTransferSessionIdentity(subscription.$session)

--- a/packages/node-opcua-server/source/server_publish_engine_for_orphan_subscriptions.ts
+++ b/packages/node-opcua-server/source/server_publish_engine_for_orphan_subscriptions.ts
@@ -31,7 +31,7 @@ export class ServerSidePublishEngineForOrphanSubscription extends ServerSidePubl
         doDebug && debugLog(chalk.bgCyan.yellow.bold(" adding live subscription with id="), subscription.id, " to orphan");
 
         // retain the identity of the owning session so that a later TransferSubscriptions request can
-        // still be validated against the original owner (OPC UA Part 4 §5.14.7), even though the
+        // still be validated against the original owner (OPC UA Part 4 §5.13.7), even though the
         // session itself is about to be detached.
         if (subscription.$session) {
             subscription.$transferSessionIdentity = getTransferSessionIdentity(subscription.$session);

--- a/packages/node-opcua-server/source/server_subscription.ts
+++ b/packages/node-opcua-server/source/server_subscription.ts
@@ -597,7 +597,7 @@ export class Subscription extends EventEmitter {
      * Snapshot of the identity of the Session that owns this Subscription. It is retained when the
      * Subscription loses its Session (e.g. when it is moved to the orphan publish engine after a
      * Session timeout) so that a later TransferSubscriptions request can still be validated against
-     * the original owner as required by OPC UA Part 4 §5.14.7.
+     * the original owner as required by OPC UA Part 4 §5.13.7.
      */
     public $transferSessionIdentity?: ITransferSessionIdentity;
 

--- a/packages/node-opcua-server/source/sessions_compatible_for_transfer.ts
+++ b/packages/node-opcua-server/source/sessions_compatible_for_transfer.ts
@@ -12,7 +12,7 @@ import type { ServerSession } from "./server_session.js";
 export type TransferUserIdentityKind = "none" | "anonymous" | "username" | "x509" | "unsupported";
 
 /**
- * The subset of a Session's identity that OPC UA Part 4 §5.14.7 (TransferSubscriptions) requires in
+ * The subset of a Session's identity that OPC UA Part 4 §5.13.7 (TransferSubscriptions) requires in
  * order to decide whether a Subscription may be transferred to another Session.
  *
  * A snapshot of this identity is retained on the Subscription so that the ownership / user-identity
@@ -36,7 +36,7 @@ export interface ITransferSessionIdentity {
 
 export interface SessionsCompatibleForTransferOptions {
     /**
-     * OPC UA Part 4 §5.14.7 requires that an anonymous user may only transfer a Subscription when the
+     * OPC UA Part 4 §5.13.7 requires that an anonymous user may only transfer a Subscription when the
      * old and the new Session share the same ApplicationUri AND the channel MessageSecurityMode is Sign
      * or SignAndEncrypt. Setting this flag to `true` relaxes that requirement and accepts
      * anonymous-to-anonymous transfers over an unsecured channel.
@@ -86,7 +86,7 @@ function isSecuredChannel(securityMode: MessageSecurityMode | undefined): boolea
 /**
  * Determine whether a Subscription owned by `sourceIdentity` may be transferred to `sessionDest`.
  *
- * OPC UA Part 4 §5.14.7 requires that the Server validate that the Client of the destination Session
+ * OPC UA Part 4 §5.13.7 requires that the Server validate that the Client of the destination Session
  * is operating on behalf of the same user as the Session that owns the Subscription:
  *  - for a non-anonymous user, the ClientUserId (UserName / X509 subject / ...) must match;
  *  - for an anonymous user (whose ClientUserId is null), the ApplicationUri must match and the channel
@@ -124,7 +124,7 @@ export function sessionsCompatibleForTransfer(
             if (options?.allowAnonymousTransferOnUnsecuredChannel) {
                 return true;
             }
-            // §5.14.7: for anonymous users the ApplicationUri must match and both the old and the new
+            // §5.13.7: for anonymous users the ApplicationUri must match and both the old and the new
             // Session must operate on a secured (Sign / SignAndEncrypt) channel.
             if (!isSecuredChannel(sourceIdentity.securityMode) || !isSecuredChannel(dest.securityMode)) {
                 return false;

--- a/packages/node-opcua-server/test/test_server_transfer_subscription.ts
+++ b/packages/node-opcua-server/test/test_server_transfer_subscription.ts
@@ -873,7 +873,7 @@ describe("ServerEngine Subscriptions Transfer", function (this: ITestContext) {
         });
     });
 
-    // OPC UA Part 4 §5.14.7: TransferSubscriptions shall validate that the destination session is
+    // OPC UA Part 4 §5.13.7: TransferSubscriptions shall validate that the destination session is
     // operating on behalf of the same user as the session that owns the subscription. This must remain
     // enforced even once the owning session has timed out and the subscription has been orphaned.
     it("ZDZ-ST11 - should NOT transfer an orphaned subscription to a session of a different user", async () => {

--- a/packages/node-opcua-server/test/test_sessions_compatible_for_transfer.ts
+++ b/packages/node-opcua-server/test/test_sessions_compatible_for_transfer.ts
@@ -37,9 +37,9 @@ function identity(
     return getTransferSessionIdentity(fakeSession(userIdentityToken, applicationUri, securityMode));
 }
 
-// OPC UA Part 4 §5.14.7: a Subscription may only be transferred to a Session that operates on
+// OPC UA Part 4 §5.13.7: a Subscription may only be transferred to a Session that operates on
 // behalf of the same user as the Session that owns the Subscription.
-describe("sessionsCompatibleForTransfer (OPC UA Part 4 §5.14.7)", () => {
+describe("sessionsCompatibleForTransfer (OPC UA Part 4 §5.13.7)", () => {
     it("SCT-01 - refuses the transfer when the owning identity is unknown (fail closed)", () => {
         should(sessionsCompatibleForTransfer(undefined, fakeSession(new UserNameIdentityToken({ userName: "user1" })))).eql(false);
         should(sessionsCompatibleForTransfer(undefined, fakeSession(undefined))).eql(false);
@@ -117,7 +117,7 @@ describe("sessionsCompatibleForTransfer (OPC UA Part 4 §5.14.7)", () => {
         should(sessionsCompatibleForTransfer(snapshot, fakeSession(new UserNameIdentityToken({ userName: "user2" })))).eql(false);
     });
 
-    // ---- anonymous user rule (§5.14.7): same ApplicationUri AND Sign/SignAndEncrypt channel ----
+    // ---- anonymous user rule (§5.13.7): same ApplicationUri AND Sign/SignAndEncrypt channel ----
 
     it("SCT-12 - refuses anonymous -> username", () => {
         should(


### PR DESCRIPTION
# fix(server): enforce the anonymous TransferSubscriptions rule by default

## Why

OPC UA Part 4 §5.13.7 (TransferSubscriptions) rules that a Subscription created by an
**anonymous** Session may only be transferred to another Session when

- the SecureChannel `MessageSecurityMode` is `Sign` or `SignAndEncrypt`, **and**
- the client certificate's ApplicationUri is the one of the original Session.

node-opcua already implemented that check, behind the server option
`allowAnonymousSubscriptionTransferOnUnsecuredChannel` — but the option **defaulted to
`true`**, so a stock node-opcua server happily transferred an anonymous subscription over a
`None` endpoint. That is non-conformant, and the OPC Foundation CTT 1.05.513 script
*Subscription Services / Subscription Transfer / Err-017* fails against it. Flipping the
option to `false` in the certification server makes the CTT unit pass; the fix is to make
that the default for everybody.

## What

- `packages/node-opcua-server/source/server_engine.ts` — the default flips:
  `options.allowAnonymousSubscriptionTransferOnUnsecuredChannel === true` (was `!== false`).
  `ServerEngineOptions` doc updated (`@default false`).
- `packages/node-opcua-server/source/opcua_server.ts` — `OPCUAServerOptions` doc rewritten:
  states the spec rule, that `false` is the conformant default, that `true` restores the
  pre-change behaviour, and names the CTT script. `@default false`.
- The refusal path is **unchanged**: `ServerEngine#transferSubscription` still returns
  `Bad_UserAccessDenied` through `sessionsCompatibleForTransfer` — the status code the CTT
  accepted. No new status code, no new code path.
- `packages/node-opcua-end2end-test/test/end_to_end/test_e2e_transfer_subscription_anonymous_secured_channel.ts`
  (new, 6 cases) — an anonymous session orphans a subscription, another anonymous session
  tries to take it over:
  - `GHTR3-A` the engine default is `false`
  - `GHTR3-B` None → None is refused with `BadUserAccessDenied`
  - `GHTR3-C` / `GHTR3-D` Sign and SignAndEncrypt with the same client certificate succeed
  - `GHTR3-E` a SignAndEncrypt-owned subscription cannot be taken over from a None channel
  - `GHTR3-F` with the option explicitly `true`, the None transfer succeeds as before
- `packages/node-opcua-end2end-test/test/end_to_end/_helper_umbrella.ts` — the umbrella
  suites (`#TSS TransferSessionService`, `SubscriptionDiagnostics-5`, issue 195-B) transfer
  anonymously over a `None` endpoint by design; they now opt into the relaxation explicitly,
  with a comment pointing at the test above for the rule itself. This is the only existing
  test that relied on the old default.
- `packages/node-opcua-end2end-test/test_helpers/external_server_fixture.ts` — `IStartServerOptions`
  carries the flag so the umbrella options object typechecks on both the internal and the
  external server path.
- `RELEASE_NOTES.md` — new top section, see below.
- Spec-reference correction across the transfer code and its tests: `§5.14.7` → `§5.13.7`
  (TransferSubscriptions is 5.13.7 in Part 4; 5.14.7 was wrong everywhere it appeared).
  Comment/title only, no behaviour.

Note: `test_e2e_subscription_survives_refused_transfer_on_reconnection.ts` already passed the
option explicitly for both values, so it needed no change — and it documents the client-side
consequence: on a refused transfer the client rebuilds the subscription instead of keeping
its subscriptionId.

## Behaviour change

`OPCUAServerOptions.allowAnonymousSubscriptionTransferOnUnsecuredChannel` now defaults to
`false` (it used to default to `true`). This lands in a minor release.

An anonymous client that reconnects over a `None` endpoint and expects to keep its
`subscriptionId` will now see the transfer refused with `Bad_UserAccessDenied` and its
subscription rebuilt (node-opcua's own client does this transparently — see
`attempt_subscription_transfer` in the client reconnection path). To restore the previous
behaviour:

```ts
const server = new OPCUAServer({
    // relaxes OPC UA Part 4 §5.13.7 for anonymous sessions on unsecured channels
    allowAnonymousSubscriptionTransferOnUnsecuredChannel: true
});
```

Unaffected: the cross-user ownership check (a transfer is refused unless the destination
Session operates on behalf of the same user as the Subscription owner) was always enforced
and stays so, whatever this flag is set to.

## Verification

Run from the worktree, after `pnpm run build:all`.

| command | result |
| --- | --- |
| `mocha` in `packages/node-opcua-server` (full package suite) | **530 passing** |
| `mocha test/test_server_transfer_subscription.ts test/test_sessions_compatible_for_transfer.ts` | **28 passing** |
| `mocha test/end_to_end/test_e2e_transfer_subscription_anonymous_secured_channel.ts` (new) | **6 passing** |
| `mocha test/end_to_end/test_e2e_subscription_survives_refused_transfer_on_reconnection.ts test/end_to_end/test_e2e_transfer_subscription_cross_user_denied.ts` | **4 passing** |
| `mocha test/end_to_end/test_umbrella_e2e_seriesC.ts --grep Transfer` | **4 passing** |
| `mocha test/end_to_end/test_e2e_connection_reconnection.ts` | **22 passing** |
| `mocha` on the three remaining transfer/reconnection e2e files (678, restarting-server, large-subscription) | **6 passing** |
| `tsc --noEmit -p packages/node-opcua-end2end-test/test/tsconfig.json` | clean |

Repo checks at the root:

- `pnpm run lint:ci` — green (biome needed one format pass on the new test file, applied)
- `pnpm run check:shortcircuit` — `3282 files scanned, no assertion sits behind an optional chain`
- `node tools/check-test-ports.mjs --summary` — `229 fixed ports, 0 collisions … OK - nothing
  unaccounted for` (the new test uses port `5801`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
