### PR TITLE
feat(address-space): publish the deviation alarm setpoint hook

### DIFF
--- a/packages/node-opcua-address-space/api/interfaces/alarms_and_conditions/deviation_stuff.ts
+++ b/packages/node-opcua-address-space/api/interfaces/alarms_and_conditions/deviation_stuff.ts
@@ -4,7 +4,37 @@ import type { DataValue } from "node-opcua-data-value";
 import type { SetPointSupport } from "./install_setpoint_options.js";
 
 export interface DeviationStuff extends SetPointSupport {
+    /**
+     * What the alarm does when the value of its setpoint node changes. A deviation alarm
+     * watches two nodes, not one, and this is the setpoint half: assign to it to decide what
+     * moving the setpoint means, without deriving from an implementation class:
+     *
+     * ```ts
+     * alarm.onSetpointDataValueChange = (dataValue) => {
+     *     // a setpoint the operator is still dialling in should not trip the alarm
+     *     if (dataValue.statusCode.isGood()) {
+     *         alarm.setStateBasedOnInputValue(alarm.getInputNodeValue()!);
+     *     }
+     * };
+     * ```
+     *
+     * The default re-evaluates the alarm state against the new setpoint, which is what a
+     * deviation alarm means; assigning to it replaces that.
+     *
+     * The old name `_onSetpointDataValueChange` still works and is deprecated.
+     */
+    onSetpointDataValueChange(dataValue: DataValue): void;
+
+    /**
+     * @deprecated assign {@link DeviationStuff.onSetpointDataValueChange} instead; this delegates to it.
+     */
     _onSetpointDataValueChange(dataValue: DataValue): void;
+
+    /**
+     * @deprecated assign `setStateBasedOnInputValue` on `UALimitAlarmHelper` instead, which every
+     * deviation alarm also is; this delegates to it. It is kept here, with its original looser
+     * signature, because removing it from a published interface would break implementers.
+     */
     _setStateBasedOnInputValue(value: unknown): void;
 
     getSetpointNodeNode(): UAVariableT<number, DataType.Double> | UAVariableT<number, DataType.Float> | undefined;

--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/deviation_alarm_helper.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/deviation_alarm_helper.ts
@@ -61,6 +61,9 @@ export function DeviationAlarmHelper_install_setpoint(this: DeviationStuff, opti
         });
         // install inputNode monitoring for change
         this.setpointNodeNode.on("value_changed", (newDataValue: DataValue) => {
+            // deliberately the deprecated name, for the same reason as _setStateBasedOnInputValue:
+            // an old subclass that overrode `_onSetpointDataValueChange` is still reached, and a
+            // new assignment of the published name is reached through the delegate on the impl.
             this._onSetpointDataValueChange(newDataValue);
         });
     } else {

--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_exclusive_deviation_alarm_impl.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_exclusive_deviation_alarm_impl.ts
@@ -70,8 +70,19 @@ export class UAExclusiveDeviationAlarmImplBase extends UAExclusiveLimitAlarmImpl
         return DeviationAlarmHelper_getSetpointValue.call(this);
     }
 
