### PR TITLE
docs: state the real Node.js floor (22.13) in the tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ ./node_modules/.bin/simple_client -e "opc.tcp://opcuademo.sterfive.com:26543"
 
 ## Node.js Requirement
 
-- **Node.js 20** or above is required.
+- **Node.js 22.13** or above is required.
 
 ## Documentation
 

--- a/documentation/creating_a_client_callback.md
+++ b/documentation/creating_a_client_callback.md
@@ -15,7 +15,7 @@ you've been warned !
 
 ## preparation
 
-- (note: please make sure node.js is installed. Follow the instructions [here](http://nodejs.org/)).
+- (note: please make sure node.js 22.13 or above is installed. Follow the instructions [here](http://nodejs.org/)).
 
 Let's create a node project for our client.
 

--- a/documentation/creating_a_client_typescript.md
+++ b/documentation/creating_a_client_typescript.md
@@ -5,7 +5,7 @@ In this example, we want to create a OPCUA Client to monitor a variable on the s
 
 ## preparation
 
-- make sure node.js 18 or above is installed. Follow the instructions [here](http://nodejs.org/)).
+- make sure node.js 22.13 or above is installed. Follow the instructions [here](http://nodejs.org/)).
 - make sure also to install typescript version 5.0 or above
 
 Let's create a node project for our client.

--- a/documentation/creating_a_server.md
+++ b/documentation/creating_a_server.md
@@ -18,7 +18,7 @@ or under [Git Bash](http://msysgit.github.io/) cmd on Windows.
 
 ## preparation
 
-* (note: please make sure node.js is installed. Follow the instructions [here](http://nodejs.org/) ).
+* (note: please make sure node.js 22.13 or above is installed. Follow the instructions [here](http://nodejs.org/) ).
 
 
 Let's create a node project for our server.


### PR DESCRIPTION
The getting-started docs advertised a Node.js floor that no longer matches the code.

| file | said | says now |
| --- | --- | --- |
| `documentation/creating_a_client_typescript.md` | node.js 18 or above | node.js 22.13 or above |
| `documentation/creating_a_client_callback.md` | node.js is installed (no version) | node.js 22.13 or above |
| `documentation/creating_a_server.md` | node.js is installed (no version) | node.js 22.13 or above |
| `README.md` | **Node.js 20** or above | **Node.js 22.13** or above |

Each claim was checked against `engines.node` rather than assumed. The root `package.json` declares `">=22.13.0"`, `tools/check-engines` propagates that exact string to every published package, and all 113 published packages currently carry it (the 9 without an `engines` block are private test packages). `tools/check-engines/src/rule.js` records the reason: Node 18 and 20 were dropped from CI in May.

`README.md` sits outside `documentation/` but carried the same stale claim, and it is the most visible copy of it (npm page and GitHub landing), so it is fixed here too.

Rest of the sweep, nothing else to change:

- `documentation/rfc/nodeset-ndjson.md:887` mentions Node.js 22.22.3, but as the machine a benchmark ran on, not as a requirement.
- `documentation/create_a_weather_station.md` and `monitoring_home_temperature_with_a_raspberry.md` mention NodeJS with no version claim.
- `.github/CONTRIBUTING.md`, `CONTRIBUTING.md`, `SECURITY.md`, `supported_features.md`, `tools/README.md`, `code_gen/README.md` state no Node version.

One note: the TypeScript line immediately below the one changed in `creating_a_client_typescript.md` is corrected to 5.0 by the nodeset `export type *` PR. Adjacent lines in the same hunk, so whichever lands second gets a one-line conflict there.

No code, tests or package manifests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)