### PR TITLE
fix(address-space): the declared parent names the node, and instantiate forwards it

### DIFF
--- a/packages/node-opcua-address-space-base/source/instantiate_options.ts
+++ b/packages/node-opcua-address-space-base/source/instantiate_options.ts
@@ -35,6 +35,15 @@ export interface InstantiateOptions {
     organizedBy?: NodeIdLike | BaseNode;
 
     /**
+     * the declared parent, as `ParentNodeId` in a NodeSet: the instance's parent
+     * and what its symbolic name is built from, even when the only reference
+     * between the two is `Organizes` (a folder a type organizes is
+     * `<Type>_<Folder>` in the ModelCompiler's NodeIds.csv).
+     * See {@link AddBaseNodeOptions.parentNodeId}.
+     */
+    parentNodeId?: NodeIdLike | BaseNode;
+
+    /**
      *  the parent Object holding this object
      * note
      *  - when componentOf is specified, organizedBy nor addInOf must not be defined

--- a/packages/node-opcua-address-space/impl/nodeid_manager.ts
+++ b/packages/node-opcua-address-space/impl/nodeid_manager.ts
@@ -51,11 +51,17 @@ function _filterAggregates(addressSpace: AddressSpacePartial, references: UARefe
     return [ref.nodeId, ""];
 }
 
+function _declaredParent(options: ConstructNodeIdOptions): NodeId | null {
+    const declared = options.parentNodeId;
+    if (!declared) return null;
+    if (declared instanceof BaseNodeImpl) return declared.nodeId;
+    const nodeId = resolveNodeId(declared as NodeIdLike);
+    return nodeId.isEmpty() ? null : nodeId;
+}
+
 function _findParentNodeId(addressSpace: AddressSpacePartial, options: ConstructNodeIdOptions): [NodeId, Suffix] | null {
-    if (!options.references) {
-        return null;
-    }
-    for (const ref of options.references) {
+    const references = options.references ?? [];
+    for (const ref of references) {
         const _ref = ref as ReferenceImpl;
         _ref._referenceType = addressSpace.findReferenceType(ref.referenceType) ?? undefined;
         /* c8 ignore next */
@@ -64,8 +70,19 @@ function _findParentNodeId(addressSpace: AddressSpacePartial, options: Construct
         }
         _ref.referenceType = _ref._referenceType.nodeId;
     }
+    // A declared parent names the node, whatever reference links the two, as it
+    // is the node's parent: an Organizes-only member of a type is
+    // `<Type>_MachineryBuildingBlocks` in the ModelCompiler's NodeIds.csv, and a
+    // node with two aggregating parents is named after the declared one.
+    const declared = _declaredParent(options);
+    if (declared) {
+        const viaEncoding = references.some(
+            (ref) => !ref.isForward && sameNodeId(ref.nodeId, declared) && sameNodeId(ref.referenceType, hasEncoding)
+        );
+        return [declared, viaEncoding ? "_Encoding" : ""];
+    }
     // find HasComponent, or has Property reverse
