### PR TITLE
fix(address-space): a state machine type declares the transition event it raises (FEAT-57)

### DIFF
--- a/packages/node-opcua-address-space/impl/state_machine/finite_state_machine.ts
+++ b/packages/node-opcua-address-space/impl/state_machine/finite_state_machine.ts
@@ -65,6 +65,50 @@ function getComponentOfType(typeDef: UAObjectType, typedefinition: UAObjectType)
     return components_parts as UAObject[];
 }
 
+/**
+ * OPC 10000-16 requires that a StateMachineType (or subtype) that raises events declares a
+ * GeneratesEvent reference to the EventType(s) it raises, on the type itself or on one of its
+ * super types (the CTT's "Base Info State Machine Instance / 001.js" script walks the instance's
+ * type up to StateMachineType looking for one such reference and accepts BaseEventType or any
+ * subtype as the target).
+ *
+ * node-opcua's finite state machine implementation always raises a "TransitionEventType" event
+ * when the current state changes (see FiniteStateMachineType#setState), for every state machine
+ * instance, whichever subtype of FiniteStateMachineType it is instantiated from. Declaring the
+ * reference once on FiniteStateMachineType therefore covers every state machine exposed by the
+ * server (ExclusiveLimitStateMachineType included), matching the CTT's parent walk.
+ *
+ * This is called from every state machine's _post_initialize, so it must be idempotent.
+ */
+function ensureFiniteStateMachineTypeGeneratesTransitionEvent(finiteStateMachineType: UAObjectType): void {
+    const addressSpace = finiteStateMachineType.addressSpace;
+
+    // Some minimal test fixtures load only a handful of namespace-0 nodes and do not carry the
+    // GeneratesEvent ReferenceType or TransitionEventType ObjectType at all: nothing to attach to.
+    if (!addressSpace.findReferenceType("GeneratesEvent")) {
+        return;
+    }
+    const transitionEventType = addressSpace.findObjectType("TransitionEventType");
+    if (!transitionEventType) {
+        // c8 ignore next
+        return;
+    }
+
+    const hasReferenceAlready = finiteStateMachineType
+        .findReferencesEx("GeneratesEvent", BrowseDirection.Forward)
+        .some((ref) => sameNodeId(ref.nodeId, transitionEventType.nodeId));
+
+    if (hasReferenceAlready) {
+        return;
+    }
+
+    finiteStateMachineType.addReference({
+        referenceType: "GeneratesEvent",
+        isForward: true,
+        nodeId: transitionEventType.nodeId
+    });
+}
+
 const defaultPredicate = (transitions: UATransition[], fromState: UAState, toState: UAState) => {
     if (transitions.length === 0) {
         return null;
@@ -589,6 +633,8 @@ export class UAStateMachineImplBase extends UAObjectImpl implements UAStateMachi
         if (!finiteStateMachineType) {
             throw new Error("cannot find FiniteStateMachineType");
         }
+
+        ensureFiniteStateMachineTypeGeneratesTransitionEvent(finiteStateMachineType);
 
         // xx assert(this.typeDefinitionObj && !this.subtypeOfObj);
         // xx assert(!this.typeDefinitionObj || this.typeDefinitionObj.isSubtypeOf(finiteStateMachineType));

--- a/packages/node-opcua-address-space/test/finite_state_machine/test_feat57_state_machine_generates_event.ts
+++ b/packages/node-opcua-address-space/test/finite_state_machine/test_feat57_state_machine_generates_event.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs";
+import { BrowseDirection } from "node-opcua-data-model";
+import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
+import { nodesets } from "node-opcua-nodesets";
+import should from "should";
+
+import type { AddressSpace, UAObject, UAObjectType } from "../../dist/api/index.js";
+import { AddressSpace as AddressSpaceCtor, promoteToStateMachine } from "../../dist/api/index.js";
+import { generateAddressSpace } from "../../nodeJS.js";
+
+/**
+ * FEAT-57: the CTT's "Base Info State Machine Instance / 001.js" script walks, for every
+ * StateMachine instance, from the instance's TypeDefinition up through its super types (stopping
+ * at StateMachineType) looking for a forward GeneratesEvent reference, and requires its target to
+ * be BaseEventType or a subtype. node-opcua's finite state machines always raise
+ * "TransitionEventType" on a state change (finite_state_machine.ts), so FiniteStateMachineType
+ * must carry that reference for the CTT's walk to succeed.
+ *
+ * This test reproduces the CTT's own walk (GetReferenceTypeFirstParent equivalent) rather than
+ * just checking FiniteStateMachineType directly, so it also validates that the reference is
+ * reachable from a concrete subtype (ExclusiveLimitStateMachineType) exactly as the CTT sees it.
+ */
+function findGeneratesEventTargetByWalkingUp(addressSpace: AddressSpace, startType: UAObjectType): UAObjectType | null {
+    const stateMachineType = addressSpace.findObjectType("StateMachineType")!;
+
+    let current: UAObjectType | null = startType;
+    for (let i = 0; i < 10 && current; i++) {
+        const refs = current.findReferencesEx("GeneratesEvent", BrowseDirection.Forward);
+        if (refs.length > 0) {
+            return addressSpace.findNode(refs[0].nodeId) as UAObjectType;
+        }
+        if (current.nodeId.toString() === stateMachineType.nodeId.toString()) {
+            break;
+        }
+        current = current.subtypeOfObj as UAObjectType | null;
+    }
+    return null;
+}
+
+describe("FEAT-57 - state machine types must expose GeneratesEvent -> TransitionEventType", () => {
+    let addressSpace: AddressSpace;
+
+    before(async () => {
+        addressSpace = AddressSpaceCtor.create();
+        addressSpace.registerNamespace("PRIVATE_NAMESPACE");
+        const xml_file = nodesets.standard;
+        fs.existsSync(xml_file).should.be.eql(true);
+        await generateAddressSpace(addressSpace, xml_file);
+        addressSpace.installAlarmsAndConditionsService();
+    });
+    after(async () => {
+        if (addressSpace) {
+            addressSpace.dispose();
+        }
+    });
+
+    const transitionEventTypeNodeId = () => addressSpace.findObjectType("TransitionEventType")!.nodeId.toString();
+
+    it("an ordinary FiniteStateMachine instance's type answers the CTT's parent walk with TransitionEventType", () => {
+        // FiniteStateMachineType itself is abstract in the standard nodeset; ProgramStateMachineType
+        // is a concrete subtype of it, used here purely as "some ordinary state machine that is not
+        // an alarm's LimitState", to prove the reference is reachable through the type hierarchy.
+        const stateMachineType = addressSpace.findObjectType("ProgramStateMachineType")!;
+        const machine = stateMachineType.instantiate({
+            browseName: "MyPlainStateMachine",
+            organizedBy: addressSpace.rootFolder.objects
+        }) as UAObject;
+        promoteToStateMachine(machine);
+
+        const found = findGeneratesEventTargetByWalkingUp(addressSpace, machine.typeDefinitionObj as UAObjectType);
+        should.exist(found);
+        should(found!.isSubtypeOf(addressSpace.findObjectType("BaseEventType")!)).eql(true);
+        should(found!.nodeId.toString()).eql(transitionEventTypeNodeId());
+    });
+
+    it("FiniteStateMachineType itself now carries a GeneratesEvent reference to TransitionEventType (installed on first instantiation)", () => {
+        const finiteStateMachineType = addressSpace.findObjectType("FiniteStateMachineType")!;
+        const refs = finiteStateMachineType.findReferencesEx("GeneratesEvent", BrowseDirection.Forward);
+        should(refs.length).be.aboveOrEqual(1);
+        should(refs.map((r) => r.nodeId.toString())).containEql(transitionEventTypeNodeId());
+    });
+
+    it("an ExclusiveLimitAlarm's LimitState machine's type answers the CTT's parent walk with TransitionEventType (the CTT-reported case)", () => {
+        const namespace = addressSpace.getOwnNamespace();
+
+        const green = namespace.addObject({
+            browseName: "Feat57Green",
+            eventNotifier: 0x1,
+            notifierOf: addressSpace.rootFolder.objects.server,
+            organizedBy: addressSpace.rootFolder.objects
+        });
+        const source = namespace.addObject({
+            browseName: "Feat57Source",
+            componentOf: green,
+            eventSourceOf: green
+        });
+        const variableWithAlarm = namespace.addVariable({
+            browseName: "Feat57VariableWithLimit",
+            dataType: "Double",
+            propertyOf: source
+        });
+
+        const alarm = namespace.instantiateExclusiveLimitAlarm("ExclusiveLimitAlarmType", {
+            browseName: "Feat57ExclusiveAlarm",
+            conditionSource: source,
+            highHighLimit: 100.0,
+            highLimit: 10.0,
+            inputNode: variableWithAlarm,
+            lowLimit: 1.0,
+            lowLowLimit: -10.0
+        });
+
+        const limitStateMachine = alarm.limitState as unknown as UAObject;
+        should.exist(limitStateMachine.typeDefinitionObj);
+
+        const found = findGeneratesEventTargetByWalkingUp(addressSpace, limitStateMachine.typeDefinitionObj as UAObjectType);
+        should.exist(found);
+        should(found!.isSubtypeOf(addressSpace.findObjectType("BaseEventType")!)).eql(true);
+        should(found!.nodeId.toString()).eql(transitionEventTypeNodeId());
+    });
+
+    it("adding a second and third state machine instance does not duplicate the GeneratesEvent reference", () => {
+        const stateMachineType = addressSpace.findObjectType("ProgramStateMachineType")!;
+        promoteToStateMachine(
+            stateMachineType.instantiate({
+                browseName: "MyPlainStateMachine2",
+                organizedBy: addressSpace.rootFolder.objects
+            }) as UAObject
+        );
+        promoteToStateMachine(
+            stateMachineType.instantiate({
+                browseName: "MyPlainStateMachine3",
+                organizedBy: addressSpace.rootFolder.objects
+            }) as UAObject
+        );
+
+        const finiteStateMachineType = addressSpace.findObjectType("FiniteStateMachineType")!;
+        const refs = finiteStateMachineType
+            .findReferencesEx("GeneratesEvent", BrowseDirection.Forward)
+            .filter((r) => r.nodeId.toString() === transitionEventTypeNodeId());
+        should(refs.length).eql(1);
+    });
+});

--- a/packages/node-opcua-address-space/test/fixtures/nodeset_catalog_digests.json
+++ b/packages/node-opcua-address-space/test/fixtures/nodeset_catalog_digests.json
@@ -23,8 +23,8 @@
       "adi"
     ],
     "nodes": 6608,
-    "references": 23873,
-    "hash": "1305b4b22cdff479307ef83f43cf0bfca24e6e62"
+    "references": 23875,
+    "hash": "c689d08cedc69357e80cec9c3947adeb7b068721"
   },
   "autoId": {
     "files": [


### PR DESCRIPTION
## Why

OPC 10000-16 requires that a StateMachineType (or a subtype of it) that raises events
declare a `GeneratesEvent` reference to the event type(s) it raises. The CTT's
`Base Information / Base Info State Machine Instance / 001.js` enforces exactly that: for
every `StateMachineType` instance it finds in the address space, it takes the instance's
own type and walks up the type hierarchy (via `GetReferenceTypeFirstParent`, stopping at
`StateMachineType`) looking for a forward `GeneratesEvent` reference; if it finds one it
also checks that the target is `BaseEventType` or a subtype. No such reference existed
anywhere between an instance's type and `StateMachineType`, so the script failed on all 27
StateMachine instances of a certification run (nightly 11784, node-opcua 2.183.1), the
`ExclusiveLevelAlarm-LimitState` machines of the conformance alarms included.

Checking `Opc.Ua.NodeSet2.xml`: exactly one `ObjectType` declares `GeneratesEvent`
(`OrderedListType`, i=23518) - `StateMachineType` (i=2299), `FiniteStateMachineType`
(i=2771) and `ExclusiveLimitStateMachineType` (i=9318) declare none. The standard nodeset
cannot declare it on node-opcua's behalf: whether a given server's state machines raise
events at all is up to the server. node-opcua's own finite state machine implementation
does: every state change raises a `TransitionEventType` event
(`finite_state_machine.ts`, `UAStateMachineImplBase#setState`), for every state machine
instance regardless of which subtype of `FiniteStateMachineType` it was instantiated from.
The reference is therefore node-opcua's to add.

## What

- `packages/node-opcua-address-space/impl/state_machine/finite_state_machine.ts`: added
  `ensureFiniteStateMachineTypeGeneratesTransitionEvent`, called from every state machine's
  `_post_initialize` (i.e. every time a state machine instance is promoted, whether at
  nodeset load or by explicit `promoteToStateMachine`). It adds a forward `GeneratesEvent`
  reference from `FiniteStateMachineType` to `TransitionEventType`, once - it checks for an
  existing matching reference first, so calling it from many state machine instances (the
  normal case) is idempotent. Declaring it once on `FiniteStateMachineType` covers every
  subtype the CTT's parent walk will ever meet (`ExclusiveLimitStateMachineType` included),
  since the walk stops only once it reaches a matching reference or `StateMachineType`
  itself. The function bails out harmlessly if either `GeneratesEvent` or
  `TransitionEventType` is absent from the address space (some minimal test fixtures do not
  carry either).
- `packages/node-opcua-address-space/test/finite_state_machine/test_feat57_state_machine_generates_event.ts`
  (new): reproduces the CTT's own parent walk and asserts it lands on `TransitionEventType`
  for (a) a plain `ProgramStateMachineType` instance, (b) an `ExclusiveLimitAlarm`'s
  `LimitState` machine - the exact case the CTT reported - and asserts the reference is not
  duplicated when several state machine instances are promoted.
- `packages/node-opcua-address-space/test/fixtures/nodeset_catalog_digests.json`: refreshed
  golden reference count/hash for the `adi` catalog entry (`standard`+`di`+`adi`), which
  loads a `FiniteStateMachineType`-typed instance during nodeset load and so now carries the
  extra reference (+2, one per direction); every other catalog entry is unchanged.

Not addressed: `AuditUpdateStateEventType` (raised by `UACondition`/
`UAAcknowledgeableConditionImpl`) is out of scope - the CTT script only walks
`StateMachineType` instances (`CU_Variables.StateMachineInstances`), and Conditions are not
state machine instances, so this defect and script do not reach them.

## Verification

- `node-opcua-address-space` suite: 1387 passing, 0 failing.
- `node-opcua-server` suite: 532 passing, 0 failing.
- `node tools/check-test-ports.mjs --summary`: OK, nothing unaccounted for (no new ports
  used).
- `pnpm run check:shortcircuit`: 3300 files scanned, no assertion behind an optional chain.
- `pnpm run lint:ci`: green (biome + every `check:*` script).

No CTT run was performed here (by instruction); the CTT replay is done separately.
