### PR TITLE
feat(address-space): publish the alarm extension points

### DIFF
--- a/packages/node-opcua-address-space/api/interfaces/alarms_and_conditions/ua_alarm_condition_ex.ts
+++ b/packages/node-opcua-address-space/api/interfaces/alarms_and_conditions/ua_alarm_condition_ex.ts
@@ -1,4 +1,5 @@
 import type { BaseNode, ListenerSignature, UAVariable } from "node-opcua-address-space-base";
+import type { DataValue } from "node-opcua-data-value";
 import type { NodeId } from "node-opcua-nodeid";
 import type { UAAlarmCondition_Base } from "node-opcua-nodeset-ua";
 import type { UATwoStateVariableEx } from "../../ua_two_state_variable_ex.js";
@@ -51,6 +52,38 @@ export interface UAAlarmConditionHelper extends UAAcknowledgeableConditionHelper
         value: string,
         oldConditionInfo: ConditionInfo
     ): ConditionInfo;
+
+    /**
+     * What the alarm does when the value of its input node changes. Assign to it to give an
+     * alarm a behaviour of its own, without deriving from an implementation class:
+     *
+     * ```ts
+     * alarm.onInputDataValueChange = (newValue) => {
+     *     const tooHot = newValue.value.value > 80;
+     *     if (tooHot !== alarm.activeState.getValue()) {
+     *         alarm.signalNewCondition(tooHot ? "Active" : "Inactive", tooHot, `${newValue.value.value}`);
+     *     }
+     * };
+     * ```
+     *
+     * The default does nothing: a plain AlarmConditionType cannot know what its input means.
+     * Alarm types that do know (limit alarms, off-normal alarms) already define it, so
+     * assigning to one of those replaces the behaviour it came with.
+     *
+     * The old name `_onInputDataValueChange` still works and is deprecated.
+     */
+    onInputDataValueChange(newValue: DataValue): void;
+
+    /**
+     * Raise a new condition event for this alarm, moving it to the given state.
+     *
+     * Call this only when the condition has actually changed: it throws when the ConditionInfo
+     * it computes is equal to the current one, because an event that reports nothing new is a
+     * bug in the caller rather than a state the alarm can represent.
+     *
+     * The old name `_signalNewCondition` still works and is deprecated.
+     */
+    signalNewCondition(stateName: string | null, isActive: boolean, value: string): void;
 }
 
 export interface UALarmConditionEvents extends UAAcknowledgeableConditionEvents {}

--- a/packages/node-opcua-address-space/api/interfaces/alarms_and_conditions/ua_limit_alarm_ex.ts
+++ b/packages/node-opcua-address-space/api/interfaces/alarms_and_conditions/ua_limit_alarm_ex.ts
@@ -12,6 +12,24 @@ export interface UALimitAlarmHelper extends UAAlarmConditionHelper {
     getHighLimit(): number;
     getLowLimit(): number;
     getLowLowLimit(): number;
+
+    /**
+     * How the alarm turns the value of its input node into limit states. Assign to it to give
+     * a limit alarm a rule of its own:
+     *
+     * ```ts
+     * alarm.setStateBasedOnInputValue = (value) => {
+     *     const isActive = value > alarm.getHighLimit();
+     *     alarm.signalNewCondition(isActive ? "High" : null, isActive, value.toFixed(3));
+     * };
+     * ```
+     *
+     * Every concrete limit alarm type already defines this, so assigning to one replaces the
+     * rule it came with; the base LimitAlarmType has no limit states of its own and throws.
+     *
+     * The old name `_setStateBasedOnInputValue` still works and is deprecated.
+     */
+    setStateBasedOnInputValue(value: number): void;
 }
 export interface UALimitAlarmEx extends UALimitAlarm_Base, UAAlarmConditionEx, UALimitAlarmHelper {
     enabledState: UATwoStateVariableEx;

--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_alarm_condition_impl.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_alarm_condition_impl.ts
@@ -323,8 +323,34 @@ export class UAAlarmConditionImplBase extends UAAcknowledgeableConditionImplBase
         this._onInputDataValueChange(dataValue);
     }
 
