### PR TITLE
build(esm-convert): scan .js files, rewrite entry shims, report CommonJS left behind

### DIFF
--- a/tools/esm-convert/README.md
+++ b/tools/esm-convert/README.md
@@ -45,11 +45,15 @@ These alter behaviour rather than syntax, so they are listed and left alone:
 | module-scope `await` | breaks `require(esm)` for every CJS consumer downstream |
 | `typeof __filename` / `typeof __dirname` | always `"undefined"` under ESM, so the branch that reads the value goes dead |
 | `cjs-entry` | an entry shim whose require specifier is not a relative path, so it cannot be resolved with confidence |
-| `cjs-module` | a CommonJS `.js` file, elsewhere in the package, that is shipped or referenced by a live file (or is in a `"private": true` package, where it is a script run by hand) |
-| `cjs-dead` | a CommonJS `.js` file that is neither shipped nor referenced by anything live - not blocking, but worth deleting before the package flips |
+| `cjs-module` | a CommonJS `.js` file, elsewhere in the package, that is shipped or referenced by a live file - or is in a `"private": true` package, sits in a test/`bin` tree, or opens with a `#!` shebang, where it is a script or fixture reached some way a static search cannot see |
+| `cjs-dead` | a CommonJS `.js` file that is neither shipped nor referenced by anything live, and is not the kind of file a static search could miss - not blocking, but worth deleting before the package flips |
 
-`cjs-dead` does not count as needing a decision: nothing depends on the file, so it can simply
-be removed. Everything else in the table does.
+`cjs-dead` means "safe to delete", so it is only emitted when that is provable from static
+references: a test fixture reached by a computed path (`testPath("fixtures")`, then spawned as
+a child process) or a script meant to be run by hand is `cjs-module` even with zero references,
+because "no reference found" does not mean "unused" for either of those. `cjs-dead` does not
+count as needing a decision: nothing depends on the file, so it can simply be removed.
+Everything else in the table does.
 
 ## After it runs
 

--- a/tools/esm-convert/README.md
+++ b/tools/esm-convert/README.md
@@ -16,11 +16,21 @@ Not a gate. It exits 0 either way; it is a helper for FEAT-2.
 | `package.json` | adds `"type": "module"` |
 | `.mocharc.js` | renamed to `.mocharc.cjs`, contents untouched |
 | `const here = __dirname;` | → `import.meta.dirname`, and drops the note saying it cannot be used yet |
+| `module.exports = require("./dist...")` | → `export * from "./dist.../index.js"`, and the same for a `.d.ts` twin that still has no extension on its specifier |
 
 The anchor is only mechanical because FEAT-1 concentrated the scattered uses into one line per
 module and `check-dirname` keeps them that way. A tool cannot safely rewrite
 `path.join(__dirname, ...)` sprinkled through a file; it can rewrite one known line. That is
 what the anchor work bought.
+
+The entry shim is the same story for `.js`: `packageFiles` only ever looked at
+`.ts`/`.mts`/`.cts`, so a package whose entry point (no `exports` map, so consumers import
+`pkg/nodeJS` or `pkg/testHelpers` directly) is a one-line `module.exports = require(...)` file
+was invisible. Once the package is ESM that file is parsed as ESM too. The tool only rewrites
+the exact single-statement shape, resolving the specifier to something `export *` can use -
+already `.js`, a directory that exists, or a tsconfig outDir (so a `dist*` that has not been
+built yet still resolves). A specifier that is not a relative path cannot be resolved with
+confidence and is reported instead, under `cjs-entry`.
 
 ## What it refuses to change
 
@@ -33,6 +43,13 @@ These alter behaviour rather than syntax, so they are listed and left alone:
 | `require(nonLiteral)` | deliberate, so bundlers skip it |
 | `module.exports` | a named or default export, but which is a decision |
 | module-scope `await` | breaks `require(esm)` for every CJS consumer downstream |
+| `typeof __filename` / `typeof __dirname` | always `"undefined"` under ESM, so the branch that reads the value goes dead |
+| `cjs-entry` | an entry shim whose require specifier is not a relative path, so it cannot be resolved with confidence |
+| `cjs-module` | a CommonJS `.js` file, elsewhere in the package, that is shipped or referenced by a live file (or is in a `"private": true` package, where it is a script run by hand) |
+| `cjs-dead` | a CommonJS `.js` file that is neither shipped nor referenced by anything live - not blocking, but worth deleting before the package flips |
+
+`cjs-dead` does not count as needing a decision: nothing depends on the file, so it can simply
+be removed. Everything else in the table does.
 
 ## After it runs
 

--- a/tools/esm-convert/src/index.js
+++ b/tools/esm-convert/src/index.js
@@ -57,6 +57,17 @@ function apply(result) {
             fs.writeFileSync(file, text);
         }
     }
+
+    for (const shim of result.shims) {
+        fs.writeFileSync(shim.file, shim.rewritten);
+        const rel = path.relative(result.dir, shim.file).replace(/\\/g, "/");
+        done.push(`${rel}: module.exports = require("${shim.spec}") -> export * from "${shim.resolved}"`);
+        if (shim.dts) {
+            fs.writeFileSync(shim.dts.file, shim.dts.rewritten);
+            const dtsRel = path.relative(result.dir, shim.dts.file).replace(/\\/g, "/");
+            done.push(`${dtsRel}: export * from "..." -> export * from "${shim.resolved}"`);
+        }
+    }
     return done;
 }
 
