### PR TITLE
test: fix flaky keepalive count assertion in issue #141-A

### DIFF
--- a/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_issue_141.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_issue_141.ts
@@ -53,7 +53,11 @@ export function t(test: TestHarness) {
         });
 
         it("#141-A PublishRequest timeoutHint shall exceed keepalive gap", async () => {
-            const timeout = 25000; // original test window
+            // wait until at least 2 keepalives have been observed (proves the gap is
+            // sustainable across multiple cycles), with a generous safety timeout so a
+            // slow/loaded CI runner doesn't fail on a single missed keepalive window
+            const targetKeepaliveCount = 2;
+            const safetyTimeout = 60000;
             await perform_operation_on_client_session(client, endpointUrl, async (session) => {
                 const subscription = ClientSubscription.create(session, {
                     requestedPublishingInterval: 6000,
@@ -64,12 +68,16 @@ export function t(test: TestHarness) {
                     priority: 10
                 });
                 let keepaliveCounter = 0;
-                subscription.on("keepalive", () => {
-                    keepaliveCounter++;
-                });
 
                 await new Promise<void>((resolve, reject) => {
-                    const to = setTimeout(() => resolve(), timeout);
+                    const to = setTimeout(() => resolve(), safetyTimeout);
+                    subscription.on("keepalive", () => {
+                        keepaliveCounter++;
+                        if (keepaliveCounter >= targetKeepaliveCount) {
+                            clearTimeout(to);
+                            resolve();
+                        }
+                    });
                     subscription.on("internal_error", (err) => {
                         clearTimeout(to);
                         reject(err);
@@ -79,10 +87,10 @@ export function t(test: TestHarness) {
                     });
                 });
                 await new Promise((r) => subscription.terminate(r));
-                keepaliveCounter.should.be.greaterThan(1);
+                keepaliveCounter.should.be.aboveOrEqual(targetKeepaliveCount);
                 (client as InternalAny).timedOutRequestCount.should.eql(0);
             });
-        });
+        }).timeout(90000);
 
         it("#141-B client emits timed_out_request when request timeoutHint exhausted", async () => {
             const node = server.engine.addressSpace!.getOwnNamespace().addVariable({

--- a/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_issue_141.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_issue_141.ts
@@ -52,7 +52,7 @@ export function t(test: TestHarness) {
             client = null;
         });
 
-        it("#141-A PublishRequest timeoutHint shall exceed keepalive gap", async function () {
+        it("#141-A PublishRequest timeoutHint shall exceed keepalive gap", async function (this: Mocha.Context) {
             // wait until at least 2 keepalives have been observed (proves the gap is
             // sustainable across multiple cycles), with a generous safety timeout so a
             // slow/loaded CI runner doesn't fail on a single missed keepalive window

--- a/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_issue_141.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_issue_141.ts
@@ -52,10 +52,11 @@ export function t(test: TestHarness) {
             client = null;
         });
 
-        it("#141-A PublishRequest timeoutHint shall exceed keepalive gap", async () => {
+        it("#141-A PublishRequest timeoutHint shall exceed keepalive gap", async function () {
             // wait until at least 2 keepalives have been observed (proves the gap is
             // sustainable across multiple cycles), with a generous safety timeout so a
             // slow/loaded CI runner doesn't fail on a single missed keepalive window
+            this.timeout(90000);
             const targetKeepaliveCount = 2;
             const safetyTimeout = 60000;
             await perform_operation_on_client_session(client, endpointUrl, async (session) => {
@@ -90,7 +91,7 @@ export function t(test: TestHarness) {
                 keepaliveCounter.should.be.aboveOrEqual(targetKeepaliveCount);
                 (client as InternalAny).timedOutRequestCount.should.eql(0);
             });
-        }).timeout(90000);
+        });
 
         it("#141-B client emits timed_out_request when request timeoutHint exhausted", async () => {
             const node = server.engine.addressSpace!.getOwnNamespace().addVariable({


### PR DESCRIPTION
## Summary
- The #141-A end2end test raced a blind 25s timer against subscription `keepalive` events, then asserted more than one keepalive had fired within that window.
- Under CI timing variance (slow/loaded runner), only a single keepalive could land in the window, causing a spurious `expected 1 to be above 1` failure.
- The test now waits event-driven for 2 keepalives (with a 60s safety timeout and a 90s mocha timeout) instead of relying on a fixed clock window.

## Test plan
- [ ] CI passes for `test_umbrella_e2e_seriesJ.ts` / issue #141 suite