-    protected _onInputDataValueChange(_newValue: DataValue): void {
+    /**
+     * What the alarm does when the value of its input node changes. Assign to it to give an
+     * alarm a state machine of its own, without deriving from anything.
+     *
+     * @example
+     *
+     * ```ts
+     * const myAlarm = namespace.instantiateAlarmCondition("AlarmConditionType", { ... });
+     * myAlarm.onInputDataValueChange = (newValue) => {
+     *     const tooHot = newValue.value.value > 80;
+     *     if (tooHot !== myAlarm.activeState.getValue()) {
+     *         myAlarm.signalNewCondition(tooHot ? "Active" : "Inactive", tooHot, `${newValue.value.value}`);
+     *     }
+     * };
+     * ```
+     *
+     * The default does nothing: a plain AlarmConditionType has no idea what its input means.
+     * The alarm types that do (limit alarms, off-normal alarms) override this.
+     */
+    public onInputDataValueChange(_newValue: DataValue): void {
         /**  */
+    }
+
+    /**
+     * @deprecated assign {@link onInputDataValueChange} instead; this delegates to it.
+     */
+    protected _onInputDataValueChange(newValue: DataValue): void {
+        this.onInputDataValueChange(newValue);
     }
 
     /**
@@ -464,7 +490,21 @@ export class UAAlarmConditionImplBase extends UAAcknowledgeableConditionImplBase
         this.currentBranch().setActiveState(false);
         this.currentBranch().setAckedState(true);
     }
+    /**
+     * @deprecated call {@link signalNewCondition} instead; this delegates to it.
+     */
     public _signalNewCondition(stateName: string | null, isActive: boolean, value: string): void {
+        this.signalNewCondition(stateName, isActive, value);
+    }
+
+    /**
+     * Raise a new condition event for this alarm.
+     *
+     * Call this only when the condition has actually changed: it throws when the new
+     * ConditionInfo is equal to the current one, because raising an event that reports
+     * nothing new is a bug in the caller rather than a state the alarm can represent.
+     */
+    public signalNewCondition(stateName: string | null, isActive: boolean, value: string): void {
         // xx if(stateName === null) {
         // xx     alarm.currentBranch().setActiveState(false);
         // xx     alarm.currentBranch().setAckedState(true);
@@ -480,7 +520,7 @@ export class UAAlarmConditionImplBase extends UAAcknowledgeableConditionImplBase
         // `calculateConditionInfo` is reached by the default below. Both work.
         const newConditionInfo = this._calculateConditionInfo(stateName, isActive, value, oldConditionInfo);
 
-        // detect potential internal bugs due to misused of _signalNewCondition
+        // detect potential internal bugs due to misused of signalNewCondition
         if (isEqual(oldConditionInfo, newConditionInfo)) {
             // c8 ignore next
             if (doDebug) {

--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_exclusive_deviation_alarm_impl.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_exclusive_deviation_alarm_impl.ts
@@ -78,14 +78,14 @@ export class UAExclusiveDeviationAlarmImplBase extends UAExclusiveLimitAlarmImpl
         DeviationAlarmHelper_install_setpoint.call(this, options);
     }
 
-    public _setStateBasedOnInputValue(value: number): void {
+    public setStateBasedOnInputValue(value: number): void {
         const setpointValue = this.getSetpointValue();
         if (setpointValue === null) {
             return;
         }
         assert(Number.isFinite(setpointValue));
         // call base class implementation
-        UAExclusiveLimitAlarmImpl.prototype._setStateBasedOnInputValue.call(this, value - setpointValue);
+        UAExclusiveLimitAlarmImpl.prototype.setStateBasedOnInputValue.call(this, value - setpointValue);
     }
 }
 /** @internal */

--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_exclusive_limit_alarm_impl.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_exclusive_limit_alarm_impl.ts
@@ -62,7 +62,7 @@ export class UAExclusiveLimitAlarmImplBase extends UALimitAlarmImpl implements U
 
         return alarm as UAExclusiveLimitAlarmImpl;
     }
-    public _signalNewCondition(stateName: string | null, isActive: boolean, value: string): void {
+    public signalNewCondition(stateName: string | null, isActive: boolean, value: string): void {
         assert(stateName === null || typeof isActive === "boolean");
         assert(validState.indexOf(stateName) >= 0, `must have a valid state : ${stateName}`);
 
@@ -75,10 +75,10 @@ export class UAExclusiveLimitAlarmImplBase extends UALimitAlarmImpl implements U
             assert(stateName === null);
             this.limitState.setState(stateName);
         }
-        super._signalNewCondition(stateName, isActive, value);
+        super.signalNewCondition(stateName, isActive, value);
     }
 
-    public _setStateBasedOnInputValue(value: number): void {
+    public setStateBasedOnInputValue(value: number): void {
         assert(Number.isFinite(value));
         let isActive = false;
 
@@ -101,7 +101,7 @@ export class UAExclusiveLimitAlarmImplBase extends UALimitAlarmImpl implements U
         }
 
         if (state !== oldState) {
-            this._signalNewCondition(state, isActive, value.toFixed(3));
+            this.signalNewCondition(state, isActive, value.toFixed(3));
         }
     }
 }

--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_limit_alarm_impl.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_limit_alarm_impl.ts
@@ -203,7 +203,7 @@ export class UALimitAlarmImplBase extends UAAlarmConditionImplBase implements UA
         this.lowLowLimit.setValueFromSource({ dataType: DataType.Double, value });
     }
 
