### PR TITLE
feat(address-space): promote an existing node to an alarm

### DIFF
--- a/packages/node-opcua-address-space/api/index.ts
+++ b/packages/node-opcua-address-space/api/index.ts
@@ -45,6 +45,14 @@ export {
     UANonExclusiveLimitAlarmImpl,
     UANonExclusiveLimitAlarmImplBase
 } from "../impl/alarms_and_conditions/index.js";
+/**
+ * Upgrading a node to the typed view of what it already is.
+ *
+ * An alarm built by `objectType.instantiate` or loaded from a nodeset has the children of an alarm
+ * and none of the behaviour; promoting it retypes the node in place and installs the machinery
+ * `namespace.instantiateAlarmCondition` would have installed.
+ */
+export { promoteToAlarm } from "../impl/alarms_and_conditions/ua_alarm_condition_impl.js";
 export { instantiateCertificateExpirationAlarm } from "../impl/alarms_and_conditions/ua_certificate_expiration_alarm_impl.js";
 /** The event name a node emits when one of its attributes changes. */
 export { childAccessorNamesShadowedBy, makeAttributeEventName } from "../impl/base_node_impl.js";
@@ -134,6 +142,7 @@ export * from "./interfaces/alarms_and_conditions/instantiate_condition_options.
 export * from "./interfaces/alarms_and_conditions/instantiate_exclusive_limit_alarm_options.js";
 export * from "./interfaces/alarms_and_conditions/instantiate_limit_alarm_options.js";
 export * from "./interfaces/alarms_and_conditions/instantiate_off_normal_alarm_options.js";
+export * from "./interfaces/alarms_and_conditions/promote_to_alarm_options.js";
 export * from "./interfaces/alarms_and_conditions/ua_acknowledgeable_condition_ex.js";
 export * from "./interfaces/alarms_and_conditions/ua_alarm_condition_ex.js";
 export * from "./interfaces/alarms_and_conditions/ua_base_event_ex.js";

--- a/packages/node-opcua-address-space/api/interfaces/alarms_and_conditions/promote_to_alarm_options.ts
+++ b/packages/node-opcua-address-space/api/interfaces/alarms_and_conditions/promote_to_alarm_options.ts
@@ -1,0 +1,24 @@
+import type { BaseNode, UAObject, UAVariable } from "node-opcua-address-space-base";
+import type { NodeId } from "node-opcua-nodeid";
+
+/**
+ * The options {@link promoteToAlarm} accepts.
+ *
+ * The names are the ones `instantiateAlarmCondition` already uses, so the two routes to a working
+ * alarm read the same. Everything is optional here: a node being promoted usually already carries
+ * the children and references the factory would have created.
+ */
+export interface PromoteToAlarmOptions {
+    /**
+     * The node this alarm reports on. Wired as a backward HasCondition reference and used to fill
+     * SourceNode and SourceName, exactly as at instantiation time. The node has to be an event
+     * source, otherwise the events the alarm raises reach no one.
+     */
+    conditionSource?: UAObject | BaseNode | NodeId | null;
+    /** The variable whose value drives the alarm; monitoring is installed when it is given. */
+    inputNode?: UAVariable | NodeId;
+    /** Defaults to the ConditionType, as at instantiation time. */
+    conditionClass?: UAObject | BaseNode | NodeId | null;
+    conditionName?: string;
+    maxTimeShelved?: number;
+}

--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_acknowledgeable_condition_impl.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_acknowledgeable_condition_impl.ts
@@ -67,47 +67,7 @@ export class UAAcknowledgeableConditionImplBase<
             data
         ) as UAAcknowledgeableConditionImpl;
 
-        Object.setPrototypeOf(conditionNode, UAAcknowledgeableConditionImpl.prototype);
-
-        // ----------------------- Install Acknowledge-able Condition stuff
-        // install ackedState - Mandatory
-        /**
-         * @property ackedState
-         * @type TwoStateVariable
-         */
-        _install_TwoStateVariable_machinery(conditionNode.ackedState, {
-            falseState: "Unacknowledged",
-            trueState: "Acknowledged"
-        });
-
-        /**
-         * @property acknowledge
-         * @type UAMethod
-         */
-        conditionNode.acknowledge.bindMethod(_acknowledge_method);
-
-        // install confirmedState - Optional
-        /**
-         * @property confirmedState
-         * @type TwoStateVariable
-         */
-        if (conditionNode.confirmedState) {
-            _install_TwoStateVariable_machinery(conditionNode.confirmedState, {
-                falseState: "Unconfirmed",
-                trueState: "Confirmed"
-            });
-        }
-
-        // install confirm Method - Optional
-        /**
-         * @property confirm
-         * @type UAMethod
-         */
-        if (conditionNode.confirm) {
-            conditionNode.confirm.bindMethod(_confirm_method);
-        }
-        assert(conditionNode instanceof UAAcknowledgeableConditionImpl);
-        return conditionNode;
+        return _initialize_acknowledgeable_condition_node(conditionNode);
     }
 
     public static install_method_handle_on_type(addressSpace: AddressSpacePrivate): void {
@@ -348,4 +308,56 @@ function _confirm_method(inputArguments: VariantLike[], context: ISessionContext
             return StatusCodes.Good;
         }
     );
