### PR TITLE
feat(tools): gate the published shape with publint and attw

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -429,6 +429,14 @@ jobs:
       - run: pnpm run check:pack
       - name: Unit tests for the packaging rule
         run: node tools/check-pack/test/test_rule.js
+      # publint reads the packed manifest, attw resolves the package the way a consumer's
+      # TypeScript does. check:pack proves a promised file is shipped; these two ask whether
+      # the promise itself is usable. Ratcheted against tools/package-shape-baseline.json, so
+      # known gaps stay green and the list can only shrink. Here rather than in lint because
+      # both tools pack every package.
+      - run: pnpm run check:shape
+      - name: Unit tests for the package-shape rule
+        run: node tools/check-package-shape/test/test_rule.js
       - run: pnpm run pretest
       # Dry run first. It loads every package's .mocharc and every test file but runs no
       # test body, so a config that cannot resolve fails here in seconds instead of

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "check:importext:fix": "node tools/check-import-extension.mjs --fix",
     "check:pack": "node tools/check-pack.mjs",
     "check:buildgraph": "node tools/check-build-graph.mjs",
+    "check:shape": "node tools/check-package-shape.mjs",
+    "check:shape:update": "node tools/check-package-shape.mjs --update",
     "check:cycles": "node tools/check-import-cycles.mjs",
     "check:ctorcast": "node tools/check-construction-cast.mjs",
     "check:engines": "node tools/check-engines.mjs",
@@ -97,6 +99,7 @@
     "packages_extra/*"
   ],
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.5",
     "@biomejs/biome": "^2.5.12",
     "@types/mocha": "^10.0.10",
     "@types/node": "24.13.3",
@@ -109,6 +112,7 @@
     "json5": "^2.2.3",
     "mocha": "12.0.0",
     "mocha-lcov-reporter": "^1.3.0",
+    "publint": "^0.3.24",
     "should": "^13.2.3",
     "source-map-support": "^0.5.21",
     "tsx": "^4.23.13",

--- a/packages/node-opcua-convert-nodeset-to-javascript/source/main.ts
+++ b/packages/node-opcua-convert-nodeset-to-javascript/source/main.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       '*':
         injected: true
     devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: ^0.18.5
+        version: 0.18.5
       '@biomejs/biome':
         specifier: ^2.5.12
         version: 2.5.12
@@ -181,6 +184,9 @@ importers:
       mocha-lcov-reporter:
         specifier: ^1.3.0
         version: 1.3.0
+      publint:
+        specifier: ^0.3.24
+        version: 0.3.24
       should:
         specifier: ^13.2.3
         version: 13.2.3
@@ -4547,6 +4553,8 @@ importers:
 
   tools/check-pack: {}
 
+  tools/check-package-shape: {}
+
   tools/check-short-circuit-assertion:
     devDependencies:
       typescript-5:
@@ -4577,6 +4585,18 @@ importers:
         version: 4.23.13
 
 packages:
