### PR TITLE
refactor(playground): device health alarms use the published alarm hooks

### DIFF
--- a/packages/playground/device_health_extra.ts
+++ b/packages/playground/device_health_extra.ts
@@ -1,203 +1,140 @@
-import type {
+/**
+ * The four DI DeviceHealth alarms (Failure, CheckFunction, OffSpec, MaintenanceRequired) of a
+ * device, all watching the same DeviceHealth enumeration variable.
+ *
+ * It is kept as a worked example of giving an alarm a behaviour of its own from application
+ * code: nothing is imported from inside a package, no implementation class is derived from, and
+ * the behaviour is installed by assigning the published hooks. The hooks are assigned as
+ * closures on purpose - a closure carries the application context (here the device and the
+ * diagnostics this module collects for it), which is the one thing a prototype method could
+ * never reach without bolting an extra field onto the node.
+ */
+import {
     ConditionInfo,
-    INamespace,
-    Namespace,
-    UAAlarmConditionEx,
-    UADiscreteAlarm,
-    UAObject,
-    UAObjectType
-} from "node-opcua-address-space";
-import { ConditionInfoImpl } from "node-opcua-address-space/dist/impl/alarms_and_conditions/condition_info_impl";
-import { UAAlarmConditionImpl } from "node-opcua-address-space/dist/impl/alarms_and_conditions/ua_alarm_condition_impl";
-import type { DataValue } from "node-opcua-data-value";
-import { StatusCodes } from "node-opcua-status-code";
-import { DataType } from "node-opcua-variant";
+    DataType,
+    type Namespace,
+    NodeClass,
+    StatusCodes,
+    type UAAlarmConditionEx,
+    type UAEventType,
+    type UAObject,
+    type UAVariable
+} from "node-opcua";
+import { EnumDeviceHealth } from "node-opcua-nodeset-di";
 
-import { EnumDeviceHealth } from "../enum_device_health";
+/**
+ * Diagnostics the application gathers elsewhere, deliberately owned by this module rather than
+ * stored on the node: the alarm hooks reach it through their closure, which is why the alarms
+ * need no `$device` field of their own.
+ */
+const recentDiagnostics = new Map<UAObject, string[]>();
 