+}
+
+/**
+ * The acknowledgeable half of a condition's wiring, shared by {@link UAAcknowledgeableConditionImplBase.instantiate}
+ * and by the promotion of an existing node, so neither route can drift from the other.
+ *
+ * @internal
+ */
+export function _initialize_acknowledgeable_condition_node(
+    conditionNode: UAAcknowledgeableConditionImpl
+): UAAcknowledgeableConditionImpl {
+    Object.setPrototypeOf(conditionNode, UAAcknowledgeableConditionImpl.prototype);
+
+    // ----------------------- Install Acknowledge-able Condition stuff
+    // install ackedState - Mandatory
+    /**
+     * @property ackedState
+     * @type TwoStateVariable
+     */
+    _install_TwoStateVariable_machinery(conditionNode.ackedState, {
+        falseState: "Unacknowledged",
+        trueState: "Acknowledged"
+    });
+
+    /**
+     * @property acknowledge
+     * @type UAMethod
+     */
+    conditionNode.acknowledge.bindMethod(_acknowledge_method);
+
+    // install confirmedState - Optional
+    /**
+     * @property confirmedState
+     * @type TwoStateVariable
+     */
+    if (conditionNode.confirmedState) {
+        _install_TwoStateVariable_machinery(conditionNode.confirmedState, {
+            falseState: "Unconfirmed",
+            trueState: "Confirmed"
+        });
+    }
+
+    // install confirm Method - Optional
+    /**
+     * @property confirm
+     * @type UAMethod
+     */
+    if (conditionNode.confirm) {
+        conditionNode.confirm.bindMethod(_confirm_method);
+    }
+    assert(conditionNode instanceof UAAcknowledgeableConditionImpl);
+    return conditionNode;
 }

--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_alarm_condition_impl.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_alarm_condition_impl.ts
@@ -2,7 +2,7 @@
  * @module node-opcua-address-space.AlarmsAndConditions
  */
 import { isDeepStrictEqual as isEqual } from "node:util";
-import type { BaseNode, INamespace, UAEventType, UAProperty, UAVariable } from "node-opcua-address-space-base";
+import type { BaseNode, INamespace, UAEventType, UAObject, UAProperty, UAVariable } from "node-opcua-address-space-base";
 import { assert } from "node-opcua-assert";
 import { NodeClass } from "node-opcua-data-model";
 import type { DataValue } from "node-opcua-data-value";
@@ -12,6 +12,7 @@ import { StatusCodes } from "node-opcua-status-code";
 import { DataType, type VariantOptions } from "node-opcua-variant";
 import type { ConditionInfo } from "../../api/interfaces/alarms_and_conditions/condition_info_i.js";
 import type { InstantiateAlarmConditionOptions } from "../../api/interfaces/alarms_and_conditions/instantiate_alarm_condition_options.js";
+import type { PromoteToAlarmOptions } from "../../api/interfaces/alarms_and_conditions/promote_to_alarm_options.js";
 import type { UAAlarmConditionEx } from "../../api/interfaces/alarms_and_conditions/ua_alarm_condition_ex.js";
 import type { UAShelvedStateMachineEx } from "../../api/interfaces/state_machine/ua_shelved_state_machine_ex.js";
 import type { UATwoStateVariableEx } from "../../api/ua_two_state_variable_ex.js";
@@ -23,7 +24,12 @@ import {
 } from "../state_machine/ua_shelving_state_machine_ex.js";
 import { _install_TwoStateVariable_machinery } from "../state_machine/ua_two_state_variable.js";
 import { ConditionInfoImpl } from "./condition_info_impl.js";
-import { UAAcknowledgeableConditionImpl, UAAcknowledgeableConditionImplBase } from "./ua_acknowledgeable_condition_impl.js";
+import {
+    _initialize_acknowledgeable_condition_node,
+    UAAcknowledgeableConditionImpl,
+    UAAcknowledgeableConditionImplBase
+} from "./ua_acknowledgeable_condition_impl.js";
+import { _initialize_condition_node, type ConditionInitializationOptions } from "./ua_condition_impl.js";
 
 const debugLog = make_debugLog("ua_alarm_condition_impl");
 const doDebug = checkDebugFlag("ua_alarm_condition_impl");
@@ -62,6 +68,7 @@ export class UAAlarmConditionImplBase extends UAAcknowledgeableConditionImplBase
         const addressSpace = namespace.addressSpace;
         // xx assert(Object.prototype.hasOwnProperty.call(options,"conditionOf")); // must provide a conditionOf
         assert(Object.hasOwn(options, "inputNode")); // must provide a inputNode
