### PR TITLE
feat(address-space): add namespaceOf, so a node reaches its full namespace

### DIFF
--- a/packages/node-opcua-address-space/api/index.ts
+++ b/packages/node-opcua-address-space/api/index.ts
@@ -244,6 +244,7 @@ export * from "./loader/register_node_promoter.js";
 export * from "./namespace.js";
 export type { INamespaceAlarmAndCondition } from "./namespace_alarm_and_condition.js";
 export * from "./namespace_data_access.js";
+export * from "./namespace_of.js";
 export * from "./pseudo_session.js";
 export * from "./session_context.js";
 export * from "./set_namespace_meta_data.js";

--- a/packages/node-opcua-address-space/api/namespace_of.ts
+++ b/packages/node-opcua-address-space/api/namespace_of.ts
@@ -1,0 +1,28 @@
+import type { BaseNode } from "node-opcua-address-space-base";
+import type { Namespace } from "./namespace.js";
+
+/**
+ * The namespace a node belongs to, seen through the published {@link Namespace}.
+ *
+ * `BaseNode.namespace` is declared in node-opcua-address-space-base, which cannot name the
+ * alarm-and-condition, data-access and machine-state methods this package adds without
+ * depending on it. So a caller holding only a node saw the narrower `INamespace`, and reaching
+ * `instantiateAlarmCondition` meant asserting the type at every call site.
+ *
+ * The same mismatch was already corrected for `AddressSpace.getOwnNamespace()`, which used to
+ * return the narrower interface and hide those methods. This closes the remaining case: the
+ * assertion happens once, here, where both types are in scope.
+ *
+ * ```ts
+ * const alarm = namespaceOf(deviceNode).instantiateAlarmCondition(alarmType, {
+ *     browseName: "FailureAlarm",
+ *     conditionSource: deviceNode,
+ *     inputNode: deviceHealthNode
+ * });
+ * ```
+ */
+export function namespaceOf(node: BaseNode): Namespace {
+    // every namespace in this address space is a NamespaceImpl, which satisfies Namespace;
+    // only the declaration BaseNode can reach is narrower
+    return node.namespace as Namespace;
+}

--- a/packages/node-opcua-address-space/test/test_namespace_of.ts
+++ b/packages/node-opcua-address-space/test/test_namespace_of.ts
@@ -1,0 +1,41 @@
+/**
+ * Tests for namespaceOf.
+ *
+ * The point of the helper is what it lets an application write, so the test is written the way
+ * an application would write it: only published names, and no type assertion anywhere. If
+ * reaching a namespace method from a node ever needs a cast again, this stops compiling.
+ */
+import "should";
+import { nodesets } from "node-opcua-nodesets";
+import should from "should";
+import { AddressSpace, namespaceOf, type UAObject } from "../dist/api/index.js";
+import { generateAddressSpace } from "../distNodeJS/index.js";
+
+describe("namespaceOf", () => {
+    let addressSpace: AddressSpace;
+    let node: UAObject;
+
+    before(async () => {
+        addressSpace = AddressSpace.create();
+        await generateAddressSpace(addressSpace, nodesets.standard);
+        const namespace = addressSpace.registerNamespace("urn:test");
+        node = namespace.addObject({ browseName: "Some", organizedBy: addressSpace.rootFolder.objects });
+    });
+    after(() => addressSpace.dispose());
+
+    it("NSOF-1 returns the very namespace the node belongs to", () => {
+        should(namespaceOf(node)).eql(node.namespace);
+    });
+
+    it("NSOF-2 reaches a method that BaseNode.namespace does not declare", () => {
+        // instantiateAlarmCondition lives on Namespace, not on the INamespace a node exposes;
+        // before this helper an application had to assert the type to get here
+        should(typeof namespaceOf(node).instantiateAlarmCondition).eql("function");
+        should(typeof namespaceOf(node).instantiateOffNormalAlarm).eql("function");
+    });
+
+    it("NSOF-3 works for a node from the standard nodeset too, not just one just created", () => {
+        const server = addressSpace.rootFolder.objects.server;
+        should(namespaceOf(server).index).eql(0);
+    });
+});


### PR DESCRIPTION
An application holding a node cannot reach the methods its namespace really has.

```ts
const namespace = deviceNode.namespace as Namespace;   // the assertion this removes
namespace.instantiateAlarmCondition(...);
```

`BaseNode.namespace` is declared `INamespace` in **node-opcua-address-space-base**, and that
package cannot name the alarm-and-condition, data-access or machine-state methods that
**node-opcua-address-space** adds without depending on it. So the narrower interface is all a
node exposes, and every caller wanting `instantiateAlarmCondition` asserted the type itself.

## Precedent

This is the same mismatch that was already corrected one level up. From
`api/address_space_public.ts`:

> `getOwnNamespace()` returned a `NamespacePrivate` that extended `INamespace` rather than the
> published `Namespace`, hiding the alarm-and-condition, data-access and machine-state methods
> `NamespaceImpl` really has

That was fixed for the address space. `namespaceOf` closes the remaining case, for callers who
have a node rather than the address space.

## What it is

```ts
export function namespaceOf(node: BaseNode): Namespace {
    return node.namespace as Namespace;
}
```

The assertion is real but now happens **once**, in the package where both types are in scope and
where the invariant is checkable: every namespace in this address space is a `NamespaceImpl`,
which satisfies `Namespace`; only the declaration `BaseNode` can reach is narrower.

Nothing else was widened. Making `BaseNode.namespace` itself richer would mean the base package
depending on this one, which is why it was declared narrow in the first place.

## Test

`test/test_namespace_of.ts` is written the way an application would write it - only published
names, and **no type assertion anywhere**, so it stops compiling if reaching a namespace method
from a node ever needs a cast again.

```
NSOF-1 returns the very namespace the node belongs to
NSOF-2 reaches a method that BaseNode.namespace does not declare
NSOF-3 works for a node from the standard nodeset too, not just one just created
3 passing
```

## Verification

```
npx tsc -b packages          0
pnpm run lint:ci             0
pnpm run check:testtypes     OK (76 packages, 0 grandfathered)
```

## Follow-up

`packages/playground/device_health_extra.ts` still carries `deviceNode.namespace as Namespace`.
Once this and #1679 are both in, that line becomes `namespaceOf(deviceNode)` and the file has no
assertions left at all - which was the point of rewriting it as a worked example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
