### PR TITLE
fix(ci): prune old API docs before deploying to Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -179,6 +179,58 @@ jobs:
           NEW_VERSION: ${{ steps.version.outputs.version }}
           GIT_SSH_COMMAND: "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no"
 
+      - name: Prune old documentation versions
+        # GitHub Pages rejects deployments whose artifact exceeds 1GB. The site
+        # accumulates one full TypeDoc build per release (keep_files: true), so
+        # once enough versions pile up the deploy starts failing outright. Drop
+        # the oldest versions until the site fits comfortably under the limit.
+        run: |
+          node -e "
+          const fs = require('fs');
+          const path = require('path');
+          const apiDir = '_ghpages_clone/api_doc';
+          const BUDGET_BYTES = 700 * 1024 * 1024;
+          function dirSize(dir) {
+            let total = 0;
+            for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+              const f = path.join(dir, e.name);
+              total += e.isDirectory() ? dirSize(f) : fs.statSync(f).size;
+            }
+            return total;
+          }
+          if (!fs.existsSync(apiDir)) { console.log('No api_doc dir found'); process.exit(0); }
+          const dirs = fs.readdirSync(apiDir, { withFileTypes: true })
+            .filter(e => e.isDirectory() && e.name !== 'latest' && /^\d+\./.test(e.name))
+            .map(e => e.name)
+            .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+          const sizes = dirs.map(v => ({ v, size: dirSize(path.join(apiDir, v)) }));
+          let total = sizes.reduce((s, x) => s + x.size, 0) + dirSize(path.join(apiDir, 'latest'));
+          console.log('Current api_doc size: ' + (total / 1024 / 1024).toFixed(1) + ' MB');
+          const removed = [];
+          while (total > BUDGET_BYTES && sizes.length > 1) {
+            const oldest = sizes.shift();
+            fs.rmSync(path.join(apiDir, oldest.v), { recursive: true, force: true });
+            total -= oldest.size;
+            removed.push(oldest.v);
+          }
+          console.log('Pruned versions: ' + (removed.join(', ') || '(none)'));
+          console.log('New api_doc size: ' + (total / 1024 / 1024).toFixed(1) + ' MB');
+          "
+
+      - name: Commit and push pruned versions
+        run: |
+          cd _ghpages_clone
+          if [ -n "$(git status --porcelain api_doc)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A api_doc
+            git commit -m "docs: prune old API doc versions to stay under Pages size limit"
+            git push origin master
+          else
+            echo "Nothing to prune"
+          fi
+        env:
+          GIT_SSH_COMMAND: "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no"
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -179,11 +179,12 @@ jobs:
           NEW_VERSION: ${{ steps.version.outputs.version }}
           GIT_SSH_COMMAND: "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no"
 
-      - name: Prune old documentation versions
+      - name: Curate documentation versions
         # GitHub Pages rejects deployments whose artifact exceeds 1GB. The site
         # accumulates one full TypeDoc build per release (keep_files: true), so
-        # once enough versions pile up the deploy starts failing outright. Drop
-        # the oldest versions until the site fits comfortably under the limit.
+        # once enough versions pile up the deploy starts failing outright. Keep
+        # only the newest patch per major.minor line, and fall back to dropping
+        # the oldest lines if that still doesn't fit under the limit.
         run: |
           node -e "
           const fs = require('fs');
@@ -199,22 +200,43 @@ jobs:
             return total;
           }
           if (!fs.existsSync(apiDir)) { console.log('No api_doc dir found'); process.exit(0); }
-          const dirs = fs.readdirSync(apiDir, { withFileTypes: true })
-            .filter(e => e.isDirectory() && e.name !== 'latest' && /^\d+\./.test(e.name))
+          let dirs = fs.readdirSync(apiDir, { withFileTypes: true })
+            .filter(e => e.isDirectory() && e.name !== 'latest' && /^\d+\.\d+\.\d+/.test(e.name))
             .map(e => e.name)
             .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+
