### PR TITLE
fix(pack): a path without ./ is still a path, and ship what it names

### DIFF
--- a/packages/node-opcua-leak-detector/package.json
+++ b/packages/node-opcua-leak-detector/package.json
@@ -30,7 +30,9 @@
         "node": ">=22.13.0"
     },
     "files": [
-        "src"
+        "src",
+        "index.js",
+        "index.d.ts"
     ],
     "dependencies": {
         "chalk": "4.1.2",

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -46,6 +46,7 @@
         { "path": "node-opcua-nodeset-di" },
         { "path": "node-opcua-nodeset-gds" },
         { "path": "node-opcua-nodeset-glass-flat" },
+        { "path": "node-opcua-nodeset-i-4-aas" },
         { "path": "node-opcua-nodeset-ia" },
         { "path": "node-opcua-nodeset-ijt-base" },
         { "path": "node-opcua-nodeset-ijt-tightening" },

--- a/tools/check-pack/src/rule.js
+++ b/tools/check-pack/src/rule.js
@@ -31,24 +31,27 @@ const normalize = (p) => p.replace(/^\.\//, "").replace(/\\/g, "/");
  */
 export function declaredEntryPoints(pkg) {
     const out = [];
+    // main/types/typings/module/browser always name a file in this package, with or without a
+    // leading "./". Only an exports target can be a bare specifier redirecting elsewhere, so
+    // fromExports records which rule applies; see missingEntryPoints.
     for (const field of ["main", "types", "typings", "module"]) {
         if (typeof pkg[field] === "string") {
-            out.push({ field, target: pkg[field] });
+            out.push({ field, target: pkg[field], fromExports: false });
         }
     }
     // browser may be a string or a mapping
     if (typeof pkg.browser === "string") {
-        out.push({ field: "browser", target: pkg.browser });
+        out.push({ field: "browser", target: pkg.browser, fromExports: false });
     } else if (pkg.browser && typeof pkg.browser === "object") {
         for (const [k, v] of Object.entries(pkg.browser)) {
             if (typeof v === "string") {
-                out.push({ field: `browser["${k}"]`, target: v });
+                out.push({ field: `browser["${k}"]`, target: v, fromExports: false });
             }
         }
     }
     const walkExports = (node, trail) => {
         if (typeof node === "string") {
-            out.push({ field: `exports${trail}`, target: node });
+            out.push({ field: `exports${trail}`, target: node, fromExports: true });
             return;
         }
         if (node && typeof node === "object") {
@@ -71,10 +74,12 @@ export function missingEntryPoints(pkg, packedFiles) {
     const shippedList = packedFiles.map(normalize);
     const shipped = new Set(shippedList);
     const out = [];
-    for (const { field, target } of declaredEntryPoints(pkg)) {
-        // only relative targets describe a file in this tarball; a bare specifier in an
-        // exports map is a redirect to another package and is not ours to verify
-        if (!target.startsWith(".") && !target.startsWith("/")) {
+    for (const { field, target, fromExports } of declaredEntryPoints(pkg)) {
+        // a bare specifier in an exports map is a redirect to another package and is not ours
+        // to verify. main/types/module/browser have no such form: "dist/index.js" is the same
+        // file as "./dist/index.js", and skipping the unprefixed spelling silently exempted a
+        // third of the workspace, including a package that shipped no dist at all.
+        if (fromExports && !target.startsWith(".") && !target.startsWith("/")) {
             continue;
         }
         const wanted = normalize(target);

--- a/tools/check-pack/test/test_rule.js
+++ b/tools/check-pack/test/test_rule.js
@@ -82,6 +82,18 @@ test("leading ./ is not significant either way", () => {
     assert.deepEqual(missingEntryPoints({ main: "./dist/index.js" }, ["dist/index.js"]), []);
 });
 
+// node-opcua-nodeset-i-4-aas shipped no dist at all and this rule stayed green: a target
+// without the ./ prefix was read as a bare specifier and skipped, which exempted a third of
+// the workspace. Only an exports target can be a bare specifier.
+test("an unprefixed main or types is a path, so a missing one is still reported", () => {
+    const pkg = { main: "dist/index.js", types: "dist/index.d.ts" };
+    const missing = missingEntryPoints(pkg, ["LICENSE", "package.json", "source/index.ts"]);
+    assert.deepEqual(
+        missing.map((m) => m.field).sort(),
+        ["main", "types"]
+    );
+});
+
 test("a subpath pattern is satisfied by any shipped file the star expands to", () => {
     const pkg = { exports: { "./dist/*": { types: "./dist/*.d.ts", default: "./dist/*.js" } } };
     assert.deepEqual(missingEntryPoints(pkg, ["dist/index.js", "dist/index.d.ts", "dist/104/index.js"]), []);


### PR DESCRIPTION
## What is wrong

`node-opcua-nodeset-i-4-aas@2.183.1` is published with no code. The tarball on npm holds
`LICENSE`, `package.json` and 44 `source/*.ts` files, nothing else, while the manifest says
`main: dist/index.js` and `types: dist/index.d.ts`. Any consumer importing the I4AAS companion
nodeset fails to resolve it.

```
$ npm pack node-opcua-nodeset-i-4-aas@2.183.1 && tar -tzf *.tgz | cut -d/ -f2 | sort -u
LICENSE
package.json
source
```

It is the only package under `packages/` missing from `packages/tsconfig.json`, so `tsc -b packages`
never builds it, and `files: ["dist", "source"]` then ships the half that exists.

`check-pack` is the rule whose whole purpose is to catch a declared entry point that is not in the
tarball, and it stayed green, because of this line:

```js
// only relative targets describe a file in this tarball; a bare specifier in an
// exports map is a redirect to another package and is not ours to verify
if (!target.startsWith(".") && !target.startsWith("/")) continue;
```

`main: "dist/index.js"` does not start with `.`, so it was read as a bare specifier and skipped.
Only an `exports` target can take that form; `main`, `types`, `typings`, `module` and `browser`
always name a file in the package. **37 of 115 publishable packages write their entry points
without the `./` prefix**, so their `main` and `types` were never checked.

## What changed

- `tools/check-pack/src/rule.js`: the bare-specifier exemption now applies only to `exports`
  targets. `declaredEntryPoints` records `fromExports` so the two cases stay distinguishable.
- `packages/tsconfig.json`: the missing `node-opcua-nodeset-i-4-aas` reference. It builds clean
  and produces 132 files in `dist`.
- `packages/node-opcua-leak-detector/package.json`: `files` listed only `src`, while `main` and
  `types` name `index.js` and `index.d.ts` at the package root. npm force-includes the `main`
  file but not `types`, so that package has been shipping without its types. This is the one
  further bug the widened rule found across the workspace.

## Verification

- the widened rule reports exactly the two missing entry points when `dist` is hidden again, and
  nothing once it is built
- full `check-pack` run: 113 publishable packages, every declared entry point shipped
- `tools/check-pack/test/test_rule.js`: 16 passing, including a new case for an unprefixed `main`
  and `types` that are absent from the tarball, which is the shape that escaped
- `lint:ci` green
- publint and attw (which independently flagged both packages) are clean on them now

## Follow-up, not in this PR

Nothing checks that a package under `packages/` is in the build graph at all. `fix-tsconfigs`
maintains each package's own references, not the aggregate list, so a newly generated nodeset
package is one forgotten line away from this failure. This PR makes the consequence impossible to
ship unnoticed; a cheap graph check would catch the cause earlier.

