### PR TITLE
fix(server): a deadband under the StatusValueTimestamp trigger behaves as StatusValue (FEAT-52)

### DIFF
--- a/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_issue_214_StatusValueTimestamp.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_issue_214_StatusValueTimestamp.ts
@@ -1,4 +1,3 @@
-import "should";
 import {
     AttributeIds,
     DataChangeFilter,
@@ -13,12 +12,14 @@ import {
 } from "node-opcua";
 import type { UAVariableImpl } from "node-opcua-address-space/impl/ua_variable_impl.js";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import should from "should";
 import { perform_operation_on_subscription_async } from "../../test_helpers/perform_operation_on_client_session.js";
 import type { UmbrellaTestContext } from "./_helper_umbrella.js";
 
 export function t(test: UmbrellaTestContext) {
     describe("NXX1 Testing issue #214 - DataChangeTrigger.StatusValueTimestamp", () => {
-        it("#214 - DataChangeTrigger.StatusValueTimestamp", async () => {
+        // the variable value never changes: only its SourceTimestamp is refreshed
+        async function countNotifications(filter: DataChangeFilter): Promise<number> {
             const nodeId = "ns=2;s=Static_Scalar_Double";
             const variable = test.server!.engine.addressSpace!.findNode(nodeId) as unknown as UAVariableImpl;
             const variant = new Variant({ dataType: DataType.Double, value: 3.14 });
@@ -43,11 +44,6 @@ export function t(test: UmbrellaTestContext) {
 
             try {
                 await perform_operation_on_subscription_async(client, endpointUrl, async (_session, subscription) => {
-                    const filter = new DataChangeFilter({
-                        trigger: DataChangeTrigger.StatusValueTimestamp,
-                        deadbandType: DeadbandType.Absolute,
-                        deadbandValue: 1.0
-                    });
                     const itemToMonitor = { nodeId, attributeId: AttributeIds.Value };
                     const parameters = { samplingInterval: 100, discardOldest: false, queueSize: 10000, filter };
 
@@ -61,7 +57,32 @@ export function t(test: UmbrellaTestContext) {
             } finally {
                 clearInterval(timerId);
             }
-            nbChanges.should.be.above(5);
+            return nbChanges;
+        }
+
+        it("#214 - DataChangeTrigger.StatusValueTimestamp - a SourceTimestamp change is reported when no Deadband is set", async () => {
+            const nbChanges = await countNotifications(
+                new DataChangeFilter({
+                    trigger: DataChangeTrigger.StatusValueTimestamp,
+                    deadbandType: DeadbandType.None,
+                    deadbandValue: 0
+                })
+            );
+            should(nbChanges).be.above(5);
+        });
+
+        it("#214 - DataChangeTrigger.StatusValueTimestamp - a Deadband makes it behave as STATUS_VALUE", async () => {
+            // OPC 10000-4 (1.05) 7.22.2, STATUS_VALUE_TIMESTAMP_2:
+            //   "If a Deadband filter is specified, this trigger has the same behaviour as STATUS_VALUE_1."
+            // so a timestamp-only refresh must NOT be reported here: only the initial value is.
+            const nbChanges = await countNotifications(
+                new DataChangeFilter({
+                    trigger: DataChangeTrigger.StatusValueTimestamp,
+                    deadbandType: DeadbandType.Absolute,
+                    deadbandValue: 1.0
+                })
+            );
+            should(nbChanges).be.belowOrEqual(2);
         });
     });
 }

--- a/packages/node-opcua-server/source/monitored_item.ts
+++ b/packages/node-opcua-server/source/monitored_item.ts
@@ -193,11 +193,9 @@ function valueHasChanged(
 }
 
 function timestampHasChanged(t1: DateTime, t2: DateTime): boolean {
-    if (t1 || !t2 || t2 || !t1) {
-        return true;
-    }
     if (!t1 || !t2) {
-        return false;
+        // one of them is null/undefined: a change only if the other one is set
+        return !!t1 !== !!t2;
     }
     return (t1 as Date).getTime() !== (t2 as Date).getTime();
 }
@@ -264,8 +262,12 @@ function apply_dataChange_filter(this: MonitoredItem, newDataValue: DataValue, o
             //              If the DataChangeFilter is not applied to the monitored item, STATUS_VALUE_1
             //              is the default reporting behavior
             assert(trigger === DataChangeTrigger.StatusValueTimestamp);
+            // OPC 10000-4 (1.05) 7.22.2, DataChangeTrigger STATUS_VALUE_TIMESTAMP_2:
+            //   "If a Deadband filter is specified, this trigger has the same behaviour as STATUS_VALUE_1."
+            // So the SourceTimestamp is only a trigger when no Deadband is in effect.
+            const deadbandInEffect = this.filter.deadbandType !== DeadbandType.None;
             return (
-                timestampHasChanged(newDataValue.sourceTimestamp, oldDataValue.sourceTimestamp) ||
+                (!deadbandInEffect && timestampHasChanged(newDataValue.sourceTimestamp, oldDataValue.sourceTimestamp)) ||
                 statusCodeHasChanged(newDataValue, oldDataValue) ||
                 valueHasChanged.call(this, newDataValue, oldDataValue, this.filter.deadbandType, this.filter.deadbandValue)
             );

--- a/packages/node-opcua-server/test/test_monitored_item.ts
+++ b/packages/node-opcua-server/test/test_monitored_item.ts
@@ -1654,9 +1654,120 @@ describe("MonitoredItem with DataChangeFilter", () => {
 
             // f.Repeat the last step, but also specify a timestamp that is * now *.Call Publish().
             // f.All service / operation results are Good.The Publish() call yields a KeepAlive.
+            // OPC 10000-4 (1.05) 7.22.2: with a Deadband, STATUS_VALUE_TIMESTAMP_2 behaves like
+            // STATUS_VALUE_1, so a new SourceTimestamp alone is not a data change.
             writeVQT(-100, StatusCodes.Good, date2);
-            q(monitoredItem).should.eql([-100, -100, -100, -100]);
-            f(monitoredItem).should.eql([o, X, o, o]);
+            q(monitoredItem).should.eql([-100, -100, -100]);
+            f(monitoredItem).should.eql([o, X, o]);
         }
+    });
+
+    it("ctt DataAccess PercentDeadBand 017 - STATUS_VALUE_TIMESTAMP with a PercentDeadband behaves as STATUS_VALUE", () => {
+        /*  CreateMonitoredItems for all available numeric Analog types specifying a DeadbandPercent of 10,
+            and a filter of STATUS_VALUE_TIMESTAMP_2.
+                Write a value that is +20% than the value received. Call Publish() #2 -> DataChange
+                Write a value that is -11% than the value received. Call Publish() #3 -> DataChange
+                Write a value that is +10% than the value received. Call Publish() #4 -> KeepAlive
+                Write a value that is -1%  than the value received. Call Publish() #5 -> KeepAlive
+                Write a new SourceTimestamp, same value and status.  Call Publish() #6 -> KeepAlive
+                Write a new StatusCode, same value and timestamp.    Call Publish() #7 -> DataChange
+        */
+        const dataChangeFilter = new DataChangeFilter({
+            trigger: DataChangeTrigger.StatusValueTimestamp,
+            deadbandType: DeadbandType.Percent,
+            deadbandValue: 10
+        });
+
+        monitoredItem = createMonitoredItem({
+            clientHandle: 1,
+            samplingInterval: 100,
+            discardOldest: true,
+            queueSize: 100,
+            filter: dataChangeFilter,
+            monitoredItemId: 50
+        });
+        monitoredItem.$subscription = fakeSubscription;
+        monitoredItem.setNode(fakeNode);
+
+        // EURange is -100 .. 100 => a 10 percent deadband is 20 engineering units
+        const range = fakeNode.getChildByName("EURange").readValue().value.value;
+        range.low.should.eql(-100);
+        range.high.should.eql(100);
+
+        const t1 = new Date(2019, 10, 11, 10, 0, 0);
+        const t2 = new Date(2019, 10, 11, 10, 0, 1);
+        const t3 = new Date(2019, 10, 11, 10, 0, 2);
+        const t4 = new Date(2019, 10, 11, 10, 0, 3);
+        const t5 = new Date(2019, 10, 11, 10, 0, 4);
+        const t6 = new Date(2019, 10, 11, 10, 0, 5);
+        const t7 = new Date(2019, 10, 11, 10, 0, 6);
+
+        // Publish #1: the initial value is always reported
+        writeVQT(0, StatusCodes.Good, t1);
+        q(monitoredItem).should.eql([0]);
+
+        // Publish #2: +20% of EURange = +40 => 40, |40 - 0| = 40 > 20 => DataChange
+        writeVQT(40, StatusCodes.Good, t2);
+        q(monitoredItem).should.eql([0, 40]);
+
+        // Publish #3: -11% of EURange = -22 => 18, |18 - 40| = 22 > 20 => DataChange
+        writeVQT(18, StatusCodes.Good, t3);
+        q(monitoredItem).should.eql([0, 40, 18]);
+
+        // Publish #4: +10% of EURange = +20 => 38, |38 - 18| = 20, not > 20 => KeepAlive
+        writeVQT(38, StatusCodes.Good, t4);
+        q(monitoredItem).should.eql([0, 40, 18]);
+
+        // Publish #5: -1% of EURange = -2 => 36, |36 - 18| = 18 < 20 => KeepAlive
+        writeVQT(36, StatusCodes.Good, t5);
+        q(monitoredItem).should.eql([0, 40, 18]);
+
+        // Publish #6: a new SourceTimestamp only, same value and status => KeepAlive
+        writeVQT(36, StatusCodes.Good, t6);
+        q(monitoredItem).should.eql([0, 40, 18]);
+        f(monitoredItem).should.eql([o, o, o]);
+
+        // Publish #7: a new StatusCode, same value and timestamp => DataChange
+        writeVQT(36, StatusCodes.Bad, t6);
+        q(monitoredItem).should.eql([0, 40, 18, 36]);
+        f(monitoredItem).should.eql([o, o, o, X]);
+
+        // and a SourceTimestamp change on its own is still not a data change
+        writeVQT(36, StatusCodes.Bad, t7);
+        q(monitoredItem).should.eql([0, 40, 18, 36]);
+    });
+
+    it("DeadbandType.None - StatusValueTimestamp still reports a SourceTimestamp only change", () => {
+        // no Deadband is specified: the SourceTimestamp remains a trigger of its own
+        const dataChangeFilter = new DataChangeFilter({
+            trigger: DataChangeTrigger.StatusValueTimestamp,
+            deadbandType: DeadbandType.None,
+            deadbandValue: 0
+        });
+
+        monitoredItem = createMonitoredItem({
+            clientHandle: 1,
+            samplingInterval: 100,
+            discardOldest: true,
+            queueSize: 100,
+            filter: dataChangeFilter,
+            monitoredItemId: 50
+        });
+        monitoredItem.$subscription = fakeSubscription;
+        monitoredItem.setNode(fakeNode);
+
+        const date1 = new Date(2019, 10, 11);
+        const date2 = new Date(2019, 10, 12);
+
+        writeVQT(10, StatusCodes.Good, date1);
+        q(monitoredItem).should.eql([10]);
+
+        // same value, same status, same timestamp => no data change
+        writeVQT(10, StatusCodes.Good, date1);
+        q(monitoredItem).should.eql([10]);
+
+        // same value, same status, a new SourceTimestamp => data change
+        writeVQT(10, StatusCodes.Good, date2);
+        q(monitoredItem).should.eql([10, 10]);
     });
 });


### PR DESCRIPTION
# A PercentDeadband makes STATUS_VALUE_TIMESTAMP behave as STATUS_VALUE (CTT Data Access PercentDeadband 017)

## Why

CTT 1.05.513 `Data Access / Data Access PercentDeadBand / 017.js` creates a monitored item on
every static AnalogItem with `DataChangeFilter { trigger = STATUS_VALUE_TIMESTAMP_2,
deadbandType = PercentDeadband, deadbandValue = 10 }` and then walks seven Publishes:

| step | write | expected |
| --- | --- | --- |
| #2 | value +20 % of EURange | DataChange |
| #3 | value -11 % of EURange | DataChange |
| #4 | value +10 % of EURange | KeepAlive |
| #5 | value -1 % of EURange | KeepAlive |
| #6 | a new SourceTimestamp only, same Value and StatusCode | KeepAlive |
| #7 | a new StatusCode, same Value and SourceTimestamp | DataChange |

node-opcua sent a DataChange at #4, #5 and #6, and the CTT reported
`Publish: Received data change, but expected only keep alive!` at each.

**Adjudication: the CTT is right.** OPC 10000-4 (1.05) 7.22.2 *DataChangeFilter*, in the
table that defines the `DataChangeTrigger` enumeration, says of `STATUS_VALUE_TIMESTAMP_2`:

> "Report a notification if either StatusCode, value or the SourceTimestamp change.
> If a Deadband filter is specified, this trigger has the same behaviour as STATUS_VALUE_1.
> If the DataChangeFilter is not applied to the monitored item, STATUS_VALUE_1 is the
> default reporting behaviour."

and of `STATUS_VALUE_1`:

> "Report a notification if either the StatusCode or the value change. The Deadband filter
> can be used in addition for filtering value changes. This is the default setting if no
> filter is set."

The PercentDeadband itself is defined in the same clause as

> "DataChange if (absolute value of (last cached value - current value) >
> (deadbandValue/100.0) \* ((high-low) of EURange)))"

Three consequences, all of which node-opcua got wrong or right by accident:

1. Because a Deadband **is** specified here, the SourceTimestamp is not a trigger at all:
   step #6 must be a KeepAlive. node-opcua reported it.
2. The comparison is strictly `>`, so the +10 % step (exactly the deadband) is inside the
   band: step #4 must be a KeepAlive.
3. The reference is the *last cached* — i.e. last reported — value, not the last sampled
   one, so #5 is measured against the value reported at #3 (18 %, a difference of 9 %) and
   is also a KeepAlive. node-opcua already keeps `oldDataValue` only on enqueue, so this
   part was correct.

`apply_dataChange_filter` in `monitored_item.ts` already carried the spec sentence as a
comment ("If a Deadband filter is specified, this trigger has the same behavior as
STATUS_VALUE_1") but never implemented it: the `StatusValueTimestamp` branch OR-ed
`timestampHasChanged(...)` in unconditionally. And `timestampHasChanged` was itself dead:

```ts
if (t1 || !t2 || t2 || !t1) {
    return true;      // a tautology: every timestamp comparison answered "changed"
}
```

so `STATUS_VALUE_TIMESTAMP_2` reported *every* sample regardless of the filter — the
deadband, and the value and status comparisons behind it, were never consulted. That is
what made #4 and #5 fail as well as #6.

### 018 is a CTT script defect, not a node-opcua one

`018.js` is titled "Make sure that PercentDeadband filter treats a VQT filter as a VQ
filter only" and its six expectations are exactly the VQT-with-deadband semantics above.
But the filter it actually builds is

```js
items[i].Filter = Event.GetDataChangeFilter( DeadbandType.Percent, DEADBAND, DataChangeTrigger.Status );
```

— `STATUS_0`, not `STATUS_VALUE_TIMESTAMP_2`. `Event.GetDataChangeFilter(deadbandType,
deadbandValue, dataChangeTrigger)` (library/Base/Objects/event.js) passes the third
argument straight through as `Trigger`, and the sibling test `Monitored Item Services /
Monitor Value Change V2 / 034.js` pins the meaning of that constant: with
`DataChangeFilter(deadbandType = None, trigger = Status)` it expects the Publish that
follows a *value* write to be **empty**. So `DataChangeTrigger.Status` is `STATUS_0`, and
under it Part 4 requires

> "Report a notification ONLY if the StatusCode associated with the value changes."

018's Test 1 writes a new Value with an unchanged StatusCode and asserts it receives a
DataChange carrying that value. No conformant server can satisfy that: the write is not a
trigger at all. The script is unsatisfiable as written.

The observed symptom follows exactly. 018 never drains the initial data change (unlike
017, it has no "Publish #1" step), so with `QueueSize` 0 → 1 the one notification in the
queue is still the item's creation sample. Its first Publish therefore returns the value
the node held *before* Test 1 — the run 11739 log's `expected -159, got 97` — and
`Assert.CoercedEqual` fails on a stale value rather than on the missing notification.
`Assert.True(CurrentlyContainsData())` passes for the same reason, which is why the
failure reads as an ordering bug instead of a filter bug.

Nothing here is a server defect: reporting the first sample of a monitored item
unconditionally is required (Part 4 5.12.1), and suppressing a value-only change under
`STATUS_0` is required by the sentence above. 018 should pass `DataChangeTrigger.
StatusValueTimestamp` (matching its own description and expectations) and should call
Publish once after CreateMonitoredItems to consume the initial data change. Filed as
evidence for a Foundation issue; no code change on our side.

## What

**`packages/node-opcua-server/source/monitored_item.ts`**

- `timestampHasChanged` no longer short-circuits to `true` for every pair. It answers
  `!!t1 !== !!t2` when either side is null/undefined and compares `getTime()` otherwise.
- `apply_dataChange_filter`, `DataChangeTrigger.StatusValueTimestamp` branch: the
  SourceTimestamp is only OR-ed in when `filter.deadbandType === DeadbandType.None`. With
  a Deadband in effect the branch is now literally the `StatusValue` one, as 7.22.2
  requires. The spec sentence is quoted at the site.

**`packages/node-opcua-server/test/test_monitored_item.ts`**

- `ctt DataAccess PercentDeadBand 018` had encoded the bug: its step (f), whose own
  comment says "The Publish() call yields a KeepAlive", asserted the queue *grew* on a
  SourceTimestamp-only write. Corrected to the KeepAlive the comment (and the spec) call
  for.
- New `ctt DataAccess PercentDeadBand 017 …`: the seven steps of 017 against an EURange of
  -100..100 with a 10 % deadband (= 20 EU), including the exactly-at-the-deadband step #4
  that must not report, the timestamp-only step #6, and the StatusCode-only step #7 that
  must.
- New `DeadbandType.None - StatusValueTimestamp still reports a SourceTimestamp only
  change`: the guard is on the Deadband, not on the trigger — with no Deadband the
  SourceTimestamp remains a trigger of its own, which is what CTT `Attribute Write
  StatusCode & TimeStamp` 010/011 exercise.

## Verification

- `packages/node-opcua-server`: `npx mocha test/test_monitored_item.ts` — **35 passing, 0
  failing** (32 before, plus the two new cases and the corrected 018).
- The monitored-item and subscription suites together —
  `test_monitored_item.ts`, `test_subscription.ts`,
  `test_subscription_with_monitored_items.ts`,
  `test_subscription_with_monitored_items_limits.ts`,
  `test_subscription_with_monitored_items_boolean_string_bytestring.ts` — **126 passing, 0
  failing**.
- `pnpm run lint:ci` at the repo root: exit 0 (biome plus every `check:*` job).
- `pnpm run check:shortcircuit`: 3282 files scanned, clean.
- `node tools/check-test-ports.mjs --summary`: OK (the new tests open no sockets).
- `pnpm run build:all`: exit 0.
- Not run: the whole `node-opcua-server` package suite. It aborts at load time in a fresh
  worktree with `expecting certificate store at …/packages/node-opcua-samples/certificates`;
  reproduced identically with the change stashed, so it is an environment prerequisite,
  not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