-export class UADeviceHealthDiagnosticAlarmEx extends UAAlarmConditionImpl implements UAAlarmConditionEx {
-    public $device: UAObject;
-    getLastDeviceError(): string[] {
-        return [];
-    }
-    public _calculateConditionInfo(
-        _states: string | null,
-        isActive: boolean,
-        value: string,
-        _oldConditionInfo: ConditionInfo
-    ): ConditionInfo {
-        if (!isActive) {
-            return new ConditionInfoImpl({
-                message: "Back to normal",
-                quality: StatusCodes.Good,
-                retain: true,
-                severity: 0
-            });
-        } else {
-            // build-up state string
-            return new ConditionInfoImpl({
-                message: value,
-                quality: StatusCodes.Good,
-                retain: true,
-                severity: 150
-            });
-        }
-    }
-
-    public _updateAlarmState(normalStateValue: number, inputValue: number): void {
-        const isActive = normalStateValue === inputValue;
-        if (isActive === this.activeState.getValue()) {
-            // no change => ignore !
-            return;
-        }
-
-        const stateName = isActive ? "Active" : "Inactive";
-        // also raise the event
-
-        // get device node last error info
-        if (isActive) {
-            const description = this.getLastDeviceError();
-            this._signalNewCondition(stateName, isActive, description.join("\n"));
-        } else {
-            this._signalNewCondition(stateName, isActive, "");
-        }
-    }
+/** Called by the application whenever the device reports something worth quoting in an alarm. */
+export function recordDeviceDiagnostic(deviceNode: UAObject, diagnostic: string): void {
+    const history = recentDiagnostics.get(deviceNode) || [];
+    // an alarm message is read by a human, so only the tail of the history is worth carrying
+    recentDiagnostics.set(deviceNode, [...history, diagnostic].slice(-3));
 }
 
-export class UAFailureAlarm extends UADeviceHealthDiagnosticAlarmEx {
-    public _onInputDataValueChange(newValue: DataValue) {
-        const inputValue = newValue.value.value;
-        const normalStateValue = EnumDeviceHealth.FAILURE;
-        this._updateAlarmState(normalStateValue, inputValue);
-    }
-}
-
-export class UACheckFunctionAlarm extends UADeviceHealthDiagnosticAlarmEx {
-    public _onInputDataValueChange(newValue: DataValue) {
-        const inputValue = newValue.value.value;
-        const normalStateValue = EnumDeviceHealth.CHECK_FUNCTION;
-        this._updateAlarmState(normalStateValue, inputValue);
-    }
-}
-export class UAOffSpecAlarm extends UADeviceHealthDiagnosticAlarmEx {
-    public _onInputDataValueChange(newValue: DataValue) {
-        const inputValue = newValue.value.value;
-        const normalStateValue = EnumDeviceHealth.OFF_SPEC;
-        this._updateAlarmState(normalStateValue, inputValue);
-    }
-}
-export class UAMaintenanceRequiredAlarm extends UADeviceHealthDiagnosticAlarmEx {
-    public _onInputDataValueChange(newValue: DataValue) {
-        const inputValue = newValue.value.value;
-        const normalStateValue = EnumDeviceHealth.MAINTENANCE_REQUIRED;
-        this._updateAlarmState(normalStateValue, inputValue);
-    }
+function lastDeviceErrors(deviceNode: UAObject): string {
+    const history = recentDiagnostics.get(deviceNode);
+    return history && history.length > 0 ? history.join(" / ") : "no diagnostic reported";
 }
 
 interface UADeviceObjectWithHealthChildren extends UAObject {
-    deviceHealth?: UAObject;
+    deviceHealth?: UAVariable;
     deviceHealthAlarms?: UAObject;
 }
 
-function _createXXXXAlarm(
-    namespace: INamespace,
-    deviceNode: UAObject,
-    alarmType: UAObjectType,
-    browseName: string
-): UADiscreteAlarm {
-    const deviceNodeWithHealth = deviceNode as UADeviceObjectWithHealthChildren;
-    const deviceHealthNode = deviceNodeWithHealth.deviceHealth;
+function installDeviceHealthAlarm(
+    namespace: Namespace,
+    deviceNode: UADeviceObjectWithHealthChildren,
+    alarmType: UAEventType,
+    browseName: string,
+    alarmingHealth: EnumDeviceHealth
+): UAAlarmConditionEx {
+    const deviceHealthNode = deviceNode.deviceHealth;
     if (!deviceHealthNode) {
         throw new Error("DeviceHealth must exist");
     }
-    const deviceHealthAlarms = deviceNodeWithHealth.deviceHealthAlarms;
+    const deviceHealthAlarms = deviceNode.deviceHealthAlarms;
     if (!deviceHealthAlarms) {
         throw new Error("deviceHealthAlarms must exist");
     }
 
-    (alarmType as unknown as { isAbstract: boolean }).isAbstract = false;
-
-    if (alarmType.isAbstract) {
-        throw new Error(`Alarm Type cannot be abstract ${alarmType.browseName.toString()}`);
-    }
-
     deviceNode.setEventNotifier(1);
 
-    const options = {
+    const alarm = namespace.instantiateAlarmCondition(alarmType, {
         browseName,
+        componentOf: deviceHealthAlarms,
         conditionSource: deviceNode,
         inputNode: deviceHealthNode,
-        componentOf: deviceHealthAlarms,
-        // normalState: normalStateNode,
         optionals: ["ConfirmedState", "Confirm"]
-    };
+    });
 
-    const n = namespace as Namespace;
-    const alarmNode = n.instantiateAlarmCondition(alarmType, options) as UADeviceHealthDiagnosticAlarmEx;
-
-    alarmNode.conditionName.setValueFromSource({
+    alarm.conditionName.setValueFromSource({
         dataType: DataType.String,
         value: browseName.replace("Alarm", "")
     });
 
-    alarmNode._updateAlarmState = UADeviceHealthDiagnosticAlarmEx.prototype._updateAlarmState;
-    alarmNode._calculateConditionInfo = UADeviceHealthDiagnosticAlarmEx.prototype._calculateConditionInfo;
-    alarmNode.getLastDeviceError = UADeviceHealthDiagnosticAlarmEx.prototype.getLastDeviceError;
+    // the device is whatever was passed as conditionSource; asking the alarm rather than
+    // remembering it separately keeps the two from drifting apart
+    const conditionOf = alarm.conditionOfNode();
+    const device = conditionOf && conditionOf.nodeClass === NodeClass.Object ? conditionOf : deviceNode;
 
-    // Object.setPrototypeOf(alarmNode, UADeviceHealthDiagnosticAlarm.prototype);
+    alarm.calculateConditionInfo = (_stateName, isActive, value, _oldConditionInfo) =>
+        new ConditionInfo({
+            message: isActive ? `${browseName}: ${value}` : "Back to normal",
+            quality: StatusCodes.Good,
+            retain: true,
+            severity: isActive ? 150 : 0
+        });
 
-    // install inputNode Node monitoring for change
-    alarmNode.installInputNodeMonitoring(options.inputNode);
-    alarmNode.activeState.setValue(false);
-    alarmNode.$device = deviceNode;
+    alarm.onInputDataValueChange = (newValue) => {
+        const isActive = newValue.value.value === alarmingHealth;
+        if (isActive === alarm.activeState.getValue()) {
+            // the same health value can be written repeatedly; only the edges are events
+            return;
+        }
+        alarm.signalNewCondition(isActive ? "Active" : "Inactive", isActive, isActive ? lastDeviceErrors(device) : "");
+    };
 
-    return alarmNode;
+    alarm.installInputNodeMonitoring(deviceHealthNode);
+    alarm.activeState.setValue(false);
+
+    return alarm;
 }
 
+/**
+ * What an application calls once per device, after the DI nodeset has been loaded and the
+ * device object built.
+ */
 export function createDeviceHealthAlarms(deviceNode: UAObject): void {
-    try {
-        const namespace = deviceNode.namespace;
-        const addressSpace = namespace.addressSpace;
-        const nsDI = addressSpace.getNamespaceIndex("http://opcfoundation.org/UA/DI/");
-        if (nsDI < 0) {
-            throw new Error("Cannot find DI namespace!");
-        }
-        const checkFunctionAlarmType = addressSpace.findEventType("CheckFunctionAlarmType", nsDI);
-        const failureAlarmType = addressSpace.findEventType("FailureAlarmType", nsDI);
-        const maintenanceRequiredAlarmType = addressSpace.findEventType("MaintenanceRequiredAlarmType", nsDI);
-        const offSpecAlarmType = addressSpace.findEventType("OffSpecAlarmType", nsDI);
-        if (!checkFunctionAlarmType || !failureAlarmType || !maintenanceRequiredAlarmType || !offSpecAlarmType) {
-            throw new Error("Cannot find one of the DI alarm event types");
-        }
+    const namespace = deviceNode.namespace as Namespace;
+    const addressSpace = namespace.addressSpace;
+    const nsDI = addressSpace.getNamespaceIndex("http://opcfoundation.org/UA/DI/");
+    if (nsDI < 0) {
+        throw new Error("Cannot find DI namespace!");
+    }
 
-        const failureAlarm = _createXXXXAlarm(namespace, deviceNode, failureAlarmType, "FailureAlarm");
-        const maintenanceRequiredAlarm = _createXXXXAlarm(
+    const alarms: [string, EnumDeviceHealth][] = [
+        ["FailureAlarmType", EnumDeviceHealth.FAILURE],
+        ["MaintenanceRequiredAlarmType", EnumDeviceHealth.MAINTENANCE_REQUIRED],
+        ["CheckFunctionAlarmType", EnumDeviceHealth.CHECK_FUNCTION],
+        ["OffSpecAlarmType", EnumDeviceHealth.OFF_SPEC]
+    ];
+
+    for (const [typeName, alarmingHealth] of alarms) {
+        const alarmType = addressSpace.findEventType(typeName, nsDI);
+        if (!alarmType) {
+            throw new Error(`Cannot find DI alarm event type ${typeName}`);
+        }
+        installDeviceHealthAlarm(
             namespace,
-            deviceNode,
-            maintenanceRequiredAlarmType,
-            "MaintenanceRequiredAlarm"
+            deviceNode as UADeviceObjectWithHealthChildren,
+            alarmType,
+            typeName.replace("Type", ""),
+            alarmingHealth
         );
-        const checkFunctionAlarm = _createXXXXAlarm(namespace, deviceNode, checkFunctionAlarmType, "CheckFunctionAlarm");
-        const offSpecAlarm = _createXXXXAlarm(namespace, deviceNode, offSpecAlarmType, "OffSpecAlarm");
-
-        type AlarmWithInputChange = UADeviceHealthDiagnosticAlarmEx & {
-            _onInputDataValueChange: (newValue: DataValue) => void;
-        };
-        (failureAlarm as AlarmWithInputChange)._onInputDataValueChange = UAFailureAlarm.prototype._onInputDataValueChange;
-        (maintenanceRequiredAlarm as AlarmWithInputChange)._onInputDataValueChange =
-            UAMaintenanceRequiredAlarm.prototype._onInputDataValueChange;
-        (checkFunctionAlarm as AlarmWithInputChange)._onInputDataValueChange =
-            UACheckFunctionAlarm.prototype._onInputDataValueChange;
-        (offSpecAlarm as AlarmWithInputChange)._onInputDataValueChange = UAOffSpecAlarm.prototype._onInputDataValueChange;
-
-        /*
-            console.log(failureAlarm.toString());
-            console.log(maintenanceRequiredAlarm.toString());
-            console.log(checkFunctionAlarm.toString());
-            console.log(offSpecAlarm.toString());
-        */
-    } catch (err) {
-        console.log("err ", err.message);
-        console.log(err);
     }
 }

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -14,6 +14,7 @@
         "node-opcua-client": "2.182.2",
         "node-opcua-debug": "2.181.0",
         "node-opcua-modeler": "2.182.2",
+        "node-opcua-nodeset-di": "2.182.0",
         "readline": "*",
         "winston": "*"
     },

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -5,7 +5,8 @@
     "main": "sample1.js",
     "private": true,
     "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 0"
+        "test": "echo \"Error: no test specified\" && exit 0",
+        "test:check": "tsc --noEmit -p tsconfig.json"
     },
     "dependencies": {
         "bcryptjs": "3.0.3",

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -1,5 +1,5 @@
 {
     "extends": "../../tsconfig.json",
-    "include": ["server_with_slow_osc.ts"],
+    "include": ["device_health_extra.ts", "server_with_slow_osc.ts"],
     "exclude": []
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4487,6 +4487,9 @@ importers:
       node-opcua-modeler:
         specifier: 2.182.2
         version: link:../node-opcua-modeler
+      node-opcua-nodeset-di:
+        specifier: 2.182.0
+        version: link:../node-opcua-nodeset-di
       readline:
         specifier: '*'
         version: 1.3.0


### PR DESCRIPTION
`packages/playground/device_health_extra.ts` was the evidence that node-opcua had no supported
way to give an alarm behaviour of its own. It is a distilled copy of shipped application code,
and it motivated the two previous PRs. Now it is rewritten as a worked example of the supported
way, and put under a gate so it cannot rot again.

## Before and after

| before | after |
|---|---|
| 2 deep imports from `dist/impl/alarms_and_conditions/...` | everything from `node-opcua` and `node-opcua-nodeset-di` |
| 5 classes extending `UAAlarmConditionImpl`, **none ever instantiated** | no classes at all |
| 7 hand-copied prototype methods onto the instance | hooks assigned as closures |
| a commented-out `Object.setPrototypeOf` where the author gave up | gone |
| `public $device: UAObject`, assigned and **never read** | `alarm.conditionOfNode()` |
| `(alarmType as any).isAbstract = false` | gone: the DI types load concrete |
| `import { EnumDeviceHealth } from "../enum_device_health"` - a path that does not exist | `from "node-opcua-nodeset-di"` |
| nothing compiled the file | under `check:testtypes` |

Behaviour is unchanged in shape: one DeviceHealth enumeration variable is the input of four
alarms, each comparing it to its own constant, edge-detecting against `activeState` and calling
`signalNewCondition` only on a transition.

## Why closures, not a context field

`$device` existed because a prototype method has no closure, so `this` was the only channel for
application context. Assigned hooks are closures, so they capture what they need directly. The
module keeps a `Map<UAObject, string[]>` of recent diagnostics and the hook reads it through the
closure - which is why the message now actually carries them, where the original's
`getLastDeviceError()` always returned `[]` because the real provider lived in another module
and was never wired in.

The device itself comes from `alarm.conditionOfNode()`, which returns whatever was passed as
`conditionSource`. Asking the alarm rather than storing a second reference keeps the two from
drifting apart.

## Proof it runs

Loading the standard + DI nodesets, building a device, recording two diagnostics and driving
DeviceHealth 0 -> 1 (FAILURE) -> 3 (OFF_SPEC):

```
event: Failure active=Active   : FailureAlarm: bearing temperature 92C / vibration above threshold
event: Failure active=Inactive : Back to normal
event: OffSpec active=Active   : OffSpecAlarm: bearing temperature 92C / vibration above threshold
```

The closure-captured diagnostics reach the message, the edge detection deactivates Failure when
health moves off 1, and OffSpec picks it up.

## The gate, and why not the build graph

`npx tsc -b packages` does **not** typecheck playground - it is not among the 77 project
references - so that command was green whether or not this file compiled. That is precisely how
it came to import a non-existent path with nobody noticing.

Adding a project reference would be the wrong fix: playground declares no `outDir`, so building
it emits `.js` and `.d.ts` beside the sources. Instead the package now declares
`"test:check": "tsc --noEmit -p tsconfig.json"`, which the existing `check:testtypes` gate picks
up automatically - it covers every package declaring that script. 76 packages checked became 77.

Verified the gate bites: adding a deliberate type error makes it fail with
`device_health_extra.ts(142,7): error TS2322`, and removing it makes it pass again.

## Verification

```
npx tsc -b packages/playground --force                 0   (what actually builds it)
npx tsc -b packages                                    0
pnpm run check:testtypes                               OK (77 packages, 0 grandfathered)
pnpm run lint:ci                                       0
grep "dist/|impl/|as any|setPrototypeOf|prototype\."   no matches
```

## Left as is, and reported

`deviceNode.namespace as Namespace` remains: `BaseNode.namespace` is typed `INamespace`, while
`instantiateAlarmCondition` lives on `Namespace`. It is the last cast in the file, and removing
it means widening `INamespace` in node-opcua-address-space - out of scope here, worth its own
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