-    public _onSetpointDataValueChange(dataValue: DataValue): void {
+    /**
+     * What the alarm does when the value of its setpoint node changes: re-evaluate the state
+     * of the alarm against the new setpoint, since the deviation it watches has just moved.
+     */
+    public onSetpointDataValueChange(dataValue: DataValue): void {
         DeviationAlarmHelper_onSetpointDataValueChange.call(this, dataValue);
+    }
+
+    /**
+     * @deprecated assign {@link onSetpointDataValueChange} instead; this delegates to it.
+     */
+    public _onSetpointDataValueChange(dataValue: DataValue): void {
+        this.onSetpointDataValueChange(dataValue);
     }
 
     public _install_setpoint(options: InstallSetPointOptions): void {

--- a/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_non_exclusive_deviation_alarm_impl.ts
+++ b/packages/node-opcua-address-space/impl/alarms_and_conditions/ua_non_exclusive_deviation_alarm_impl.ts
@@ -79,8 +79,19 @@ export class UANonExclusiveDeviationAlarmImplBase
         return DeviationAlarmHelper_getSetpointValue.call(this);
     }
 
-    public _onSetpointDataValueChange(dataValue: DataValue): void {
+    /**
+     * What the alarm does when the value of its setpoint node changes: re-evaluate the state
+     * of the alarm against the new setpoint, since the deviation it watches has just moved.
+     */
+    public onSetpointDataValueChange(dataValue: DataValue): void {
         DeviationAlarmHelper_onSetpointDataValueChange.call(this, dataValue);
+    }
+
+    /**
+     * @deprecated assign {@link onSetpointDataValueChange} instead; this delegates to it.
+     */
+    public _onSetpointDataValueChange(dataValue: DataValue): void {
+        this.onSetpointDataValueChange(dataValue);
     }
 
     public _install_setpoint(options: InstallSetPointOptions): void {

--- a/packages/node-opcua-address-space/test/test_deviation_alarm_hooks.ts
+++ b/packages/node-opcua-address-space/test/test_deviation_alarm_hooks.ts
@@ -1,0 +1,132 @@
+/**
+ * Customising a deviation alarm from outside the package.
+ *
+ * A deviation alarm watches two nodes: the input node, whose hook `onInputDataValueChange` is
+ * published on every alarm, and the setpoint node, whose hook was only ever reachable under
+ * the underscore-prefixed name on the implementation class.
+ *
+ * The imports below are the point of the test, as in test_custom_alarm_hooks.ts: everything an
+ * application needs to give a deviation alarm its own behaviour has to be reachable from the
+ * package entry points. If any of these names has to come from a deep path again, this stops
+ * compiling.
+ */
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { nodesets } from "node-opcua-nodesets";
+import { DataType } from "node-opcua-variant";
+import should from "should";
+
+import {
+    AddressSpace,
+    type Namespace,
+    type UANonExclusiveDeviationAlarmEx,
+    type UAObject,
+    type UAVariableT
+} from "../dist/api/index.js";
+import { generateAddressSpace } from "../distNodeJS/index.js";
+
+describe("deviation alarm hooks", function (this: Mocha.Suite) {
+    this.timeout(Math.max(this.timeout(), 30000));
+
+    let addressSpace: AddressSpace;
+    let namespace: Namespace;
+    let source: UAObject;
+    let inputNode: UAVariableT<number, DataType.Double>;
+    let setpointNode: UAVariableT<number, DataType.Double>;
+
+    before(async () => {
+        addressSpace = AddressSpace.create();
+        await generateAddressSpace(addressSpace, [nodesets.standard]);
+        namespace = addressSpace.registerNamespace("Private");
+        addressSpace.installAlarmsAndConditionsService();
+
+        // a condition source has to be an event source, otherwise instantiation refuses it
+        source = namespace.addObject({
+            browseName: "Tank",
+            eventSourceOf: addressSpace.rootFolder.objects.server,
+            organizedBy: addressSpace.rootFolder.objects
+        });
+        inputNode = namespace.addVariable({
+            browseName: "TankLevel",
+            dataType: "Double",
+            propertyOf: source
+        }) as UAVariableT<number, DataType.Double>;
+        setpointNode = namespace.addVariable({
+            browseName: "TankLevelSetpoint",
+            dataType: "Double",
+            propertyOf: source
+        }) as UAVariableT<number, DataType.Double>;
+    });
+
+    after(() => addressSpace.dispose());
+
+    let counter = 0;
+    const makeAlarm = (): UANonExclusiveDeviationAlarmEx => {
+        inputNode.setValueFromSource({ dataType: DataType.Double, value: 0 });
+        setpointNode.setValueFromSource({ dataType: DataType.Double, value: 0 });
+        counter += 1;
+        return namespace.instantiateNonExclusiveDeviationAlarm({
+            browseName: `TankLevelDeviationAlarm${counter}`,
+            conditionSource: source,
+            inputNode,
+            setpointNode,
+
+            highHighLimit: 100.0,
+            highLimit: 10.0,
+            lowLimit: -1.0,
+            lowLowLimit: -10.0
+        });
+    };
+
+    it("runs an assigned onSetpointDataValueChange when the setpoint node value changes", () => {
+        const alarm = makeAlarm();
+
+        const seen: number[] = [];
+        alarm.onSetpointDataValueChange = (dataValue) => {
+            seen.push(dataValue.value.value as number);
+        };
+
+        setpointNode.setValueFromSource({ dataType: DataType.Double, value: 25.0 });
+
+        should(seen).eql([25.0]);
+    });
+
+    it("still honours the deprecated _onSetpointDataValueChange, so a legacy override keeps winning", () => {
+        const alarm = makeAlarm();
+
+        let published = 0;
+        alarm.onSetpointDataValueChange = () => {
+            published++;
+        };
+
+        let legacy = 0;
+        // the shape a subclass written against the old documentation carried, assigned here on
+        // the instance so the test needs no implementation class
+        alarm._onSetpointDataValueChange = () => {
+            legacy++;
+        };
+
+        setpointNode.setValueFromSource({ dataType: DataType.Double, value: 7.0 });
+
+        should(legacy).eql(1, "expecting an override of the deprecated name to still win");
+        should(published).eql(0, "expecting the legacy override to shadow the published hook, not to run beside it");
+    });
+
+    it("re-evaluates the alarm state when the setpoint moves, with no hook assigned", () => {
+        const alarm = makeAlarm();
+
+        // 5 is well inside the -1..10 deviation band around a setpoint of 0
+        inputNode.setValueFromSource({ dataType: DataType.Double, value: 5.0 });
+        should(alarm.activeState.getValue()).eql(false);
+        should(alarm.highState?.getValue()).eql(false);
+
+        // the input has not moved, but a setpoint of -20 puts the deviation at 25, above HighLimit
+        setpointNode.setValueFromSource({ dataType: DataType.Double, value: -20.0 });
+        should(alarm.activeState.getValue()).eql(true);
+        should(alarm.highState?.getValue()).eql(true);
+
+        // and bringing the setpoint back to the input value clears it again
+        setpointNode.setValueFromSource({ dataType: DataType.Double, value: 5.0 });
+        should(alarm.activeState.getValue()).eql(false);
+        should(alarm.highState?.getValue()).eql(false);
+    });
+});


### PR DESCRIPTION
#1675 published the alarm extension points. One surface was missed, because it lives in a
different file: `api/interfaces/alarms_and_conditions/deviation_stuff.ts`.

`DeviationStuff` is **published** - both `UAExclusiveDeviationAlarmEx` and
`UANonExclusiveDeviationAlarmEx` extend it - and it declares two underscore-prefixed members.
Applications extending a deviation alarm therefore still had to reach for a name the rest of the
API had already stopped using.

## What is published

`onSetpointDataValueChange(dataValue)` - the deviation-alarm counterpart of
`onInputDataValueChange`. It fires when the **setpoint** variable changes rather than the input,
and by default re-evaluates the alarm state against the new setpoint.

Same treatment as before: a public member carrying the default, `_onSetpointDataValueChange`
kept as a `@deprecated` delegate, and the internal call site in `deviation_alarm_helper.ts`
still calling the underscore name so a legacy override keeps winning.

`_setStateBasedOnInputValue(value: unknown)` on the same interface is now marked `@deprecated`
too, pointing at `setStateBasedOnInputValue(value: number)` on `UALimitAlarmHelper`, which #1675
published. It is kept rather than removed: it is on a published interface, so removing it would
break anyone implementing `DeviationStuff`. The two names differ, so there is no member conflict.

## Test

`test/test_deviation_alarm_hooks.ts`, importing only from published entry points:

```
✔ runs an assigned onSetpointDataValueChange when the setpoint node value changes
✔ still honours the deprecated _onSetpointDataValueChange, so a legacy override keeps winning
✔ re-evaluates the alarm state when the setpoint moves, with no hook assigned
3 passing
```

The second is the one that matters: it is the compatibility guarantee, not an assertion about it.

Worth noting the test needs **no cast** to assign the deprecated name, unlike
`test_custom_alarm_hooks.ts` - because here the underscore member is on the published interface,
which is the whole reason this file needed the treatment.

## Verification

```
npx tsc -b packages                          0
pnpm run lint:ci                             0
test/test_deviation_alarm_hooks.ts           3 passing
test/alarms_and_conditions/**/*.ts           91 passing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
