### PR TITLE
feat(address-space): registerNodePromoter accepts a NodeId

### DIFF
--- a/packages/node-opcua-address-space/api/loader/register_node_promoter.ts
+++ b/packages/node-opcua-address-space/api/loader/register_node_promoter.ts
@@ -1,6 +1,14 @@
+import type { NodeId } from "node-opcua-nodeid";
 import { resolveNodeId } from "node-opcua-nodeid";
 import { g_promotableObject, type Promoter } from "./namespace_post_step.js";
 
-export function registerNodePromoter(standardNodeId: number, promoter: Promoter, onInstanceOnly = false): void {
-    g_promotableObject.set(resolveNodeId(standardNodeId).toString(), { promoter, onInstanceOnly });
+/**
+ * A promoter is not only for namespace 0. An application registers one for a type it defines
+ * itself, or for a companion-specification type (DI, ADI, Machinery...), and those types have a
+ * namespace index that is only known once the nodeset is loaded - hence the NodeId overload.
+ * The numeric form stays because a namespace-0 type is naturally written as an `ObjectTypeIds`
+ * or `VariableTypeIds` constant.
+ */
+export function registerNodePromoter(typeDefinitionNodeId: NodeId | number, promoter: Promoter, onInstanceOnly = false): void {
+    g_promotableObject.set(resolveNodeId(typeDefinitionNodeId).toString(), { promoter, onInstanceOnly });
 }

--- a/packages/node-opcua-address-space/test/test_register_node_promoter.ts
+++ b/packages/node-opcua-address-space/test/test_register_node_promoter.ts
@@ -1,0 +1,84 @@
+/**
+ * Giving an application's own types a richer implementation class at nodeset load time.
+ *
+ * The test is written the way an application would have to write it: only published names, and
+ * the promoter is registered for a NodeId that only exists once the nodeset declares it - the
+ * numeric-only signature could never express that.
+ *
+ * There is no unregister: the registry is module level and not published, so a promoter
+ * registered here stays registered for the rest of the mocha process. That is why the fixture
+ * uses string NodeIds ("ns=1;s=Promoter...") that no other test's address space can produce -
+ * a leftover entry cannot match anything but this fixture.
+ */
+import { nodesets } from "node-opcua-nodesets";
+import should from "should";
+
+import { AddressSpace, registerNodePromoter, type UAObject } from "../dist/api/index.js";
+import { generateAddressSpace } from "../distNodeJS/index.js";
+import { getAddressSpaceFixture } from "../test_helpers/get_address_space_fixture.js";
+
+const fixture = getAddressSpaceFixture("fixture_promoter_types.xml");
+
+/** browseNames the test promoters were handed, in the order the loader promoted them */
+const promoted: string[] = [];
+
+async function loadFixture(): Promise<AddressSpace> {
+    const addressSpace = AddressSpace.create();
+    await generateAddressSpace(addressSpace, [nodesets.standard, fixture]);
+    return addressSpace;
+}
+
+describe("registerNodePromoter", function (this: Mocha.Suite) {
+    this.timeout(Math.max(this.timeout(), 60000));
+
+    let addressSpace: AddressSpace;
+
+    before(async () => {
+        // The NodeIds are discovered from a first load rather than hard-coded, because the
+        // namespace index of an application nodeset is a property of the load, not of the file.
+        const probe = await loadFixture();
+        const namespaceIndex = probe.getNamespaceIndex("urn:promoter-test/");
+        const findTypeNodeId = (browseName: string) => {
+            const type = probe.findObjectType(browseName, namespaceIndex);
+            if (!type) {
+                throw new Error(`cannot find ${browseName} in the fixture`);
+            }
+            return type.nodeId;
+        };
+        const baseTypeNodeId = findTypeNodeId("PromoterBaseType");
+        const instanceOnlyTypeNodeId = findTypeNodeId("PromoterInstanceOnlyType");
+        probe.dispose();
+
+        const record = (node: UAObject) => {
+            promoted.push(node.browseName.name?.toString() ?? "");
+            return node;
+        };
+        registerNodePromoter(baseTypeNodeId, record);
+        registerNodePromoter(instanceOnlyTypeNodeId, record, true);
+
+        promoted.length = 0;
+        addressSpace = await loadFixture();
+    });
+
+    after(() => addressSpace.dispose());
+
+    it("RNP-1 promotes an instance of a type registered by NodeId in an application namespace", () => {
+        should(promoted).containEql("ExactInstance");
+    });
+
+    it("RNP-2 keeps the exact-match behaviour the built-in promoters rely on", () => {
+        // AlarmConditionType.ActiveState is a TwoStateVariableType exactly, and the built-in
+        // promoter is the only thing that gives it setValue - reading the member through
+        // Reflect keeps the assertion about what the loader did, with no type assertion.
+        const alarmConditionType = addressSpace.findObjectType("AlarmConditionType");
+        should.exist(alarmConditionType);
+        const activeState = alarmConditionType?.getComponentByName("ActiveState");
+        should.exist(activeState);
+        should(typeof Reflect.get(Object(activeState), "setValue")).eql("function");
+    });
+
+    it("RNP-3 onInstanceOnly still suppresses promotion under a type definition", () => {
+        should(promoted).containEql("InstanceOnlyInstance");
+        should(promoted).not.containEql("HolderInstanceOnlyChild");
+    });
+});

--- a/packages/node-opcua-address-space/test_helpers/test_fixtures/fixture_promoter_types.xml
+++ b/packages/node-opcua-address-space/test_helpers/test_fixtures/fixture_promoter_types.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Types for test_register_node_promoter.
+
+    The shape matters: a base type with a subtype of it, an instance of each directly under
+    Objects, plus one instance sitting *under an ObjectType* so that `onInstanceOnly` has
+    something to suppress. String NodeIds are deliberate - a promoter registered for
+    "ns=1;s=Promoter..." cannot collide with the numeric ids other tests generate, and the
+    registry the promoter goes into is module level and has no unregister.
+-->
+<UANodeSet xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" LastModified="2024-01-01T00:00:00Z"
+    xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+    <NamespaceUris>
+        <Uri>urn:promoter-test/</Uri>
+    </NamespaceUris>
+    <Models>
+        <Model ModelUri="urn:promoter-test/" Version="1.0.0" PublicationDate="2024-01-01T00:00:00Z">
+            <RequiredModel ModelUri="http://opcfoundation.org/UA/" Version="1.04.4" PublicationDate="2020-01-08T00:00:00Z" />
+        </Model>
+    </Models>
+    <Aliases>
+        <Alias Alias="Organizes">i=35</Alias>
+        <Alias Alias="HasModellingRule">i=37</Alias>
+        <Alias Alias="HasComponent">i=47</Alias>
+        <Alias Alias="HasSubtype">i=45</Alias>
+        <Alias Alias="HasTypeDefinition">i=40</Alias>
+    </Aliases>
+
+    <UAObjectType NodeId="ns=1;s=PromoterBaseType" BrowseName="1:PromoterBaseType">
+        <DisplayName>PromoterBaseType</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+        </References>
+    </UAObjectType>
+
+    <UAObjectType NodeId="ns=1;s=PromoterInstanceOnlyType" BrowseName="1:PromoterInstanceOnlyType">
+        <DisplayName>PromoterInstanceOnlyType</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+        </References>
+    </UAObjectType>
+
+    <UAObjectType NodeId="ns=1;s=PromoterHolderType" BrowseName="1:PromoterHolderType">
+        <DisplayName>PromoterHolderType</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+            <Reference ReferenceType="HasComponent">ns=1;s=HolderInstanceOnlyChild</Reference>
+        </References>
+    </UAObjectType>
+
+    <UAObject NodeId="ns=1;s=HolderInstanceOnlyChild" BrowseName="1:HolderInstanceOnlyChild" ParentNodeId="ns=1;s=PromoterHolderType">
+        <DisplayName>HolderInstanceOnlyChild</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;s=PromoterHolderType</Reference>
+            <Reference ReferenceType="HasTypeDefinition">ns=1;s=PromoterInstanceOnlyType</Reference>
+            <Reference ReferenceType="HasModellingRule">i=78</Reference>
+        </References>
+    </UAObject>
+
+    <UAObject NodeId="ns=1;s=ExactInstance" BrowseName="1:ExactInstance">
+        <DisplayName>ExactInstance</DisplayName>
+        <References>
+            <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
+            <Reference ReferenceType="HasTypeDefinition">ns=1;s=PromoterBaseType</Reference>
+        </References>
+    </UAObject>
+
+    <UAObject NodeId="ns=1;s=InstanceOnlyInstance" BrowseName="1:InstanceOnlyInstance">
+        <DisplayName>InstanceOnlyInstance</DisplayName>
+        <References>
+            <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
+            <Reference ReferenceType="HasTypeDefinition">ns=1;s=PromoterInstanceOnlyType</Reference>
+        </References>
+    </UAObject>
+</UANodeSet>


### PR DESCRIPTION
`registerNodePromoter` gives a type a richer implementation class when a nodeset is loaded. It is
public, but its signature took a `number`:

```ts
export function registerNodePromoter(standardNodeId: number, promoter: Promoter, onInstanceOnly = false): void
```

A number resolves to namespace 0 only. So an application could not register a promoter for a
type it defines itself, or for a companion-specification type (DI, ADI, Machinery...), whose
namespace index is not a constant at all - it is a property of the load, known only once the
nodeset declares it.

The parameter now accepts a `NodeId` as well. The numeric form stays, because a namespace-0 type
is naturally written as an `ObjectTypeIds` / `VariableTypeIds` constant, and the six existing
registrations compile unchanged.

## Deliberately NOT in this PR

The lookup is still an **exact** match on the type definition: an instance of a *subtype* of a
registered type is not promoted. Making it subtype-aware was prototyped and held back, because it
is a behaviour change on data that loads fine today:

- it changed the loaded **values** of eight companion nodesets (packML, padim,
  machineryProcessValues, scales, weihenstephan, surfaceTechnologyGeneralTypes and two more) -
  node and reference counts identical, values not - and it is not yet established whether that is
  correct initialisation that was previously missing or a regression;
- it exposed a crash: state-machine templates inside ObjectTypes, which carry no `CurrentState`
  of their own, started being promoted, and the initialiser read `CurrentState` unconditionally.

That work is parked on its own branch until the value difference is explained.

The split is checkable: on this branch the golden digest fixture is untouched and all 33 nodeset
digests still match it.

## Test

`test/test_register_node_promoter.ts`, importing only published names. The promoter is
registered for a NodeId discovered from a first load, because an application nodeset's namespace
index cannot be hard-coded - which is exactly what the numeric-only signature could not express.

```
RNP-1 promotes an instance of a type registered by NodeId in an application namespace
RNP-2 keeps the exact-match behaviour the built-in promoters rely on
RNP-3 onInstanceOnly still suppresses promotion under a type definition
3 passing
```

There is no unregister - the registry is module level and unpublished - so the fixture uses string
NodeIds no other test's address space can produce, and a leftover entry cannot match anything else.

## Verification

```
npx tsc -b packages                        0
pnpm run lint:ci                           0
pnpm run check:testtypes                   OK (77 packages)
test/test_nodeset_catalog_digests.ts       33 passing, fixture unchanged
node-opcua-address-space, whole suite      1375 passing, 1 pending
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