+          // Keep only the newest patch release for each major.minor line —
+          // patch releases rarely change the public API, so older patches
+          // within the same line are just dead weight.
+          const newestPatchPerLine = new Map();
+          for (const v of dirs) {
+            const [major, minor, patch] = v.split('.').map(Number);
+            const line = major + '.' + minor;
+            const current = newestPatchPerLine.get(line);
+            if (!current || patch > current.patch) newestPatchPerLine.set(line, { v, patch });
+          }
+          const keep = new Set([...newestPatchPerLine.values()].map(x => x.v));
+          const supersededPatches = dirs.filter(v => !keep.has(v));
+          for (const v of supersededPatches) {
+            fs.rmSync(path.join(apiDir, v), { recursive: true, force: true });
+          }
+          console.log('Removed superseded patch versions: ' + (supersededPatches.join(', ') || '(none)'));
+          dirs = dirs.filter(v => keep.has(v));
+
+          // Safety net: if the curated set is still too large, drop the
+          // oldest major.minor lines until we are back under budget.
           const sizes = dirs.map(v => ({ v, size: dirSize(path.join(apiDir, v)) }));
           let total = sizes.reduce((s, x) => s + x.size, 0) + dirSize(path.join(apiDir, 'latest'));
-          console.log('Current api_doc size: ' + (total / 1024 / 1024).toFixed(1) + ' MB');
-          const removed = [];
+          console.log('api_doc size after curation: ' + (total / 1024 / 1024).toFixed(1) + ' MB');
+          const removedForBudget = [];
           while (total > BUDGET_BYTES && sizes.length > 1) {
             const oldest = sizes.shift();
             fs.rmSync(path.join(apiDir, oldest.v), { recursive: true, force: true });
             total -= oldest.size;
-            removed.push(oldest.v);
+            removedForBudget.push(oldest.v);
           }
-          console.log('Pruned versions: ' + (removed.join(', ') || '(none)'));
-          console.log('New api_doc size: ' + (total / 1024 / 1024).toFixed(1) + ' MB');
+          console.log('Pruned for size budget: ' + (removedForBudget.join(', ') || '(none)'));
+          console.log('Final api_doc size: ' + (total / 1024 / 1024).toFixed(1) + ' MB');
           "
 
       - name: Commit and push pruned versions
@@ -224,7 +246,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add -A api_doc
-            git commit -m "docs: prune old API doc versions to stay under Pages size limit"
+            git commit -m "docs: curate API doc versions, keep latest patch per release line"
             git push origin master
           else
             echo "Nothing to prune"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -182,62 +182,15 @@ jobs:
       - name: Curate documentation versions
         # GitHub Pages rejects deployments whose artifact exceeds 1GB. The site
         # accumulates one full TypeDoc build per release (keep_files: true), so
-        # once enough versions pile up the deploy starts failing outright. Keep
-        # only the newest patch per major.minor line, and fall back to dropping
-        # the oldest lines if that still doesn't fit under the limit.
-        run: |
-          node -e "
-          const fs = require('fs');
-          const path = require('path');
-          const apiDir = '_ghpages_clone/api_doc';
-          const BUDGET_BYTES = 700 * 1024 * 1024;
-          function dirSize(dir) {
-            let total = 0;
-            for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
-              const f = path.join(dir, e.name);
-              total += e.isDirectory() ? dirSize(f) : fs.statSync(f).size;
-            }
-            return total;
-          }
-          if (!fs.existsSync(apiDir)) { console.log('No api_doc dir found'); process.exit(0); }
-          let dirs = fs.readdirSync(apiDir, { withFileTypes: true })
-            .filter(e => e.isDirectory() && e.name !== 'latest' && /^\d+\.\d+\.\d+/.test(e.name))
-            .map(e => e.name)
-            .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
-
-          // Keep only the newest patch release for each major.minor line —
-          // patch releases rarely change the public API, so older patches
-          // within the same line are just dead weight.
-          const newestPatchPerLine = new Map();
-          for (const v of dirs) {
-            const [major, minor, patch] = v.split('.').map(Number);
-            const line = major + '.' + minor;
-            const current = newestPatchPerLine.get(line);
-            if (!current || patch > current.patch) newestPatchPerLine.set(line, { v, patch });
-          }
-          const keep = new Set([...newestPatchPerLine.values()].map(x => x.v));
-          const supersededPatches = dirs.filter(v => !keep.has(v));
-          for (const v of supersededPatches) {
-            fs.rmSync(path.join(apiDir, v), { recursive: true, force: true });
-          }
-          console.log('Removed superseded patch versions: ' + (supersededPatches.join(', ') || '(none)'));
-          dirs = dirs.filter(v => keep.has(v));
-
-          // Safety net: if the curated set is still too large, drop the
-          // oldest major.minor lines until we are back under budget.
-          const sizes = dirs.map(v => ({ v, size: dirSize(path.join(apiDir, v)) }));
-          let total = sizes.reduce((s, x) => s + x.size, 0) + dirSize(path.join(apiDir, 'latest'));
-          console.log('api_doc size after curation: ' + (total / 1024 / 1024).toFixed(1) + ' MB');
-          const removedForBudget = [];
-          while (total > BUDGET_BYTES && sizes.length > 1) {
-            const oldest = sizes.shift();
-            fs.rmSync(path.join(apiDir, oldest.v), { recursive: true, force: true });
-            total -= oldest.size;
-            removedForBudget.push(oldest.v);
-          }
-          console.log('Pruned for size budget: ' + (removedForBudget.join(', ') || '(none)'));
-          console.log('Final api_doc size: ' + (total / 1024 / 1024).toFixed(1) + ' MB');
-          "
+        # once enough versions pile up the deploy starts failing outright.
+        # tools/curate-api-docs.mjs drops pre-1.0 versions, superseded patches,
+        # near-duplicate releases, and (as a safety net) the oldest remaining
+        # lines if the result is still over budget. Run it with --dry-run
+        # locally against a clone to preview a curation pass before it runs
+        # here for real.
+        run: node tools/curate-api-docs.mjs _ghpages_clone/api_doc
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Commit and push pruned versions
         run: |