-    return _filterAggregates(addressSpace, options.references);
+    return references.length ? _filterAggregates(addressSpace, references) : null;
 }
 
 function prepareName(browseName?: QualifiedName | QualifiedNameOptions): string {
@@ -83,6 +100,11 @@ export interface ConstructNodeIdOptions {
     nodeClass?: NodeClass;
     references?: UAReference[];
     registerSymbolicNames?: boolean;
+    /**
+     * The declared parent (NodeSet `ParentNodeId`, or `parentNodeId` on the add* API).
+     * When present it names the node, as it is the node's parent (see `BaseNode.parent`).
+     */
+    parentNodeId?: NodeIdLike | BaseNode | null;
 }
 export type NodeEntry = [string, number, NodeClass];
 export type NodeEntry1 = [string, number, string /*"Object" | "Variable" etc...*/];

--- a/packages/node-opcua-address-space/impl/ua_object_type_impl.ts
+++ b/packages/node-opcua-address-space/impl/ua_object_type_impl.ts
@@ -147,6 +147,7 @@ export class UAObjectTypeImpl extends BaseNodeImpl<BaseNodeEvents> implements UA
             eventSourceOf: options.eventSourceOf,
             notifierOf: options.notifierOf,
             organizedBy: options.organizedBy,
+            parentNodeId: options.parentNodeId,
             addInOf: options.addInOf,
             references,
 

--- a/packages/node-opcua-address-space/impl/ua_variable_type_impl.ts
+++ b/packages/node-opcua-address-space/impl/ua_variable_type_impl.ts
@@ -331,6 +331,7 @@ export class UAVariableTypeImpl extends BaseNodeImpl<BaseNodeEvents> implements 
             nodeId: options.nodeId,
             notifierOf: options.notifierOf,
             organizedBy: options.organizedBy,
+            parentNodeId: options.parentNodeId,
             // see InstantiateOptions.references: created with the node so the
             // NodeIdManager derives the symbolic name from that parent
             references: options.references,

--- a/packages/node-opcua-address-space/test/test_declared_parent_symbolic_name.ts
+++ b/packages/node-opcua-address-space/test/test_declared_parent_symbolic_name.ts
@@ -1,0 +1,101 @@
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { nodesets } from "node-opcua-nodesets";
+import should from "should";
+import { AddressSpace, getSymbols, setSymbols, type UAObjectType, type UAVariableType } from "../dist/api/index.js";
+import { generateAddressSpace } from "../distNodeJS/index.js";
+
+/**
+ * The declared parent names the node it declares.
+ *
+ * Since the loader honours `ParentNodeId`, a folder a type only organizes has
+ * that type for parent, and its children are named through it
+ * (`DeviceType_BuildingBlocks_Counter`). The folder itself was not: the
+ * NodeIdManager built a new node's symbolic name from its inverse *aggregating*
+ * references only, so it was `BuildingBlocks` where the OPC Foundation's
+ * ModelCompiler writes `DeviceType_BuildingBlocks` in NodeIds.csv — and a
+ * modeler seeding its ids from that table could not match it. instantiate()
+ * also dropped `parentNodeId`, so a declared parent could not reach a node built
+ * from a type at all.
+ */
+describe("the declared parent names the node (NodeIdManager, instantiate)", () => {
+    let addressSpace: AddressSpace;
+    let deviceType: UAObjectType;
+
+    beforeEach(async () => {
+        addressSpace = AddressSpace.create();
+        addressSpace.registerNamespace("Private");
+        await generateAddressSpace(addressSpace, [nodesets.standard]);
+        const ns = addressSpace.getOwnNamespace();
+        setSymbols(ns, []);
+        deviceType = ns.addObjectType({ browseName: "DeviceType" });
+    });
+    afterEach(() => {
+        addressSpace.dispose();
+    });
+
+    const names = () => getSymbols(addressSpace.getOwnNamespace()).map((s) => s[0]);
+
+    it("DPSN-1 an organized folder declared with parentNodeId is named after its declared parent", () => {
+        const ns = addressSpace.getOwnNamespace();
+        const folder = ns.addObject({
+            browseName: "BuildingBlocks",
+            organizedBy: deviceType,
+            parentNodeId: deviceType,
+            typeDefinition: "FolderType",
+            modellingRule: "Mandatory"
+        });
+        ns.addVariable({ browseName: "Counter", componentOf: folder, dataType: "UInt32", modellingRule: "Mandatory" });
+
+        should(names()).containEql("DeviceType_BuildingBlocks");
+        should(names()).containEql("DeviceType_BuildingBlocks_Counter");
+        should(names()).not.containEql("BuildingBlocks");
+    });
+
+    it("DPSN-2 without a declaration an organized node keeps its own name (Organizes is not a parent relation)", () => {
+        const ns = addressSpace.getOwnNamespace();
+        ns.addObject({ browseName: "Loose", organizedBy: deviceType, typeDefinition: "FolderType" });
+        should(names()).containEql("Loose");
+        should(names()).not.containEql("DeviceType_Loose");
+    });
+
+    it("DPSN-3 UAObjectType.instantiate forwards parentNodeId: parent, ParentNodeId and name follow it", () => {
+        const folderType = addressSpace.findObjectType("FolderType");
+        if (!folderType) throw new Error("FolderType not found");
+        const folder = folderType.instantiate({
+            browseName: "BuildingBlocks",
+            organizedBy: deviceType,
+            parentNodeId: deviceType,
+            modellingRule: "Mandatory"
+        });
+
+        should(folder.parentNodeId?.toString()).eql(deviceType.nodeId.toString());
+        should(names()).containEql("DeviceType_BuildingBlocks");
+        const xml = addressSpace.getOwnNamespace().toNodeset2XML();
+        should(xml).match(/BrowseName="1:BuildingBlocks" ParentNodeId="ns=1;i=1000"/);
+    });
+
+    it("DPSN-4 UAVariableType.instantiate forwards parentNodeId too", () => {
+        const ns = addressSpace.getOwnNamespace();
+        const sampleType: UAVariableType = ns.addVariableType({ browseName: "SampleType", dataType: "Double" });
+        const sample = sampleType.instantiate({
+            browseName: "Sample",
+            organizedBy: deviceType,
+            parentNodeId: deviceType,
+            modellingRule: "Mandatory"
+        });
+        should(sample.parentNodeId?.toString()).eql(deviceType.nodeId.toString());
+        should(names()).containEql("DeviceType_Sample");
+    });
+
+    it("DPSN-5 when the declared parent is also the aggregating parent, the name is unchanged", () => {
+        const ns = addressSpace.getOwnNamespace();
+        ns.addVariable({
+            browseName: "Level",
+            componentOf: deviceType,
+            parentNodeId: deviceType,
+            dataType: "Double",
+            modellingRule: "Mandatory"
+        });
+        should(names()).containEql("DeviceType_Level");
+    });
+});


### PR DESCRIPTION
Follow-up to #1664, which made the declared parent (`ParentNodeId` in a NodeSet, `parentNodeId` on the `add*` API) the node's parent.

## What was still wrong

Two places ignore the declared parent:

1. **The NodeIdManager names a new node from its inverse *aggregating* references only.** A folder that a type only organizes therefore gets its own name without the type. Its children are named correctly, because naming walks up `parentNodeId`, so the result is half-chained:

   | node | symbolic name before | ModelCompiler's `NodeIds.csv` |
   |---|---|---|
   | the organized folder | `BuildingBlocks` | `DeviceType_BuildingBlocks` |
   | its child | `DeviceType_BuildingBlocks_Counter` | `DeviceType_BuildingBlocks_Counter` |

   A modeler that seeds its ids from a working group's `NodeIds.csv` cannot match the folder. OPC 30500 LADS hits this: `LADSDeviceType/MachineryBuildingBlocks` is Organizes-only, with `ParentNodeId` naming the type.

2. **`instantiate()` drops `parentNodeId`.** `UAObjectType.instantiate()` and `UAVariableType.instantiate()` build their `addObject`/`addVariable` options field by field, so a member built from a type — a `FolderType` folder, typically — cannot declare a parent at all.

## Change

- `ConstructNodeIdOptions.parentNodeId`. `_findParentNodeId` uses a declared parent first, whatever reference links the two (keeping the `_Encoding` suffix when that reference is `HasEncoding`), and falls back to the aggregating references as before. Both `constructNodeId` call sites already receive the full creation options, so this covers the `add*` API and the NodeSet loader alike.
- `InstantiateOptions.parentNodeId`, forwarded by both `instantiate()` implementations.

When the declared parent is also the aggregating parent — every ordinary node, and every NodeSet node whose `ParentNodeId` agrees with its aggregate — the name is unchanged (DPSN-5). Without a declaration, Organizes is still not a parent relation (DPSN-2, like LNPN-4 of #1664).

## Tests

`test_declared_parent_symbolic_name.ts`, DPSN-1 to DPSN-5: the organized folder and its child are both named through the declared parent; an undeclared organized node keeps its own name; both `instantiate()` forward the parent (checked through `parentNodeId`, the symbolic name, and `ParentNodeId` in the export); names are unchanged when the declared parent is the aggregating one. DPSN-1 fails on master.

- `pnpm run lint:ci`: green.
- `node-opcua-address-space`: 1292 passing. The only failures are suites that need `packages/node-opcua-samples/certificates`, which my worktree does not have (`expecting certificate store at …`). The leak detector cascade makes five more suites fail their hooks after the first missing-certificate failure; run on their own, they pass (82 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
