### PR TITLE
build: emit declaration maps

### DIFF
--- a/packages/tsconfig.test.json
+++ b/packages/tsconfig.test.json
@@ -11,6 +11,9 @@
         "composite": false,
         "incremental": false,
         "declaration": false,
+        // both maps describe an emit that does not happen here, and TypeScript rejects
+        // declarationMap without declaration (TS5069)
+        "declarationMap": false,
         "sourceMap": false,
         "skipLibCheck": true,
         "types": ["node", "mocha"]

--- a/tsconfig.common.json
+++ b/tsconfig.common.json
@@ -14,6 +14,11 @@
         "target": "es2022",
         "module": "NodeNext",
         "declaration": true,
+        // the .d.ts is generated, so "go to definition" lands in it and stops there. The map
+        // sends an editor on to the .ts the declaration came from, which every package publishes
+        // beside its dist. Same reason sourceMap is on: the shipped artefact should lead back to
+        // the source a reader can actually follow.
+        "declarationMap": true,
         "sourceMap": true,
         "strict": true,
         "listFiles": false,


### PR DESCRIPTION
## Why

"Go to definition" on a node-opcua symbol currently lands in the generated `.d.ts` and stops
there. That file states the shape of the declaration, not the code that produced it, so a reader
chasing behaviour (why does this overload exist, what does this guard do) has to leave the editor
and find the source by hand.

`declarationMap` emits a `.d.ts.map` next to each `.d.ts`, and the editor follows it to the `.ts`
the declaration came from. The sources are already published beside `dist` in these packages, for
the same reason `sourceMap: true` has been on all along: a shipped artefact should lead back to
something a reader can follow.

## What changed

`tsconfig.common.json` gains `declarationMap: true`, so every package inherits it.

`packages/tsconfig.test.json` gains `declarationMap: false`, beside the `sourceMap: false` already
there. The test projects type-check without emitting, so they turn `declaration` off, and
TypeScript rejects a declaration map without a declaration (TS5069). Without this, all 77 test
projects fail to type-check: CI caught it on the first push of this branch.

## Evidence

- **2628 declaration maps**, one per emitted `.d.ts`.
- **Every map resolves**: a sweep over all of them, resolving each `sources` entry relative to the
  map, found 0 pointing at a file that does not exist.
- A map reads as expected: `dist/variant.d.ts.map` has
  `{"file":"variant.d.ts","sources":["../source/variant.ts"]}`, and `dist/variant.d.ts` ends with
  `//# sourceMappingURL=variant.d.ts.map`. That relative path is the published layout, the same one
  the existing `.js.map` files already use.
- **Size**: `packages/*/dist` grows from 135 MB to 138 MB, about 2%. Build time is unchanged
  (29 s for `build:all`).

## One honest limitation

Five map targets are directories that `files` does not publish, all of them test-helper trees
rather than API:

```
node-opcua-packet-analyzer   test_helpers/
node-opcua-secure-channel    test_helpers/
node-opcua-transport         test_helpers/, test-fixtures/
node-opcua-samples           bin/
```

For declarations emitted from those, an editor follows the map and finds nothing. It is not a
regression: those packages already ship a `.js.map` for the same files with the same unpublished
target. Fixing it means either publishing those trees or not emitting maps for them, which is a
separate decision about what a test-helper entry point owes its consumers.

## Verification

- `pnpm run build:all` clean
- `pnpm run check:pack`, `pnpm run check:shape`, `pnpm run check:consumers`, `pnpm run lint:ci` all green