+
+  '@andrewbranch/untar.js@1.0.4':
+    resolution: {integrity: sha512-pVXSwPsLuw8IGLo2Di0EaOfsk+ntVvpkk942J/sHYIkwvtKUakEcPh7HBgZ6tuimgzKSEHgCvO4XgQ05DEbwDw==}
+
+  '@arethetypeswrong/cli@0.18.5':
+    resolution: {integrity: sha512-gM+8vRsQOD/Uc7EnBedUhkG5OCsDWE4uoak5QvomGpMpaky0Eh41p04nIMgrWb8EOmqZUJGc6zz9hsP6E56R7g==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  '@arethetypeswrong/core@0.18.5':
+    resolution: {integrity: sha512-9ytjzGwxjm9Uz7I9avfbt5vlQt6uk9uRRESzJjqrznl6WKvI6dwYTo+vJ3U02Wrq/mR3iql/PzhvHhKdJIAjDQ==}
+    engines: {node: '>=20'}
 
   '@biomejs/biome@2.5.12':
     resolution: {integrity: sha512-Lw4VHZRebrReBBnlHa12JQjnIBm3JJAA55PDB9LbBVBF0q4RYphm6KfmIjqtPhf61MxZ5Q9KoK8R8x+7per5Aw==}
@@ -4634,6 +4654,9 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@braidai/lang@1.1.2':
+    resolution: {integrity: sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -5059,6 +5082,9 @@ packages:
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
 
+  '@loaderkit/resolve@1.0.6':
+    resolution: {integrity: sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg==}
+
   '@peculiar/asn1-cms@2.9.0':
     resolution: {integrity: sha512-VKQz6sJYgSxtGaK6UdnNBUx7hmSdg0K331qrEWh5qxpQsyZGWBjxbq05AJ2bTWWjd7d+nJIxFzwvsR5T7DWC/A==}
 
@@ -5131,6 +5157,14 @@ packages:
     resolution: {integrity: sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==}
     engines: {node: '>=20'}
     hasBin: true
+
+  '@publint/pack@0.1.7':
+    resolution: {integrity: sha512-4EDEmvxWtgsCnnVeBvtFIFZtUhPPt1+bA9JrSwU4Sa//6oKtzCSlGGXYJr44OD9aGISymbieJ4mCKHUygUDU+g==}
+    engines: {node: '>=18'}
+
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
 
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
@@ -5330,13 +5364,24 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
   app-module-path@2.2.0:
     resolution: {integrity: sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ==}
@@ -5437,6 +5482,14 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
@@ -5447,6 +5500,14 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
 
   cli-table3@0.6.5:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
@@ -5459,6 +5520,9 @@ packages:
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -5501,6 +5565,10 @@ packages:
   command-line-usage@7.0.4:
     resolution: {integrity: sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==}
     engines: {node: '>=12.20.0'}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
 
   commander@15.0.0:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
@@ -5570,6 +5638,9 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  emojilib@2.4.0:
+    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
   enabled@2.0.0:
     resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
 
@@ -5580,6 +5651,10 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   ersatz-node-expat@0.1.6:
     resolution: {integrity: sha512-SRtJyyhTvgL7m1aPjqUemceu8aZHU4CjpLTF020DnGjTQqI9d/G55XnrZs4jB/wdlZxJdcyRkLBf+IEDlim6Vg==}
@@ -5600,6 +5675,10 @@ packages:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -5628,6 +5707,9 @@ packages:
 
   fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   find-replace@5.0.2:
     resolution: {integrity: sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==}
@@ -5660,6 +5742,10 @@ packages:
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -5709,6 +5795,9 @@ packages:
     resolution: {integrity: sha512-HxJ6HCV/zrSBeAVRNEhr3CE6yTlCYklMHfCVfJkp7kC+HJqSP1SQ+howWPiHK37t++ELUtgoAoGJut5HyRhIvg==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
   humanize@0.0.9:
     resolution: {integrity: sha512-bvZZ7vXpr1RKoImjuQ45hJb5OvE2oJafHysiD/AL3nkqTZH2hFCjQ3YZfCd63FefDitbJze/ispUPP0gfDsT2Q==}
@@ -5810,6 +5899,17 @@ packages:
     resolution: {integrity: sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==}
     engines: {node: 20 || >=22}
 
+  marked-terminal@7.3.0:
+    resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      marked: '>=1 <16'
+
+  marked@9.1.6:
+    resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
+    engines: {node: '>= 16'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -5840,6 +5940,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -5850,6 +5954,13 @@ packages:
   mute-stream@3.0.0:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  node-emoji@2.2.0:
+    resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
+    engines: {node: '>=18'}
 
   node-opcua-crypto@5.10.1:
     resolution: {integrity: sha512-cx3PPl90Rxixcx4ONvFp4v7BmIIurXuqibcq5S8xj+AQ5i9EMAkhIw//9i7i5MhM2AuGaxSTIcF+o9zSyrDYvQ==}
@@ -5867,6 +5978,10 @@ packages:
     resolution: {integrity: sha512-gVuB6EgkzcLmz0P4xxU+Zas2L3Hs0uLwWWub2XKWiIllvyr82qKLzLApr/H/a+I/QLUvVoa52NDN127c/yfyZw==}
     engines: {node: '>=0.1.93'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   one-time@1.0.0:
     resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
 
@@ -5880,6 +5995,18 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -5924,6 +6051,11 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  publint@0.3.24:
+    resolution: {integrity: sha512-9zS56KrKBoqi5Qt8h92uMP8TTM9AYZSgnmCo4u2priMqkOZvQnTsziZ2p5LJ2ywbYkAjoCDp2jda9u4cgFefIw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   pvtsutils@1.3.6:
     resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
 
@@ -5949,10 +6081,18 @@ packages:
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   rimraf@6.1.3:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
     hasBin: true
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -6009,6 +6149,10 @@ packages:
   sinon@22.1.0:
     resolution: {integrity: sha512-n1ajF2rBWMTtEwbKcw4UdFg4nCnDdq/U6RDoxtOd7oapOlRoJ5ynwFx60owROyhDpA9QhMZi0pCO/xtmwFjG7w==}
 
+  skin-tone@2.0.0:
+    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
+
   slice-ansi@3.0.0:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
     engines: {node: '>=8'}
@@ -6064,6 +6208,10 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  supports-hyperlinks@3.2.0:
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
+    engines: {node: '>=14.18'}
+
   table-layout@4.1.1:
     resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==}
     engines: {node: '>=12.17'}
@@ -6071,8 +6219,15 @@ packages:
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
 
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
   thenify-ex@4.4.0:
     resolution: {integrity: sha512-YHA/2DlY1vWpqGLCc7BzdT9aTrqyHCbsX5J3zbW68LLeD4RPwd+2tMEWshMP+27ikuTnaeKbFDmjqc7fKWmDew==}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   thingies@2.5.0:
     resolution: {integrity: sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==}
@@ -6082,6 +6237,10 @@ packages:
 
   thunky@1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
+
+  tinyexec@1.3.1:
+    resolution: {integrity: sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
@@ -6134,6 +6293,11 @@ packages:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
 
+  typescript@5.6.1-rc:
+    resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -6151,11 +6315,19 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  unicode-emoji-modifier-base@1.0.0:
+    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
+    engines: {node: '>=4'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
+
+  validate-npm-package-name@5.0.1:
+    resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
@@ -6185,6 +6357,10 @@ packages:
   workerpool@10.0.1:
     resolution: {integrity: sha512-NAnKwZJxWlj/U1cp6ZkEtPE+GQY1S6KtOS3AlCiPfPFLxV3m64giSp7g2LsNJxzYCocDT7TSl+7T0sgrDp3KoQ==}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   ws@8.21.3:
     resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
@@ -6211,6 +6387,18 @@ packages:
     resolution: {integrity: sha512-elFVMRiV5jb59fbc87zzVa0C01QLBEWP909mRuWqFqrYC5wNTH5QW4AaKMNv7d6zAsuOulkD7wnztZNLQW0Nfg==}
     engines: {node: '>=0.4.0'}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
+  yargs@16.2.2:
+    resolution: {integrity: sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==}
+    engines: {node: '>=10'}
+
   yauzl@3.4.0:
     resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
     engines: {node: '>=12'}
@@ -6220,6 +6408,29 @@ packages:
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@andrewbranch/untar.js@1.0.4': {}
+
+  '@arethetypeswrong/cli@0.18.5':
+    dependencies:
+      '@arethetypeswrong/core': 0.18.5
+      chalk: 4.1.2
+      cli-table3: 0.6.5
+      commander: 10.0.1
+      marked: 9.1.6
+      marked-terminal: 7.3.0(marked@9.1.6)
+      semver: 7.8.5
+
+  '@arethetypeswrong/core@0.18.5':
+    dependencies:
+      '@andrewbranch/untar.js': 1.0.4
+      '@loaderkit/resolve': 1.0.6
+      cjs-module-lexer: 1.4.3
+      fflate: 0.8.3
+      lru-cache: 11.0.2
+      semver: 7.8.5
+      typescript: 5.6.1-rc
+      validate-npm-package-name: 5.0.1
 
   '@biomejs/biome@2.5.12':
     optionalDependencies:
@@ -6255,6 +6466,8 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.5.12':
     optional: true
+
+  '@braidai/lang@1.1.2': {}
 
   '@colors/colors@1.5.0':
     optional: true
@@ -6593,6 +6806,10 @@ snapshots:
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
+  '@loaderkit/resolve@1.0.6':
+    dependencies:
+      '@braidai/lang': 1.1.2
+
   '@peculiar/asn1-cms@2.9.0':
     dependencies:
       '@peculiar/asn1-schema': 2.9.4
@@ -6742,6 +6959,12 @@ snapshots:
     dependencies:
       playwright: 1.63.0
 
+  '@publint/pack@0.1.7':
+    dependencies:
+      tinyexec: 1.3.1
+
+  '@sindresorhus/is@4.6.0': {}
+
   '@sinonjs/commons@3.0.1':
     dependencies:
       type-detect: 4.0.8
@@ -6878,11 +7101,19 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
+
+  ansi-regex@6.3.0: {}
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  any-promise@1.3.0: {}
 
   app-module-path@2.2.0: {}
 
@@ -6973,6 +7204,10 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
+  char-regex@1.0.2: {}
+
   chardet@2.1.1: {}
 
   chokidar@4.0.3:
@@ -6982,6 +7217,17 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  cjs-module-lexer@1.4.3: {}
+
+  cli-highlight@2.1.11:
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.2
 
   cli-table3@0.6.5:
     dependencies:
@@ -6995,6 +7241,12 @@ snapshots:
       string-width: 4.2.3
 
   cli-width@4.1.0: {}
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   clone@1.0.4:
     optional: true
@@ -7041,6 +7293,8 @@ snapshots:
       chalk-template: 0.4.0
       table-layout: 4.1.1
       typical: 7.3.0
+
+  commander@10.0.1: {}
 
   commander@15.0.0: {}
 
@@ -7109,11 +7363,15 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
+  emojilib@2.4.0: {}
+
   enabled@2.0.0: {}
 
   enum@3.0.4: {}
 
   env-paths@2.2.1: {}
+
+  environment@1.1.0: {}
 
   ersatz-node-expat@0.1.6:
     dependencies:
@@ -7157,6 +7415,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
 
+  escalade@3.2.0: {}
+
   events@3.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -7177,6 +7437,8 @@ snapshots:
 
   fecha@4.2.3: {}
 
+  fflate@0.8.3: {}
+
   find-replace@5.0.2: {}
 
   find-up@5.0.0:
@@ -7196,6 +7458,8 @@ snapshots:
   function-bind@1.1.2: {}
 
   generator-function@2.0.1: {}
+
+  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -7248,6 +7512,8 @@ snapshots:
       function-bind: 1.1.2
 
   hexy@0.4.0: {}
+
+  highlight.js@10.7.3: {}
 
   humanize@0.0.9: {}
 
@@ -7332,6 +7598,19 @@ snapshots:
 
   lru-cache@11.0.2: {}
 
+  marked-terminal@7.3.0(marked@9.1.6):
+    dependencies:
+      ansi-escapes: 7.3.0
+      ansi-regex: 6.3.0
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      cli-table3: 0.6.5
+      marked: 9.1.6
+      node-emoji: 2.2.0
+      supports-hyperlinks: 3.2.0
+
+  marked@9.1.6: {}
+
   math-intrinsics@1.1.0: {}
 
   memfs@4.71.0:
@@ -7382,6 +7661,8 @@ snapshots:
       supports-color: 8.1.1
       workerpool: 10.0.1
 
+  mri@1.2.0: {}
+
   ms@2.1.3: {}
 
   multicast-dns@7.2.5:
@@ -7390,6 +7671,19 @@ snapshots:
       thunky: 1.1.0
 
   mute-stream@3.0.0: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  node-emoji@2.2.0:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      char-regex: 1.0.2
+      emojilib: 2.4.0
+      skin-tone: 2.0.0
 
   node-opcua-crypto@5.10.1:
     dependencies:
@@ -7422,6 +7716,8 @@ snapshots:
 
   node-xml@1.0.2: {}
 
+  object-assign@4.1.1: {}
+
   one-time@1.0.0:
     dependencies:
       fn.name: 1.1.0
@@ -7435,6 +7731,16 @@ snapshots:
       p-limit: 3.1.0
 
   package-json-from-dist@1.0.1: {}
+
+  package-manager-detector@1.8.0: {}
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    dependencies:
+      parse5: 6.0.1
+
+  parse5@5.1.1: {}
+
+  parse5@6.0.1: {}
 
   path-browserify@1.0.1: {}
 
@@ -7463,6 +7769,13 @@ snapshots:
 
   process@0.11.10: {}
 
+  publint@0.3.24:
+    dependencies:
+      '@publint/pack': 0.1.7
+      package-manager-detector: 1.8.0
+      picocolors: 1.1.1
+      sade: 1.8.1
+
   pvtsutils@1.3.6:
     dependencies:
       tslib: 2.8.1
@@ -7483,10 +7796,16 @@ snapshots:
 
   reflect-metadata@0.2.2: {}
 
+  require-directory@2.1.1: {}
+
   rimraf@6.1.3:
     dependencies:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   safe-buffer@5.2.1: {}
 
@@ -7551,6 +7870,10 @@ snapshots:
       '@sinonjs/fake-timers': 15.4.0
       '@sinonjs/samsam': 10.0.2
       diff: 9.0.0
+
+  skin-tone@2.0.0:
+    dependencies:
+      unicode-emoji-modifier-base: 1.0.0
 
   slice-ansi@3.0.0:
     dependencies:
@@ -7617,6 +7940,11 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-hyperlinks@3.2.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+
   table-layout@4.1.1:
     dependencies:
       array-back: 6.2.3
@@ -7624,13 +7952,23 @@ snapshots:
 
   text-hex@1.0.0: {}
 
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
   thenify-ex@4.4.0: {}
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
 
   thingies@2.5.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
 
   thunky@1.1.0: {}
+
+  tinyexec@1.3.1: {}
 
   tinyglobby@0.2.15:
     dependencies:
@@ -7676,6 +8014,8 @@ snapshots:
 
   type-detect@4.1.0: {}
 
+  typescript@5.6.1-rc: {}
+
   typescript@5.9.3: {}
 
   typescript@7.0.2:
@@ -7705,6 +8045,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  unicode-emoji-modifier-base@1.0.0: {}
+
   util-deprecate@1.0.2: {}
 
   util@0.12.5:
@@ -7714,6 +8056,8 @@ snapshots:
       is-generator-function: 1.1.2
       is-typed-array: 1.1.15
       which-typed-array: 1.1.20
+
+  validate-npm-package-name@5.0.1: {}
 
   wcwidth@1.0.1:
     dependencies:
@@ -7764,6 +8108,12 @@ snapshots:
 
   workerpool@10.0.1: {}
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   ws@8.21.3: {}
 
   wtfnode@0.10.1: {}
@@ -7771,6 +8121,20 @@ snapshots:
   xlsx-ugnis@0.20.3: {}
 
   xml-writer@1.7.0: {}
+
+  y18n@5.0.8: {}
+
+  yargs-parser@20.2.9: {}
+
+  yargs@16.2.2:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yauzl@3.4.0:
     dependencies:

--- a/tools/README.md
+++ b/tools/README.md
@@ -91,6 +91,7 @@ Each has its own README with the reasoning behind the rule.
 - `check-module-identity/`: a file must reach any one package by a single route
 - `check-pack/`: declared entry points must actually be published
 - `check-build-graph/`: every publishable package is reachable in the build graph
+- `check-package-shape/`: publint and attw on the published shape, ratcheted
 - `check-test-types/`: ratchet on test-suite type-checking
 - `check-test-ports/`: no hard-coded ports in tests
 - `clean/`: Cleanup utilities
@@ -115,6 +116,7 @@ tools/
 ├── check-short-circuit-assertion/  # Assertions an optional chain can switch off
 ├── check-pack/              # Declared entry points are published
 ├── check-build-graph/       # Publishable packages are actually built
+├── check-package-shape/     # publint + attw on the published shape
 ├── check-test-types/        # Test-suite type-check ratchet
 ├── clean/                   # Cleanup utilities
 ├── fix-tsconfigs/           # TypeScript config fixes
@@ -132,5 +134,6 @@ tools/
 ├── check-entry-points.mjs
 ├── check-short-circuit-assertion.mjs
 ├── check-build-graph.mjs
+├── check-package-shape.mjs
 └── README.md                # This file
 ``` 

--- a/tools/check-package-shape.mjs
+++ b/tools/check-package-shape.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+/** launcher for tools/check-package-shape - see tools/README.md */
+import "./check-package-shape/src/index.js";

--- a/tools/check-package-shape/README.md
+++ b/tools/check-package-shape/README.md
@@ -1,0 +1,64 @@
+# check-package-shape
+
+`publint` and `attw` on every publishable package: is the manifest coherent, and does a consumer
+actually resolve what it promises?
+
+## Why, and how it differs from the neighbours
+
+Three rules now look at packaging, and they ask different questions:
+
+| rule | question |
+| --- | --- |
+| `check-build-graph` | is the package compiled at all? |
+| `check-pack` | is every declared entry point in the tarball? |
+| this one | is the manifest coherent, and do a consumer's imports resolve? |
+
+`check-pack` proves a promised file exists. It cannot tell you the promise is wrong: an `exports`
+map with its conditions in the wrong order, a `bin` without a shebang (which simply fails to
+execute on Linux), a file extension that contradicts `type`, or declarations a consumer's
+TypeScript resolves to something unusable. publint reads the packed manifest; attw resolves the
+package as both an ESM and a CommonJS consumer.
+
+It earned its place before it was written: a trial run found `node-opcua-nodeset-i-4-aas` shipping
+no `dist` and `node-opcua-leak-detector` shipping no types, both fixed in #1695.
+
+## The esm-only profile
+
+attw runs with `--profile esm-only`, which ignores the `node10` and `node16-cjs` resolutions. That
+is a decision, not a convenience. The workspace is moving to ESM, `require(esm)` works from
+Node 22.12, and the declared floor is 22.13. Without the profile every ESM package reports
+`node16 (from CJS): ESM (dynamic import only)` and the gate would be permanently red for something
+deliberate.
+
+## The ratchet
+
+Packages already failing are listed in `tools/package-shape-baseline.json`. A package that is green,
+or new, must stay green. When you repair a baselined package, remove it from the baseline:
+
+```bash
+pnpm run check:shape            # report, exit 1 on a new failure
+pnpm run check:shape:update     # rewrite the baseline
+node tools/check-package-shape.mjs --package node-opcua-client
+node tools/check-package-shape.mjs --concurrency 8
+```
+
+Never commit an `--update` that *adds* a package. The list only shrinks.
+
+### What is in the baseline today, and why
+
+- `node-opcua`, `node-opcua-client`, `node-opcua-modeler`, `node-opcua-secure-channel`:
+  attw's *named exports* problem. TypeScript lets an ESM consumer write
+  `import { OPCUAClient } from "node-opcua"`, but Node cannot statically detect those exports in
+  the CommonJS file, so the import crashes at run time. The ESM migration (FEAT-2) removes this by
+  making the packages real ESM; these entries should disappear as the flip reaches them.
+- `node-opcua-client-browser`: attw's *unexpected module syntax*, its second (browser) build
+  carries syntax that contradicts the module kind its extension implies.
+- `node-opcua-samples`: `bin.simple_client` names `./dist/simple_client_ts.js`, and no file of that
+  name exists anywhere in the package. Repairing it means either dropping a published command name
+  or pointing it at a different sample, which is a decision rather than a fix.
+
+## Cost
+
+Both tools pack the package, so this is slower than the lint rules, around 12 seconds per package
+before concurrency. It runs in the `build_per_package` CI job, which already has a built workspace
+and does per-package work, rather than inside `lint:ci`.

--- a/tools/check-package-shape/package.json
+++ b/tools/check-package-shape/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "@sterfive/check-package-shape",
+    "version": "1.0.0",
+    "private": true,
+    "description": "publint and attw on every publishable package, so the published shape is one a consumer can use",
+    "bin": {
+        "check-package-shape": "src/index.js"
+    },
+    "type": "module",
+    "scripts": {
+        "check": "node src/index.js",
+        "update": "node src/index.js --update",
+        "test": "node test/test_rule.js"
+    }
+}

--- a/tools/check-package-shape/src/index.js
+++ b/tools/check-package-shape/src/index.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * check-package-shape - command line around src/rule.js.
+ *
+ * Usage:
+ *     node tools/check-package-shape.mjs
+ *     node tools/check-package-shape.mjs --package node-opcua-client
+ *     node tools/check-package-shape.mjs --concurrency 8
+ *     node tools/check-package-shape.mjs --update      # rewrite the baseline
+ *
+ * Slower than the lint rules, because publint and attw each pack the package. It runs beside
+ * check-pack in the per-package CI job rather than inside lint.
+ */
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { evaluate, exitCode, formatReport, publishableTargets, readBaseline, writeBaseline } from "./rule.js";
+
+function valueOf(argv, flag) {
+    const i = argv.indexOf(flag);
+    return i === -1 ? undefined : argv[i + 1];
+}
+
+/**
+ * The launcher npm installed for a dependency. .bin is the one location that is correct on both
+ * platforms: on Windows it is the .CMD shim, elsewhere the executable symlink.
+ */
+function binary(repoRoot, name) {
+    // absolute: each tool runs with cwd set to the package being checked, so a relative path
+    // would resolve against that package and silently fail every check
+    const file = path.resolve(repoRoot, "node_modules", ".bin", process.platform === "win32" ? `${name}.CMD` : name);
+    if (!fs.existsSync(file)) {
+        throw new Error(`${name} is not installed (looked for ${file}); run pnpm install at the repository root`);
+    }
+    return file;
+}
+
+const run = (cmd, args, cwd) =>
+    new Promise((resolve) => {
+        const child = spawn(cmd, args, { cwd, shell: true });
+        let out = "";
+        child.stdout.on("data", (d) => (out += d));
+        child.stderr.on("data", (d) => (out += d));
+        // both tools report through the exit code; strip the colouring so the report is readable
+        child.on("close", (code) => resolve({ ok: code === 0, output: out.replace(/\[[0-9;]*m/g, "") }));
+    });
+
+async function collect(repoRoot, targets, concurrency) {
+    const publint = binary(repoRoot, "publint");
+    const attw = binary(repoRoot, "attw");
+    const results = [];
+    let next = 0;
+    const worker = async () => {
+        while (next < targets.length) {
+            const t = targets[next++];
+            results.push({
+                name: t.name,
+                // the esm-only profile is deliberate: see the note in rule.js
+                publint: await run(publint, [], t.dir),
+                attw: await run(attw, ["--pack", ".", "--profile", "esm-only"], t.dir)
+            });
+            if (process.stdout.isTTY) {
+                process.stdout.write(`${results.length}/${targets.length}\r`);
+            }
+        }
+    };
+    await Promise.all(Array.from({ length: concurrency }, worker));
+    return results.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function main() {
+    const argv = process.argv.slice(2);
+    const repoRoot = valueOf(argv, "--root") ?? ".";
+    const only = valueOf(argv, "--package");
+    const concurrency = Number(valueOf(argv, "--concurrency") ?? Math.min(8, Math.max(2, os.cpus().length >> 1)));
+
+    const targets = publishableTargets(repoRoot).filter((t) => !only || t.name === only || path.basename(t.dir) === only);
+    if (targets.length === 0) {
+        console.error(only ? `check-package-shape: no publishable package named ${only}` : "check-package-shape: no publishable packages found");
+        return 1;
+    }
+
+    const results = await collect(repoRoot, targets, concurrency);
+
+    if (argv.includes("--update")) {
+        const failing = results.filter((r) => !r.publint.ok || !r.attw.ok).map((r) => r.name);
+        const file = writeBaseline(repoRoot, failing);
+        console.log(`package-shape baseline updated: ${failing.length} failing package(s) -> ${file}`);
+        return 0;
+    }
+
+    const result = evaluate(results, readBaseline(repoRoot));
+    console.log(formatReport(result));
+    return exitCode(result);
+}
+
+main().then((code) => process.exit(code));

--- a/tools/check-package-shape/src/rule.js
+++ b/tools/check-package-shape/src/rule.js
@@ -1,0 +1,138 @@
+/**
+ * rule - the published shape of every package, as a consumer resolves it.
+ *
+ * Three checks now look at packaging, and they ask different questions:
+ *
+ *   check-build-graph  is the package compiled at all?
+ *   check-pack         is every declared entry point in the tarball?
+ *   this one           is the manifest coherent, and does a consumer resolve types?
+ *
+ * publint reads the packed manifest: exports ordering, a bin without a shebang, a file extension
+ * that contradicts "type". attw resolves the package as both an ESM and a CommonJS consumer, which
+ * is the only way to see that a consumer is handed declarations it cannot use. Neither duplicates
+ * the other two: check-pack proved a promised file exists, not that the promise makes sense.
+ *
+ * attw runs under the esm-only profile, which ignores the node10 and node16-cjs resolutions. That
+ * is a decision, not a convenience: the workspace is moving to ESM, `require(esm)` works from
+ * Node 22.12, and the declared floor is 22.13. Without the profile every ESM package reports
+ * "node16 (from CJS): ESM (dynamic import only)" and the gate would be permanently red for
+ * something deliberate.
+ *
+ * Ratchet, like check-test-types: packages already failing are grandfathered in
+ * tools/package-shape-baseline.json. A package that is green, or new, must stay green. Repair a
+ * baselined package and remove it from the baseline with --update; the list only shrinks.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+export const SOURCE_ROOTS = ["packages", "packages_extra"];
+
+/** every publishable package, the ones a consumer can install */
+export function publishableTargets(repoRoot = ".") {
+    const out = [];
+    for (const root of SOURCE_ROOTS) {
+        const base = path.join(repoRoot, root);
+        if (!fs.existsSync(base)) {
+            continue;
+        }
+        for (const entry of fs.readdirSync(base, { withFileTypes: true })) {
+            if (!entry.isDirectory()) {
+                continue;
+            }
+            const manifest = path.join(base, entry.name, "package.json");
+            if (!fs.existsSync(manifest)) {
+                continue;
+            }
+            let pkg;
+            try {
+                pkg = JSON.parse(fs.readFileSync(manifest, "utf8").replace(/^﻿/, ""));
+            } catch {
+                continue;
+            }
+            if (pkg.private === true) {
+                continue;
+            }
+            out.push({ name: pkg.name ?? entry.name, dir: path.join(base, entry.name) });
+        }
+    }
+    return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function readBaseline(repoRoot = ".") {
+    const file = path.join(repoRoot, "tools", "package-shape-baseline.json");
+    if (!fs.existsSync(file)) {
+        return new Set();
+    }
+    return new Set(JSON.parse(fs.readFileSync(file, "utf8")).failingPackages ?? []);
+}
+
+export function writeBaseline(repoRoot, failing) {
+    const file = path.join(repoRoot, "tools", "package-shape-baseline.json");
+    fs.writeFileSync(file, `${JSON.stringify({ failingPackages: [...failing].sort() }, null, 4)}\n`);
+    return file;
+}
+
+/**
+ * Compare results against the baseline. Pure: `results` is [{name, publint, attw}] where each
+ * tool result is { ok, output }, so the tests drive it without packing anything.
+ */
+export function evaluate(results, baseline) {
+    const failures = [];
+    const fixed = [];
+    for (const r of results) {
+        const failedTools = [];
+        if (!r.publint.ok) {
+            failedTools.push("publint");
+        }
+        if (!r.attw.ok) {
+            failedTools.push("attw");
+        }
+        if (failedTools.length > 0) {
+            if (!baseline.has(r.name)) {
+                failures.push({ name: r.name, tools: failedTools, output: outputOf(r, failedTools) });
+            }
+        } else if (baseline.has(r.name)) {
+            fixed.push(r.name);
+        }
+    }
+    return { scanned: results.length, grandfathered: baseline.size, failures, fixed };
+}
+
+function outputOf(result, failedTools) {
+    return failedTools
+        .map((t) => `--- ${t}\n${(result[t].output ?? "").trim()}`)
+        .join("\n")
+        .split("\n")
+        .slice(0, 24)
+        .join("\n");
+}
+
+export function exitCode(result) {
+    return result.failures.length > 0 ? 1 : 0;
+}
+
+export function formatReport(result) {
+    const lines = [];
+    for (const name of result.fixed) {
+        lines.push(`note: ${name} is green but still baselined - tighten it with: node tools/check-package-shape.mjs --update`);
+    }
+    if (result.failures.length === 0) {
+        lines.push(`package-shape ratchet: OK (${result.scanned} packages checked, ${result.grandfathered} grandfathered)`);
+        return lines.join("\n");
+    }
+    lines.push(`package-shape: ${result.failures.length} package(s) publish a shape a consumer cannot use`, "");
+    for (const f of result.failures) {
+        lines.push(`  ${f.name}  (${f.tools.join(", ")})`);
+        for (const line of f.output.split("\n")) {
+            lines.push(`      ${line}`);
+        }
+        lines.push("");
+    }
+    lines.push(
+        "publint reads the packed manifest; attw resolves the package the way a consumer's",
+        "TypeScript does. Fix the package, or, if this is a known gap being worked on, add it",
+        "with: node tools/check-package-shape.mjs --update"
+    );
+    return lines.join("\n");
+}

--- a/tools/check-package-shape/test/test_rule.js
+++ b/tools/check-package-shape/test/test_rule.js
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for the package-shape rule.
+ *
+ * The tool results are fabricated, so these run in milliseconds and assert on the ratchet rather
+ * than on publint and attw themselves (those have their own test suites, and packing 113 packages
+ * is the CI job's work, not a unit test's).
+ *
+ * Run: node test/test_rule.js
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { evaluate, exitCode, formatReport, publishableTargets, readBaseline, writeBaseline } from "../src/rule.js";
+
+const ok = { ok: true, output: "" };
+const bad = (output = "boom") => ({ ok: false, output });
+
+test("a green package is not a finding", () => {
+    const result = evaluate([{ name: "a", publint: ok, attw: ok }], new Set());
+    assert.deepEqual(result.failures, []);
+    assert.equal(exitCode(result), 0);
+    assert.match(formatReport(result), /1 packages checked, 0 grandfathered/);
+});
+
+test("a package failing publint is reported, with the tool named", () => {
+    const result = evaluate([{ name: "a", publint: bad("pkg.bin is not executable"), attw: ok }], new Set());
+    assert.equal(result.failures.length, 1);
+    assert.deepEqual(result.failures[0].tools, ["publint"]);
+    assert.match(formatReport(result), /pkg\.bin is not executable/);
+    assert.equal(exitCode(result), 1);
+});
+
+test("a package failing both tools names both", () => {
+    const result = evaluate([{ name: "a", publint: bad(), attw: bad() }], new Set());
+    assert.deepEqual(result.failures[0].tools, ["publint", "attw"]);
+});
+
+test("a baselined failure is grandfathered, not a finding", () => {
+    const result = evaluate([{ name: "a", publint: bad(), attw: ok }], new Set(["a"]));
+    assert.deepEqual(result.failures, []);
+    assert.equal(exitCode(result), 0);
+    assert.equal(result.grandfathered, 1);
+});
+
+test("a new package failing is a finding even while others are baselined", () => {
+    const result = evaluate(
+        [
+            { name: "old", publint: bad(), attw: ok },
+            { name: "new", publint: ok, attw: bad() }
+        ],
+        new Set(["old"])
+    );
+    assert.deepEqual(
+        result.failures.map((f) => f.name),
+        ["new"]
+    );
+    assert.equal(exitCode(result), 1);
+});
+
+test("a repaired package still in the baseline is a note, not a failure", () => {
+    const result = evaluate([{ name: "a", publint: ok, attw: ok }], new Set(["a"]));
+    assert.deepEqual(result.fixed, ["a"]);
+    assert.equal(exitCode(result), 0);
+    assert.match(formatReport(result), /green but still baselined/);
+});
+
+test("the report truncates a long tool output", () => {
+    const long = Array.from({ length: 200 }, (_, i) => `line ${i}`).join("\n");
+    const report = formatReport(evaluate([{ name: "a", publint: bad(long), attw: ok }], new Set()));
+    assert.ok(report.split("\n").length < 60, "report should not dump hundreds of lines");
+});
+
+// --- workspace scanning and the baseline file ----------------------------------------------
+
+function makeRepo(packages) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "pkg-shape-"));
+    fs.mkdirSync(path.join(root, "packages"), { recursive: true });
+    fs.mkdirSync(path.join(root, "tools"), { recursive: true });
+    for (const [name, spec] of Object.entries(packages)) {
+        const dir = path.join(root, "packages", name);
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name, private: spec.private === true }));
+    }
+    return root;
+}
+
+test("private packages are not published, so they are out of scope", () => {
+    const root = makeRepo({ a: {}, playground: { private: true } });
+    assert.deepEqual(
+        publishableTargets(root).map((t) => t.name),
+        ["a"]
+    );
+});
+
+test("the baseline round-trips and stays sorted", () => {
+    const root = makeRepo({ a: {} });
+    writeBaseline(root, ["zeta", "alpha"]);
+    assert.deepEqual([...readBaseline(root)], ["alpha", "zeta"]);
+    const written = JSON.parse(fs.readFileSync(path.join(root, "tools", "package-shape-baseline.json"), "utf8"));
+    assert.deepEqual(written.failingPackages, ["alpha", "zeta"]);
+});
+
+test("a missing baseline file means nothing is grandfathered", () => {
+    assert.equal(readBaseline(makeRepo({ a: {} })).size, 0);
+});

--- a/tools/package-shape-baseline.json
+++ b/tools/package-shape-baseline.json
@@ -1,0 +1,10 @@
+{
+    "failingPackages": [
+        "node-opcua",
+        "node-opcua-client",
+        "node-opcua-client-browser",
+        "node-opcua-modeler",
+        "node-opcua-samples",
+        "node-opcua-secure-channel"
+    ]
+}


### PR DESCRIPTION
## Why

Last of the packaging rules, after #1695 (`check-pack`) and #1698 (`check-build-graph`). The three
ask different questions:

| rule | question | where it runs |
| --- | --- | --- |
| `check-build-graph` | is the package compiled at all? | `lint:ci` |
| `check-pack` | is every declared entry point in the tarball? | `build_per_package` |
| this one | is the manifest coherent, and do a consumer's imports resolve? | `build_per_package` |

`check-pack` proves a promised file exists. It cannot tell you the promise itself is wrong: an
`exports` map with conditions in the wrong order, a `bin` without a shebang (which simply fails to
execute on Linux), a file extension contradicting `type`, or declarations a consumer's TypeScript
resolves to something it cannot use.

This approach already paid for itself before becoming a gate: the trial run that led to #1695 is
what found `node-opcua-nodeset-i-4-aas` publishing no `dist` and `node-opcua-leak-detector`
publishing no types.

## The esm-only profile

attw runs with `--profile esm-only`, ignoring the `node10` and `node16-cjs` resolutions. Deliberate,
not convenience: the workspace is moving to ESM, `require(esm)` works from Node 22.12, and the
declared floor is 22.13. Without it every ESM package reports
`node16 (from CJS): ESM (dynamic import only)` and the gate is permanently red for a decision the
project already took.

## One failure fixed rather than baselined

`node-opcua-convert-nodeset-to-javascript` declares `bin: dist/main.js`, and that file had no
shebang, so the published CLI is not executable on Linux. `source/main.ts` now starts with
`#!/usr/bin/env node`, which TypeScript preserves into the emit. publint passes that package now.

## What is grandfathered, and why

`tools/package-shape-baseline.json`, six entries:

- `node-opcua`, `node-opcua-client`, `node-opcua-modeler`, `node-opcua-secure-channel` — attw's
  **named exports**: TypeScript allows `import { OPCUAClient } from "node-opcua"` from ESM, but
  Node cannot statically detect those exports in the CommonJS file, so it crashes at run time. The
  ESM flip (FEAT-2) removes this as it reaches each package; these entries should disappear on
  their own.
- `node-opcua-client-browser` — attw's **unexpected module syntax** in its second, browser build.
- `node-opcua-samples` — `bin.simple_client` names `./dist/simple_client_ts.js` and **no file of
  that name exists anywhere in the package**, so that published command is dead. Repairing it means
  either dropping a published command name or pointing it at a different sample, which is a
  decision rather than a fix, so it is recorded rather than guessed.

The ratchet behaves like `check-test-types`: a new or green package that fails is an error; a
baselined package that turns green prints a note asking you to tighten the list with
`pnpm run check:shape:update`. Never commit an update that *adds* an entry.

## Verification

- `pnpm run check:shape`: OK, 113 packages checked, 6 grandfathered
- mutation check: pointing a green package's `types` at a file that is not shipped makes the gate
  report it and exit 1
- `tools/check-package-shape/test/test_rule.js`: 10 passing, on fabricated tool results so the
  ratchet is tested without packing anything
- `lint:ci` green

## Cost

Both tools pack each package, about 12 s per package before concurrency, so it runs in
`build_per_package` (which already has a built workspace) rather than in lint. The runner defaults
to half the available cores.
