### PR TITLE
fix: the SemanticsChanged bit follows every semantics-bearing Property write (FEAT-50)

### DIFF
--- a/packages/node-opcua-address-space/impl/data_access/semantics_changed.ts
+++ b/packages/node-opcua-address-space/impl/data_access/semantics_changed.ts
@@ -1,0 +1,102 @@
+/**
+ * @module node-opcua-address-space
+ *
+ * OPC 10000-8 (Data Access) 5.2: some Properties of a DataItem carry the *meaning* of its
+ * value rather than the value itself. When one of them changes, a client that has cached the
+ * old meaning would misinterpret every subsequent value, so the Server has to say so: the
+ * next data change notification of the DataItem carries the SemanticsChanged bit of
+ * OPC 10000-4 7.39.
+ *
+ * The address space side of that is `UAVariable#handle_semantic_changed()`, which bumps
+ * `semantic_version`; the MonitoredItem watches that counter. What was missing is the wiring
+ * between a Property and its DataItem: the `addAnalogDataItem` / `addTwoStateDiscrete` /
+ * `addMultiStateDiscrete` helpers each attached a "value_changed" listener by hand, so only a
+ * node built through one of those helpers was covered. A DataItem instantiated from its
+ * VariableType, loaded from a NodeSet, or assembled property by property (which is the only
+ * way to build the ArrayItemType subtypes) had none, and its EURange could be written without
+ * any notification ever carrying the bit.
+ *
+ * So the relation is resolved from the Property instead, at the moment its value changes:
+ * a Property named after one of the semantics-bearing Properties below, whose parent is a
+ * DataItem, notifies that parent. That covers every way a DataItem can come into existence,
+ * and needs no bookkeeping at construction time - which is what defeated a creation-time hook,
+ * since a hand-built DataItem gets its Properties *after* the Variable itself.
+ */
+import type { UAVariable, UAVariableType } from "node-opcua-address-space-base";
+import { VariableTypeIds } from "node-opcua-constants";
+import { NodeClass } from "node-opcua-data-model";
+import { resolveNodeId } from "node-opcua-nodeid";
+
+/**
+ * the Properties whose value carries the semantics of the DataItem they belong to.
+ *
+ * DataItemType             : Definition, ValuePrecision
+ * AnalogItemType/UnitType  : EURange, InstrumentRange, EngineeringUnits
+ * ArrayItemType (+subtypes): Title, AxisScaleType, XAxisDefinition, YAxisDefinition, ZAxisDefinition
+ * TwoStateDiscreteType     : TrueState, FalseState
+ * MultiStateDiscreteType   : EnumStrings
+ * MultiStateValueDiscrete  : EnumValues
+ */
+const semanticsBearingProperties = new Set<string>([
+    "AxisScaleType",
+    "Definition",
+    "EngineeringUnits",
+    "EURange",
+    "EnumStrings",
+    "EnumValues",
+    "FalseState",
+    "InstrumentRange",
+    "Title",
+    "TrueState",
+    "ValuePrecision",
+    "XAxisDefinition",
+    "YAxisDefinition",
+    "ZAxisDefinition"
+]);
+
+const dataItemTypeNodeId = resolveNodeId(VariableTypeIds.DataItemType);
+
+/**
+ * the DataItem whose semantics `property` carries, or null when `property` is not one of them.
+ *
+ * A positive answer is memoized on the Property; a negative one is not, because the name test
+ * that gates the lookup is a single Set hit and because a Property can be attached to its
+ * DataItem after its first value change.
+ */
+function semanticsOwnerOf(property: UAVariable): UAVariable | null {
+    const name = property.browseName.name;
+    if (!name || !semanticsBearingProperties.has(name)) {
+        return null;
+    }
+    const cache = property as UAVariable & { $$semanticsOwner?: UAVariable };
+    if (cache.$$semanticsOwner) {
+        return cache.$$semanticsOwner;
+    }
+    const parent = property.parent;
+    if (!parent || parent.nodeClass !== NodeClass.Variable) {
+        return null;
+    }
+    const dataItem = parent as UAVariable;
+    const typeDefinition = dataItem.typeDefinitionObj;
+    if (!typeDefinition || typeDefinition.nodeClass !== NodeClass.VariableType) {
+        return null;
+    }
+    const dataItemType = dataItem.addressSpace.findNode(dataItemTypeNodeId) as UAVariableType | null;
+    if (!dataItemType || !typeDefinition.isSubtypeOf(dataItemType)) {
+        return null;
+    }
+    cache.$$semanticsOwner = dataItem;
+    return dataItem;
+}
+
+/**
+ * called whenever a Variable's value really changed: if that Variable is a semantics-bearing
+ * Property of a DataItem, the DataItem's semantic_version is bumped so that the next data
+ * change notification of the DataItem carries the SemanticsChanged bit.
+ */
+export function notifySemanticsChangedIfNeeded(property: UAVariable): void {
+    const dataItem = semanticsOwnerOf(property);
+    if (dataItem) {
+        (dataItem as UAVariable & { handle_semantic_changed: (dataValue?: unknown) => void }).handle_semantic_changed();
+    }
+}

