### PR TITLE
fix(service-discovery): release the mDNS instance on every path

### DIFF
--- a/packages/node-opcua-service-discovery/source/bonjourHolder.ts
+++ b/packages/node-opcua-service-discovery/source/bonjourHolder.ts
@@ -33,6 +33,19 @@ async function releaseMulticastDNS(bonjour: Bonjour) {
     registry.unregister(bonjour);
 }
 
+/**
+ * How many multicast-DNS instances are currently held.
+ *
+ * A test seam, and the only way this leak is visible from inside the process: an instance left
+ * behind holds a socket on udp/5353, which keeps the event loop alive, so the symptom is a test
+ * run that finishes its assertions and then never exits.
+ *
+ * @internal
+ */
+export function multicastDNSInstanceCount(): number {
+    return registry.count();
+}
+
 export function acquireMulticastDNS(): Bonjour {
     const bonjour = new Bonjour();
     registry.register(bonjour);
@@ -131,8 +144,13 @@ export class BonjourHolder {
 
         this.#pendingAnnouncement = true;
         this.serviceConfig = serviceConfig;
-        this.#_service = await _announceServerOnMulticastSubnet(this.#_multicastDNS, serviceConfig);
-        this.#pendingAnnouncement = false;
+        try {
+            this.#_service = await _announceServerOnMulticastSubnet(this.#_multicastDNS, serviceConfig);
+        } finally {
+            // the announcement rejects on a 10s timeout; leaving the flag set would make
+            // stopAnnouncedOnMulticastSubnet retry forever and never release the instance
+            this.#pendingAnnouncement = false;
+        }
         // c8 ignore next
         doDebug && debugLog(chalk.yellow("exiting announcedOnMulticastSubnet-3", true));
         return true;
@@ -166,21 +184,26 @@ export class BonjourHolder {
                 )
             );
 
-        if (!this.#_service) {
-            // c8 ignore next
-            doDebug && debugLog(chalk.green("leaving stop_announcedOnMulticastSubnet = no service"));
-            return;
-        }
-        // due to a wrong declaration of Service.stop in the d.ts file we
-        // need to use a workaround here
+        // Take ownership of both handles first, then work on the locals. Everything below has
+        // to reach releaseMulticastDNS: a Bonjour instance holds a socket on udp/5353, and one
+        // left behind keeps the event loop alive, so a test run never exits.
         const that_service = this.#_service;
         const that_multicastDNS = this.#_multicastDNS;
         this.#_service = undefined;
         this.#_multicastDNS = undefined;
-
         this.serviceConfig = undefined;
 
-        if (that_multicastDNS && that_service.stop) {
+        if (!that_multicastDNS) {
+            // nothing was ever acquired
+            // c8 ignore next
+            doDebug && debugLog(chalk.green("leaving stop_announcedOnMulticastSubnet = no multicast DNS"));
+            return;
+        }
+
+        // A service exists only once the announcement completed; stopping is skipped when it
+        // did not, but the instance is released either way. `stop` is declared wrongly in the
+        // .d.ts, hence the check rather than a plain call.
+        if (that_service?.stop) {
             await new Promise<void>((resolve) => {
                 that_service.stop((err?: Error) => {
                     // c8 ignore next
@@ -191,8 +214,8 @@ export class BonjourHolder {
                     });
                 });
             });
-            await releaseMulticastDNS(that_multicastDNS);
         }
+        await releaseMulticastDNS(that_multicastDNS);
 
         // c8 ignore next
         if (doDebug) {

--- a/packages/node-opcua-service-discovery/source/index.ts
+++ b/packages/node-opcua-service-discovery/source/index.ts
@@ -23,7 +23,7 @@ export {
 } from "node-opcua-types";
 export { Announcement } from "./Announcement.js";
 export { announcementToServiceConfig } from "./announcement_to_service_config.js";
-export { BonjourHolder } from "./bonjourHolder.js";
+export { BonjourHolder, multicastDNSInstanceCount } from "./bonjourHolder.js";
 export { serverCapabilities } from "./server_capabilities.js";
 export {
     isSameService,

--- a/packages/node-opcua-service-discovery/test/test_bonjour.ts
+++ b/packages/node-opcua-service-discovery/test/test_bonjour.ts
@@ -1,9 +1,16 @@
+import { EventEmitter } from "node:events";
 import { make_debugLog } from "node-opcua-debug";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
 import should from "should";
 import sinon from "sinon";
 import Bonjour from "sterfive-bonjour-service";
-import { type Announcement, announcementToServiceConfig, BonjourHolder, serviceToString } from "../dist/index.js";
+import {
+    type Announcement,
+    announcementToServiceConfig,
+    BonjourHolder,
+    multicastDNSInstanceCount,
+    serviceToString
+} from "../dist/index.js";
 
 const port = 1234;
 
@@ -104,5 +111,67 @@ describe("Bonjour", () => {
         spyDown.callCount.should.eql(1);
         spyUp.callCount.should.eql(1);
         shutdown();
+    });
+});
+
+// ── releasing the multicast-DNS instance ────────────────────────────────────────
+//
+// Every exit path of stopAnnouncedOnMulticastSubnet has to release the Bonjour instance it
+// acquired. One left behind holds a socket on udp/5353 and keeps the event loop alive, so the
+// failure is not an assertion: it is a mocha run that prints its results and then hangs. That
+// was seen once for 1h35m, holding six of these sockets.
+
+describe("BonjourHolder multicast-DNS lifetime", () => {
+    it("MDNS-1 releases the instance when an announcement was made", async () => {
+        const before = multicastDNSInstanceCount();
+        const holder = new BonjourHolder();
+        await holder.announcedOnMulticastSubnet({ name: "mdns-1", capabilities: ["DA"], host: "host", path: "path", port });
+        should(multicastDNSInstanceCount()).eql(before + 1);
+
+        await holder.stopAnnouncedOnMulticastSubnet();
+        should(multicastDNSInstanceCount()).eql(before);
+        should(holder.isStarted()).eql(false);
+    });
+
+    it("MDNS-2 stopping without an announcement releases nothing and returns", async () => {
+        const before = multicastDNSInstanceCount();
+        const holder = new BonjourHolder();
+        await holder.stopAnnouncedOnMulticastSubnet();
+        should(multicastDNSInstanceCount()).eql(before);
+    });
+
+    it("MDNS-3 stopping twice is safe", async () => {
+        const before = multicastDNSInstanceCount();
+        const holder = new BonjourHolder();
+        await holder.announcedOnMulticastSubnet({ name: "mdns-3", capabilities: ["DA"], host: "host", path: "path", port });
+        await holder.stopAnnouncedOnMulticastSubnet();
+        await holder.stopAnnouncedOnMulticastSubnet();
+        should(multicastDNSInstanceCount()).eql(before);
+    });
+
+    it("MDNS-4 releases the instance when the announcement failed", async () => {
+        // the announcement rejects on an error event or a 10s timeout. Before the fix the
+        // instance was acquired but never reached the release, because stop() returned early
+        // on `!this.#_service` - and the pending flag stayed set, so a later stop recursed
+        // forever rather than failing.
+        const before = multicastDNSInstanceCount();
+        const holder = new BonjourHolder();
+        const publish = sinon.stub(Bonjour.prototype, "publish").callsFake(() => {
+            const service = new EventEmitter() as unknown as ReturnType<Bonjour["publish"]>;
+            setImmediate(() => (service as unknown as EventEmitter).emit("error", new Error("announce refused")));
+            return service;
+        });
+        try {
+            await holder
+                .announcedOnMulticastSubnet({ name: "mdns-4", capabilities: ["DA"], host: "host", path: "path", port })
+                .then(
+                    () => undefined,
+                    () => undefined
+                );
+        } finally {
+            publish.restore();
+        }
+        await holder.stopAnnouncedOnMulticastSubnet();
+        should(multicastDNSInstanceCount()).eql(before);
     });
 });


### PR DESCRIPTION
`BonjourHolder.stopAnnouncedOnMulticastSubnet` could return without releasing the
multicast-DNS instance it had acquired. Each one holds a socket on udp/5353, which keeps the
event loop alive.

## The flaw

```ts
this.#_multicastDNS = acquireMulticastDNS();          // a new Bonjour, its own :5353 socket
this.#_service = await _announceServerOnMulticastSubnet(...);

// stopAnnouncedOnMulticastSubnet():
if (!this.#_service) { return; }                      // (a) early return
const that_multicastDNS = this.#_multicastDNS;
this.#_service = undefined;
this.#_multicastDNS = undefined;                      // fields cleared FIRST
if (that_multicastDNS && that_service.stop) {         // (b) guard comes AFTER
    await releaseMulticastDNS(that_multicastDNS);     // the only caller of bonjour.destroy()
}
```

Two paths orphan the instance:

**(a)** `#_service` is unset while `#_multicastDNS` is set - the window between acquiring and
the announcement resolving. The early return leaves the instance unreachable and undestroyed.

**(b)** `that_service.stop` is falsy. The fields have already been nulled, so the instance is
both unreachable and never released. The code's own comment says `stop` is unreliably declared
in the `.d.ts`, which is why the check exists at all.

The fix takes ownership of both handles up front and works on locals, so every path reaches
`releaseMulticastDNS`. Stopping the service is skipped when there is nothing to stop; releasing
is not.

## A second flaw in the same pair

`announcedOnMulticastSubnet` sets `#pendingAnnouncement = true`, awaits, then clears it. The
announcement rejects on a 10s timeout, and on that path the flag stayed set - so a later
`stopAnnouncedOnMulticastSubnet` hit its `if (#pendingAnnouncement)` branch and **recursed
forever** on a 500ms retry, never releasing anything. Now cleared in a `finally`.

## Tests

Four regression tests in `test/test_bonjour.ts`, using a new `@internal`
`multicastDNSInstanceCount()` seam over the `ObjectRegistry` the module already keeps. That
seam matters: this leak is otherwise invisible from inside the process, because the symptom is
not a failed assertion but a run that prints its results and never exits.

| | |
|---|---|
| MDNS-1 | releases after a successful announcement |
| MDNS-2 | stopping without an announcement releases nothing and returns |
| MDNS-3 | stopping twice is safe |
| MDNS-4 | **releases when the announcement failed** - fails on the old code, passes on the new |

Verified in both directions: with the old logic restored, MDNS-4 fails; with the fix, all pass.

```
npx mocha test/**/*.ts        8 passing
npx tsc -b packages           0
pnpm run lint:ci              0
```

## What this does not fix

This was found while chasing a `test/discovery/test_discovery.ts` run that finished its
assertions in 1m and then stayed alive for 1h35m, holding six udp/5353 sockets among other
handles. **The fix removes those sockets but the suite still does not exit** on that machine:
90s after the tests finish it still holds `TCPServerWrap: 6, UDPWrap: 7, Timeout: 19`.

That remainder looks environmental rather than a defect here - on that machine three discovery
tests fail because something else already answers on port 4840, and servers created inside the
failing tests are left running. Recorded so nobody reads this PR as closing that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