@@ -246,7 +199,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add -A api_doc
-            git commit -m "docs: curate API doc versions, keep latest patch per release line"
+            git commit -m "docs: curate API doc versions, drop patches and near-duplicate releases"
             git push origin master
           else
             echo "Nothing to prune"

--- a/tools/curate-api-docs.mjs
+++ b/tools/curate-api-docs.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+// Curates the published API doc versions under <site>/api_doc so the
+// GitHub Pages artifact stays under the platform's 1GB deploy limit.
+//
+// Usage:
+//   node tools/curate-api-docs.mjs <path-to-api_doc-dir> [options]
+//
+// Options:
+//   --dry-run           Report what would be removed without touching disk
+//   --budget-mb <n>     Size budget in MB for the safety-net pass (default 700)
+//   --min-gap-days <n>  Minimum days between two kept releases (default 14)
+//
+// Each api_doc/<version> folder corresponds to the `v<version>` tag in
+// node-opcua/node-opcua, so release dates are looked up from that tag via
+// the GitHub API (`gh api`) rather than from gh-pages commit history —
+// history there gets rewritten by the deprecation-banner step, and a full
+// clone of that repo is large. Requires `gh` to be authenticated.
+//
+// This is the logic run by .github/workflows/docs.yml after each doc
+// deploy; run it locally against a shallow clone to preview a curation pass
+// (a shallow clone is enough since dates come from the GitHub API, not
+// local git history):
+//
+//   git clone --depth 1 git@github.com:node-opcua/node-opcua.github.io.git /tmp/ghp
+//   node tools/curate-api-docs.mjs /tmp/ghp/api_doc --dry-run
+
+import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+const dateCache = new Map();
+function releaseDate(version, releaseRepo) {
+    if (dateCache.has(version)) return dateCache.get(version);
+    let date = null;
+    try {
+        const out = execFileSync("gh", ["api", `repos/${releaseRepo}/commits/v${version}`, "--jq", ".commit.committer.date"], {
+            stdio: ["ignore", "pipe", "ignore"]
+        })
+            .toString()
+            .trim();
+        date = out ? new Date(out) : null;
+    } catch {
+        date = null;
+    }
+    dateCache.set(version, date);
+    return date;
+}
+
+function parseArgs(argv) {
+    const args = { apiDir: null, dryRun: false, budgetMb: 700, minGapDays: 5 };
+    const rest = [];
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === "--dry-run") args.dryRun = true;
+        else if (a === "--budget-mb") args.budgetMb = Number(argv[++i]);
+        else if (a === "--min-gap-days") args.minGapDays = Number(argv[++i]);
+        else rest.push(a);
+    }
+    args.apiDir = rest[0];
+    return args;
+}
+
+function dirSize(dir) {
+    let total = 0;
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+        const f = path.join(dir, e.name);
+        total += e.isDirectory() ? dirSize(f) : statSync(f).size;
+    }
+    return total;
+}
+
+function mb(bytes) {
+    return (bytes / 1024 / 1024).toFixed(1) + " MB";
+}
+
+export function curate(apiDir, { dryRun = false, budgetMb = 700, minGapDays = 5, releaseRepo = "node-opcua/node-opcua" } = {}) {
+    const budgetBytes = budgetMb * 1024 * 1024;
+    const minGapMs = minGapDays * 24 * 60 * 60 * 1000;
+
+    if (!existsSync(apiDir)) {
+        console.log(`No api_doc dir found at ${apiDir}`);
+        return { kept: [], removed: [] };
+    }
+
+    const remove = (v, reason) => {
+        console.log(`  - ${v}  (${reason})`);
+        if (!dryRun) rmSync(path.join(apiDir, v), { recursive: true, force: true });
+    };
+
+    let dirs = readdirSync(apiDir, { withFileTypes: true })
+        .filter((e) => e.isDirectory() && e.name !== "latest" && /^\d+\.\d+\.\d+/.test(e.name))
+        .map((e) => e.name)
+        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+
+    console.log(`Found ${dirs.length} version(s) under ${apiDir}${dryRun ? " (dry run)" : ""}`);
+
+    // Step 0: drop pre-1.0 versions — they predate the project's first
+    // proper (npm-published) release and aren't worth preserving.
+    console.log("\nStep 0: drop pre-1.0 versions");
+    const removedPre1 = [];
+    dirs = dirs.filter((v) => {
+        const major = Number(v.split(".")[0]);
+        if (major === 0) {
+            remove(v, "pre-1.0");
+            removedPre1.push(v);
+            return false;
+        }
+        return true;
+    });
+
+    // Step 1: keep only the newest patch per major.minor line.
+    const newestPatchPerLine = new Map();
+    for (const v of dirs) {
+        const [major, minor, patch] = v.split(".").map(Number);
+        const line = `${major}.${minor}`;
+        const current = newestPatchPerLine.get(line);
+        if (!current || patch > current.patch) newestPatchPerLine.set(line, { v, patch });
+    }
+    const keepAfterPatch = new Set([...newestPatchPerLine.values()].map((x) => x.v));
+
+    console.log("\nStep 1: drop superseded patch releases (same major.minor line)");
+    const removedPatch = [];
+    for (const v of dirs) {
+        if (!keepAfterPatch.has(v)) {
+            remove(v, "superseded patch");
+            removedPatch.push(v);
+        }
+    }
+    dirs = dirs.filter((v) => keepAfterPatch.has(v));
+
+    // Step 2: drop a release if it was published less than minGapDays before
+    // the next kept one.
+    console.log(`\nStep 2: drop releases published < ${minGapDays} day(s) before a newer one`);
+    const dated = dirs.map((v) => ({ v, date: releaseDate(v, releaseRepo) }));
+    const survivors = [];
+    const removedRecency = [];
+    for (const item of dated) {
+        while (
+            survivors.length &&
+            item.date &&
+            survivors[survivors.length - 1].date &&
+            item.date - survivors[survivors.length - 1].date < minGapMs
+        ) {
+            const old = survivors.pop();
+            remove(old.v, `< ${minGapDays}d before ${item.v}`);
+            removedRecency.push(old.v);
+        }
+        survivors.push(item);
+    }
+    dirs = survivors.map((x) => x.v);
+
+    // Step 3 (safety net): if still over budget, drop the oldest lines.
+    console.log(`\nStep 3: safety-net size budget (${budgetMb} MB)`);
+    const sizes = dirs.map((v) => ({ v, size: dirSize(path.join(apiDir, v)) }));
+    const latestDir = path.join(apiDir, "latest");
+    let total = sizes.reduce((s, x) => s + x.size, 0) + (existsSync(latestDir) ? dirSize(latestDir) : 0);
+    console.log(`  size after steps 1-2: ${mb(total)}`);
+    const removedBudget = [];
+    while (total > budgetBytes && sizes.length > 1) {
+        const oldest = sizes.shift();
+        remove(oldest.v, "over size budget");
+        total -= oldest.size;
+        removedBudget.push(oldest.v);
+    }
+    dirs = sizes.map((x) => x.v);
+
+    console.log(`\nFinal kept set (${dirs.length}): ${dirs.join(", ") || "(none)"}`);
+    console.log(`Final size: ${mb(total)}`);
+
+    return { kept: dirs, removed: [...removedPre1, ...removedPatch, ...removedRecency, ...removedBudget] };
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (!args.apiDir) {
+    console.error("Usage: node tools/curate-api-docs.mjs <path-to-api_doc-dir> [--dry-run] [--budget-mb n] [--min-gap-days n]");
+    process.exit(1);
+}
+curate(path.resolve(args.apiDir), args);


### PR DESCRIPTION
Prunes oldest api_doc/ versions so the Pages artifact stays under the 1GB limit.