--- a/packages/node-opcua-address-space/impl/data_access/ua_multistate_discrete_impl.ts
+++ b/packages/node-opcua-address-space/impl/data_access/ua_multistate_discrete_impl.ts
@@ -128,8 +128,6 @@ export function promoteToMultiStateDiscrete<T, DT extends DataType>(node: UAVari
     _node._post_initialize();
 
     assert(_node.enumStrings.browseName.toString() === "EnumStrings");
-    const handler = _node.handle_semantic_changed.bind(_node);
-    _node.enumStrings.on("value_changed", handler);
     _node.install_extra_properties();
     return node as UAMultiStateDiscreteImpl<T, DT>;
 }

--- a/packages/node-opcua-address-space/impl/data_access/ua_two_state_discrete_impl.ts
+++ b/packages/node-opcua-address-space/impl/data_access/ua_two_state_discrete_impl.ts
@@ -32,13 +32,10 @@ export class UATwoStateDiscreteImplBase extends UAVariableImplT<boolean, DataTyp
     _post_initialize(): void {
         // The StatusCode SemanticsChanged bit shall be set if any of the FalseState or TrueState
         // (changes can cause misinterpretation by users or (scripting) programs) Properties are changed
-        // (see section 5.2 for additional information).
-        const handler = this.handle_semantic_changed.bind(this);
-
+        // (see section 5.2 for additional information). That is done generically in
+        // impl/data_access/semantics_changed.ts; all this has to do is warn about a missing Property.
         const falseState = this.getPropertyByName("FalseState");
-        if (falseState) {
-            falseState.on("value_changed", handler);
-        } else {
+        if (!falseState) {
             /* c8 ignore next */
             console.warn(
                 "warning: UATwoStateDiscrete -> a FalseState property is mandatory ",
@@ -47,9 +44,7 @@ export class UATwoStateDiscreteImplBase extends UAVariableImplT<boolean, DataTyp
             );
         }
         const trueState = this.getPropertyByName("TrueState");
-        if (trueState) {
-            trueState.on("value_changed", handler);
-        } else {
+        if (!trueState) {
             /* c8 ignore next */
             console.warn(
                 "waring: UATwoStateDiscrete -> a TrueState property is mandatory",
@@ -154,11 +149,10 @@ export function _addTwoStateDiscrete(namespace: INamespace, options: AddTwoState
     const dataValueVerif = variable.readValue();
     assert(dataValueVerif.value.dataType === DataType.Boolean);
     */
-    const handler = (variable as UAVariableImpl).handle_semantic_changed.bind(variable);
 
     add_dataItem_stuff(variable, options);
 
-    const trueStateNode = namespace.addVariable({
+    namespace.addVariable({
         browseName: { name: "TrueState", namespaceIndex: 0 },
         dataType: "LocalizedText",
         minimumSamplingInterval: 0,
@@ -171,9 +165,7 @@ export function _addTwoStateDiscrete(namespace: INamespace, options: AddTwoState
         })
     });
 
-    trueStateNode.on("value_changed", handler);
-
-    const falseStateNode = namespace.addVariable({
+    namespace.addVariable({
         browseName: { name: "FalseState", namespaceIndex: 0 },
         dataType: "LocalizedText",
         minimumSamplingInterval: 0,
@@ -186,8 +178,6 @@ export function _addTwoStateDiscrete(namespace: INamespace, options: AddTwoState
             value: coerceLocalizedText(options.falseState || "OFF")
         })
     });
-
-    falseStateNode.on("value_changed", handler);
 
     variable.install_extra_properties();
 

--- a/packages/node-opcua-address-space/impl/namespace_impl.ts
+++ b/packages/node-opcua-address-space/impl/namespace_impl.ts
@@ -1036,8 +1036,8 @@ export class NamespaceImpl implements NamespacePrivate {
 
         assert(euRange.readValue().value.value instanceof Range);
 
-        const handler = variable.handle_semantic_changed.bind(variable);
-        euRange.on("value_changed", handler);
+        // the SemanticsChanged wiring of EURange/InstrumentRange/EngineeringUnits is generic and
+        // lives in impl/data_access/semantics_changed.ts: it covers DataItems built any other way too.
 
         if (Object.hasOwn(options, "instrumentRange")) {
             const instrumentRangeExisting = variable.getPropertyByName("InstrumentRange") as UAVariableImpl | null;
@@ -1062,8 +1062,6 @@ export class NamespaceImpl implements NamespacePrivate {
                     StatusCodes.Good
                 );
             }
-
-            instrumentRange.on("value_changed", handler);
         }
         (variable as unknown as { acceptValueOutOfRange?: boolean }).acceptValueOutOfRange = options.acceptValueOutOfRange;
 
@@ -1096,8 +1094,6 @@ export class NamespaceImpl implements NamespacePrivate {
                     StatusCodes.Good
                 );
             }
-
-            eu.on("value_changed", handler);
         }
 
         variable.install_extra_properties();

--- a/packages/node-opcua-address-space/impl/ua_variable_impl.ts
+++ b/packages/node-opcua-address-space/impl/ua_variable_impl.ts
@@ -84,6 +84,7 @@ import { apply_condition_refresh, type ConditionRefreshCache } from "./apply_con
 import { BaseNodeImpl, type InternalBaseNodeOptions } from "./base_node_impl.js";
 import { _clone, ToStringBuilder, UAVariable_toString, valueRankToString } from "./base_node_private.js";
 import { adjustDataValueStatusCode } from "./data_access/adjust_datavalue_status_code.js";
+import { notifySemanticsChangedIfNeeded } from "./data_access/semantics_changed.js";
 import { _getBasicDataType } from "./get_basic_datatype.js";
 import { type EnumerationInfo, type IEnumItem, UADataTypeImpl } from "./ua_data_type_impl.js";
 import {
@@ -1964,6 +1965,15 @@ export class UAVariableImpl<T extends UAVariableEvents & ListenerSignature<T> = 
         }
 
         if (!sameDataValue(old_dataValue, dataValue)) {
+            // a Property that carries the semantics of a DataItem (EURange, TrueState, ...) has to make
+            // the DataItem's next notification carry the SemanticsChanged bit. Done from the Property
+            // rather than with a listener installed when the DataItem is built, because a hand-built
+            // DataItem gets its Properties after itself - see impl/data_access/semantics_changed.ts.
+            // ... but a Property receiving its first value is a Variable being built, not a
+            // semantics change: until then its StatusCode is UncertainInitialValue.
+            if (old_dataValue.statusCode.isGood()) {
+                notifySemanticsChangedIfNeeded(this as UAVariable);
+            }
             if (this.getBasicDataType() === DataType.ExtensionObject) {
                 const preciseClock = coerceClock(this.$dataValue.sourceTimestamp, this.$dataValue.sourcePicoseconds);
                 const cache: Set<UAVariable> = new Set();

--- a/packages/node-opcua-address-space/test/data_access/test_semantics_changed.ts
+++ b/packages/node-opcua-address-space/test/data_access/test_semantics_changed.ts
@@ -1,0 +1,169 @@
+/**
+ * OPC 10000-8 5.2 / OPC 10000-4 7.39: writing a Property that carries the semantics of a
+ * DataItem has to make the DataItem's next notification carry the SemanticsChanged bit.
+ *
+ * Only DataItems built through addAnalogDataItem() / addTwoStateDiscrete() used to be wired
+ * up, because the wiring was a listener installed by those helpers. These tests cover the
+ * other ways a DataItem exists: instantiated from its VariableType, and assembled Property by
+ * Property - which is the only way to build the ArrayItemType subtypes, and is what the CTT
+ * Data Access Semantic Changes 013-017 scripts exercise.
+ */
+import { Range, standardUnits } from "node-opcua-data-access";
+import { AttributeIds } from "node-opcua-data-model";
+import { DataValue } from "node-opcua-data-value";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { nodesets } from "node-opcua-nodesets";
+import { WriteValue } from "node-opcua-service-write";
+import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
+import should from "should";
+import { AddressSpace, type Namespace, SessionContext, type UAVariable } from "../../dist/api/index.js";
+import { generateAddressSpace } from "../../nodeJS.js";
+
+const context = SessionContext.defaultContext;
+
+async function writeProperty(property: UAVariable, value: Variant): Promise<void> {
+    const statusCode = await property.writeAttribute(
+        context,
+        new WriteValue({ attributeId: AttributeIds.Value, value: new DataValue({ value }) })
+    );
+    should(statusCode.isGood()).eql(true, `write of ${property.browseName.toString()} failed: ${statusCode.toString()}`);
+}
+
+const range = (low: number, high: number) => new Variant({ dataType: DataType.ExtensionObject, value: new Range({ low, high }) });
+
+describe("SemanticsChanged: the DataItem of a semantics-bearing Property", () => {
+    let addressSpace: AddressSpace;
+    let namespace: Namespace;
+
+    before(async () => {
+        addressSpace = AddressSpace.create();
+        addressSpace.registerNamespace("Private");
+        await generateAddressSpace(addressSpace, [nodesets.standard]);
+        namespace = addressSpace.getOwnNamespace();
+    });
+    after(async () => {
+        await addressSpace.shutdown();
+        addressSpace.dispose();
+    });
+
+    it("SC1 bumps semantic_version when EURange is written on an addAnalogDataItem() item", async () => {
+        const analog = namespace.addAnalogDataItem({
+            organizedBy: addressSpace.rootFolder.objects,
+            browseName: "SC1_Analog",
+            engineeringUnits: standardUnits.degree_celsius,
+            engineeringUnitsRange: { low: -100, high: 100 },
+            instrumentRange: { low: -200, high: 200 },
+            dataType: "Double",
+            value: { dataType: DataType.Double, value: 1 }
+        }) as unknown as UAVariable;
+
+        const before = analog.semantic_version;
+        await writeProperty(analog.getPropertyByName("EURange") as UAVariable, range(-50, 50));
+        // exactly one bump: the generic wiring must not double up with a per-property listener
+        should(analog.semantic_version).eql(before + 1);
+
+        await writeProperty(analog.getPropertyByName("InstrumentRange") as UAVariable, range(-150, 150));
+        should(analog.semantic_version).eql(before + 2);
+    });
+
+    it("SC2 bumps semantic_version when EURange is written on an instantiated AnalogItemType", async () => {
+        const analogItemType = addressSpace.findVariableType("AnalogItemType")!;
+        const analog = analogItemType.instantiate({
+            browseName: "SC2_Analog",
+            organizedBy: addressSpace.rootFolder.objects,
+            dataType: "Double",
+            optionals: ["InstrumentRange", "EngineeringUnits"]
+        }) as unknown as UAVariable;
+        analog.setValueFromSource(new Variant({ dataType: DataType.Double, value: 1 }));
+
+        const euRange = analog.getPropertyByName("EURange") as UAVariable;
+        should.exist(euRange);
+        // the instantiated Property is read-only by default; the CTT writes it
+        euRange.accessLevel = 3;
+        euRange.userAccessLevel = 3;
+        euRange.setValueFromSource(range(0, 100));
+
+        const before = analog.semantic_version;
+        await writeProperty(euRange, range(0, 90));
+        should(analog.semantic_version).eql(before + 1);
+    });
+
+    it("SC3 bumps semantic_version when a hand-built ArrayItemType Property is written", async () => {
+        // how the ArrayItemType subtypes have to be built: instantiate() refuses a ValueRank that
+        // differs from the type's, so the Properties are added one by one after the Variable.
+        const arrayItem = namespace.addVariable({
+            organizedBy: addressSpace.rootFolder.objects,
+            browseName: "SC3_YArrayItem",
+            typeDefinition: "YArrayItemType",
+            dataType: "Double",
+            valueRank: 1,
+            accessLevel: "CurrentRead | CurrentWrite",
+            userAccessLevel: "CurrentRead | CurrentWrite",
+            value: new Variant({ dataType: DataType.Double, arrayType: VariantArrayType.Array, value: [1, 2, 3] })
+        }) as unknown as UAVariable;
+
+        const property = (browseName: string, dataType: string, value: Variant) =>
+            namespace.addVariable({ propertyOf: arrayItem, browseName, dataType, value }) as unknown as UAVariable;
+
+        const title = property("Title", "LocalizedText", new Variant({ dataType: DataType.LocalizedText, value: { text: "t" } }));
+        const euRange = property("EURange", "Range", range(0, 100));
+
+        let expected = arrayItem.semantic_version;
+        await writeProperty(euRange, range(0, 90));
+        should(arrayItem.semantic_version).eql(++expected);
+
+        await writeProperty(title, new Variant({ dataType: DataType.LocalizedText, value: { text: "CTTt" } }));
+        should(arrayItem.semantic_version).eql(++expected);
+    });
+
+    it("SC4 bumps semantic_version when TrueState is written on a TwoStateDiscrete", async () => {
+        const twoState = namespace.addTwoStateDiscrete({
+            organizedBy: addressSpace.rootFolder.objects,
+            browseName: "SC4_TwoState",
+            trueState: "Open",
+            falseState: "Closed",
+            value: false
+        }) as unknown as UAVariable;
+
+        const before = twoState.semantic_version;
+        await writeProperty(
+            twoState.getPropertyByName("TrueState") as UAVariable,
+            new Variant({ dataType: DataType.LocalizedText, value: { text: "Opened" } })
+        );
+        should(twoState.semantic_version).eql(before + 1);
+    });
+
+    it("SC5 leaves semantic_version alone when the DataItem's own value changes", async () => {
+        const analog = namespace.addAnalogDataItem({
+            organizedBy: addressSpace.rootFolder.objects,
+            browseName: "SC5_Analog",
+            engineeringUnits: standardUnits.degree_celsius,
+            engineeringUnitsRange: { low: -100, high: 100 },
+            dataType: "Double",
+            value: { dataType: DataType.Double, value: 1 }
+        }) as unknown as UAVariable;
+
+        const before = analog.semantic_version;
+        analog.setValueFromSource(new Variant({ dataType: DataType.Double, value: 42 }));
+        should(analog.semantic_version).eql(before);
+    });
+
+    it("SC6 leaves semantic_version alone for a same-named Property of a plain variable", async () => {
+        const plain = namespace.addVariable({
+            organizedBy: addressSpace.rootFolder.objects,
+            browseName: "SC6_Plain",
+            dataType: "Double",
+            value: new Variant({ dataType: DataType.Double, value: 1 })
+        }) as unknown as UAVariable;
+        const title = namespace.addVariable({
+            propertyOf: plain,
+            browseName: "Title",
+            dataType: "LocalizedText",
+            value: new Variant({ dataType: DataType.LocalizedText, value: { text: "t" } })
+        }) as unknown as UAVariable;
+
+        const before = plain.semantic_version;
+        await writeProperty(title, new Variant({ dataType: DataType.LocalizedText, value: { text: "other" } }));
+        should(plain.semantic_version).eql(before);
+    });
+});

--- a/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_monitored_item_semantic_changed.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_monitored_item_semantic_changed.ts
@@ -1,13 +1,15 @@
-import "should";
 import {
     AttributeIds,
     type ClientSession,
     type ClientSessionPublishService,
     type ClientSessionRawSubscriptionService,
     CreateMonitoredItemsRequest,
+    DataChangeFilter,
     type DataChangeNotification,
+    DataChangeTrigger,
     DataType,
     DataValue,
+    DeadbandType,
     type MonitoredItemNotification,
     MonitoringMode,
     MonitoringParameters,
@@ -22,6 +24,7 @@ import {
     TimestampsToReturn
 } from "node-opcua";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import should from "should";
 import { perform_operation_on_raw_subscription } from "../../test_helpers/perform_operation_on_client_session.js";
 
 interface TestHarness {
@@ -166,6 +169,55 @@ export function t(test: TestHarness) {
                 }
             );
         }
+
+        /**
+         * CTT Data Access AnalogItemType 008: the item carries an absolute deadband of 10 and the
+         * initial data change has already been consumed, so nothing but the semantic change can
+         * produce the notification the script then publishes for. The DataChangeFilter must not
+         * swallow it, and it has to be produced although the value itself never changed.
+         */
+        it("YY4 semanticChanged reaches an item with a deadband filter and no value change", async () => {
+            const analogNodeId = "ns=2;s=DoubleAnalogDataItem";
+
+            await perform_operation_on_raw_subscription(client, test.endpointUrl, async (session, { subscriptionId }) => {
+                const orgEURange = await readEURange(session, analogNodeId);
+
+                const createReq = new CreateMonitoredItemsRequest({
+                    subscriptionId,
+                    timestampsToReturn: TimestampsToReturn.Both,
+                    itemsToCreate: [
+                        {
+                            itemToMonitor: new ReadValueId({ attributeId: AttributeIds.Value, nodeId: analogNodeId }),
+                            monitoringMode: MonitoringMode.Reporting,
+                            requestedParameters: new MonitoringParameters({
+                                clientHandle: 1001,
+                                samplingInterval: 100,
+                                queueSize: 10,
+                                discardOldest: true,
+                                filter: new DataChangeFilter({
+                                    trigger: DataChangeTrigger.StatusValue,
+                                    deadbandType: DeadbandType.Absolute,
+                                    deadbandValue: 10
+                                })
+                            })
+                        }
+                    ]
+                });
+                const createResponse = await (session as RawSession).createMonitoredItems(createReq);
+                should(createResponse.results?.[0].statusCode).eql(StatusCodes.Good);
+
+                // consume the initial data change, as the script does
+                const firstNotif = await getNextDataChangeNotification(session);
+                firstNotif.value.statusCode.hasSemanticChangedBit.should.eql(false);
+
+                await writeEURange(session, analogNodeId, { low: orgEURange.low + 1, high: orgEURange.high - 1 });
+
+                const secondNotif = await getNextDataChangeNotification(session);
+                secondNotif.value.statusCode.hasSemanticChangedBit.should.eql(true);
+
+                await writeEURange(session, analogNodeId, orgEURange);
+            });
+        });
 
         it("YY3 semanticChanged with sampling 1000ms", async () => {
             await checkSemanticChange(1000);

--- a/packages/node-opcua-server/source/monitored_item.ts
+++ b/packages/node-opcua-server/source/monitored_item.ts
@@ -1084,7 +1084,6 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
 
         if (this._semantic_changed_callback) {
             assert(typeof this._semantic_changed_callback === "function");
-            assert(!this._samplingId);
             (this.node as UAVariable).removeListener("semantic_changed", this._semantic_changed_callback);
             this._semantic_changed_callback = null;
         }
@@ -1173,7 +1172,9 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
         if (!this.node) {
             throw new Error("_on_semantic_changed: expecting a valid node");
         }
-        const dataValue: DataValue = (this.node as UAVariable).readValue();
+        // readValue() hands out the node's own DataValue: recordValue stores what it is given, so
+        // a clone is required or the queue would alias the node's live value.
+        const dataValue: DataValue = (this.node as UAVariable).readValue().clone();
         this._on_value_changed(dataValue);
     }
 
@@ -1303,16 +1304,22 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
             return;
         }
 
+        // A semantic change is not a value change: a sampled item would only notice it at its next
+        // tick, and OPC 10000-4 7.39 wants the *next* notification to carry the SemanticsChanged bit.
+        // CTT Data Access AnalogItemType 008 publishes right after writing EURange, so the item is
+        // told about the change as it happens, whether it is sampled or exception-based.
+        if (!this._semantic_changed_callback && this.node.nodeClass === NodeClass.Variable) {
+            this._semantic_changed_callback = this._on_semantic_changed.bind(this);
+            this.node.on("semantic_changed", this._semantic_changed_callback);
+        }
+
         if (this._exceptionBased) {
             // we have a exception-based dataItem : event based model, so we do not need a timer
             // rather , we setup the "value_changed_event"; samplingInterval is the coalescing window
             if (!this._value_changed_callback) {
-                assert(!this._semantic_changed_callback);
                 this._value_changed_callback = this._on_value_changed_exception_based.bind(this);
-                this._semantic_changed_callback = this._on_semantic_changed.bind(this);
                 if (this.node.nodeClass === NodeClass.Variable) {
                     this.node.on("value_changed", this._value_changed_callback);
-                    this.node.on("semantic_changed", this._semantic_changed_callback);
                 }
             }
 


### PR DESCRIPTION
# fix(data-access): the SemanticsChanged bit reaches every DataItem, not only the ones a helper built

## Why

OPC 10000-8 5.2 and OPC 10000-4 7.39: some Properties of a DataItem carry the *meaning* of
its value rather than the value itself (EURange, EngineeringUnits, InstrumentRange, Title,
TrueState/FalseState, EnumStrings, …). When one of them is written, the DataItem's next data
change notification has to carry the SemanticsChanged bit (0x4000) in its StatusCode, so that a
client which cached the old meaning stops misreading every subsequent value.

The counter that drives this (`UAVariable#semantic_version`, bumped by `handle_semantic_changed`)
and the MonitoredItem that watches it were both already there. What was missing was the wiring
between a Property and its DataItem: `addAnalogDataItem()`, `addTwoStateDiscrete()` and
`addMultiStateDiscrete()` each attached a `"value_changed"` listener **by hand**, so only a node
built through one of those helpers was ever covered. A DataItem instantiated from its
VariableType, loaded from a NodeSet, or assembled Property by Property - which is the only way to
build the ArrayItemType subtypes, since `instantiate()` refuses a ValueRank that differs from the
type's - had no wiring at all. Its EURange could be written and no notification ever carried the
bit.

A creation-time hook cannot fix that: a hand-built DataItem gets its Properties *after* the
Variable itself exists, so at the moment the Variable is created there is nothing to listen to.

Second half of the defect, on the server side: the `semantic_changed` listener was installed only
for exception-based monitored items. A timer-sampled item noticed a semantic change at its next
tick at the earliest - and the CTT publishes immediately after the write.

CTT 1.05.513 failures this closes: Data Access AnalogItemType 008 and Data Access Semantic
Changes 003/004/005/010/013 (warnings 014-017), all of them
`Expected the SemanticChanged bit = TRUE … Expected <16384> but got <0>`.

## What

**`packages/node-opcua-address-space/impl/data_access/semantics_changed.ts`** (new)
Resolves the relation from the Property instead of the DataItem, lazily, at the moment the
Property's value changes: a Property named after one of the Part-8 semantics-bearing Properties,
whose parent is a Variable whose type definition is a subtype of `DataItemType`, notifies that
parent. Covers every way a DataItem can come into existence and needs no bookkeeping at
construction time. The name test is a single `Set` hit, so the type-hierarchy walk runs only for
the fourteen known names; a positive answer is memoized on the Property, a negative one is not
(a Property can be attached to its DataItem after its first value change).

**`packages/node-opcua-address-space/impl/ua_variable_impl.ts`**
Calls it from `_inner_replace_dataValue`, the one point both the Write service and
`setValueFromSource` pass through, inside the existing "the value really changed" test. Guarded
on the *old* StatusCode being Good: a Property receiving its first value is a Variable being
built (its StatusCode is `UncertainInitialValue` until then), not a semantics change.

**`impl/namespace_impl.ts`, `impl/data_access/ua_two_state_discrete_impl.ts`,
`impl/data_access/ua_multistate_discrete_impl.ts`**
Drop the hand-installed per-Property `"value_changed"` listeners, now redundant - leaving them
would bump `semantic_version` twice for the nodes they covered. `_post_initialize()` of
UATwoStateDiscrete keeps only its "this mandatory Property is missing" warnings.

**`packages/node-opcua-server/source/monitored_item.ts`**
Installs the `semantic_changed` listener for every monitored item on a Variable, not just
exception-based ones, so a sampled item is told about the change as it happens rather than at its
next tick. `_on_semantic_changed` now clones the DataValue it reads (`readValue()` hands out the
node's own object, and `recordValue` stores what it is given). `_stop_sampling` no longer asserts
`!_samplingId` when removing that listener - a sampled item legitimately has both now.

The path that puts the bit on the wire was already correct and is unchanged: `recordValue`
enqueues on a semantic change *before* the change test and before `apply_filter`, so the
notification is produced although the value never changed and although a DataChangeFilter with a
deadband is in force (CTT AnalogItemType 008 needs both).

**`packages/node-opcua-address-space/test/data_access/test_semantics_changed.ts`** (new)
Six cases: EURange/InstrumentRange on an `addAnalogDataItem()` item (and exactly one bump per
write, which is what proves the old and new wiring do not double up); EURange on an
`AnalogItemType.instantiate()`d item; EURange and Title on a hand-built `YArrayItemType`;
TrueState on a TwoStateDiscrete; and two negatives - the DataItem's own value changing, and a
`Title` Property hanging off a plain BaseDataVariable.

**`packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_monitored_item_semantic_changed.ts`**
Adds YY4, the CTT AnalogItemType 008 sequence over the wire: an absolute deadband of 10, the
initial data change consumed, then a write to EURange and a publish - the notification must arrive
and carry the bit, with no value change to carry it.

## Verification

- `packages/node-opcua-address-space`: full suite 1348 passing, 1 pending, 0 failing (the new
  `test/data_access/test_semantics_changed.ts` is 6 of them).
- `packages/node-opcua-server`: full suite 530 passing, 0 failing.
- `packages/node-opcua-end2end-test` umbrella series C, `--grep SemanticChanged`: 4 passing
  (YY1/YY2/YY3 unchanged, YY4 new).
- `npx tsc -b packages` clean.
- `pnpm run lint:ci` at the repo root: green.
- `pnpm run check:shortcircuit`: 3284 files, no assertion behind an optional chain.
- `node tools/check-test-ports.mjs --summary`: OK, nothing unaccounted for (no new ports).
- CTT replay against the conformance server is done separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
