### PR TITLE
fix(alias-name-server): FindAlias refuses a ReferenceTypeFilter that is not AliasFor (FEAT-54)

### DIFF
--- a/packages/node-opcua-alias-name-client/test/test_client_alias_set.ts
+++ b/packages/node-opcua-alias-name-client/test/test_client_alias_set.ts
@@ -118,10 +118,29 @@ describe("OPC 10000-17: ClientAliasSet", () => {
             }
         });
 
-        it("should honour a ReferenceTypeFilter", async () => {
+        it("should honour a ReferenceTypeFilter that is AliasFor", async () => {
+            // clause 6.3.2 Table 3 / clause 8.2: AliasFor is the default
+            // ReferenceType every alias uses to reach its target, so filtering
+            // on it changes nothing here - it is a legal filter, not a no-op.
+            const aliasFor = addressSpace.findReferenceType("AliasFor")!;
+            const entries = await aliases.findAlias("TI101", { referenceTypeFilter: aliasFor.nodeId });
+            entries.should.have.length(1);
+            entries[0].aliasName.should.eql("TI101");
+        });
+
+        it("should reject a ReferenceTypeFilter that is not AliasFor or a subtype of it", async () => {
+            // clause 6.3.2 Table 3: the filter must be AliasFor or a subtype;
+            // Organizes is neither, so the Server must answer
+            // Bad_InvalidArgument (CTT AliasName Base Err-004) rather than
+            // silently reporting an empty result.
             const organizes = addressSpace.findReferenceType("Organizes")!;
-            const entries = await aliases.findAlias("%", { referenceTypeFilter: organizes.nodeId });
-            entries.should.eql([], "no alias reaches its target through Organizes");
+            try {
+                await aliases.findAlias("%", { referenceTypeFilter: organizes.nodeId });
+                throw new Error("should have thrown");
+            } catch (err) {
+                should(err).be.instanceOf(AliasNameCallError);
+                (err as AliasNameCallError).statusCode.should.eql(StatusCodes.BadInvalidArgument);
+            }
         });
     });
 

--- a/packages/node-opcua-alias-name-server/source/bind_find_alias.ts
+++ b/packages/node-opcua-alias-name-server/source/bind_find_alias.ts
@@ -16,6 +16,7 @@ import type { CallMethodResultOptions } from "node-opcua-service-call";
 import { StatusCodes } from "node-opcua-status-code";
 import { AliasNameDataType, AliasNameVerboseDataType } from "node-opcua-types";
 import { DataType, type Variant, VariantArrayType } from "node-opcua-variant";