-    protected _onInputDataValueChange(dataValue: DataValue): void {
+    public onInputDataValueChange(dataValue: DataValue): void {
         assert(dataValue instanceof DataValue);
 
         if (dataValue.statusCode.equals(StatusCodes.BadWaitingForInitialData)) {
@@ -212,20 +212,37 @@ export class UALimitAlarmImplBase extends UAAlarmConditionImplBase implements UA
         }
         if (dataValue.statusCode.isNotGood() && !dataValue.statusCode.equals(StatusCodes.UncertainInitialValue)) {
             // genuinely bad status (not the initial uncertain state) → no specific limit state, alarm inactive
-            this._signalNewCondition(null, false, "Input node value is not good");
+            this.signalNewCondition(null, false, "Input node value is not good");
             return;
         }
         if (dataValue.value.dataType === DataType.Null) {
             // input not yet set → no specific limit state, alarm inactive
-            this._signalNewCondition(null, false, "Input node value is null");
+            this.signalNewCondition(null, false, "Input node value is null");
             return;
         }
         const value = dataValue.value.value;
+        // deliberately the deprecated name, for the same reason as _calculateConditionInfo:
+        // an old subclass that overrode `_setStateBasedOnInputValue` is still reached, and a
+        // new assignment of the published name is reached through the delegate below.
         this._setStateBasedOnInputValue(value);
     }
 
-    protected _setStateBasedOnInputValue(_value: number): void {
-        throw new Error("_setStateBasedOnInputValue must be overriden");
+    /**
+     * How the alarm turns a numeric input value into limit states. Assign to it to give a
+     * limit alarm a rule of its own.
+     *
+     * The base implementation throws: a bare LimitAlarmType has no limit states to set, so
+     * every concrete limit alarm type defines this.
+     */
+    public setStateBasedOnInputValue(_value: number): void {
+        throw new Error("setStateBasedOnInputValue must be overriden");
+    }
+
+    /**
+     * @deprecated assign {@link setStateBasedOnInputValue} instead; this delegates to it.
+     */
+    public _setStateBasedOnInputValue(value: number): void {
+        this.setStateBasedOnInputValue(value);
     }
 
     protected _watchLimits(): void {

--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_non_exclusive_deviation_alarm_impl.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_non_exclusive_deviation_alarm_impl.ts
@@ -61,14 +61,14 @@ export class UANonExclusiveDeviationAlarmImplBase
 
         return alarm;
     }
-    public _setStateBasedOnInputValue(value: number): void {
+    public setStateBasedOnInputValue(value: number): void {
         const setpointValue = this.getSetpointValue();
         if (setpointValue === null) {
             throw new Error("Cannot access setpoint Value");
         }
         assert(Number.isFinite(setpointValue), "expecting a valid setpoint value");
         // call base class implementation
-        super._setStateBasedOnInputValue(value - setpointValue);
+        super.setStateBasedOnInputValue(value - setpointValue);
     }
 
     public getSetpointNodeNode(): UAVariableT<number, DataType.Double> | UAVariableT<number, DataType.Float> | undefined {

--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_non_exclusive_limit_alarm_impl.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_non_exclusive_limit_alarm_impl.ts
@@ -180,9 +180,9 @@ export class UANonExclusiveLimitAlarmImplBase extends UALimitAlarmImpl implement
 
         state_str = JSON.stringify(states);
 
-        UALimitAlarmImpl.prototype._signalNewCondition.call(this, state_str, isActive, value);
+        UALimitAlarmImpl.prototype.signalNewCondition.call(this, state_str, isActive, value);
     }
-    protected _setStateBasedOnInputValue(value: number): void {
+    public setStateBasedOnInputValue(value: number): void {
         assert(Number.isFinite(value), "expecting a valid value here");
 
         let isActive = false;

--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_off_normal_alarm_impl.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_off_normal_alarm_impl.ts
@@ -168,7 +168,7 @@ export class UAOffNormalAlarmImplBase extends UADiscreteAlarmImplBase implements
         }
         const stateName = isActive ? "Active" : "Inactive";
         // also raise the event
-        this._signalNewCondition(stateName, isActive, message);
+        this.signalNewCondition(stateName, isActive, message);
         if (!isActive) {
             this.currentBranch().setRetain(false);
         }
@@ -183,7 +183,7 @@ export class UAOffNormalAlarmImplBase extends UADiscreteAlarmImplBase implements
         this.updateAlarmState(isActive, "automatique update");
     }
 
-    protected _onInputDataValueChange(dataValue: DataValue): void {
+    public onInputDataValueChange(dataValue: DataValue): void {
         if (dataValue.statusCode.isNotGood()) {
             // what shall we do ?
             return;

--- a/packages/node-opcua-address-space/test/test_custom_alarm_hooks.ts
+++ b/packages/node-opcua-address-space/test/test_custom_alarm_hooks.ts
@@ -1,0 +1,145 @@
+/**
+ * Customising an alarm from outside the package.
+ *
+ * An application that wants an alarm of its own used to have to reach for
+ * `node-opcua-address-space/dist/impl/alarms_and_conditions/...`, derive from the
+ * implementation class and override underscore-prefixed methods, because the extension points
+ * were not published anywhere else.
+ *
+ * The imports below are the point of the test: everything an application needs to give an
+ * alarm its own behaviour has to be reachable from the package entry points. If any of these
+ * names has to come from a deep path again, this stops compiling.
+ */
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { nodesets } from "node-opcua-nodesets";
+import { StatusCodes } from "node-opcua-status-code";
+import { DataType } from "node-opcua-variant";
+import should from "should";
+
+import {
+    AddressSpace,
+    ConditionInfo,
+    type Namespace,
+    type UAAlarmConditionEx,
+    type UAObject,
+    type UAVariable
+} from "../dist/api/index.js";
+import { generateAddressSpace } from "../distNodeJS/index.js";
+
+describe("custom alarm hooks", function (this: Mocha.Suite) {
+    this.timeout(Math.max(this.timeout(), 30000));
+
+    let addressSpace: AddressSpace;
+    let namespace: Namespace;
+    let source: UAObject;
+    let inputNode: UAVariable;
+
+    before(async () => {
+        addressSpace = AddressSpace.create();
+        await generateAddressSpace(addressSpace, [nodesets.standard]);
+        namespace = addressSpace.registerNamespace("Private");
+        addressSpace.installAlarmsAndConditionsService();
+
+        const green = namespace.addObject({
+            browseName: "Green",
+            eventNotifier: 0x1,
+            notifierOf: addressSpace.rootFolder.objects.server,
+            organizedBy: addressSpace.rootFolder.objects
+        });
+        source = namespace.addObject({ browseName: "Boiler", componentOf: green, eventSourceOf: green });
+        inputNode = namespace.addVariable({ browseName: "BoilerTemperature", dataType: "Double", propertyOf: source });
+        inputNode.setValueFromSource({ dataType: DataType.Double, value: 0 });
+    });
+
+    after(() => addressSpace.dispose());
+
+    const makeAlarm = (browseName: string) =>
+        namespace.instantiateAlarmCondition("AlarmConditionType", {
+            browseName,
+            conditionSource: source,
+            inputNode
+        }) as UAAlarmConditionEx;
+
+    it("runs an assigned onInputDataValueChange when the input node value changes", () => {
+        const alarm = makeAlarm("BoilerTemperatureAlarm1");
+
+        const seen: number[] = [];
+        alarm.onInputDataValueChange = (newValue) => {
+            seen.push(newValue.value.value as number);
+        };
+
+        inputNode.setValueFromSource({ dataType: DataType.Double, value: 42.0 });
+
+        should(seen).eql([42.0]);
+    });
+
+    it("lets the two hooks work together: onInputDataValueChange decides, calculateConditionInfo words it", () => {
+        const alarm = makeAlarm("BoilerTemperatureAlarm2");
+
+        alarm.onInputDataValueChange = (newValue) => {
+            const temperature = newValue.value.value as number;
+            const tooHot = temperature > 80;
+            if (tooHot !== alarm.activeState.getValue()) {
+                alarm.signalNewCondition(tooHot ? "Active" : "Inactive", tooHot, temperature.toFixed(1));
+            }
+        };
+        alarm.calculateConditionInfo = (stateName, _isActive, value, _oldConditionInfo) =>
+            new ConditionInfo({
+                message: `Boiler is ${stateName} at ${value} degrees`,
+                severity: 200,
+                quality: StatusCodes.Good,
+                retain: true
+            });
+
+        inputNode.setValueFromSource({ dataType: DataType.Double, value: 91.5 });
+
+        should(alarm.activeState.getValue()).eql(true);
+        should(alarm.getCurrentConditionInfo().message?.text).eql("Boiler is Active at 91.5 degrees");
+        should(alarm.getCurrentConditionInfo().severity).eql(200);
+    });
+
+    it("still honours the deprecated _onInputDataValueChange, so a legacy override keeps winning", () => {
+        const alarm = makeAlarm("BoilerTemperatureAlarm3");
+
+        let published = 0;
+        alarm.onInputDataValueChange = () => {
+            published++;
+        };
+
+        let legacy = 0;
+        // the shape a subclass written against the old documentation carried, assigned here on
+        // the instance so the test needs no implementation class
+        (alarm as unknown as { _onInputDataValueChange: (newValue: unknown) => void })._onInputDataValueChange = () => {
+            legacy++;
+        };
+
+        inputNode.setValueFromSource({ dataType: DataType.Double, value: 13.0 });
+
+        should(legacy).eql(1, "expecting an override of the deprecated name to still win");
+        should(published).eql(0, "expecting the legacy override to shadow the published hook, not to run beside it");
+    });
+
+    it("lets application code call signalNewCondition directly", () => {
+        const alarm = makeAlarm("BoilerTemperatureAlarm4");
+
+        const raised: string[] = [];
+        alarm.calculateConditionInfo = (_stateName, _isActive, value, _oldConditionInfo) => {
+            raised.push(value);
+            return new ConditionInfo({
+                message: value,
+                severity: 100,
+                quality: StatusCodes.Good,
+                retain: true
+            });
+        };
+
+        alarm.signalNewCondition("Active", true, "manual trip");
+
+        should(raised).eql(["manual trip"]);
+        should(alarm.activeState.getValue()).eql(true);
+        should(alarm.getCurrentConditionInfo().message?.text).eql("manual trip");
+
+        // raising an event that reports nothing new is a caller bug, and says so
+        should(() => alarm.signalNewCondition("Active", true, "manual trip")).throwError(/condition values have not change/);
+    });
+});


### PR DESCRIPTION
Applications customising alarm behaviour have had no supported way to do it. The extension
points are underscore-prefixed methods on internal classes, so real integrations deep-import
`node-opcua-address-space/dist/.../ua_alarm_condition_impl.js`, `extends UAAlarmConditionImpl`,
and then hand-copy prototype methods onto instantiated nodes because the subclass is never
actually used for construction.

This publishes the extension points. No behaviour changes.

## What is published

| name | kind | replaces |
|---|---|---|
| `onInputDataValueChange(newValue)` | assignable hook | `protected _onInputDataValueChange` |
| `setStateBasedOnInputValue(value)` | assignable hook, limit-alarm family | `_setStateBasedOnInputValue`, which threw "must be overriden" |
| `signalNewCondition(stateName, isActive, value)` | callable method | `_signalNewCondition` |

Declared on `UAAlarmConditionHelper` and `UALimitAlarmHelper`, following how
`calculateConditionInfo` was published: a public member carrying the default, the underscore
name kept as a `@deprecated` delegate, and internal call sites still calling the underscore
name so an existing subclass override keeps winning. That is the trick `_signalNewCondition`
already used for `_calculateConditionInfo`, and its comment is preserved.

The two kinds are not interchangeable. A plain `AlarmConditionType` wants
`onInputDataValueChange`; the limit-alarm family reserves that internally and wants
`setStateBasedOnInputValue`. `signalNewCondition` is called by application code, not assigned -
verified against a real integration, where it is invoked from the application's own state
updater.

## The part that would have shipped broken

A naive underscore-to-public delegate is not enough: several internal classes already override
the underscore names, and would have shadowed the public hook, so an application's assignment
would do **nothing at all** - no error, just silence. Every such override moved to the public
name:

- `_onInputDataValueChange` in `ua_limit_alarm_impl`, `ua_off_normal_alarm_impl`
- `_setStateBasedOnInputValue` in the exclusive/non-exclusive limit and deviation alarms
- `_signalNewCondition` in `ua_exclusive_limit_alarm_impl` - **this one was not in the original
  brief**; leaving it would have made every internal call bypass the limit-state update
- two deliberate base-class bypasses spelled `X.prototype._name.call(this, ...)`, retargeted

One consequence worth recording: `api/interfaces/alarms_and_conditions/deviation_stuff.ts`
already declares `_setStateBasedOnInputValue` on a **published** interface, so the base's
deprecated delegate had to stay `public` for the deviation alarms to keep satisfying it. That
underscore surface is a separate item, worth publishing the same way later.

## Backwards compatibility, demonstrated rather than asserted

`packages/playground/device_health_extra.ts` is the deep-import pattern this replaces: it
imports the impl class, overrides `_calculateConditionInfo` and `_onInputDataValueChange`,
calls `_signalNewCondition`, and copies prototype methods onto instances. It is **untouched by
this PR and still compiles and behaves identically** - which is the evidence the delegate
pattern holds.

## Verification

```
npx tsc -b packages                                   0
pnpm run lint:ci                                      0
pnpm run check:testtypes                              0
test/test_custom_alarm_hooks.ts                       4 passing   (new)
test/test_custom_alarm_condition_info.ts              3 passing
test/alarms_and_conditions/**/*.ts                    91 passing
node-opcua-address-space, whole suite                 1346 passing
```

The new test is written the way `test_custom_alarm_condition_info.ts` is - importing only from
published entry points, so it stops compiling if any of these names has to come from a deep
path again. It covers an assigned hook running, the two hooks working together, a legacy
underscore override still winning, and application code calling `signalNewCondition` directly.

## Next

This removes the need to copy prototype methods. Still to come: promoting an existing object to
an alarm, and injecting application context into an alarm instance without ad-hoc fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