+        assert(options.inputNode, " must provide options.inputNode (NodeId or BaseNode object)");
         const alarmConditionType = addressSpace.findEventType(alarmConditionTypeId);
 
         /* c8 ignore next */
@@ -99,114 +106,8 @@ export class UAAlarmConditionImplBase extends UAAcknowledgeableConditionImplBase
             options,
             data
         ) as unknown as UAAlarmConditionImpl;
-        Object.setPrototypeOf(alarmNode, UAAlarmConditionImpl.prototype);
 
-        // ----------------------- Install Alarm specifics
-        //
-
-        // Specs 1.03:
-        // ActiveState/Id when set to TRUE indicates that the situation the Condition is representing
-        // currently exists. When a Condition instance is in the inactive state (ActiveState/Id when set to
-        // FALSE) it is representing a situation that has returned to a normal state. The transitions of
-        // Conditions to the inactive and Active states are triggered by Server specific actions. Sub-
-        // Types of the AlarmConditionType specified later in this document will have sub-state models
-        // that further define the Active state. Recommended state names are described in Annex A.
-        // install activeState - Mandatory
-
-        /**
-         * @property activeState
-         * @type {UATwoStateVariable}
-         */
-        _install_TwoStateVariable_machinery(alarmNode.activeState, {
-            falseState: "Inactive",
-            trueState: "Active"
-        });
-
-        alarmNode.currentBranch().setActiveState(false);
-
-        // Specs 1.03:
-        /**
-         *
-         * SuppressState is used internally by a Server to automatically suppress Alarms due to system
-         * specific reasons. For example a system may be configured to suppress Alarms that are
-         * associated with machinery that is shutdown, such as a low level Alarm for a tank that is
-         * currently not in use.
-         *
-         * @property suppressedState
-         * @type UATwoStateVariable
-         */
-        if (alarmNode.suppressedState) {
-            // install activeState - Optional
-            _install_TwoStateVariable_machinery(alarmNode.suppressedState, {
-                falseState: "Unsuppressed",
-                trueState: "Suppressed"
-            });
-        }
-        // Specs 1.03:
-        /**
-         * ShelvingState suggests whether an Alarm shall (temporarily) be prevented from being
-         * displayed to the user. It is quite often used to block nuisance Alarms.
-         *
-         * @property shelvingState
-         * @type ShelvingStateMachine
-         */
-        if (alarmNode.shelvingState) {
-            UAShelvedStateMachineExImplBase.promote(alarmNode.shelvingState);
-        }
-
-        // SuppressedOrShelved : Mandatory
-        // install suppressedOrShelved automatic detection
-        /**
-         * The SuppressedState and the ShelvingState together result in the SuppressedOrShelved status of the
-         * Condition. When an Alarm is in one of the states, the SuppressedOrShelved property will be set TRUE
-         * and this Alarm is then typically not displayed by the Client. State transitions associated with the
-         * Alarm do occur, but they are not typically displayed by the Clients as long as the Alarm remains in
-         * either the Suppressed or Shelved state.
-         * The dataType is Boolean.
-         * @property suppressedState
-         * @type UAVariable
-         *
-         */
-        if (alarmNode.suppressedState) {
-            alarmNode.suppressedState.on("value_changed", (_newDataValue: DataValue) => {
-                _update_suppressedOrShelved(alarmNode);
-            });
-        }
-        if (alarmNode.shelvingState) {
-            alarmNode.shelvingState.currentState.on("value_changed", (_newDataValue: DataValue) => {
-                _update_suppressedOrShelved(alarmNode);
-            });
-        }
-        _update_suppressedOrShelved(alarmNode);
-
-        /**
-         * The optional Property MaxTimeShelved is used to set the maximum time that an Alarm Condition may be shelved.
-         * The value is expressed as duration. Systems can use this Property to prevent permanent Shelving of an Alarm.
-         * If this Property is present it will be an upper limit on the duration passed into a TimedShelve Method call.
-         * If a value that exceeds the value of this property is passed to the TimedShelve Method,
-         * than a BadShelvingTimeOutOfRange error code is returned on the call. If this Property is present it will
-         * also be enforced for the OneShotShelved state, in that an Alarm Condition will transition to the Unshelved
-         * state from the OneShotShelved state if the duration specified in this Property expires following a
-         * OneShotShelve operation without a change of any of the other items associated with the Condition.
-         *
-         * @property maxTimeShelved
-         * @type {UAVariable}
-         */
-        if (alarmNode.maxTimeShelved) {
-            options.maxTimeShelved = options.maxTimeShelved || 60.0 * 1000; // 60 seconds
-            alarmNode.maxTimeShelved.setValueFromSource({
-                dataType: "Duration",
-                value: options.maxTimeShelved
-            });
-        }
-
-        // ---------- install inputNode
-        assert(options.inputNode, " must provide options.inputNode (NodeId or BaseNode object)");
-        alarmNode.installInputNodeMonitoring(options.inputNode);
-
-        assert(alarmNode instanceof UAAcknowledgeableConditionImpl);
-        assert(alarmNode instanceof UAAlarmConditionImpl);
-        return alarmNode;
+        return _initialize_alarm_condition_node(alarmNode, options);
     }
 
     public dispose(): void {
@@ -563,3 +464,199 @@ export class UAAlarmConditionImplBase extends UAAcknowledgeableConditionImplBase
 export type UAAlarmConditionImpl = UAAlarmConditionImplBase;
 /** @internal */
 export const UAAlarmConditionImpl = UAAlarmConditionImplBase;
+
+/**
+ * The part of {@link InstantiateAlarmConditionOptions} that the initialization step below reads.
+ *
+ * @internal
+ */
+export type AlarmConditionInitializationOptions = ConditionInitializationOptions & {
+    maxTimeShelved?: number;
+    inputNode?: UAVariable | NodeId;
+};
+
+/**
+ * The alarm half of the wiring, everything that follows the creation of the node.
+ *
+ * Shared by {@link UAAlarmConditionImplBase.instantiate} and by {@link promoteToAlarm}, so a node
+ * that was created some other way ends up with exactly the same machinery rather than an
+ * approximation of it. `inputNode` is optional here because a node being promoted may already
+ * carry its InputNode property, or may be given one later.
+ *
+ * @internal
+ */
+export function _initialize_alarm_condition_node(
+    alarmNode: UAAlarmConditionImpl,
+    options: AlarmConditionInitializationOptions
+): UAAlarmConditionImpl {
+    Object.setPrototypeOf(alarmNode, UAAlarmConditionImpl.prototype);
+
+    // ----------------------- Install Alarm specifics
+    //
+
+    // Specs 1.03:
+    // ActiveState/Id when set to TRUE indicates that the situation the Condition is representing
+    // currently exists. When a Condition instance is in the inactive state (ActiveState/Id when set to
+    // FALSE) it is representing a situation that has returned to a normal state. The transitions of
+    // Conditions to the inactive and Active states are triggered by Server specific actions. Sub-
+    // Types of the AlarmConditionType specified later in this document will have sub-state models
+    // that further define the Active state. Recommended state names are described in Annex A.
+    // install activeState - Mandatory
+
+    /**
+     * @property activeState
+     * @type {UATwoStateVariable}
+     */
+    _install_TwoStateVariable_machinery(alarmNode.activeState, {
+        falseState: "Inactive",
+        trueState: "Active"
+    });
+
+    alarmNode.currentBranch().setActiveState(false);
+
+    // Specs 1.03:
+    /**
+     *
+     * SuppressState is used internally by a Server to automatically suppress Alarms due to system
+     * specific reasons. For example a system may be configured to suppress Alarms that are
+     * associated with machinery that is shutdown, such as a low level Alarm for a tank that is
+     * currently not in use.
+     *
+     * @property suppressedState
+     * @type UATwoStateVariable
+     */
+    if (alarmNode.suppressedState) {
+        // install activeState - Optional
+        _install_TwoStateVariable_machinery(alarmNode.suppressedState, {
+            falseState: "Unsuppressed",
+            trueState: "Suppressed"
+        });
+    }
+    // Specs 1.03:
+    /**
+     * ShelvingState suggests whether an Alarm shall (temporarily) be prevented from being
+     * displayed to the user. It is quite often used to block nuisance Alarms.
+     *
+     * @property shelvingState
+     * @type ShelvingStateMachine
+     */
+    if (alarmNode.shelvingState) {
+        UAShelvedStateMachineExImplBase.promote(alarmNode.shelvingState);
+    }
+
+    // SuppressedOrShelved : Mandatory
+    // install suppressedOrShelved automatic detection
+    /**
+     * The SuppressedState and the ShelvingState together result in the SuppressedOrShelved status of the
+     * Condition. When an Alarm is in one of the states, the SuppressedOrShelved property will be set TRUE
+     * and this Alarm is then typically not displayed by the Client. State transitions associated with the
+     * Alarm do occur, but they are not typically displayed by the Clients as long as the Alarm remains in
+     * either the Suppressed or Shelved state.
+     * The dataType is Boolean.
+     * @property suppressedState
+     * @type UAVariable
+     *
+     */
+    if (alarmNode.suppressedState) {
+        alarmNode.suppressedState.on("value_changed", (_newDataValue: DataValue) => {
+            _update_suppressedOrShelved(alarmNode);
+        });
+    }
+    if (alarmNode.shelvingState) {
+        alarmNode.shelvingState.currentState.on("value_changed", (_newDataValue: DataValue) => {
+            _update_suppressedOrShelved(alarmNode);
+        });
+    }
+    _update_suppressedOrShelved(alarmNode);
+
+    /**
+     * The optional Property MaxTimeShelved is used to set the maximum time that an Alarm Condition may be shelved.
+     * The value is expressed as duration. Systems can use this Property to prevent permanent Shelving of an Alarm.
+     * If this Property is present it will be an upper limit on the duration passed into a TimedShelve Method call.
+     * If a value that exceeds the value of this property is passed to the TimedShelve Method,
+     * than a BadShelvingTimeOutOfRange error code is returned on the call. If this Property is present it will
+     * also be enforced for the OneShotShelved state, in that an Alarm Condition will transition to the Unshelved
+     * state from the OneShotShelved state if the duration specified in this Property expires following a
+     * OneShotShelve operation without a change of any of the other items associated with the Condition.
+     *
+     * @property maxTimeShelved
+     * @type {UAVariable}
+     */
+    if (alarmNode.maxTimeShelved) {
+        options.maxTimeShelved = options.maxTimeShelved || 60.0 * 1000; // 60 seconds
+        alarmNode.maxTimeShelved.setValueFromSource({
+            dataType: "Duration",
+            value: options.maxTimeShelved
+        });
+    }
+
+    // ---------- install inputNode
+    if (options.inputNode) {
+        alarmNode.installInputNodeMonitoring(options.inputNode);
+    }
+
+    assert(alarmNode instanceof UAAcknowledgeableConditionImpl);
+    assert(alarmNode instanceof UAAlarmConditionImpl);
+    return alarmNode;
+}
+
+/**
+ * Give an existing node the behaviour of the alarm its type says it is.
+ *
+ * A node only becomes a working alarm when `namespace.instantiateAlarmCondition` builds it; a node
+ * that arrived any other way - `objectType.instantiate()`, or a nodeset XML - carries the right
+ * children but none of the machinery, so `activateAlarm` and `signalNewCondition` are simply not
+ * there. This retypes the node in place, keeping its identity in the address space index and every
+ * reference already pointing at it, and then runs the same initialization the factory runs.
+ *
+ * Limit alarms are refused rather than half-promoted: their behaviour lives in
+ * UALimitAlarmImpl and its subclasses, and a node wearing the plain alarm prototype would look
+ * promoted while ignoring its own limit set points.
+ */
+export function promoteToAlarm(node: UAObject, options?: PromoteToAlarmOptions): UAAlarmConditionEx {
+    if (node instanceof UAAlarmConditionImplBase) {
+        return node as unknown as UAAlarmConditionImpl; // already promoted
+    }
+    const addressSpace = node.addressSpace;
+    const typeDefinition = node.typeDefinitionObj;
+
+    const alarmConditionType = addressSpace.findObjectType("AlarmConditionType");
+    /* c8 ignore next */
+    if (!alarmConditionType) {
+        throw new Error("promoteToAlarm: cannot find AlarmConditionType - is the standard nodeset loaded ?");
+    }
+    if (!typeDefinition || (typeDefinition !== alarmConditionType && !typeDefinition.isSubtypeOf(alarmConditionType))) {
+        throw new Error(
+            `promoteToAlarm: ${node.browseName.toString()} has type definition ` +
+                `${typeDefinition ? typeDefinition.browseName.toString() : "<none>"} ` +
+                "which does not derive from AlarmConditionType - only alarms can be promoted"
+        );
+    }
+    const limitAlarmType = addressSpace.findObjectType("LimitAlarmType");
+    if (limitAlarmType && (typeDefinition === limitAlarmType || typeDefinition.isSubtypeOf(limitAlarmType))) {
+        throw new Error(
+            `promoteToAlarm: ${node.browseName.toString()} is a ${typeDefinition.browseName.toString()}, ` +
+                "a limit alarm - promoting limit alarms is not supported, use namespace.instantiateLimitAlarm instead"
+        );
+    }
+    const alarmConditionEventType = addressSpace.findEventType(typeDefinition.nodeId);
+    /* c8 ignore next */
+    if (!alarmConditionEventType) {
+        throw new Error(`promoteToAlarm: cannot find event type for ${typeDefinition.browseName.toString()}`);
+    }
+
+    // conditionSource has to be an own property even when it is absent: the condition
+    // initialization tells "no source" from "source not considered" by its presence.
+    const initializationOptions: AlarmConditionInitializationOptions = {
+        conditionClass: options?.conditionClass,
+        conditionName: options?.conditionName || node.browseName.name || undefined,
+        conditionSource: options?.conditionSource ?? null,
+        inputNode: options?.inputNode,
+        maxTimeShelved: options?.maxTimeShelved
+    };
+
+    const conditionNode = node as unknown as UAAlarmConditionImpl;
+    _initialize_condition_node(node.namespace, conditionNode, alarmConditionEventType, initializationOptions);
+    _initialize_acknowledgeable_condition_node(conditionNode);
+    return _initialize_alarm_condition_node(conditionNode, initializationOptions);
+}

--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_alarm_condition_impl.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_alarm_condition_impl.ts
@@ -639,6 +639,20 @@ export function promoteToAlarm(node: UAObject, options?: PromoteToAlarmOptions):
                 "a limit alarm - promoting limit alarms is not supported, use namespace.instantiateLimitAlarm instead"
         );
     }