@@ -76,7 +87,15 @@ function report(result, applied) {
         if (result.mocharc === "rename") lines.push("    .mocharc.js -> .mocharc.cjs");
         for (const a of result.anchors) lines.push(`    ${a}: __dirname -> import.meta.dirname`);
         for (const d of result.dynamicRequires ?? []) lines.push(`    ${d}: require(nonLiteral) kept, behind createRequire`);
-        if (result.alreadyEsm && result.mocharc !== "rename" && result.anchors.length === 0) {
+        for (const shim of result.shims ?? []) {
+            const shimRel = shim.file.replace(/\\/g, "/").slice(result.dir.length + 1);
+            lines.push(`    ${shimRel}: module.exports = require("${shim.spec}") -> export * from "${shim.resolved}"`);
+            if (shim.dts) {
+                const dtsRel = shim.dts.file.replace(/\\/g, "/").slice(result.dir.length + 1);
+                lines.push(`    ${dtsRel}: export * from "..." -> export * from "${shim.resolved}"`);
+            }
+        }
+        if (result.alreadyEsm && result.mocharc !== "rename" && result.anchors.length === 0 && (result.shims ?? []).length === 0) {
             lines.push("    nothing");
         }
     }
@@ -88,6 +107,11 @@ function report(result, applied) {
             lines.push(`        ${m.text}`);
             lines.push(`        -> ${m.why}`);
         }
+    }
+
+    if (result.deadFiles?.length) {
+        lines.push("", `  dead - not shipped, nothing live references it (${result.deadFiles.length}):`);
+        for (const d of result.deadFiles) lines.push(`    ${d.file}`);
     }
 
     lines.push(
@@ -102,7 +126,8 @@ function report(result, applied) {
 /** the workspace at a glance: how much of FEAT-2 a tool can finish on its own */
 function reportSurvey(s) {
     const lines = [
-        `esm-convert: ${s.total} packages - ${s.alreadyEsm.length} already ESM, ${s.mechanical.length} mechanical, ${s.needsDecision.length} need a decision`,
+        `esm-convert: ${s.total} packages - ${s.alreadyEsm.length} already ESM, ${s.mechanical.length} mechanical, ` +
+            `${s.needsDecision.length} need a decision, ${s.deadTotal} dead files not shipped`,
         ""
     ];
 
@@ -123,6 +148,27 @@ function reportSurvey(s) {
         lines.push("  by kind:");
         for (const [kind, n] of [...byKind].sort((a, b) => b[1] - a[1])) {
             lines.push(`    ${String(n).padStart(3)}  ${kind}`);
+        }
+        lines.push("");
+    }
+
+    if (s.stillHasCommonJs.length) {
+        lines.push("  already ESM but still has CommonJS left:");
+        for (const p of s.stillHasCommonJs) {
+            const what = [
+                ...(p.shims.length ? [`${p.shims.length} entry shim(s) to rewrite`] : []),
+                ...(p.manual.length ? [...new Set(p.manual.map((m) => m.kind))] : [])
+            ];
+            lines.push(`    ${p.packageName.padEnd(46)} ${what.join(", ")}`);
+        }
+        lines.push("");
+    }
+
+    if (s.deadTotal) {
+        lines.push(`  dead - not shipped, nothing live references it (${s.deadTotal}):`);
+        for (const p of s.packages) {
+            if (!p.deadFiles?.length) continue;
+            for (const d of p.deadFiles) lines.push(`    ${d.file}`);
         }
         lines.push("");
     }

--- a/tools/esm-convert/src/index.js
+++ b/tools/esm-convert/src/index.js
@@ -38,7 +38,7 @@ function apply(result) {
         done.push(".mocharc.js -> .mocharc.cjs");
     }
 
-    for (const file of packageFiles(result.dir)) {
+    for (const file of packageFiles(result.dir, result.repoRoot)) {
         const original = fs.readFileSync(file, "utf8");
         const rel = path.relative(result.dir, file).replace(/\\/g, "/");
         let text = original;

--- a/tools/esm-convert/src/rule.js
+++ b/tools/esm-convert/src/rule.js
@@ -46,6 +46,7 @@
  * with confidence is reported, not rewritten.
  */
 
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import ts from "typescript";
@@ -53,6 +54,43 @@ import { emittedFrom, shippedDirsOf, SOURCE_ROOTS } from "../../shared/shipped_d
 import { TEST_DIRS } from "../../shared/test_dirs.mjs";
 
 const SKIP_DIRS = new Set(["node_modules", "dist", "dist-esm", "distNodeJS", "distHelpers", "coverage", "build"]);
+
+const normalizeSlashes = (p) => p.replace(/\\/g, "/");
+
+const trackedFilesCache = new Map();
+
+/**
+ * Every file this checkout's git knows about, tracked or untracked-but-not-ignored - so the
+ * scan never reports a gitignored, machine-generated file (a certificate directory the pki
+ * setup writes before tests, say) that a developer's checkout has on disk and CI does not.
+ * `--others --exclude-standard` adds the untracked-but-would-be-added files, since a file
+ * nobody has committed yet is not the same thing as a file git is told to ignore.
+ *
+ * Returns null when git is unavailable or `repoRoot` is not a repository - the walk then
+ * falls back to reading the filesystem directly, which is what the temp-dir fixtures these
+ * tests build need, since they are not git repositories.
+ */
+function gitTrackedFiles(repoRoot) {
+    const key = path.resolve(repoRoot);
+    if (trackedFilesCache.has(key)) return trackedFilesCache.get(key);
+    let result = null;
+    try {
+        const out = execFileSync("git", ["ls-files", "--cached", "--others", "--exclude-standard"], {
+            cwd: key,
+            encoding: "utf8"
+        });
+        const set = new Set();
+        for (const line of out.split("\n")) {
+            const rel = line.trim();
+            if (rel) set.add(normalizeSlashes(path.resolve(key, rel)));
+        }
+        result = set;
+    } catch {
+        result = null;
+    }
+    trackedFilesCache.set(key, result);
+    return result;
+}
 
 /** the anchor FEAT-1 established, and the comment that goes with it */
 
@@ -71,35 +109,36 @@ export function packageDir(repoRoot, name) {
 }
 
 /** every .ts file in the package's shipped and test trees */
-export function packageFiles(pkgDir) {
+export function packageFiles(pkgDir, repoRoot) {
     const files = [];
+    const tracked = repoRoot ? gitTrackedFiles(repoRoot) : null;
     const roots = [...shippedDirsOf(pkgDir), ...TEST_DIRS];
     for (const sub of new Set(roots)) {
-        walk(path.join(pkgDir, sub), files);
+        walk(path.join(pkgDir, sub), files, tracked);
     }
     return files;
 }
 
-function walk(dir, out) {
+function walk(dir, out, tracked) {
     if (!fs.existsSync(dir)) return;
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
         const full = path.join(dir, entry.name);
         if (entry.isDirectory()) {
-            if (!SKIP_DIRS.has(entry.name)) walk(full, out);
+            if (!SKIP_DIRS.has(entry.name)) walk(full, out, tracked);
         } else if (/\.(ts|mts|cts)$/.test(entry.name) && !entry.name.endsWith(".d.ts")) {
-            out.push(full);
+            if (!tracked || tracked.has(normalizeSlashes(path.resolve(full)))) out.push(full);
         }
     }
 }
 
 /** every file under `dir`, skipping SKIP_DIRS and node_modules. `visit(fullPath, entryName)`. */
-function walkGeneric(dir, visit) {
+function walkGeneric(dir, visit, tracked) {
     if (!fs.existsSync(dir)) return;
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
         const full = path.join(dir, entry.name);
         if (entry.isDirectory()) {
-            if (!SKIP_DIRS.has(entry.name)) walkGeneric(full, visit);
-        } else {
+            if (!SKIP_DIRS.has(entry.name)) walkGeneric(full, visit, tracked);
+        } else if (!tracked || tracked.has(normalizeSlashes(path.resolve(full)))) {
             visit(full, entry.name);
         }
     }
@@ -113,11 +152,16 @@ function walkGeneric(dir, visit) {
  * config is handled separately (a rename, not a scan), and `.cjs`/`.mjs` are excluded because
  * their extension already says what they are.
  */
-export function jsFilesOf(pkgDir) {
+export function jsFilesOf(pkgDir, repoRoot) {
     const files = [];
-    walkGeneric(pkgDir, (full, name) => {
-        if (name.endsWith(".js") && name !== ".mocharc.js") files.push(full);
-    });
+    const tracked = repoRoot ? gitTrackedFiles(repoRoot) : null;
+    walkGeneric(
+        pkgDir,
+        (full, name) => {
+            if (name.endsWith(".js") && name !== ".mocharc.js") files.push(full);
+        },
+        tracked
+    );
     return files;
 }
 
@@ -492,6 +536,7 @@ function resolveReference(fromFile, spec, pkgDirByName, allJsSet) {
  * file that a live file reaches, directly or through others, is live.
  */
 export function computeLiveJsFiles(repoRoot = ".") {
+    const tracked = gitTrackedFiles(repoRoot);
     const names = allPackages(repoRoot);
     const pkgDirByName = new Map();
     const manifestByPkg = new Map();
@@ -511,19 +556,23 @@ export function computeLiveJsFiles(repoRoot = ".") {
     const shippedJs = new Set();
     for (const [name, dir] of pkgDirByName) {
         const manifest = manifestByPkg.get(name) ?? {};
-        walkGeneric(dir, (full, entryName) => {
-            if (/\.d\.ts$/.test(entryName)) {
-                liveRoots.push(full);
-            } else if (/\.(ts|mts|cts)$/.test(entryName)) {
-                liveRoots.push(full);
-            } else if (entryName.endsWith(".js") && entryName !== ".mocharc.js") {
-                allJs.push(full);
-                if (isShipped(manifest, path.relative(dir, full))) {
-                    shippedJs.add(full);
+        walkGeneric(
+            dir,
+            (full, entryName) => {
+                if (/\.d\.ts$/.test(entryName)) {
                     liveRoots.push(full);
+                } else if (/\.(ts|mts|cts)$/.test(entryName)) {
+                    liveRoots.push(full);
+                } else if (entryName.endsWith(".js") && entryName !== ".mocharc.js") {
+                    allJs.push(full);
+                    if (isShipped(manifest, path.relative(dir, full))) {
+                        shippedJs.add(full);
+                        liveRoots.push(full);
+                    }
                 }
-            }
-        });
+            },
+            tracked
+        );
     }
 
     const allJsSet = new Set(allJs);
@@ -548,7 +597,7 @@ export function computeLiveJsFiles(repoRoot = ".") {
         }
     }
 
-    return { liveSet, shippedJs, manifestByPkg, pkgDirByName };
+    return { liveSet, shippedJs, manifestByPkg, pkgDirByName, repoRoot };
 }
 
 /**
@@ -591,7 +640,7 @@ export function classifyJsFiles(pkgDir, packageName, liveness) {
     const cjsModules = [];
     const deadFiles = [];
 
-    for (const file of jsFilesOf(pkgDir)) {
+    for (const file of jsFilesOf(pkgDir, liveness.repoRoot)) {
         const shim = entryShim(pkgDir, file);
         if (shim) {
             if (shim.resolved === null) {
@@ -687,7 +736,7 @@ export function analyze({ repoRoot = ".", packageName, liveness } = {}) {
     const anchors = [];
     const dynamicRequires = [];
     const manual = [];
-    for (const file of packageFiles(dir)) {
+    for (const file of packageFiles(dir, repoRoot)) {
         const text = fs.readFileSync(file, "utf8");
         if (convertAnchors(text) !== null) anchors.push(file.replace(/\\/g, "/"));
         if (convertDynamicRequire(text) !== null) dynamicRequires.push(file.replace(/\\/g, "/"));
@@ -703,6 +752,7 @@ export function analyze({ repoRoot = ".", packageName, liveness } = {}) {
         found: true,
         packageName,
         dir: dir.replace(/\\/g, "/"),
+        repoRoot,
         alreadyEsm,
         mocharc: rename ? "rename" : "none",
         anchors,

--- a/tools/esm-convert/src/rule.js
+++ b/tools/esm-convert/src/rule.js
@@ -2,15 +2,32 @@
  * rule - what converting one package to ESM involves, split into the part a tool can do and
  * the part that needs a person.
  *
- * The split is the point. Three things are mechanical, because earlier work made them so:
+ * The split is the point. Four things are mechanical, because earlier work made them so, or
+ * because the shape is narrow enough to resolve with confidence:
  *
  *   type field      one line in package.json
- *   mocha config    `module.exports` -> `export default`, `require` -> createRequire
+ *   mocha config    `.mocharc.js` -> `.mocharc.cjs`, a rename, not a rewrite
  *   dirname anchor  `const here = __dirname;` -> `import.meta.dirname`
+ *   entry shim      `module.exports = require("./dist...")` -> `export * from "./dist.../index.js"`
  *
  * The anchor is only mechanical because FEAT-1 concentrated the scattered uses into one line
  * per module and `check-dirname` keeps them that way. A tool cannot safely rewrite
  * `path.join(__dirname, ...)` sprinkled through a file; it can rewrite one known line.
+ *
+ * The entry shim exists because a package with no `exports` map falls back to whatever
+ * `require()` resolves, and several packages point that at a one-line CommonJS file
+ * (`nodeJS.js`, `testHelpers.js`) rather than the built output directly. Once the package is
+ * ESM those files are parsed as ESM too, so `module.exports = require(...)` has to become
+ * `export * from ...`. The tool only does this for the exact single-statement shape; a
+ * `.d.ts` twin doing the same `export * from` gets the same treatment when its specifier
+ * still lacks an extension.
+ *
+ * `packageFiles` only ever looked at `.ts`/`.mts`/`.cts`, so a plain `.js` file was invisible
+ * to every check here. Once a package gets `"type": "module"`, every `.js` in it is parsed as
+ * ESM too, so a hand-written CommonJS `.js` breaks - the shim is the one shape common enough
+ * to rewrite; everything else CommonJS in a `.js` file is reported, split into a file that is
+ * shipped or referenced (`cjs-module`, needs a decision) and a file that is neither
+ * (`cjs-dead`, does not block conversion - it can just be deleted).
  *
  * Everything else is reported and left alone, because it changes behaviour rather than
  * syntax:
@@ -18,20 +35,21 @@
  *   require() of package.json  an import attribute, a runtime read, or a build constant
  *   module.exports             a named or a default export, but which
  *   module-scope await         breaks require(esm) for every CJS consumer downstream
+ *   typeof __filename/__dirname  always "undefined" under ESM: a live branch goes dead
  *
  * Any other require() is mechanical: createRequire keeps the call synchronous and the
  * specifier opaque, which is faithful in every context. `await import()` is often nicer,
  * but it needs the call site to be async and the target to exist as .js - and while a
  * package's tests still run its .ts sources through tsx, it does not.
  *
- * The tool refuses rather than guesses: a mocha config it does not recognise is reported, not
- * rewritten.
+ * The tool refuses rather than guesses: a shim whose require specifier cannot be resolved
+ * with confidence is reported, not rewritten.
  */
 
 import fs from "node:fs";
 import path from "node:path";
 import ts from "typescript";
-import { shippedDirsOf, SOURCE_ROOTS } from "../../shared/shipped_dirs.mjs";
+import { emittedFrom, shippedDirsOf, SOURCE_ROOTS } from "../../shared/shipped_dirs.mjs";
 import { TEST_DIRS } from "../../shared/test_dirs.mjs";
 
 const SKIP_DIRS = new Set(["node_modules", "dist", "dist-esm", "distNodeJS", "distHelpers", "coverage", "build"]);
@@ -72,6 +90,35 @@ function walk(dir, out) {
             out.push(full);
         }
     }
+}
+
+/** every file under `dir`, skipping SKIP_DIRS and node_modules. `visit(fullPath, entryName)`. */
+function walkGeneric(dir, visit) {
+    if (!fs.existsSync(dir)) return;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            if (!SKIP_DIRS.has(entry.name)) walkGeneric(full, visit);
+        } else {
+            visit(full, entry.name);
+        }
+    }
+}
+
+/**
+ * Every plain `.js` file in the package, outside SKIP_DIRS and node_modules.
+ *
+ * `packageFiles` never looked here, which is the bug this file exists to fix: once a package
+ * is ESM, a `.js` file in it is parsed as ESM too. `.mocharc.js` is excluded because the mocha
+ * config is handled separately (a rename, not a scan), and `.cjs`/`.mjs` are excluded because
+ * their extension already says what they are.
+ */
+export function jsFilesOf(pkgDir) {
+    const files = [];
+    walkGeneric(pkgDir, (full, name) => {
+        if (name.endsWith(".js") && name !== ".mocharc.js") files.push(full);
+    });
+    return files;
 }
 
 // ── the mechanical half ─────────────────────────────────────────────────────────
@@ -230,10 +277,337 @@ export function findManualWork(text, filePath = "file.ts") {
                 note(node, "top-level-await", "breaks require(esm) for every CJS consumer downstream");
             }
         }
+        // `typeof __filename` / `typeof __dirname`: convertAnchors deliberately leaves these
+        // alone because they ask whether the global exists, and under ESM the answer is
+        // always "no" - which makes the branch that reads the value dead code.
+        if (ts.isTypeOfExpression(node) && ts.isIdentifier(node.expression) && (node.expression.text === "__dirname" || node.expression.text === "__filename")) {
+            note(node, "typeof-cjs-global", 'always "undefined" under ESM, so the branch that uses the value becomes dead');
+        }
         ts.forEachChild(node, visit);
     };
     visit(sf);
     return out;
+}
+
+// ── the entry shim ──────────────────────────────────────────────────────────────
+
+/** the comment lines a shim opens with, kept verbatim across the rewrite */
+function leadingCommentLines(text) {
+    const lines = text.split(/\r?\n/);
+    const out = [];
+    for (const line of lines) {
+        if (/^\s*\/\//.test(line)) out.push(line);
+        else break;
+    }
+    return out.length ? `${out.join("\n")}\n` : "";
+}
+
+/**
+ * `module.exports = require("<spec>")`, and nothing else. Returns the specifier, or null if
+ * the file is not exactly this shape - comments aside, this must be the file's only statement.
+ */
+export function parseEntryShim(text) {
+    const sf = ts.createSourceFile("shim.js", text, ts.ScriptTarget.ESNext, true, ts.ScriptKind.JS);
+    if (sf.statements.length !== 1) return null;
+    const stmt = sf.statements[0];
+    if (!ts.isExpressionStatement(stmt)) return null;
+    const expr = stmt.expression;
+    if (!ts.isBinaryExpression(expr) || expr.operatorToken.kind !== ts.SyntaxKind.EqualsToken) return null;
+    if (
+        !ts.isPropertyAccessExpression(expr.left) ||
+        !ts.isIdentifier(expr.left.expression) ||
+        expr.left.expression.text !== "module" ||
+        expr.left.name.text !== "exports"
+    ) {
+        return null;
+    }
+    if (!ts.isCallExpression(expr.right) || !ts.isIdentifier(expr.right.expression) || expr.right.expression.text !== "require") {
+        return null;
+    }
+    if (expr.right.arguments.length !== 1 || !ts.isStringLiteral(expr.right.arguments[0])) return null;
+    return expr.right.arguments[0].text;
+}
+
+/**
+ * `export * from "<spec>"`, and nothing else - the `.d.ts` twin of a shim.
+ */
+export function parseDtsReexport(text) {
+    const sf = ts.createSourceFile("shim.d.ts", text, ts.ScriptTarget.ESNext, true, ts.ScriptKind.TS);
+    if (sf.statements.length !== 1) return null;
+    const stmt = sf.statements[0];
+    if (!ts.isExportDeclaration(stmt) || stmt.exportClause || !stmt.moduleSpecifier) return null;
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) return null;
+    return stmt.moduleSpecifier.text;
+}
+
+/**
+ * A shim's specifier, resolved to something `export * from` can use.
+ *
+ * A specifier already ending in `.js` is kept as-is. Otherwise it either names a directory
+ * (the built output already exists, or the specifier is used bare because the emit renamed
+ * `index.ts` away) or a tsconfig outDir (`emittedFrom`, because a `dist*` directory may not
+ * exist yet in a fresh checkout) - either way `/index.js` is appended. Failing both, `.js` is
+ * appended, which is correct for a specifier that already names a file rather than a
+ * directory. A specifier that is not a relative path at all - a bare package import - cannot
+ * be resolved this way with any confidence, so it is left to a person.
+ */
+export function resolveEntrySpecifier(pkgDir, spec) {
+    if (!spec.startsWith(".")) return null;
+    if (spec.endsWith(".js")) return spec;
+    const bare = spec.replace(/^\.\//, "");
+    const full = path.join(pkgDir, bare);
+    if (fs.existsSync(full) && fs.statSync(full).isDirectory()) return `${spec}/index.js`;
+    if (emittedFrom(pkgDir).has(bare)) return `${spec}/index.js`;
+    return `${spec}.js`;
+}
+
+/** the sibling `.d.ts` of a `.js` file, same directory, same basename */
+function dtsTwinPath(jsFile) {
+    return jsFile.slice(0, -".js".length) + ".d.ts";
+}
+
+/**
+ * The whole-package view of one `.js` entry shim: the rewrite for the file itself, and for
+ * its `.d.ts` twin when that twin still has no extension on its specifier (TS2834 under
+ * NodeNext once the package is ESM). A shim whose specifier cannot be resolved with
+ * confidence is reported instead, under `cjs-entry`.
+ */
+export function entryShim(pkgDir, jsFile) {
+    const text = fs.readFileSync(jsFile, "utf8");
+    const spec = parseEntryShim(text);
+    if (spec === null) return null;
+
+    const resolved = resolveEntrySpecifier(pkgDir, spec);
+    if (resolved === null) {
+        return { file: jsFile, spec, resolved: null };
+    }
+
+    const rewritten = `${leadingCommentLines(text)}export * from "${resolved}";\n`;
+    let dts = null;
+    const twinPath = dtsTwinPath(jsFile);
+    if (fs.existsSync(twinPath)) {
+        const twinText = fs.readFileSync(twinPath, "utf8");
+        const twinSpec = parseDtsReexport(twinText);
+        if (twinSpec !== null && !twinSpec.endsWith(".js")) {
+            dts = { file: twinPath, rewritten: `${leadingCommentLines(twinText)}export * from "${resolved}";\n` };
+        }
+    }
+    return { file: jsFile, spec, resolved, rewritten, dts };
+}
+
+// ── CommonJS left behind in a .js file ──────────────────────────────────────────
+
+/** a `require(...)` call, `module.exports`, or `exports.x = ...` - the CommonJS a .js file carries */
+export function isCommonJsModule(text) {
+    if (!/\brequire\s*\(|\bmodule\.exports\b|\bexports\s*\./.test(text)) return false;
+    const sf = ts.createSourceFile("f.js", text, ts.ScriptTarget.ESNext, true, ts.ScriptKind.JS);
+    let found = false;
+    const visit = (node) => {
+        if (found) return;
+        if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "require") {
+            found = true;
+        } else if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "module" && node.name.text === "exports") {
+            found = true;
+        } else if (
+            ts.isBinaryExpression(node) &&
+            node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+            ts.isPropertyAccessExpression(node.left) &&
+            ts.isIdentifier(node.left.expression) &&
+            node.left.expression.text === "exports"
+        ) {
+            found = true;
+        }
+        ts.forEachChild(node, visit);
+    };
+    visit(sf);
+    return found;
+}
+
+const stripLeadingDotSlash = (s) => s.replace(/^\.\//, "").replace(/\\/g, "/");
+
+/** is `relPath` (relative to `pkgDir`) covered by the package's `files`, `main`, `bin` or `exports`? */
+export function isShipped(manifest, relPath) {
+    const rel = stripLeadingDotSlash(relPath);
+    if (typeof manifest.main === "string" && stripLeadingDotSlash(manifest.main) === rel) return true;
+    if (manifest.bin) {
+        const bins = typeof manifest.bin === "string" ? [manifest.bin] : Object.values(manifest.bin);
+        if (bins.some((b) => typeof b === "string" && stripLeadingDotSlash(b) === rel)) return true;
+    }
+    if (manifest.exports) {
+        const leaves = [];
+        const collect = (v) => {
+            if (typeof v === "string") leaves.push(v);
+            else if (v && typeof v === "object") for (const k of Object.keys(v)) collect(v[k]);
+        };
+        collect(manifest.exports);
+        if (leaves.some((l) => stripLeadingDotSlash(l) === rel)) return true;
+    }
+    if (Array.isArray(manifest.files)) {
+        for (const f of manifest.files) {
+            const entry = stripLeadingDotSlash(f).replace(/\/$/, "");
+            if (entry === rel || rel.startsWith(`${entry}/`)) return true;
+        }
+    }
+    return false;
+}
+
+/** every bare `require(...)`/`import ... from`/`import(...)` specifier a file mentions */
+function referencedSpecifiers(text) {
+    const specs = new Set();
+    const re = /\b(?:require|import)\s*\(\s*["'`]([^"'`]+)["'`]\s*\)|(?:^|[^.\w])(?:from|import)\s+["'`]([^"'`]+)["'`]/g;
+    let m = re.exec(text);
+    while (m) {
+        specs.add(m[1] ?? m[2]);
+        m = re.exec(text);
+    }
+    return specs;
+}
+
+/** resolve one specifier, seen in `fromFile`, to a `.js` file this tool knows about */
+function resolveReference(fromFile, spec, pkgDirByName, allJsSet) {
+    const candidates = [];
+    if (spec.startsWith(".")) {
+        const base = path.dirname(fromFile);
+        for (const s of [spec, `${spec}.js`, `${spec}/index.js`]) candidates.push(path.normalize(path.join(base, s)));
+    } else {
+        const slash = spec.indexOf("/");
+        if (slash === -1) return null;
+        const pkgDir = pkgDirByName.get(spec.slice(0, slash));
+        if (!pkgDir) return null;
+        const subpath = spec.slice(slash + 1);
+        for (const s of [subpath, `${subpath}.js`, `${subpath}/index.js`]) candidates.push(path.normalize(path.join(pkgDir, s)));
+    }
+    return candidates.find((c) => allJsSet.has(c)) ?? null;
+}
+
+/**
+ * The workspace's reachability graph for `.js` files, computed once and shared across
+ * `analyze()` calls: a dead file in one package can be referenced from another, so this has
+ * to see the whole repo, not one package at a time.
+ *
+ * Live roots are every shipped file, every `.ts`/`.mts`/`.cts` file, and every `.d.ts` file.
+ * From there, reference edges - read once per file, matched with a plain specifier regex, not
+ * the full AST, because this only has to be good enough to find "nothing points here" - are
+ * followed to a fixpoint. A `.js` file that only a dead file points to stays dead; a `.js`
+ * file that a live file reaches, directly or through others, is live.
+ */
+export function computeLiveJsFiles(repoRoot = ".") {
+    const names = allPackages(repoRoot);
+    const pkgDirByName = new Map();
+    const manifestByPkg = new Map();
+    for (const name of names) {
+        const dir = packageDir(repoRoot, name);
+        if (!dir) continue;
+        pkgDirByName.set(name, dir);
+        try {
+            manifestByPkg.set(name, JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf8")));
+        } catch {
+            manifestByPkg.set(name, {});
+        }
+    }
+
+    const allJs = [];
+    const liveRoots = [];
+    const shippedJs = new Set();
+    for (const [name, dir] of pkgDirByName) {
+        const manifest = manifestByPkg.get(name) ?? {};
+        walkGeneric(dir, (full, entryName) => {
+            if (/\.d\.ts$/.test(entryName)) {
+                liveRoots.push(full);
+            } else if (/\.(ts|mts|cts)$/.test(entryName)) {
+                liveRoots.push(full);
+            } else if (entryName.endsWith(".js") && entryName !== ".mocharc.js") {
+                allJs.push(full);
+                if (isShipped(manifest, path.relative(dir, full))) {
+                    shippedJs.add(full);
+                    liveRoots.push(full);
+                }
+            }
+        });
+    }
+
+    const allJsSet = new Set(allJs);
+    const liveSet = new Set(liveRoots);
+    const queue = [...liveSet];
+    const textCache = new Map();
+    while (queue.length) {
+        const f = queue.pop();
+        if (!textCache.has(f)) {
+            try {
+                textCache.set(f, fs.readFileSync(f, "utf8"));
+            } catch {
+                textCache.set(f, "");
+            }
+        }
+        for (const spec of referencedSpecifiers(textCache.get(f))) {
+            const resolved = resolveReference(f, spec, pkgDirByName, allJsSet);
+            if (resolved && !liveSet.has(resolved)) {
+                liveSet.add(resolved);
+                queue.push(resolved);
+            }
+        }
+    }
+
+    return { liveSet, shippedJs, manifestByPkg, pkgDirByName };
+}
+
+/**
+ * One package's `.js` files, sorted into: entry shims (mechanical, or `cjs-entry` when the
+ * specifier cannot be resolved), CommonJS that is shipped or referenced (`cjs-module`, needs
+ * a decision - including any `.js` in a `"private": true` package, since those are run by
+ * hand rather than imported), and CommonJS that is neither (`cjs-dead`, safe to delete but not
+ * blocking).
+ */
+export function classifyJsFiles(pkgDir, packageName, liveness) {
+    const manifest = liveness.manifestByPkg.get(packageName) ?? {};
+    const isPrivate = manifest.private === true;
+
+    const shims = [];
+    const cjsEntries = [];
+    const cjsModules = [];
+    const deadFiles = [];
+
+    for (const file of jsFilesOf(pkgDir)) {
+        const shim = entryShim(pkgDir, file);
+        if (shim) {
+            if (shim.resolved === null) {
+                cjsEntries.push({
+                    file: file.replace(/\\/g, "/"),
+                    kind: "cjs-entry",
+                    why: "the require specifier is not a relative path, so the tool cannot resolve it with confidence",
+                    line: 1,
+                    text: `module.exports = require("${shim.spec}")`
+                });
+            } else {
+                shims.push(shim);
+            }
+            continue;
+        }
+
+        const text = fs.readFileSync(file, "utf8");
+        if (!isCommonJsModule(text)) continue;
+
+        const rel = file.replace(/\\/g, "/");
+        const shipped = liveness.shippedJs.has(file);
+        const live = shipped || liveness.liveSet.has(file);
+        if (live || isPrivate) {
+            cjsModules.push({
+                file: rel,
+                kind: "cjs-module",
+                why: "a CommonJS file in an ESM package is parsed as ESM: rename to .cjs, port it, or keep the package CommonJS",
+                line: 1,
+                text: "module.exports / require() in this file"
+            });
+        } else {
+            deadFiles.push({
+                file: rel,
+                kind: "cjs-dead",
+                why: "not shipped and nothing live references it: delete before flipping"
+            });
+        }
+    }
+
+    return { shims, cjsEntries, cjsModules, deadFiles };
 }
 
 // ── putting it together ─────────────────────────────────────────────────────────
@@ -257,20 +631,26 @@ export function allPackages(repoRoot = ".") {
  * The whole workspace, sorted into what a tool can finish and what needs a person.
  *
  * This is the number that matters for planning FEAT-2: a package with no manual work can be
- * converted, rebuilt and tested without anyone reading it.
+ * converted, rebuilt and tested without anyone reading it. `needsDecision` is not restricted
+ * to packages that are not yet ESM: a package can already carry `"type": "module"` and still
+ * have CommonJS left behind (an entry shim nobody rewrote, a `.js` that needs a decision), and
+ * that has to show up here too rather than being hidden behind the `alreadyEsm` flag.
  */
 export function survey({ repoRoot = "." } = {}) {
-    const packages = allPackages(repoRoot).map((name) => analyze({ repoRoot, packageName: name }));
+    const liveness = computeLiveJsFiles(repoRoot);
+    const packages = allPackages(repoRoot).map((name) => analyze({ repoRoot, packageName: name, liveness }));
     return {
         total: packages.length,
-        alreadyEsm: packages.filter((p) => p.alreadyEsm),
+        alreadyEsm: packages.filter((p) => p.alreadyEsm && p.manual.length === 0),
         mechanical: packages.filter((p) => !p.alreadyEsm && p.manual.length === 0),
-        needsDecision: packages.filter((p) => !p.alreadyEsm && p.manual.length > 0),
+        needsDecision: packages.filter((p) => p.manual.length > 0),
+        stillHasCommonJs: packages.filter((p) => p.alreadyEsm && (p.shims.length > 0 || p.manual.length > 0)),
+        deadTotal: packages.reduce((n, p) => n + p.deadFiles.length, 0),
         packages
     };
 }
 
-export function analyze({ repoRoot = ".", packageName } = {}) {
+export function analyze({ repoRoot = ".", packageName, liveness } = {}) {
     const dir = packageDir(repoRoot, packageName);
     if (!dir) return { found: false, packageName };
 
@@ -290,6 +670,11 @@ export function analyze({ repoRoot = ".", packageName } = {}) {
         for (const m of findManualWork(text, file)) manual.push({ file: file.replace(/\\/g, "/"), ...m });
     }
 
+    const live = liveness ?? computeLiveJsFiles(repoRoot);
+    const { shims, cjsEntries, cjsModules, deadFiles } = classifyJsFiles(dir, packageName, live);
+    for (const e of cjsEntries) manual.push(e);
+    for (const m of cjsModules) manual.push(m);
+
     return {
         found: true,
         packageName,
@@ -298,6 +683,8 @@ export function analyze({ repoRoot = ".", packageName } = {}) {
         mocharc: rename ? "rename" : "none",
         anchors,
         dynamicRequires,
-        manual
+        manual,
+        shims,
+        deadFiles
     };
 }

--- a/tools/esm-convert/src/rule.js
+++ b/tools/esm-convert/src/rule.js
@@ -552,11 +552,35 @@ export function computeLiveJsFiles(repoRoot = ".") {
 }
 
 /**
+ * Directory names under which a static reference search cannot prove a file unused.
+ *
+ * A test tree builds fixture paths at runtime (`testPath("fixtures")`, then spawns the file
+ * as a child process) rather than importing them, so no static reference will ever exist for
+ * one - the same TEST_DIRS list used to walk a package's tests, plus `fixtures` on its own for
+ * a fixture tree that does not sit under one of those. A `bin/` script is meant to be run by
+ * hand and is often reached only through a README, not code.
+ */
+const UNPROVABLE_DEAD_DIRS = new Set([...TEST_DIRS, "fixtures", "bin"]);
+
+/**
+ * Is this `.js` file the kind of thing a static reference search cannot rule out, even when
+ * it finds no reference at all - a test fixture reached by a computed path, or a script run
+ * by hand? `cjs-dead` means "safe to delete", so it must only ever be emitted when deadness is
+ * provable from static references; anything that can be loaded by a computed path or run
+ * directly is at worst a decision, never dead.
+ */
+function isUnprovableDead(file, text) {
+    const segments = file.replace(/\\/g, "/").split("/");
+    if (segments.some((s) => UNPROVABLE_DEAD_DIRS.has(s))) return true;
+    return /^#!/.test(text);
+}
+
+/**
  * One package's `.js` files, sorted into: entry shims (mechanical, or `cjs-entry` when the
  * specifier cannot be resolved), CommonJS that is shipped or referenced (`cjs-module`, needs
  * a decision - including any `.js` in a `"private": true` package, since those are run by
- * hand rather than imported), and CommonJS that is neither (`cjs-dead`, safe to delete but not
- * blocking).
+ * hand rather than imported, and any test fixture or script a static search cannot rule out),
+ * and CommonJS that is neither (`cjs-dead`, safe to delete but not blocking).
  */
 export function classifyJsFiles(pkgDir, packageName, liveness) {
     const manifest = liveness.manifestByPkg.get(packageName) ?? {};
@@ -589,7 +613,7 @@ export function classifyJsFiles(pkgDir, packageName, liveness) {
 
         const rel = file.replace(/\\/g, "/");
         const shipped = liveness.shippedJs.has(file);
-        const live = shipped || liveness.liveSet.has(file);
+        const live = shipped || liveness.liveSet.has(file) || isUnprovableDead(file, text);
         if (live || isPrivate) {
             cjsModules.push({
                 file: rel,

--- a/tools/esm-convert/test/test_rule.js
+++ b/tools/esm-convert/test/test_rule.js
@@ -10,7 +10,21 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { analyze, convertAnchors, convertDynamicRequire, findManualWork, mocharcRename, setTypeModule, survey } from "../src/rule.js";
+import {
+    analyze,
+    classifyJsFiles,
+    computeLiveJsFiles,
+    convertAnchors,
+    convertDynamicRequire,
+    entryShim,
+    findManualWork,
+    mocharcRename,
+    parseDtsReexport,
+    parseEntryShim,
+    resolveEntrySpecifier,
+    setTypeModule,
+    survey
+} from "../src/rule.js";
 
 function withTree(files, fn) {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "esm-convert-"));
@@ -254,6 +268,208 @@ test("sorts packages into mechanical, needs-a-decision, and already ESM", () => 
             assert.deepEqual(s.mechanical.map((p) => p.packageName), ["clean"]);
             assert.deepEqual(s.needsDecision.map((p) => p.packageName), ["needs"]);
             assert.deepEqual(s.alreadyEsm.map((p) => p.packageName), ["done"]);
+        }
+    );
+});
+
+// ── the entry shim ──────────────────────────────────────────────────────────────
+//
+// `packageFiles` only ever looked at .ts/.mts/.cts, so a package whose entry point is a
+// one-line CommonJS `.js` file was invisible to every check. Once the package is ESM that
+// file is parsed as ESM too, so `module.exports = require(...)` has to become `export * from`.
+
+test("resolves a shim specifier that already names a built directory", () => {
+    withTree({ "p/package.json": JSON.stringify({ name: "p" }), "p/built/index.js": "" }, (root) => {
+        assert.equal(resolveEntrySpecifier(path.join(root, "p"), "./built"), "./built/index.js");
+    });
+});
+
+test("resolves a shim specifier through a tsconfig outDir, so a dist that is not built yet still resolves", () => {
+    withTree(
+        {
+            "p/package.json": JSON.stringify({ name: "p" }),
+            "p/tsconfig.json": JSON.stringify({ compilerOptions: { outDir: "./distX" }, include: ["source/**"] })
+        },
+        (root) => {
+            assert.equal(resolveEntrySpecifier(path.join(root, "p"), "./distX"), "./distX/index.js");
+        }
+    );
+});
+
+test("keeps a shim specifier that already ends in .js", () => {
+    withTree({ "p/package.json": JSON.stringify({ name: "p" }) }, (root) => {
+        assert.equal(resolveEntrySpecifier(path.join(root, "p"), "./built/index.js"), "./built/index.js");
+    });
+});
+
+test("refuses a shim specifier that is not a relative path: it cannot be resolved with confidence", () => {
+    withTree({ "p/package.json": JSON.stringify({ name: "p" }) }, (root) => {
+        assert.equal(resolveEntrySpecifier(path.join(root, "p"), "some-package"), null);
+    });
+});
+
+test("entryShim rewrites the shim and keeps its leading comment lines", () => {
+    withTree(
+        {
+            "p/package.json": JSON.stringify({ name: "p" }),
+            "p/nodeJS.js": '// A named entry point.\n// Internal to the monorepo.\nmodule.exports = require("./distNodeJS");'
+        },
+        (root) => {
+            const shim = entryShim(path.join(root, "p"), path.join(root, "p", "nodeJS.js"));
+            assert.equal(shim.resolved, "./distNodeJS.js");
+            assert.equal(shim.rewritten, '// A named entry point.\n// Internal to the monorepo.\nexport * from "./distNodeJS.js";\n');
+        }
+    );
+});
+
+test("entryShim also rewrites the .d.ts twin when its specifier still lacks an extension", () => {
+    withTree(
+        {
+            "p/package.json": JSON.stringify({ name: "p" }),
+            "p/nodeJS.js": 'module.exports = require("./distNodeJS");',
+            "p/nodeJS.d.ts": 'export * from "./distNodeJS";\n'
+        },
+        (root) => {
+            const shim = entryShim(path.join(root, "p"), path.join(root, "p", "nodeJS.js"));
+            assert.equal(shim.dts.rewritten, 'export * from "./distNodeJS.js";\n');
+        }
+    );
+});
+
+test("entryShim leaves the .d.ts twin alone once its specifier already has an extension", () => {
+    withTree(
+        {
+            "p/package.json": JSON.stringify({ name: "p" }),
+            "p/testHelpers.js": 'module.exports = require("./dist/test_helpers/index.js");',
+            "p/testHelpers.d.ts": 'export * from "./dist/test_helpers/index.js";\n'
+        },
+        (root) => {
+            const shim = entryShim(path.join(root, "p"), path.join(root, "p", "testHelpers.js"));
+            assert.equal(shim.dts, null);
+        }
+    );
+});
+
+test("entryShim reports rather than rewrites when the specifier cannot be resolved", () => {
+    withTree({ "p/package.json": JSON.stringify({ name: "p" }), "p/nodeJS.js": 'module.exports = require("some-package");' }, (root) => {
+        const shim = entryShim(path.join(root, "p"), path.join(root, "p", "nodeJS.js"));
+        assert.equal(shim.resolved, null);
+        assert.equal(shim.spec, "some-package");
+    });
+});
+
+test("parseEntryShim refuses a file with more than the one statement", () => {
+    assert.equal(parseEntryShim('require("side-effect");\nmodule.exports = require("./x");\n'), null);
+});
+
+test("parseDtsReexport reads a bare export * from", () => {
+    assert.equal(parseDtsReexport('export * from "./distNodeJS";\n'), "./distNodeJS");
+});
+
+// ── CommonJS left in a .js file ─────────────────────────────────────────────────
+
+test("a shipped CommonJS .js file needs a decision", () => {
+    withTree(
+        {
+            "packages/p/package.json": JSON.stringify({ name: "p", files: ["src"] }),
+            "packages/p/src/thing.js": 'const y = require("y");\nmodule.exports = { y };\n'
+        },
+        (root) => {
+            const liveness = computeLiveJsFiles(root);
+            const { cjsModules, deadFiles } = classifyJsFiles(path.join(root, "packages/p"), "p", liveness);
+            assert.equal(cjsModules.length, 1);
+            assert.equal(cjsModules[0].kind, "cjs-module");
+            assert.equal(deadFiles.length, 0);
+        }
+    );
+});
+
+test("an unreferenced CommonJS .js in a private package needs a decision too: it is run by hand", () => {
+    withTree(
+        {
+            "packages/p/package.json": JSON.stringify({ name: "p", private: true }),
+            "packages/p/script.js": 'const y = require("y");\nmodule.exports = { y };\n'
+        },
+        (root) => {
+            const liveness = computeLiveJsFiles(root);
+            const { cjsModules, deadFiles } = classifyJsFiles(path.join(root, "packages/p"), "p", liveness);
+            assert.equal(cjsModules.length, 1);
+            assert.equal(deadFiles.length, 0);
+        }
+    );
+});
+
+test("a mutually-referencing pair of unshipped CommonJS files stays dead", () => {
+    withTree(
+        {
+            "packages/p/package.json": JSON.stringify({ name: "p", files: ["source"] }),
+            "packages/p/source/a.ts": "export const x = 1;\n",
+            "packages/p/scripts/a.js": 'require("./b.js");\nmodule.exports = 1;\n',
+            "packages/p/scripts/b.js": 'require("./a.js");\nmodule.exports = 2;\n'
+        },
+        (root) => {
+            const liveness = computeLiveJsFiles(root);
+            const { deadFiles, cjsModules } = classifyJsFiles(path.join(root, "packages/p"), "p", liveness);
+            assert.equal(cjsModules.length, 0);
+            assert.equal(deadFiles.length, 2);
+            assert.deepEqual(
+                deadFiles.map((d) => d.kind),
+                ["cjs-dead", "cjs-dead"]
+            );
+        }
+    );
+});
+
+test("a .cjs file is left alone: its extension already says what it is", () => {
+    withTree(
+        {
+            "packages/p/package.json": JSON.stringify({ name: "p" }),
+            "packages/p/thing.cjs": "module.exports = 1;\n"
+        },
+        (root) => {
+            const liveness = computeLiveJsFiles(root);
+            const { cjsModules, deadFiles } = classifyJsFiles(path.join(root, "packages/p"), "p", liveness);
+            assert.equal(cjsModules.length, 0);
+            assert.equal(deadFiles.length, 0);
+        }
+    );
+});
+
+test("an ESM .js file is not reported", () => {
+    withTree(
+        {
+            "packages/p/package.json": JSON.stringify({ name: "p" }),
+            "packages/p/thing.js": "export const x = 1;\n"
+        },
+        (root) => {
+            const liveness = computeLiveJsFiles(root);
+            const { cjsModules, deadFiles, shims, cjsEntries } = classifyJsFiles(path.join(root, "packages/p"), "p", liveness);
+            assert.equal(cjsModules.length, 0);
+            assert.equal(deadFiles.length, 0);
+            assert.equal(shims.length, 0);
+            assert.equal(cjsEntries.length, 0);
+        }
+    );
+});
+
+test("typeof __filename is reported, not converted: the value is always undefined under ESM", () => {
+    const found = findManualWork('const x = typeof __filename === "undefined" ? "a" : __filename;\n');
+    assert.equal(found[0].kind, "typeof-cjs-global");
+});
+
+test("analyze wires the shim rewrite and CommonJS reports into one result", () => {
+    withTree(
+        {
+            "packages/p/package.json": JSON.stringify({ name: "p", files: ["source", "bin"] }),
+            "packages/p/source/a.ts": "export const x = 1;\n",
+            "packages/p/nodeJS.js": 'module.exports = require("./distNodeJS");',
+            "packages/p/bin/cli.js": 'const y = require("y");\nmodule.exports = { y };\n'
+        },
+        (root) => {
+            const r = analyze({ repoRoot: root, packageName: "p" });
+            assert.equal(r.shims.length, 1);
+            assert.equal(r.shims[0].resolved, "./distNodeJS.js");
+            assert.equal(r.manual.some((m) => m.kind === "cjs-module"), true);
         }
     );
 });

--- a/tools/esm-convert/test/test_rule.js
+++ b/tools/esm-convert/test/test_rule.js
@@ -6,6 +6,7 @@
  * change behaviour.
  */
 import assert from "node:assert";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -478,6 +479,34 @@ test("a shebang file elsewhere is cjs-module, not cjs-dead: the shebang says it 
             const liveness = computeLiveJsFiles(root);
             const { cjsModules, deadFiles } = classifyJsFiles(path.join(root, "packages/p"), "p", liveness);
             assert.equal(cjsModules.length, 1);
+            assert.equal(deadFiles.length, 0);
+        }
+    );
+});
+
+// ── gitignored files ────────────────────────────────────────────────────────────
+//
+// The scan walks the filesystem, so without this it would report a gitignored,
+// machine-generated file (a certificate directory a pki step writes before tests, say) that a
+// developer's checkout has on disk and a clean CI checkout does not - the survey would then
+// differ by machine. `git ls-files --cached --others --exclude-standard`, run once at the
+// repo root, is the source of truth for what a checkout actually has.
+
+test("a gitignored .js file is not reported: the scan only sees what git tracks or would add", () => {
+    withTree(
+        {
+            "packages/p/package.json": JSON.stringify({ name: "p", files: ["source"] }),
+            "packages/p/source/a.ts": "export const x = 1;\n",
+            "packages/p/.gitignore": "generated/\n",
+            "packages/p/generated/config.js": 'const x = require("y");\nmodule.exports = x;\n'
+        },
+        (root) => {
+            execFileSync("git", ["init", "-q"], { cwd: root });
+            execFileSync("git", ["add", "-A"], { cwd: root });
+
+            const liveness = computeLiveJsFiles(root);
+            const { cjsModules, deadFiles } = classifyJsFiles(path.join(root, "packages/p"), "p", liveness);
+            assert.equal(cjsModules.length, 0);
             assert.equal(deadFiles.length, 0);
         }
     );

--- a/tools/esm-convert/test/test_rule.js
+++ b/tools/esm-convert/test/test_rule.js
@@ -435,6 +435,54 @@ test("a .cjs file is left alone: its extension already says what it is", () => {
     );
 });
 
+test("a .js under test/fixtures with no static reference is cjs-module, not cjs-dead: a computed path can still load it", () => {
+    withTree(
+        {
+            "packages/p/package.json": JSON.stringify({ name: "p", files: ["source"] }),
+            "packages/p/source/a.ts": "export const x = 1;\n",
+            "packages/p/test/fixtures/leaked.js": "module.exports = 1;\n"
+        },
+        (root) => {
+            const liveness = computeLiveJsFiles(root);
+            const { cjsModules, deadFiles } = classifyJsFiles(path.join(root, "packages/p"), "p", liveness);
+            assert.equal(cjsModules.length, 1);
+            assert.equal(deadFiles.length, 0);
+        }
+    );
+});
+
+test("a bin/ script with no reference and no package.json bin entry is cjs-module, not cjs-dead: it is run by hand", () => {
+    withTree(
+        {
+            "packages/p/package.json": JSON.stringify({ name: "p", files: ["source"] }),
+            "packages/p/source/a.ts": "export const x = 1;\n",
+            "packages/p/bin/sample.js": 'const x = require("y");\nmodule.exports = x;\n'
+        },
+        (root) => {
+            const liveness = computeLiveJsFiles(root);
+            const { cjsModules, deadFiles } = classifyJsFiles(path.join(root, "packages/p"), "p", liveness);
+            assert.equal(cjsModules.length, 1);
+            assert.equal(deadFiles.length, 0);
+        }
+    );
+});
+
+test("a shebang file elsewhere is cjs-module, not cjs-dead: the shebang says it is run directly", () => {
+    withTree(
+        {
+            "packages/p/package.json": JSON.stringify({ name: "p", files: ["source"] }),
+            "packages/p/source/a.ts": "export const x = 1;\n",
+            "packages/p/tool.js": '#!/usr/bin/env node\nconst x = require("y");\nmodule.exports = x;\n'
+        },
+        (root) => {
+            const liveness = computeLiveJsFiles(root);
+            const { cjsModules, deadFiles } = classifyJsFiles(path.join(root, "packages/p"), "p", liveness);
+            assert.equal(cjsModules.length, 1);
+            assert.equal(deadFiles.length, 0);
+        }
+    );
+});
+
 test("an ESM .js file is not reported", () => {
     withTree(
         {


### PR DESCRIPTION
## The bug

`node tools/esm-convert.mjs --all` reported `123 packages - 2 already ESM, 121 mechanical, 0 need a decision`. That was wrong: `packageFiles()` only ever collected `.ts`/`.mts`/`.cts` files, so no plain `.js` file was ever scanned. Once a package gets `"type": "module"`, every `.js` in it is parsed as ESM, so a CommonJS `.js` breaks - and several packages have exactly that: an entry point with no `exports` map that is a one-line `module.exports = require(...)` shim (`nodeJS.js`, `testHelpers.js`), hand-written CommonJS modules (`node-opcua-leak-detector`), CLI scripts, and dead files nobody ships or references.

## What's new

- **`.js` scanning** (`jsFilesOf`): every `.js` in a package outside `SKIP_DIRS`/`node_modules`, excluding `.mocharc.js`. CommonJS is detected via the TypeScript AST (`ScriptKind.JS`), not regexes.
- **`cjs-entry` / entry shim rewrite** (mechanical): a `.js` file whose only statement is `module.exports = require("<spec>")` is rewritten to `export * from "<resolved>";`, keeping leading comments. The specifier is resolved (kept if it already ends in `.js`, `/index.js` appended for a directory that exists or a tsconfig outDir via `emittedFrom`, `.js` appended otherwise) or, if it's not a relative path, reported as `cjs-entry` instead of guessed. The sibling `.d.ts` doing the same `export * from` gets the same treatment when its specifier still lacks an extension (TS2834 under NodeNext). Applies to already-ESM packages too (`node-opcua-transport`).
- **`cjs-module`** (needs a decision): any other CommonJS `.js` that is shipped (`files`/`main`/`bin`/`exports`) or referenced by a live file - or, in a `"private": true` package, sits in a test/`bin` tree, or opens with a `#!` shebang, since a static reference search cannot prove those unused (a test fixture is reached by a computed path and spawned as a child process; a script is run by hand).
- **`cjs-dead`** (not blocking): CommonJS `.js` that is neither shipped nor referenced, and is not one of the above unprovable cases. Liveness is a repo-wide reachability scan from shipped files, every `.ts`/`.mts`/`.cts`, and every `.d.ts`, propagated to a fixpoint over `require`/`import` specifiers (regex-based, single read per file) - so a pair of dead files that only reference each other stays dead.
- **`typeof-cjs-global`**: `typeof __filename`/`typeof __dirname` in a converted file - always `"undefined"` under ESM, so the branch that reads it goes dead (caught `node-opcua-debug/source/make_loggers.ts:141`).

**Corrections during review**:
1. Test fixtures reached only by a computed path (`node-opcua-leak-detector/test/fixtures/*.js`, spawned as child processes, never statically imported) and `bin/`/shebang scripts were first classified as `cjs-dead`, which told a person to delete files that are actually in use; both are now `cjs-module` instead, since "no static reference found" does not prove either is unused.
2. The scan walked the filesystem directly, so it reported `packages/node-opcua-samples/certificates/config.js` - a file `.gitignore` excludes and the pki setup generates before tests, so it exists on a developer checkout but not on a clean CI one; both the `.ts`/`.js` collection and the liveness scan now filter against `git ls-files --cached --others --exclude-standard` (falling back to the plain filesystem walk when git is unavailable, e.g. in the test fixtures), so the survey no longer differs by machine.

## Before / after `--all`

Before: `123 packages - 2 already ESM, 121 mechanical, 0 need a decision`

After:
```
esm-convert: 123 packages - 2 already ESM, 112 mechanical, 9 need a decision, 166 dead files not shipped

  need a decision:
    node-opcua-address-space                       cjs-module
    node-opcua-aggregates                           cjs-module
    node-opcua-debug                                typeof-cjs-global, cjs-module
    node-opcua-end2end-test                         cjs-module
    node-opcua-leak-detector                        cjs-module
    node-opcua-model                                cjs-module
    node-opcua-samples                              cjs-module
    node-opcua-test-fixtures                        cjs-module
    playground                                       cjs-module

  already ESM but still has CommonJS left:
    node-opcua-transport                            2 entry shim(s) to rewrite

  dead - not shipped, nothing live references it (166): 162 schema/enum files across 13
  service-* packages, node-opcua-common/crypto_explore_certificate.js, and 3 nyc.config.js.
```

`--package node-opcua-address-space` / `node-opcua-debug` / `node-opcua-transport` each show the shim rewrite (and `.d.ts` twin where relevant) under "would apply".

## Tests

29 existing + 21 new `node:test` cases in `tools/esm-convert/test/test_rule.js`: shim resolution (directory, tsconfig outDir, explicit `.js`, unresolvable), the `.d.ts` twin rewrite (and when it's left alone), `cjs-module` for a shipped file and a private-package script, `cjs-dead` including a mutually-referencing pair, a `.cjs` file ignored, `typeof __filename` reported, an ESM `.js` file not reported, a test-fixture `.js` with no static reference, a `bin/` script with no reference and no `package.json` `bin` entry, a shebang file elsewhere (all `cjs-module`, never `cjs-dead`), and a `git init`-ed temp package proving a gitignored `.js` is skipped entirely.

`pnpm run lint:ci` passes (biome plus every `check:*` script, `esm-convert`'s tests included).

## Notes / judgment calls

- `node-opcua-test-fixtures`'s three root `fixture_*.js` files are not shipped and nothing references them, but the package is `"private": true`, so per the spec they classify as `cjs-module` (a script run by hand) rather than `cjs-dead`.
- `--write` was only exercised in tests against temp fixtures, never against the real packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)