### PR TITLE
refactor(types): store the callback form, and cast self through unknown

### DIFF
--- a/packages/node-opcua-address-space/impl/ua_method_impl.ts
+++ b/packages/node-opcua-address-space/impl/ua_method_impl.ts
@@ -68,7 +68,10 @@ export class UAMethodImpl extends BaseNodeImpl<UAMethodEvents> implements UAMeth
     public methodDeclarationId: NodeId;
     public _getExecutableFlag?: (this: UAMethod, context: ISessionContext | null) => boolean;
 
-    public _asyncExecutionFunction?: MethodFunctor;
+    // always the callback form: bindMethod normalises the promise form before storing it. A union
+    // here would be wider than what can be held, and `.call` on a union of signatures does not
+    // resolve to the callback one.
+    public _asyncExecutionFunction?: MethodFunctorC;
 
     constructor(options: IMethodOptons) {
         super(options);
@@ -138,11 +141,12 @@ export class UAMethodImpl extends BaseNodeImpl<UAMethodEvents> implements UAMeth
 
     public bindMethod(async_func: MethodFunctor): void {
         assert(typeof async_func === "function");
-        if (async_func.length === 2) {
-            async_func = callbackify(async_func as MethodFunctorA) as MethodFunctorC;
-        }
-        assert(async_func.length === 3, ` a method with callback should have 3 arguments : got ${async_func.length}`);
-        this._asyncExecutionFunction = async_func;
+        const callbackForm: MethodFunctorC =
+            async_func.length === 2
+                ? (callbackify(async_func as MethodFunctorA) as MethodFunctorC)
+                : (async_func as MethodFunctorC);
+        assert(callbackForm.length === 3, ` a method with callback should have 3 arguments : got ${callbackForm.length}`);
+        this._asyncExecutionFunction = callbackForm;
     }
     public execute(
         object: UAObject | UAObjectType | null,

--- a/packages/node-opcua-client/source/private/client_base_impl.ts
+++ b/packages/node-opcua-client/source/private/client_base_impl.ts
@@ -1722,7 +1722,10 @@ export class ClientBaseImpl<Events extends OPCUAClientBaseEvents = OPCUAClientBa
 
             clientCertificateManager: this.clientCertificateManager
         };
-        __findEndpoint.call(this, discoveryUrl, params, (err: Error | null, result?: FindEndpointResult) => {
+        // through unknown: see the note in base_server.ts, `this` is ClientBaseImpl<Events> and
+        // Events could be a narrower subtype than the helper's parameter declares.
+        const self = this as unknown as ClientBaseImpl;
+        __findEndpoint.call(self, discoveryUrl, params, (err: Error | null, result?: FindEndpointResult) => {
             if (err) {
                 callback(err);
                 return;

--- a/packages/node-opcua-server-configuration/source/server/promote_trust_list.ts
+++ b/packages/node-opcua-server-configuration/source/server/promote_trust_list.ts
@@ -11,7 +11,7 @@ import { fs as MemFs } from "memfs";
 import type {
     IAddressSpace,
     ISessionContext,
-    MethodFunctor,
+    MethodFunctorC,
     UAMethod,
     UAObject,
     UAObjectType,
@@ -248,7 +248,7 @@ async function _initializeLastUpdateTimeFromFilesystem(trustList: UATrustListEx)
 }
 
 interface UAMethodEx extends UAMethod {
-    _asyncExecutionFunction?: MethodFunctor;
+    _asyncExecutionFunction?: MethodFunctorC;
 }
 interface UATrustListEx extends UATrustList {
     $$certificateManager: OPCUACertificateManager;
@@ -366,7 +366,7 @@ async function _closeAndUpdate(
     this: UAMethod,
     inputArguments: Variant[],
     context: ISessionContext,
-    _close_method?: MethodFunctor
+    _close_method?: MethodFunctorC
 ): Promise<CallMethodResultOptions> {
     const trustList = context.object as UATrustListEx;
     const cm = trustList.$$certificateManager;
@@ -676,11 +676,11 @@ export async function promoteTrustList(trustList: UATrustList) {
 
     // we need to change the default open method
     const open = trustList.getChildByName("Open") as UAMethodEx;
-    const _open_asyncExecutionFunction = open._asyncExecutionFunction as MethodFunctor;
+    const _open_asyncExecutionFunction = open._asyncExecutionFunction as MethodFunctorC;
 
     // ... and bind the extended methods as well.
     const close = trustList.getChildByName("Close") as UAMethodEx;
-    const _close_asyncExecutionFunction = close._asyncExecutionFunction as MethodFunctor;
+    const _close_asyncExecutionFunction = close._asyncExecutionFunction as MethodFunctorC;
 
     const closeAndUpdate = trustList.getChildByName("CloseAndUpdate") as UAMethodEx;
     const openWithMasks = trustList.getChildByName("OpenWithMasks") as UAMethodEx;

--- a/packages/node-opcua-server/source/base_server.ts
+++ b/packages/node-opcua-server/source/base_server.ts
@@ -514,7 +514,10 @@ export class OPCUABaseServer<T extends OPCUABaseServerEvents = any> extends OPCU
         assert(this.endpoints.length > 0, "We need at least one end point");
 
         installPeriodicClockAdjustment();
-        const server: OPCUABaseServer<OPCUABaseServerEvents> = this;
+        // through unknown: `this` is OPCUABaseServer<T>, and T could be a narrower subtype of the
+        // constraint, so TS 7 refuses the direct conversion. The events emitted here are the ones
+        // the constraint declares, so the base instantiation is the right view of `this`.
+        const server = this as unknown as OPCUABaseServer<OPCUABaseServerEvents>;
         const _on_new_channel = function (this: OPCUAServerEndPoint, channel: ServerSecureChannelLayer) {
             server.emit("newChannel", channel, this);
         };
@@ -649,7 +652,7 @@ export class OPCUABaseServer<T extends OPCUABaseServerEvents = any> extends OPCU
         let errMessage: string;
         let response: Response;
 
-        (this as OPCUABaseServer<OPCUABaseServerEvents>).emit("request", request, channel);
+        (this as unknown as OPCUABaseServer<OPCUABaseServerEvents>).emit("request", request, channel);
 
         try {
             // handler must be named _on_ActionRequest()


### PR DESCRIPTION
## Why

Four type declarations describe something wider than what the code can actually hold, which
leaves a call expression with more than one candidate signature and forces a conversion the
compiler cannot justify. They are harmless today and cost nothing to state precisely.

They surfaced while measuring a TypeScript 7 build (a separate piece of work): TS 7 rejects all
four. That is the occasion, not the reason, so this stands on its own and changes nothing about
the toolchain.

## What changed

- `_asyncExecutionFunction` now holds `MethodFunctorC` rather than the `MethodFunctor` union, in
  `ua_method_impl.ts` and in the local `UAMethodEx` of `promote_trust_list.ts`. `bindMethod` already
  normalises a promise-form functor into the callback form (`callbackify`, then an assert that the
  functor takes 3 arguments) before storing it, so the union was never inhabited by its promise
  half. With the union gone, `.call(this, inputArguments, context, callback)` has one signature to
  resolve against instead of two.
- The three self-casts in `base_server.ts` and `client_base_impl.ts` go through `unknown`. Inside
  `OPCUABaseServer<T>` and `ClientBaseImpl<Events>`, `this` is the class at its own type parameter,
  and a parameter can be instantiated with a narrower subtype than the constraint, so the direct
  conversion is not sound. The events emitted there are the ones the constraint declares, which is
  why the base instantiation is the right view of `this`; the cast now says so explicitly.

## Effect

Type level only. Diffing the emitted output of the whole workspace before and after, compiled by
the same TypeScript 5.9.3:

- `ua_method_impl.js`: the `bindMethod` restructure (same calls, same assert, same stored value)
- `client_base_impl.js`: one added local, `const self = this`
- `base_server.js`: comments only
- `ua_method_impl.d.ts`: the narrowed field type, which is the intended change

No other file out of 2584 differs.

## Verification

- `pnpm run build` green
- `node-opcua-address-space` 1383 passing, `node-opcua-server-configuration` 147 passing,
  `node-opcua-client` 77 passing, no failures
- biome clean on the four files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