+    // CertificateExpirationAlarmType carries behaviour of its own - promoteToCertificateExpirationAlarm
+    // starts an expiry timer and registers a shutdown task. Promoting one here would give it plain
+    // alarm behaviour and silently drop that, which is worse than refusing: the node would look
+    // promoted and never fire.
+    const certificateExpirationAlarmType = addressSpace.findObjectType("CertificateExpirationAlarmType");
+    if (
+        certificateExpirationAlarmType &&
+        (typeDefinition === certificateExpirationAlarmType || typeDefinition.isSubtypeOf(certificateExpirationAlarmType))
+    ) {
+        throw new Error(
+            `promoteToAlarm: ${node.browseName.toString()} is a ${typeDefinition.browseName.toString()}, ` +
+                "which has its own expiry machinery - use promoteToCertificateExpirationAlarm instead"
+        );
+    }
     const alarmConditionEventType = addressSpace.findEventType(typeDefinition.nodeId);
     /* c8 ignore next */
     if (!alarmConditionEventType) {

--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_condition_impl.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_condition_impl.ts
@@ -749,6 +749,40 @@ function UACondition_instantiate(
         namespace: options.namespace || namespace
     };
     const conditionNode = conditionType.instantiate(options2) as unknown as UAConditionImpl;
+    return _initialize_condition_node(namespace, conditionNode, conditionType, options, data);
+}
+
+/**
+ * The part of {@link InstantiateConditionOptions} that the initialization step below reads.
+ *
+ * Named separately so a caller that is wiring an existing node - which has no browseName or
+ * parent to give - does not have to invent the creation-time half of the options.
+ *
+ * @internal
+ */
+export type ConditionInitializationOptions = Pick<
+    InstantiateConditionOptions,
+    "conditionSource" | "conditionOf" | "conditionClass" | "conditionName"
+>;
+
+/**
+ * Everything that turns a freshly created node into a working condition.
+ *
+ * Split out of {@link UACondition_instantiate} so that a node that already exists - one built by
+ * `objectType.instantiate` or loaded from a nodeset - can be given the very same wiring without
+ * being rebuilt, and so the two routes cannot drift apart.
+ *
+ * @internal
+ */
+export function _initialize_condition_node(
+    namespace: INamespace,
+    conditionNode: UAConditionImpl,
+    conditionType: UAEventType,
+    options: ConditionInitializationOptions,
+    data?: Record<string, VariantOptions>
+): UAConditionEx {
+    const addressSpace = namespace.addressSpace as AddressSpacePrivate;
+
     Object.setPrototypeOf(conditionNode, UAConditionImpl.prototype);
     conditionNode.initialize();
 

--- a/packages/node-opcua-address-space/test/test_promote_to_alarm.ts
+++ b/packages/node-opcua-address-space/test/test_promote_to_alarm.ts
@@ -138,6 +138,16 @@ describe("promoteToAlarm", function (this: Mocha.Suite) {
         );
     });
 
