### PR TITLE
build(nodesets): generate the companion packages as ESM

### DIFF
--- a/packages/node-opcua-convert-nodeset-to-javascript/source/convert_namespace_to_typescript.ts
+++ b/packages/node-opcua-convert-nodeset-to-javascript/source/convert_namespace_to_typescript.ts
@@ -237,6 +237,10 @@ async function _output_package_json(info: Info, options: Options): Promise<void>
     content2.push(`{`);
     content2.push(`    "name": "${info.module}",`);
     content2.push(`    "version": "${version}",`);
+    // These packages are almost entirely type declarations: what they emit is a handful of
+    // enums and an index that re-exports types. ESM costs them nothing and keeps them in
+    // step with the rest of the workspace, which is flipping package by package (FEAT-2).
+    content2.push(`    "type": "module",`);
     content2.push(`    "description": "pure nodejs OPCUA SDK - module ${info.module}",`);
     content2.push(`    "main": "dist/index.js",`);
     content2.push(`    "types": "dist/index.d.ts",`);

--- a/packages/node-opcua-nodeset-adi/package.json
+++ b/packages/node-opcua-nodeset-adi/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-adi",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-adi",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-amb/package.json
+++ b/packages/node-opcua-nodeset-amb/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-amb",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-amb",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-auto-id/package.json
+++ b/packages/node-opcua-nodeset-auto-id/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-auto-id",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-auto-id",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-cnc/package.json
+++ b/packages/node-opcua-nodeset-cnc/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-cnc",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-cnc",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-commercial-kitchen-equipment/package.json
+++ b/packages/node-opcua-nodeset-commercial-kitchen-equipment/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-commercial-kitchen-equipment",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-commercial-kitchen-equipment",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-di/package.json
+++ b/packages/node-opcua-nodeset-di/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-di",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-di",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-gds/package.json
+++ b/packages/node-opcua-nodeset-gds/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-gds",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-gds",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-glass-flat/package.json
+++ b/packages/node-opcua-nodeset-glass-flat/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-glass-flat",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-glass-flat",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-i-4-aas/package.json
+++ b/packages/node-opcua-nodeset-i-4-aas/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-i-4-aas",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-i-4-aas",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-ia/package.json
+++ b/packages/node-opcua-nodeset-ia/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-ia",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-ia",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-ijt-base/package.json
+++ b/packages/node-opcua-nodeset-ijt-base/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-ijt-base",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-ijt-base",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-ijt-tightening/package.json
+++ b/packages/node-opcua-nodeset-ijt-tightening/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-ijt-tightening",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-ijt-tightening",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-io-link/package.json
+++ b/packages/node-opcua-nodeset-io-link/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-io-link",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-io-link",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-isa-95-jobcontrol-v-2/package.json
+++ b/packages/node-opcua-nodeset-isa-95-jobcontrol-v-2/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-isa-95-jobcontrol-v-2",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-isa-95-jobcontrol-v-2",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-lads/package.json
+++ b/packages/node-opcua-nodeset-lads/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-lads",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-lads",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-machine-tool/package.json
+++ b/packages/node-opcua-nodeset-machine-tool/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-machine-tool",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-machine-tool",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-machine-vision/package.json
+++ b/packages/node-opcua-nodeset-machine-vision/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-machine-vision",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-machine-vision",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-machinery-jobs/package.json
+++ b/packages/node-opcua-nodeset-machinery-jobs/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-machinery-jobs",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-machinery-jobs",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-machinery-process-values/package.json
+++ b/packages/node-opcua-nodeset-machinery-process-values/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-machinery-process-values",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-machinery-process-values",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-machinery-result/package.json
+++ b/packages/node-opcua-nodeset-machinery-result/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-machinery-result",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-machinery-result",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-machinery/package.json
+++ b/packages/node-opcua-nodeset-machinery/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-machinery",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-machinery",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-metal-forming/package.json
+++ b/packages/node-opcua-nodeset-metal-forming/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-metal-forming",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-metal-forming",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-pack-ml/package.json
+++ b/packages/node-opcua-nodeset-pack-ml/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-pack-ml",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-pack-ml",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-padim/package.json
+++ b/packages/node-opcua-nodeset-padim/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-padim",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-padim",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-robotics/package.json
+++ b/packages/node-opcua-nodeset-robotics/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-robotics",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-robotics",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-scales-v-2/package.json
+++ b/packages/node-opcua-nodeset-scales-v-2/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-scales-v-2",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-scales-v-2",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-surface-technology-general-types/package.json
+++ b/packages/node-opcua-nodeset-surface-technology-general-types/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-surface-technology-general-types",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-surface-technology-general-types",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-surface-technology-oct-mss/package.json
+++ b/packages/node-opcua-nodeset-surface-technology-oct-mss/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-surface-technology-oct-mss",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-surface-technology-oct-mss",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-ua/package.json
+++ b/packages/node-opcua-nodeset-ua/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-ua",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-ua",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-weihenstephan/package.json
+++ b/packages/node-opcua-nodeset-weihenstephan/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-weihenstephan",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-weihenstephan",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/node-opcua-nodeset-woodworking/package.json
+++ b/packages/node-opcua-nodeset-woodworking/package.json
@@ -1,6 +1,7 @@
 {
     "name": "node-opcua-nodeset-woodworking",
     "version": "2.183.1",
+    "type": "module",
     "description": "pure nodejs OPCUA SDK - module node-opcua-nodeset-woodworking",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
The 31 generated companion nodeset packages become ESM. FEAT-2, 2.x, not breaking.

One line of generator change, then `pnpm run generate`. The manifests are generated, so hand-editing them would be undone by the next regeneration; the change belongs in `convert_namespace_to_typescript.ts`.

## The diff

- `_output_package_json` emits `"type": "module"`.
- 31 regenerated manifests, one line each.
- **No source diff at all.** The regeneration reproduced every generated `.ts` byte for byte, which also confirms the `export type *` output from #1688 is stable.

## Why these are the safest packages to flip

They are type declarations plus a handful of enums. Across all 31, the emitted JavaScript imports no other node-opcua package at run time.

## Evidence

- `pnpm run generate`: exit 0, and the only diff is the 31 manifests, so the drift check has nothing left to report.
- `npx tsc -b packages --force`: 0 errors. The `--force` matters, since `tsc -b` does not re-emit on a `type` change alone.
- **1545 emitted `.js` files across the 31 packages: every one carries `export` statements, none has a `require(` call or an `exports.` assignment.**
- Run-time check of the values these packages actually emit: `node-opcua-nodeset-di` resolves `EnumDeviceHealth`, `EnumSoftwareClass`, `EnumSoftwareVersionFile` through its package index, and `node-opcua-nodeset-ua` resolves its 40 exports.
- **A CommonJS consumer still works**: `require("node-opcua-nodeset-di")` from a dependent package returns the three enums.
- `pnpm run check:consumers`: `consumer-cjs: ok`, `consumer-esm: ok` on Node 22.22.3.
- `pnpm run lint:ci`: exit 0.

Depends on nothing in #1690; the two touch different packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
