### PR TITLE
fix(address-space): validate the array EURange/InstrumentRange check per element (FEAT-51)

### DIFF
--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/analog_data_items.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/analog_data_items.ts
@@ -116,7 +116,9 @@ export function addAnalogDataItems(namespace: Namespace, parentFolder: UAObject)
         { dataType: DataType.Int32, value: -100 },
         { dataType: DataType.UInt32, value: 100 },
         { dataType: DataType.Int64, value: [0, 0] },
-        { dataType: DataType.UInt64, value: [0, 0] },
+        // an unsigned range starts at 10 (makeRange): 0 is outside it and the CTT's
+        // PercentDeadband 006 warns on an initial value outside EURange
+        { dataType: DataType.UInt64, value: [0, 130] },
         { dataType: DataType.Byte, value: 65 },
         { dataType: DataType.SByte, value: -23 }
     ];

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/analog_data_items.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/analog_data_items.ts
@@ -11,7 +11,7 @@ interface RangeOptions {
     high: number;
 }
 
-function makeRange(dataType: DataType): { engineeringUnitsRange: RangeOptions; instrumentRange: RangeOptions } {
+export function makeRange(dataType: DataType): { engineeringUnitsRange: RangeOptions; instrumentRange: RangeOptions } {
     let engineeringUnitsRange = { low: -200, high: 200 };
     let instrumentRange = { low: -200, high: 200 };
     if (DataType[dataType][0] === "U" || dataType === DataType.Byte) {

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_folder.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_folder.ts
@@ -29,6 +29,7 @@ import { AccessLevelFlag } from "node-opcua-data-model";
 import { buildVariantArray, DataType, Variant, VariantArrayType } from "node-opcua-variant";
 
 import { addAlarmInputNodes } from "./alarm_input_nodes.js";
+import { makeRange } from "./analog_data_items.js";
 import { CttFolder, readWrite, TYPE_ALIAS } from "./ctt_tree.js";
 
 // ─── Static / All Profiles ──────────────────────────────────────────────
@@ -173,6 +174,11 @@ function addAnalogItemArrays(ctt: CttFolder): void {
     const folder = ctt.folder("Static/DA Profile/AnalogItemType Arrays");
     for (const dataTypeName of ["Double", "Float", "Int16", "Int32", "UInt16", "UInt32"]) {
         const dataType = DataType[dataTypeName as keyof typeof DataType];
+        // unsigned types cannot represent a negative EURange, so their range (and every
+        // element's initial value) must start at or above 0 - see makeRange(). Seeding every
+        // element at engineeringUnitsRange.low, rather than a fixed 0 that falls outside an
+        // unsigned range, keeps the node's own initial value conformant (PercentDeadband 006).
+        const { engineeringUnitsRange, instrumentRange } = makeRange(dataType);
         ctt.namespace.addAnalogDataItem({
             organizedBy: folder,
             browseName: dataTypeName,
@@ -181,10 +187,14 @@ function addAnalogItemArrays(ctt: CttFolder): void {
             valueRank: 1,
             arrayDimensions: [5],
             arrayType: VariantArrayType.Array,
-            engineeringUnitsRange: { low: -100, high: 100 },
-            instrumentRange: { low: -1000, high: 1000 },
+            engineeringUnitsRange,
+            instrumentRange,
             engineeringUnits: standardUnits.degree_celsius,
-            value: new Variant({ dataType, arrayType: VariantArrayType.Array, value: buildVariantArray(dataType, 5, 0) }),
+            value: new Variant({
+                dataType,
+                arrayType: VariantArrayType.Array,
+                value: buildVariantArray(dataType, 5, engineeringUnitsRange.low)
+            }),
             accessLevel: readWrite,
             userAccessLevel: readWrite
         });

--- a/packages/node-opcua-address-space/impl/data_access/adjust_datavalue_status_code.ts
+++ b/packages/node-opcua-address-space/impl/data_access/adjust_datavalue_status_code.ts
@@ -7,13 +7,41 @@ import { NodeClass } from "node-opcua-data-model";
 import type { DataValue } from "node-opcua-data-value";
 import { type StatusCode, StatusCodes } from "node-opcua-status-code";
 import type { Range } from "node-opcua-types";
-import type { Variant } from "node-opcua-variant";
+import { type Variant, VariantArrayType } from "node-opcua-variant";
 
-function validate_value_range(range: Range, variant: Variant) {
-    if (variant.value < range.low || variant.value > range.high) {
-        return false;
+function isOutOfRange(value: number, range: Range): boolean {
+    return value < range.low || value > range.high;
+}
+
+/**
+ * Checks that the value(s) carried by `variant` fall within `range`.
+ *
+ * `variant.value` is a plain number for a scalar write, but for an array (or matrix)
+ * variable it is an array-like (Array or a TypedArray) holding only the elements this
+ * particular Write touches - a client writing with an IndexRange sends just the sub-range
+ * it targets, so an out-of-range element elsewhere in the variable's full value (one this
+ * write leaves untouched) must never be seen here and must never fail the write. Comparing
+ * an array directly with `<`/`>` coerces it through Array.prototype.toString first: a
+ * one-element array happens to stringify to its bare element and compares correctly by
+ * accident, but any other length stringifies to a comma-joined list that parses to NaN,
+ * so every such comparison is silently false and a genuinely out-of-range multi-element
+ * write was never being rejected. Each element is compared numerically instead.
+ */
+function validate_value_range(range: Range, variant: Variant): boolean {
+    const value = variant.value;
+    if (variant.arrayType === VariantArrayType.Array || variant.arrayType === VariantArrayType.Matrix) {
+        if (value === null || value === undefined) {
+            return true;
+        }
+        const length = (value as ArrayLike<number>).length;
+        for (let i = 0; i < length; i++) {
+            if (isOutOfRange((value as ArrayLike<number>)[i], range)) {
+                return false;
+            }
+        }
+        return true;
     }
-    return true;
+    return !isOutOfRange(value as number, range);
 }
 
 export function adjustDataValueStatusCode(

--- a/packages/node-opcua-address-space/test/data_access/subtest_analog_item_type.ts
+++ b/packages/node-opcua-address-space/test/data_access/subtest_analog_item_type.ts
@@ -1,9 +1,10 @@
 import { Range, standardUnits } from "node-opcua-data-access";
 import { BrowseDirection, makeAccessLevelFlag } from "node-opcua-data-model";
 import { DataValue } from "node-opcua-data-value";
+import { NumericRange } from "node-opcua-numeric-range";
 import { BrowseDescription } from "node-opcua-service-browse";
 import { StatusCodes } from "node-opcua-status-code";
-import { DataType, Variant } from "node-opcua-variant";
+import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
 import should from "should";
 
 import { type AddressSpace, type Namespace, SessionContext } from "../../dist/api/index.js";
@@ -348,6 +349,110 @@ export function subtest_analog_item_type(maintest: MainTest): void {
             });
             const references = analogItem.browseNode(browseDescription);
             references.filter((r) => r.browseName.name === "EURange").length.should.eql(1);
+        });
+
+        describe("Writing a single element of an AnalogItemType array with IndexRange (FEAT-51)", () => {
+            // Reproduces the CTT's Data Access PercentDeadband 009/010: GetEURangeWriteValues
+            // builds a one-element array value that is inside the node's EURange and writes it
+            // with an IndexRange designating a single untouched element. The other elements are
+            // seeded at 0, which is itself outside a 10..250 EURange (as the CTT/Static/DA Profile
+            // arrays are) - those untouched elements must not make the write fail.
+            function makeUInt16ArrayItem() {
+                const objectsFolder = addressSpace.rootFolder.objects;
+                return namespace.addAnalogDataItem({
+                    browseName: "UInt16ArrayAnalog" + Date.now() + Math.random(),
+                    dataType: "UInt16",
+                    definition: "",
+                    engineeringUnits: standardUnits.degree_celsius,
+                    engineeringUnitsRange: { low: 10, high: 250 },
+                    instrumentRange: { low: 10, high: 250 },
+                    organizedBy: objectsFolder,
+                    valueRank: 1,
+                    arrayDimensions: [5],
+                    // untouched elements are seeded outside the EURange, as node-opcua-address-space-for-conformance-testing does
+                    value: new Variant({ dataType: DataType.UInt16, arrayType: VariantArrayType.Array, value: [0, 0, 0, 0, 0] }),
+                    valuePrecision: 0.5
+                });
+            }
+
+            it("writing one element in-range via IndexRange shall return Good, even though other elements are out of range", async () => {
+                const analogItem = makeUInt16ArrayItem();
+
+                const dataValue = new DataValue({
+                    value: new Variant({ dataType: DataType.UInt16, arrayType: VariantArrayType.Array, value: [15] })
+                });
+
+                const statusCode = await analogItem.writeValue(context, dataValue, NumericRange.coerce("2"));
+                statusCode.should.eql(StatusCodes.Good);
+
+                const dataValueAfter = await analogItem.readValueAsync(context);
+                dataValueAfter.statusCode.should.eql(StatusCodes.Good);
+                should(Array.from(dataValueAfter.value.value as ArrayLike<number>)).eql([0, 0, 15, 0, 0]);
+            });
+
+            it("writing one element out-of-range via IndexRange shall return BadOutOfRange", async () => {
+                const analogItem = makeUInt16ArrayItem();
+
+                const dataValue = new DataValue({
+                    value: new Variant({ dataType: DataType.UInt16, arrayType: VariantArrayType.Array, value: [9000] })
+                });
+
+                const statusCode = await analogItem.writeValue(context, dataValue, NumericRange.coerce("2"));
+                statusCode.should.eql(StatusCodes.BadOutOfRange);
+            });
+
+            it("writing multiple elements via IndexRange with one element out of range shall return BadOutOfRange", async () => {
+                // this is the latent bug: validate_value_range used to compare the write's
+                // array value against the range with plain `<`/`>`, which coerces a
+                // multi-element array through Array.prototype.toString into a comma-joined
+                // string that parses to NaN - every such comparison was silently false, so a
+                // genuinely out-of-range multi-element write was wrongly accepted as Good.
+                const analogItem = makeUInt16ArrayItem();
+                const dataValue = new DataValue({
+                    value: new Variant({ dataType: DataType.UInt16, arrayType: VariantArrayType.Array, value: [15, 9000] })
+                });
+                const statusCode = await analogItem.writeValue(context, dataValue, NumericRange.coerce("1:2"));
+                statusCode.should.eql(StatusCodes.BadOutOfRange);
+            });
+
+            it("writing multiple elements via IndexRange, all in range, shall return Good", async () => {
+                const analogItem = makeUInt16ArrayItem();
+                const dataValue = new DataValue({
+                    value: new Variant({ dataType: DataType.UInt16, arrayType: VariantArrayType.Array, value: [15, 20] })
+                });
+                const statusCode = await analogItem.writeValue(context, dataValue, NumericRange.coerce("1:2"));
+                statusCode.should.eql(StatusCodes.Good);
+            });
+
+            it("writing the whole array (scalar write, no IndexRange) with in-range values shall return Good", async () => {
+                const analogItem = makeUInt16ArrayItem();
+
+                const dataValue = new DataValue({
+                    value: new Variant({
+                        dataType: DataType.UInt16,
+                        arrayType: VariantArrayType.Array,
+                        value: [10, 10, 10, 10, 10]
+                    })
+                });
+
+                const statusCode = await analogItem.writeValue(context, dataValue);
+                statusCode.should.eql(StatusCodes.Good);
+            });
+
+            it("writing the whole array (scalar write, no IndexRange) with an out-of-range value shall return BadOutOfRange", async () => {
+                const analogItem = makeUInt16ArrayItem();
+
+                const dataValue = new DataValue({
+                    value: new Variant({
+                        dataType: DataType.UInt16,
+                        arrayType: VariantArrayType.Array,
+                        value: [10, 10, 9000, 10, 10]
+                    })
+                });
+
+                const statusCode = await analogItem.writeValue(context, dataValue);
+                statusCode.should.eql(StatusCodes.BadOutOfRange);
+            });
         });
     });
 }


### PR DESCRIPTION
## Why

The CTT's Data Access PercentDeadband 009/010 write a single in-range element of an
`AnalogItemType` array via `IndexRange`. Investigating this, `validate_value_range()`
(the EURange/InstrumentRange check invoked on every Write) compared the value being
written against the node's Range with plain `<` / `>`. For an array value, JS coerces
the array through `Array.prototype.toString` before the numeric comparison: a
one-element array happens to stringify to its bare element and compares correctly by
accident, but any other array length stringifies to a comma-joined string that parses
to `NaN`, and every such comparison is then silently `false`. The practical
consequence, confirmed with a reproduction test, is the inverse of what a range check
should do: a multi-element `IndexRange` write (or a whole-array write) carrying a
genuinely out-of-range element was wrongly accepted as `Good` instead of being
rejected with `BadOutOfRange`. The check already ran only on the value the client
actually sent, before it is merged into the destination array, so an element the
write leaves untouched was never part of what got checked - the fix keeps that
property and simply makes the per-element comparison correct instead of an accidental
side effect of string coercion.

Separately, the `CTT/Static/DA Profile/AnalogItemType Arrays/*` nodes that
`node-opcua-address-space-for-conformance-testing` builds seeded every element at a
fixed `0` and used a single `-100..100` EURange for every data type, including the
unsigned ones - `0` sits inside `-100..100`, but an unsigned analog item cannot
represent a negative low bound, and the initial value should conform to the node's
own range regardless (this is what PercentDeadband 006 warns about for the scalar
items). Reusing the same unsigned-aware range the scalar analog items already use
fixes both problems together.

## What

- `packages/node-opcua-address-space/impl/data_access/adjust_datavalue_status_code.ts`
  - Rewrote `validate_value_range()` to compare each element of an array/matrix
    Variant against the Range numerically, instead of comparing the array itself
    with `<`/`>` (which only worked by accident for a single-element array and was
    a silent no-op for any other length).
- `packages/node-opcua-address-space/test/data_access/subtest_analog_item_type.ts`
  - Added a `Writing a single element of an AnalogItemType array with IndexRange
    (FEAT-51)` suite: single-element in-range/out-of-range `IndexRange` writes,
    multi-element `IndexRange` writes (in-range, and with one out-of-range element),
    and whole-array writes (in-range, and with one out-of-range element) - covering
    both the CTT's own scenario and the multi-element defect the fix corrects.
- `packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/analog_data_items.ts`
  - Exported `makeRange()` (previously module-private) so the CTT array nodes can
    reuse the same unsigned-aware EURange/InstrumentRange logic as the scalar
    analog items.
- `packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_folder.ts`
  - `addAnalogItemArrays()` now derives its `engineeringUnitsRange`/`instrumentRange`
    from `makeRange(dataType)` instead of a fixed `-100..100`/`-1000..1000`, and
    seeds every array element at `engineeringUnitsRange.low` instead of `0`, so an
    unsigned array's initial value is always inside its own EURange.

## Verification

- `packages/node-opcua-address-space` `test/data_access/**/*.ts` (mocha): 83 passing,
  including the 6 new FEAT-51 cases.
- `packages/node-opcua-address-space` full mocha suite: 87 passing, 2 pre-existing
  failures unrelated to this change (`test/alarms_and_conditions/test_certificate_alarm.ts`
  fails both before/after `all` hooks with `ENOENT` on a missing
  `node-opcua-samples/certificates/client_cert_1024_not_active_yet.pem` fixture -
  a missing generated-certificate fixture in this checkout, not touched by this fix).
- `packages/node-opcua-address-space-for-conformance-testing` full mocha suite: 11
  passing.
- `pnpm run check:shortcircuit` (repo root): 3282 files scanned, clean.
- `pnpm run lint:ci` (repo root): green (biome + every `check:*` script the CI lint
  job runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