+import { ALIAS_FOR } from "./well_known.js";
 
 /**
  * Orders results before they are returned.
@@ -72,6 +73,31 @@ function readPattern(inputArguments: Variant[]): string | null {
 function readReferenceTypeFilter(inputArguments: Variant[]): NodeId | undefined {
     const value = inputArguments?.[1]?.value;
     return value instanceof NodeIdClass ? value : undefined;
+}
+
+/**
+ * `ReferenceTypeFilter` (clause 6.3.2 Table 3) must be `AliasFor` or a subtype
+ * of it; `null`/absent means "no filtering" and is always accepted.
+ *
+ * Mirrors the check `coerceReferenceType` in `add_alias.ts` applies when an
+ * AliasName is created, since both enforce the same clause 8.2 rule.
+ */
+function isValidReferenceTypeFilter(category: UAObject, filter: NodeId | undefined): boolean {
+    if (!filter || filter.isEmpty()) {
+        return true;
+    }
+    const addressSpace = category.addressSpace;
+    const aliasFor = addressSpace.findReferenceType(ALIAS_FOR);
+    const candidate = addressSpace.findReferenceType(filter);
+    if (!candidate) {
+        // an unknown ReferenceType can never be AliasFor or a subtype of it
+        return false;
+    }
+    if (!aliasFor) {
+        // c8 ignore next: AliasFor is a standard ReferenceType, always present
+        return true;
+    }
+    return candidate.nodeId.value === aliasFor.nodeId.value || candidate.isSubtypeOf(aliasFor);
 }
 
 /**
@@ -197,9 +223,22 @@ export function makeFindAliasHandler(options: FindAliasBindingOptions, verbose: 
             return { statusCode: StatusCodes.BadInvalidArgument };
         }
 
+        const referenceTypeFilter = readReferenceTypeFilter(inputArguments);
+        // clause 6.3.2 Table 3 / clause 8.2: ReferenceTypeFilter must be
+        // AliasFor or a subtype of it (null means "all"). A per-argument
+        // BadInvalidArgument is reported alongside the operation-level one,
+        // mirroring verifyArguments_ArgumentList in node-opcua-address-space
+        // (CTT AliasName Base Err-004).
+        if (!isValidReferenceTypeFilter(category, referenceTypeFilter)) {
+            return {
+                statusCode: StatusCodes.BadInvalidArgument,
+                inputArgumentResults: [StatusCodes.Good, StatusCodes.BadInvalidArgument]
+            };
+        }
+
         const query: AliasQuery = {
             pattern,
-            referenceTypeFilter: readReferenceTypeFilter(inputArguments),
+            referenceTypeFilter,
             categoryNodeId: category.nodeId,
             maxResults: options.maxResults,
             // Handed the same memoised closure the filter below uses, so the

--- a/packages/node-opcua-alias-name-server/source/bind_find_alias.ts
+++ b/packages/node-opcua-alias-name-server/source/bind_find_alias.ts
@@ -11,7 +11,7 @@
 
 import type { ISessionContext, UAMethod, UAObject } from "node-opcua-address-space-base";
 import { type AliasEntry, type AliasQuery, type IAliasStore, InvalidLikePatternError } from "node-opcua-alias-name-common";
-import { type NodeId, NodeId as NodeIdClass } from "node-opcua-nodeid";
+import { type NodeId, NodeId as NodeIdClass, sameNodeId } from "node-opcua-nodeid";
 import type { CallMethodResultOptions } from "node-opcua-service-call";
 import { StatusCodes } from "node-opcua-status-code";
 import { AliasNameDataType, AliasNameVerboseDataType } from "node-opcua-types";
@@ -97,7 +97,7 @@ function isValidReferenceTypeFilter(category: UAObject, filter: NodeId | undefin
         // c8 ignore next: AliasFor is a standard ReferenceType, always present
         return true;
     }
-    return candidate.nodeId.value === aliasFor.nodeId.value || candidate.isSubtypeOf(aliasFor);
+    return sameNodeId(candidate.nodeId, aliasFor.nodeId) || candidate.isSubtypeOf(aliasFor);
 }
 
 /**

--- a/packages/node-opcua-alias-name-server/test/test_find_alias.ts
+++ b/packages/node-opcua-alias-name-server/test/test_find_alias.ts
@@ -158,11 +158,19 @@ describe("OPC 10000-17: FindAlias", () => {
                     aliasNames(result).should.eql(["FIT-101", "LSH-201", "TI101"]);
                 });
 
-                it("should exclude aliases linked by an unrelated ReferenceType", async () => {
+                it("should reject a ReferenceTypeFilter that is not AliasFor or a subtype of it", async () => {
+                    // clause 6.3.2 Table 3 / clause 8.2 (CTT AliasName Base Err-004):
                     // Organizes is not AliasFor nor a subtype of it
                     const organizes = addressSpace.findReferenceType("Organizes")!;
                     const result = await callFind(tagVariables, methodName, "%", organizes.nodeId);
-                    resultAliases(result).should.have.length(0);
+                    should(result.statusCode).eql(StatusCodes.BadInvalidArgument);
+                });
+
+                it("should reject HasComponent as a ReferenceTypeFilter (CTT AliasName Base Err-004)", async () => {
+                    const hasComponent = addressSpace.findReferenceType("HasComponent")!;
+                    const result = await callFind(tagVariables, methodName, "TI101", hasComponent.nodeId);
+                    should(result.statusCode).eql(StatusCodes.BadInvalidArgument);
+                    should(result.inputArgumentResults).eql([StatusCodes.Good, StatusCodes.BadInvalidArgument]);
                 });
             });
         }


### PR DESCRIPTION
## Why

The OPC Foundation CTT 1.05.513 test `AliasName / AliasName Base / Err-004.js`
calls `FindAlias` on the `Aliases` object with an existing AliasName's
BrowseName as `AliasNameSearchPattern` and `HasComponent` (i=47) as
`ReferenceTypeFilter`, expecting `OperationResults = Bad_InvalidArgument`.

Per OPC 10000-17 clause 6.3.2 Table 3 and clause 8.2, `ReferenceTypeFilter`
must be `AliasFor` or a subtype of it — `null`/absent means "no filtering".
`node-opcua-alias-name-server`'s `FindAlias`/`FindAliasVerbose` accepted any
`ReferenceTypeFilter` NodeId and, for one that was neither `AliasFor` nor a
subtype (e.g. `HasComponent`), simply reported an empty match list with
`Good` instead of rejecting the call. `add_alias.ts` already enforces this
same clause 8.2 rule when an alias is *created*; `FindAlias` was missing the
equivalent check on the *read* side.

## What

- `packages/node-opcua-alias-name-server/source/bind_find_alias.ts`
  - Added `isValidReferenceTypeFilter(category, filter)`, resolving the
    filter against the address space's reference-type hierarchy the same
    way `coerceReferenceType` in `add_alias.ts` does (`nodeId` equality or
    `isSubtypeOf(AliasFor)`); a filter NodeId the address space cannot
    resolve is rejected too.
  - In `makeFindAliasHandler`, reject a filter that fails this check before
    building the store query: return `statusCode: BadInvalidArgument` at
    the operation level with `inputArgumentResults: [Good, BadInvalidArgument]`
    marking the `ReferenceTypeFilter` argument (index 1) — the same
    per-argument-result pattern `verifyArguments_ArgumentList` in
    `node-opcua-address-space` uses for method-call argument validation.
  - `null`/absent `ReferenceTypeFilter`, `AliasFor` itself, and any subtype
    of `AliasFor` are unaffected and keep returning `Good`.

- `packages/node-opcua-alias-name-server/test/test_find_alias.ts`
  - Changed the existing "should exclude aliases linked by an unrelated
    ReferenceType" case (filter = `Organizes`) to expect
    `BadInvalidArgument` instead of a `Good` empty result, matching the
    corrected behaviour.
  - Added "should reject HasComponent as a ReferenceTypeFilter (CTT
    AliasName Base Err-004)", asserting both the operation-level
    `BadInvalidArgument` and the `inputArgumentResults` array, run for both
    `FindAlias` and `FindAliasVerbose` (the suite already parametrises both
    bindings from one handler).
  - The `AliasFor`-itself, null-filter ("match everything"), and
    subtype-of-`AliasFor` cases were already covered by existing tests and
    needed no changes.

The other `Err-*.js` scripts in the same Test Cases folder (`Err-001`,
`Err-002`, `Err-003`) all pass malformed `Like` patterns (`"A["`, `"A\\"`,
`"A\\\\\\"`) with `ReferenceTypeFilter = AliasFor`, expecting
`Bad_InvalidArgument` for the pattern syntax error — already covered by the
existing "invalid search pattern" / "dangling escape" tests via
`InvalidLikePatternError`, so no server change was needed there.

## Verification

- `pnpm run build:all` at the worktree root — exit 0.
- `packages/node-opcua-alias-name-server`: `pnpm run test` — **205 passing**,
  0 failing (includes the 2 new/updated `FindAlias`/`FindAliasVerbose`
  ReferenceTypeFilter cases).
- `pnpm run check:shortcircuit` — 3282 files scanned, no assertion sits
  behind an optional chain.
- `pnpm run lint:ci` at the repo root — clean (biome: 1696 files, no fixes
  applied; all `check:*` scripts pass, including mocharc, dependency-cycle,
  and private-key-usage ratchets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