+    it("PTA-8 - refuses a certificate expiration alarm, which owns an expiry timer", () => {
+        // it is not a limit alarm, so the check above does not catch it; promoting one would give
+        // plain alarm behaviour and drop the timer promoteToCertificateExpirationAlarm installs
+        const node = bareAlarm("CertExpiry", "CertificateExpirationAlarmType");
+
+        should(() => promoteToAlarm(node, { conditionSource: source, inputNode })).throwError(
+            /CertificateExpirationAlarmType.*promoteToCertificateExpirationAlarm/
+        );
+    });
+
     it("PTA-7 - promotes an alarm type from a companion specification family", () => {
         // the type here matters more than its name: SystemOffNormalAlarmType is a DiscreteAlarmType,
         // the branch of the family the DI health alarms live on

--- a/packages/node-opcua-address-space/test/test_promote_to_alarm.ts
+++ b/packages/node-opcua-address-space/test/test_promote_to_alarm.ts
@@ -1,0 +1,151 @@
+/**
+ * Giving an existing node the behaviour of the alarm its type already says it is.
+ *
+ * `namespace.instantiateAlarmCondition` is not the only way an alarm node comes into being: a
+ * nodeset XML, or a plain `objectType.instantiate()`, produces a node with all the right children
+ * and none of the condition machinery. `promoteToAlarm` closes that gap in place, which is what
+ * the identity assertions below are checking - the node the address space already indexes, and
+ * that other nodes already reference, has to be the node that comes back.
+ */
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { nodesets } from "node-opcua-nodesets";
+import { DataType } from "node-opcua-variant";
+import should from "should";
+
+import {
+    AddressSpace,
+    type Namespace,
+    promoteToAlarm,
+    type UAAlarmConditionEx,
+    type UAObject,
+    type UAObjectType,
+    type UAVariable
+} from "../dist/api/index.js";
+import { generateAddressSpace } from "../distNodeJS/index.js";
+
+describe("promoteToAlarm", function (this: Mocha.Suite) {
+    this.timeout(Math.max(this.timeout(), 30000));
+
+    let addressSpace: AddressSpace;
+    let namespace: Namespace;
+    let source: UAObject;
+    let inputNode: UAVariable;
+
+    before(async () => {
+        addressSpace = AddressSpace.create();
+        await generateAddressSpace(addressSpace, [nodesets.standard]);
+        namespace = addressSpace.registerNamespace("Private");
+        addressSpace.installAlarmsAndConditionsService();
+
+        const green = namespace.addObject({
+            browseName: "Green",
+            eventNotifier: 0x1,
+            notifierOf: addressSpace.rootFolder.objects.server,
+            organizedBy: addressSpace.rootFolder.objects
+        });
+        // the condition source has to be an event source, or the condition wiring refuses it
+        source = namespace.addObject({ browseName: "Boiler", componentOf: green, eventSourceOf: green });
+        inputNode = namespace.addVariable({ browseName: "BoilerTemperature", dataType: "Double", propertyOf: source });
+        inputNode.setValueFromSource({ dataType: DataType.Double, value: 0 });
+    });
+
+    after(() => addressSpace.dispose());
+
+    const alarmConditionType = () => {
+        const t = addressSpace.findObjectType("AlarmConditionType");
+        should.exist(t);
+        return t as UAObjectType;
+    };
+
+    const bareAlarm = (browseName: string, typeName = "AlarmConditionType"): UAObject => {
+        const objectType = addressSpace.findObjectType(typeName);
+        should.exist(objectType);
+        return (objectType as UAObjectType).instantiate({
+            browseName,
+            componentOf: source,
+            optionals: ["ConfirmedState", "Confirm"]
+        });
+    };
+
+    it("PTA-1 - turns an inert node from objectType.instantiate into a working alarm", () => {
+        const node = bareAlarm("PlainAlarm");
+
+        // before promotion the node is an ordinary object: none of the condition API is there
+        should(typeof (node as unknown as Partial<UAAlarmConditionEx>).activateAlarm).eql("undefined");
+        should(typeof (node as unknown as Partial<UAAlarmConditionEx>).signalNewCondition).eql("undefined");
+
+        const alarm = promoteToAlarm(node, { conditionSource: source, inputNode });
+
+        should(typeof alarm.activateAlarm).eql("function");
+        should(typeof alarm.signalNewCondition).eql("function");
+
+        alarm.activateAlarm();
+        should(alarm.activeState.getValue()).eql(true);
+        should(alarm.currentBranch().getRetain()).eql(true);
+
+        alarm.deactivateAlarm();
+        should(alarm.activeState.getValue()).eql(false);
+    });
+
+    it("PTA-2 - promotes in place, so the node keeps its identity in the address space", () => {
+        const node = bareAlarm("InPlaceAlarm");
+        const nodeId = node.nodeId;
+
+        const alarm = promoteToAlarm(node, { conditionSource: source, inputNode });
+
+        should(alarm === (node as unknown as UAAlarmConditionEx)).eql(true);
+        should(addressSpace.findNode(nodeId) === (alarm as unknown as UAObject)).eql(true);
+        // the reference that made it a component of the source is untouched
+        should(source.getComponentByName("InPlaceAlarm") === (alarm as unknown as UAObject)).eql(true);
+    });
+
+    it("PTA-3 - is idempotent", () => {
+        const node = bareAlarm("IdempotentAlarm");
+
+        const alarm1 = promoteToAlarm(node, { conditionSource: source, inputNode });
+        const alarm2 = promoteToAlarm(node);
+
+        should(alarm2 === alarm1).eql(true);
+        alarm1.activateAlarm();
+        should(alarm1.activeState.getValue()).eql(true);
+    });
+
+    it("PTA-4 - runs an assigned onInputDataValueChange when the input node value changes", () => {
+        const node = bareAlarm("HookedAlarm");
+        const alarm = promoteToAlarm(node, { conditionSource: source, inputNode });
+
+        const seen: number[] = [];
+        alarm.onInputDataValueChange = (newValue) => {
+            seen.push(newValue.value.value as number);
+        };
+
+        inputNode.setValueFromSource({ dataType: DataType.Double, value: 77.0 });
+
+        should(seen).eql([77.0]);
+    });
+
+    it("PTA-5 - refuses a node that is not an alarm", () => {
+        const notAnAlarm = namespace.addObject({ browseName: "NotAnAlarm", organizedBy: addressSpace.rootFolder.objects });
+
+        should(() => promoteToAlarm(notAnAlarm)).throwError(/does not derive from AlarmConditionType/);
+    });
+
+    it("PTA-6 - refuses a limit alarm rather than half promoting it", () => {
+        const node = bareAlarm("LimitAlarm", "ExclusiveLevelAlarmType");
+
+        should(() => promoteToAlarm(node, { conditionSource: source, inputNode })).throwError(
+            /ExclusiveLevelAlarmType.*limit alarm/
+        );
+    });
+
+    it("PTA-7 - promotes an alarm type from a companion specification family", () => {
+        // the type here matters more than its name: SystemOffNormalAlarmType is a DiscreteAlarmType,
+        // the branch of the family the DI health alarms live on
+        const node = bareAlarm("OffNormal", "SystemOffNormalAlarmType");
+        const alarm = promoteToAlarm(node, { conditionSource: source, inputNode });
+
+        alarm.activateAlarm();
+        should(alarm.activeState.getValue()).eql(true);
+        should(alarmConditionType().nodeId.namespace).eql(0);
+    });
+});


### PR DESCRIPTION
An alarm only has behaviour if `namespace.instantiateAlarmCondition` created it. A node that
arrives any other way is inert. Measured on master:

| route | class | `activateAlarm` | `signalNewCondition` |
|---|---|---|---|
| `instantiateAlarmCondition` | `UAAlarmConditionImplBase` | yes | yes |
| `alarmType.instantiate(...)` | `UAObjectImpl` | **no** | **no** |

That is the gap: an application that already has the node - from a nodeset, or from a plain
`instantiate` - cannot give it condition behaviour. `promoteToAlarm(node, options)` does.

## In place, like the other promoters

Six promoters already retype a node in place (`promoteToStateMachine`,
`promoteToCertificateExpirationAlarm`, ...). In place matters: the node keeps its identity in
the address-space index and in every parent/child reference that already points at it. This
follows the same idiom - `instanceof` guard, `Object.setPrototypeOf`, then initialize.

## No duplicated wiring

The behaviour lived in the tail of three `instantiate` methods. Rather than copy it, each
tail became an `@internal` function that both `instantiate` and `promoteToAlarm` call:

- `_initialize_condition_node` (HasCondition back-reference, eventType/branchId, the
  Comment/Quality/LastSeverity condition variables, the EnabledState TwoStateVariable)
- `_initialize_acknowledgeable_condition_node`
- `_initialize_alarm_condition_node` (ActiveState machinery, shelving/suppressed, input monitoring)

One deliberate relaxation: `inputNode` is optional for promotion, so the
`assert(options.inputNode)` moved up into `UAAlarmConditionImplBase.instantiate`. The factory's
contract is unchanged.

## Refuses rather than half-promotes

A node that looks promoted and then misbehaves is worse than a loud failure, so the function
throws, naming the offending type, for:

- anything not deriving from `AlarmConditionType`
- **limit alarms** (`LimitAlarmType` and below - exclusive, non-exclusive, level, deviation,
  rate-of-change) which need their own implementation class
- **`CertificateExpirationAlarmType`**, which owns an expiry timer and a shutdown task that
  only `promoteToCertificateExpirationAlarm` installs. It is not a limit alarm, so the first
  guard misses it; promoting one produced a node that looked ready and would never fire. The
  error names the function to call instead.

## Known limit, recorded rather than hidden

The DI health alarms descend `DeviceHealthDiagnosticAlarmType -> InstrumentDiagnosticAlarmType
-> DiscreteAlarmType -> AlarmConditionType`. They promote correctly, because
`UADiscreteAlarmImplBase.instantiate` adds a prototype swap and no behaviour of its own - but
the promoted node wears `UAAlarmConditionImpl.prototype`, so `node instanceof UADiscreteAlarmImpl`
is `false` where the factory route would make it `true`. Giving it the discrete prototype would
make `ua_alarm_condition_impl` import `ua_discrete_alarm_impl`, which imports it back: exactly
the cycle `impl/apply_condition_refresh.ts:6-27` warns about. Left as is.

## Verification

```
npx tsc -b packages                              0
pnpm run lint:ci                                 0
pnpm run check:testtypes                         0
test/test_promote_to_alarm.ts                    8 passing  (new)
test/alarms_and_conditions/**/*.ts               91 passing
test/test_custom_alarm_hooks.ts                  4 passing
test/test_custom_alarm_condition_info.ts         3 passing
node-opcua-address-space, whole suite            1365 passing, 0 failing
```

The new test imports only from published entry points, so it stops compiling if any of this has
to come from a deep path again. It covers: an inert node gaining behaviour, identity preserved
across promotion, idempotence, an assigned `onInputDataValueChange` firing on the promoted node,
and each of the three rejections.

Out of scope here, deliberately: widening `registerNodePromoter` to accept a NodeId and walk
subtypes, and applying promoters at instantiate time. This is the imperative call only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
