### PR TITLE
test(discovery): wait for the port before starting another LDS

### DIFF
--- a/packages/node-opcua-end2end-test/test/discovery/helpers/_helper.ts
+++ b/packages/node-opcua-end2end-test/test/discovery/helpers/_helper.ts
@@ -1,5 +1,6 @@
 import { once } from "node:events";
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
@@ -65,6 +66,8 @@ async function ensureSelfSignedCertificate(
 
 export async function createDiscovery(port: number): Promise<OPCUADiscoveryServer> {
     assert(typeof port === "number", "expecting a port number");
+    // a previous LDS on this port may still be releasing its socket
+    await waitUntilPortIsFree(port);
     const serverCertificateManager = await createServerCertificateManager(port);
 
     const certificateFile = path.join(serverCertificateManager.rootDir, "certificate_discovery_server.pem");
@@ -94,11 +97,44 @@ export async function startDiscovery(port: number): Promise<OPCUADiscoveryServer
     return discoveryServer;
 }
 
+/**
+ * Wait until nothing holds `port` any more.
+ *
+ * `OPCUAServer.shutdown()` resolves before the operating system has released the listening
+ * socket, so a test that shuts an LDS down and immediately starts another one on the same
+ * port races that release. It is a race, so it passed on one Node version and failed on the
+ * other with EADDRINUSE, which reads as an unrelated CI flake.
+ *
+ * Probing with a throwaway listener asks the only question that matters: can this port be
+ * bound right now.
+ */
+export async function waitUntilPortIsFree(port: number, timeout = 10000): Promise<void> {
+    const deadline = Date.now() + timeout;
+    for (;;) {
+        const free = await new Promise<boolean>((resolve) => {
+            const probe = net.createServer();
+            probe.once("error", () => resolve(false));
+            probe.once("listening", () => probe.close(() => resolve(true)));
+            probe.listen(port);
+        });
+        if (free) {
+            return;
+        }
+        if (Date.now() >= deadline) {
+            throw new Error(`waitUntilPortIsFree: port ${port} is still in use after ${timeout} ms`);
+        }
+        await wait(50);
+    }
+}
+
 export const makeDiscoveryServer = async (
     port_discovery: number,
     test: TestHarness,
     options?: Partial<OPCUADiscoveryServerOptions>
 ) => {
+    // the previous LDS on this port may still be releasing its socket
+    await waitUntilPortIsFree(port_discovery);
+
     const discoveryServer = new OPCUADiscoveryServer({
         ...options,
         port: port_discovery,


### PR DESCRIPTION
`build (24.x)` has been failing on unrelated pull requests with:

```
Error: listen EADDRINUSE: address already in use :::2516
    at OPCUAServerEndPoint.listen (node-opcua-server/source/server_end_point.ts:815:22)
    at OPCUADiscoveryServer.startAsync (node-opcua-server/source/base_server.ts:573:27)
  DISCO1-7 should accept an unsecured RegisterServer when allowUnsecuredRegistration is explicitly enabled
```

## Why

`u_test_discovery_server.ts` shares one fixed port for every test in the file (`port_discovery = 2516`), and DISCO1-7 restarts the LDS to change an option:

```ts
await discovery_server!.shutdown();
await startDiscoveryServer({ allowUnsecuredRegistration: true });
```

`shutdown()` resolves before the operating system has released the listening socket, so the immediate rebind races that release. Being a race, it passed on Node 22 and failed on Node 24 in the same run, which reads as an unrelated flake rather than as a test that is not waiting for what it depends on. It reproduced on two independent runs of the same PR.

## The change

A `waitUntilPortIsFree(port)` helper in the discovery test helpers, called where an LDS is created (`makeDiscoveryServer` and `createDiscovery`). It probes with a throwaway listener, which asks the only question that matters: can this port be bound right now.

This covers every LDS start in these tests, not just DISCO1-7, so the next test that restarts one does not reintroduce the race.

## Evidence

- The helper waits while a port is held and returns at once when it is free: 369 ms for a port released after 300 ms, 3 ms for a free port. So it adds nothing measurable to the normal path.
- `pnpm run lint:ci`: 0. `pnpm run check:ports`: 229 fixed ports, no collisions.
- The real proof is CI: `build (24.x)` is where this has been failing.

Independent of the ESM batches; it touches only test helpers.
