### PR TITLE
refactor(playground): the workbench has no type assertions left

### DIFF
--- a/packages/playground/device_health_extra.ts
+++ b/packages/playground/device_health_extra.ts
@@ -14,6 +14,7 @@ import {
     DataType,
     type Namespace,
     NodeClass,
+    namespaceOf,
     StatusCodes,
     type UAAlarmConditionEx,
     type UAEventType,
@@ -109,8 +110,10 @@ function installDeviceHealthAlarm(
  * What an application calls once per device, after the DI nodeset has been loaded and the
  * device object built.
  */
-export function createDeviceHealthAlarms(deviceNode: UAObject): void {
-    const namespace = deviceNode.namespace as Namespace;
+// Both children are optional, so any UAObject satisfies this: declaring the parameter with it
+// costs a caller nothing and removes the last assertion from the file.
+export function createDeviceHealthAlarms(deviceNode: UADeviceObjectWithHealthChildren): void {
+    const namespace = namespaceOf(deviceNode);
     const addressSpace = namespace.addressSpace;
     const nsDI = addressSpace.getNamespaceIndex("http://opcfoundation.org/UA/DI/");
     if (nsDI < 0) {
@@ -129,12 +132,6 @@ export function createDeviceHealthAlarms(deviceNode: UAObject): void {
         if (!alarmType) {
             throw new Error(`Cannot find DI alarm event type ${typeName}`);
         }
-        installDeviceHealthAlarm(
-            namespace,
-            deviceNode as UADeviceObjectWithHealthChildren,
-            alarmType,
-            typeName.replace("Type", ""),
-            alarmingHealth
-        );
+        installDeviceHealthAlarm(namespace, deviceNode, alarmType, typeName.replace("Type", ""), alarmingHealth);
     }
 }


### PR DESCRIPTION
The follow-up promised in #1680. `packages/playground/device_health_extra.ts` exists as a worked
example of extending an alarm from application code, so any cast left in it is a claim that the
published API is not quite enough. There were two; both are gone.

| was | now |
|---|---|
| `deviceNode.namespace as Namespace` | `namespaceOf(deviceNode)` (#1680) |
| `deviceNode as UADeviceObjectWithHealthChildren` | the entry parameter is declared with that interface |

The second needs no new API. Both of its members are optional, so any `UAObject` satisfies the
interface structurally - declaring the parameter with it costs a caller nothing and removes the
assertion.

The file now contains **no type assertions at all**, which is the standard it was rewritten to
meet: an application can do everything it does using only what the package publishes.

## Verification

```
npx tsc --noEmit -p packages/playground/tsconfig.json   0
npx tsc -b packages                                      0
pnpm run lint:ci                                         0
pnpm run check:testtypes                                 OK (77 packages, 0 grandfathered)
grep -E " as [A-Za-z]|as unknown|as any"                 only prose in comments
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
