### PR TITLE
fix(server): the SemanticsChanged bit reaches the notification the client reads (FEAT-50)

### DIFF
--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_folder.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_folder.ts
@@ -249,8 +249,19 @@ function addArrayItems(ctt: CttFolder): void {
             userAccessLevel: readWrite,
             value: options.value
         });
+        // the mandatory Properties of ArrayItemType are declared in namespace 0, so their
+        // BrowseName is 0:EURange and not <this namespace>:EURange - a client translating the
+        // standard browse path finds nothing otherwise. CTT Data Access Semantic Changes 014-017
+        // warned "Mandatory property 'EURange' missing" on every one of these nodes.
         const property = (browseName: string, dataType: string, value: Variant, valueRank = -1) =>
-            namespace.addVariable({ propertyOf: v, browseName, dataType, valueRank, value, modellingRule: "Mandatory" });
+            namespace.addVariable({
+                propertyOf: v,
+                browseName: { namespaceIndex: 0, name: browseName },
+                dataType,
+                valueRank,
+                value,
+                modellingRule: "Mandatory"
+            });
         property("Title", "LocalizedText", new Variant({ dataType: DataType.LocalizedText, value: { text: typeName } }));
         property("AxisScaleType", "AxisScaleEnumeration", new Variant({ dataType: DataType.Int32, value: 0 }));
         property("EURange", "Range", extensionObject(addressSpace.constructExtensionObject(rangeType, { low: 0, high: 100 })));

--- a/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_folder.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_folder.ts
@@ -179,7 +179,7 @@ function addAnalogItemArrays(ctt: CttFolder): void {
         // element at engineeringUnitsRange.low, rather than a fixed 0 that falls outside an
         // unsigned range, keeps the node's own initial value conformant (PercentDeadband 006).
         const { engineeringUnitsRange, instrumentRange } = makeRange(dataType);
-        ctt.namespace.addAnalogDataItem({
+        const analogItem = ctt.namespace.addAnalogDataItem({
             organizedBy: folder,
             browseName: dataTypeName,
             nodeId: ctt.nodeId(`Static/DA Profile/AnalogItemType Arrays/${dataTypeName}`),
@@ -198,6 +198,19 @@ function addAnalogItemArrays(ctt: CttFolder): void {
             accessLevel: readWrite,
             userAccessLevel: readWrite
         });
+        // addAnalogDataItem builds EngineeringUnits read-only, EURange and InstrumentRange
+        // writable. A CTT run has to be able to change all three: Data Access Semantic Changes 013
+        // writes the three properties of these six items in one Write, and the six BadNotWritable
+        // results - legal, and on the script's accepted list - make it null those entries and then
+        // reuse the full-length expected-results array for its revert write, which its own
+        // WriteHelper refuses ("ExpectedOperationResultsArray[] (length: 18) must have the same
+        // size as Request.NodesToWrite[] (length: 12)"). Writable here, where the test nodes are
+        // configured, rather than changing what addAnalogDataItem gives every other server.
+        const engineeringUnitsProperty = analogItem.getPropertyByName("EngineeringUnits");
+        if (engineeringUnitsProperty) {
+            engineeringUnitsProperty.accessLevel = readWrite;
+            engineeringUnitsProperty.userAccessLevel = readWrite;
+        }
     }
 }
 

--- a/packages/node-opcua-address-space-for-conformance-testing/test/test_ctt_folder.ts
+++ b/packages/node-opcua-address-space-for-conformance-testing/test/test_ctt_folder.ts
@@ -75,6 +75,20 @@ describe("the CTT folder", function () {
         should.exist(byPath("Static/DA Profile/ArrayItemType/CubeItemType").getPropertyByName("ZAxisDefinition"));
     });
 
+    // the mandatory Properties of ArrayItemType are declared in namespace 0: a client that
+    // translates the standard browse path - as the CTT does in Data Access Semantic Changes
+    // 014-017 - finds nothing when they are named in the simulator's own namespace.
+    it("names the mandatory ArrayItemType properties in namespace 0", () => {
+        for (const t of ["YArrayItemType", "XYArrayItemType", "ImageItemType", "CubeItemType", "NDimensionArrayItemType"]) {
+            const v = byPath(`Static/DA Profile/ArrayItemType/${t}`);
+            for (const name of ["Title", "EURange", "EngineeringUnits", "InstrumentRange", "AxisScaleType"]) {
+                const property = v.getPropertyByName(name);
+                should.exist(property, `${t} ${name}`);
+                should(property?.browseName.namespaceIndex).eql(0, `${t} ${name} namespace`);
+            }
+        }
+    });
+
     it("keeps the TwoStateDiscrete variables as components of their folder", () => {
         const ns = addressSpace.getNamespaceIndex("urn://node-opcua-simulator");
         const folder = addressSpace.findNode(`ns=${ns};s=Simulation_DA_DiscreteType`) as UAObject;

--- a/packages/node-opcua-address-space/impl/data_access/semantics_changed.ts
+++ b/packages/node-opcua-address-space/impl/data_access/semantics_changed.ts
@@ -25,7 +25,9 @@
 import type { UAVariable, UAVariableType } from "node-opcua-address-space-base";
 import { VariableTypeIds } from "node-opcua-constants";
 import { NodeClass } from "node-opcua-data-model";
-import { resolveNodeId } from "node-opcua-nodeid";
+import { NodeId, resolveNodeId } from "node-opcua-nodeid";
+import { SemanticChangeStructureDataType } from "node-opcua-types";
+import { DataType, VariantArrayType } from "node-opcua-variant";
 
 /**
  * the Properties whose value carries the semantics of the DataItem they belong to.
@@ -99,4 +101,40 @@ export function notifySemanticsChangedIfNeeded(property: UAVariable): void {
     if (dataItem) {
         (dataItem as UAVariable & { handle_semantic_changed: (dataValue?: unknown) => void }).handle_semantic_changed();
     }
+}
+
+/**
+ * OPC 10000-5 6.4.31: besides the SemanticsChanged bit on the DataItem's next notification, the
+ * Server reports a semantics change as a SemanticChangeEventType on the Server object, carrying
+ * the affected Node and its TypeDefinition. A client subscribed to the Server's events learns of
+ * the change without monitoring the DataItem itself.
+ *
+ * Raised from `handle_semantic_changed`, the single point every semantics change goes through, so
+ * the event and the bit can never disagree. Modelled on how the address space raises
+ * GeneralModelChangeEventType.
+ */
+export function raiseSemanticChangeEvent(dataItem: UAVariable): void {
+    const addressSpace = dataItem.addressSpace;
+    // during construction and teardown there is no Server object to raise the event on
+    const server = addressSpace?.rootFolder?.objects?.server;
+    if (!server) {
+        return;
+    }
+    const eventTypeNode = addressSpace.findEventType("SemanticChangeEventType");
+    if (!eventTypeNode) {
+        return;
+    }
+    const changes = [
+        new SemanticChangeStructureDataType({
+            affected: dataItem.nodeId,
+            affectedType: dataItem.typeDefinitionObj?.nodeId ?? NodeId.nullNodeId
+        })
+    ];
+    server.raiseEvent(eventTypeNode, {
+        changes: {
+            dataType: DataType.ExtensionObject,
+            arrayType: VariantArrayType.Array,
+            value: changes
+        }
+    });
 }

--- a/packages/node-opcua-address-space/impl/ua_variable_impl.ts
+++ b/packages/node-opcua-address-space/impl/ua_variable_impl.ts
@@ -84,7 +84,7 @@ import { apply_condition_refresh, type ConditionRefreshCache } from "./apply_con
 import { BaseNodeImpl, type InternalBaseNodeOptions } from "./base_node_impl.js";
 import { _clone, ToStringBuilder, UAVariable_toString, valueRankToString } from "./base_node_private.js";
 import { adjustDataValueStatusCode } from "./data_access/adjust_datavalue_status_code.js";
-import { notifySemanticsChangedIfNeeded } from "./data_access/semantics_changed.js";
+import { notifySemanticsChangedIfNeeded, raiseSemanticChangeEvent } from "./data_access/semantics_changed.js";
 import { _getBasicDataType } from "./get_basic_datatype.js";
 import { type EnumerationInfo, type IEnumItem, UADataTypeImpl } from "./ua_data_type_impl.js";
 import {
@@ -1997,6 +1997,9 @@ export class UAVariableImpl<T extends UAVariableEvents & ListenerSignature<T> = 
     public handle_semantic_changed(_dataValue: DataValue): void {
         this.semantic_version = this.semantic_version + 1;
         (this as UAVariable).emit("semantic_changed");
+        // the bit tells whoever monitors this DataItem; the event tells whoever monitors the
+        // Server object (OPC 10000-5 6.4.31). Both have to come from this one place.
+        raiseSemanticChangeEvent(this as UAVariable);
     }
 
     private _readDataType(): DataValue {

--- a/packages/node-opcua-address-space/test/data_access/test_semantics_changed.ts
+++ b/packages/node-opcua-address-space/test/data_access/test_semantics_changed.ts
@@ -166,4 +166,43 @@ describe("SemanticsChanged: the DataItem of a semantics-bearing Property", () =>
         await writeProperty(title, new Variant({ dataType: DataType.LocalizedText, value: { text: "other" } }));
         should(plain.semantic_version).eql(before);
     });
+
+    /**
+     * OPC 10000-5 6.4.31: the Server also reports a semantics change as a SemanticChangeEventType
+     * on the Server object, naming the affected Node and its TypeDefinition. CTT Base Info
+     * SemanticChange 001 subscribes to the Server's events and to the DataItem, writes EURange and
+     * expects both the event and the stamped data change.
+     */
+    it("SC7 raises a SemanticChangeEventType on the Server object naming the affected DataItem", async () => {
+        const analog = namespace.addAnalogDataItem({
+            organizedBy: addressSpace.rootFolder.objects,
+            browseName: "SC7_Analog",
+            engineeringUnits: standardUnits.degree_celsius,
+            engineeringUnitsRange: { low: -100, high: 100 },
+            instrumentRange: { low: -200, high: 200 },
+            dataType: "Double",
+            value: { dataType: DataType.Double, value: 1 }
+        }) as unknown as UAVariable;
+
+        const server = addressSpace.rootFolder.objects.server;
+        const semanticChangeEventTypeNodeId = addressSpace.findEventType("SemanticChangeEventType")!.nodeId;
+        const raised: Record<string, { value?: unknown }>[] = [];
+        const onEvent = (eventData: Record<string, { value?: unknown }>) => raised.push(eventData);
+        server.on("event", onEvent);
+        try {
+            await writeProperty(analog.getPropertyByName("EURange")!, range(-50, 50));
+        } finally {
+            server.removeListener("event", onEvent);
+        }
+
+        const semanticEvents = raised.filter(
+            (eventData) => String(eventData.eventType?.value) === semanticChangeEventTypeNodeId.toString()
+        );
+        should(semanticEvents.length).eql(1, "exactly one SemanticChangeEventType per semantics change");
+
+        const changes = semanticEvents[0].changes?.value as { affected: unknown; affectedType: unknown }[];
+        should(changes.length).eql(1);
+        should(String(changes[0].affected)).eql(analog.nodeId.toString());
+        should(String(changes[0].affectedType)).eql(analog.typeDefinitionObj.nodeId.toString());
+    });
 });

--- a/packages/node-opcua-address-space/test/data_access/test_semantics_changed.ts
+++ b/packages/node-opcua-address-space/test/data_access/test_semantics_changed.ts
@@ -16,7 +16,7 @@ import { nodesets } from "node-opcua-nodesets";
 import { WriteValue } from "node-opcua-service-write";
 import { DataType, Variant, VariantArrayType } from "node-opcua-variant";
 import should from "should";
-import { AddressSpace, type Namespace, SessionContext, type UAVariable } from "../../dist/api/index.js";
+import { AddressSpace, type IEventData, type Namespace, SessionContext, type UAVariable } from "../../dist/api/index.js";
 import { generateAddressSpace } from "../../nodeJS.js";
 
 const context = SessionContext.defaultContext;
@@ -187,7 +187,9 @@ describe("SemanticsChanged: the DataItem of a semantics-bearing Property", () =>
         const server = addressSpace.rootFolder.objects.server;
         const semanticChangeEventTypeNodeId = addressSpace.findEventType("SemanticChangeEventType")!.nodeId;
         const raised: Record<string, { value?: unknown }>[] = [];
-        const onEvent = (eventData: Record<string, { value?: unknown }>) => raised.push(eventData);
+        const onEvent = (eventData: IEventData): void => {
+            raised.push(eventData as unknown as Record<string, { value?: unknown }>);
+        };
         server.on("event", onEvent);
         try {
             await writeProperty(analog.getPropertyByName("EURange")!, range(-50, 50));

--- a/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_monitored_item_semantic_changed.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_monitored_item_semantic_changed.ts
@@ -219,6 +219,50 @@ export function t(test: TestHarness) {
             });
         });
 
+        /**
+         * CTT Data Access Semantic Changes 003/004/005/010/013, to the letter: the script creates
+         * the monitored item, writes the Property and publishes ONCE - it never consumes the
+         * initial data change first, and it reads the bit off MonitoredItems[0]. So the very first
+         * notification the client receives, the queued initial value, is the one that has to carry
+         * it: OPC 10000-4 7.39's "next notification" is the next one *the client sees*.
+         */
+        it("YY5 the first notification carries the bit when the initial value is still queued", async () => {
+            const analogNodeId = "ns=2;s=ByteAnalogDataItem";
+
+            await perform_operation_on_raw_subscription(client, test.endpointUrl, async (session, { subscriptionId }) => {
+                const orgEURange = await readEURange(session, analogNodeId);
+
+                const createResponse = await (session as RawSession).createMonitoredItems(
+                    new CreateMonitoredItemsRequest({
+                        subscriptionId,
+                        timestampsToReturn: TimestampsToReturn.Server,
+                        itemsToCreate: [
+                            {
+                                itemToMonitor: new ReadValueId({ attributeId: AttributeIds.Value, nodeId: analogNodeId }),
+                                monitoringMode: MonitoringMode.Reporting,
+                                requestedParameters: new MonitoringParameters({
+                                    clientHandle: 1002,
+                                    samplingInterval: 500,
+                                    queueSize: 10,
+                                    discardOldest: true,
+                                    filter: null
+                                })
+                            }
+                        ]
+                    })
+                );
+                should(createResponse.results?.[0].statusCode).eql(StatusCodes.Good);
+
+                // no initial publish here: the write happens while the initial value is still queued
+                await writeEURange(session, analogNodeId, { low: orgEURange.low + 1, high: orgEURange.high - 1 });
+
+                const firstNotif = await getNextDataChangeNotification(session);
+                should(firstNotif.value.statusCode.hasSemanticChangedBit).eql(true);
+
+                await writeEURange(session, analogNodeId, orgEURange);
+            });
+        });
+
         it("YY3 semanticChanged with sampling 1000ms", async () => {
             await checkSemanticChange(1000);
         });

--- a/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_monitored_item_semantic_changed.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_monitored_item_semantic_changed.ts
@@ -95,6 +95,24 @@ async function getNextDataChangeNotification(session: ClientSession): Promise<Mo
     });
 }
 
+/**
+ * the next data change, or null when the subscription answers with a keep-alive - which is what
+ * "nothing more to report" looks like on the wire. Used to assert the absence of a notification.
+ */
+async function getNextDataChangeNotificationOrKeepAlive(session: ClientSession): Promise<MonitoredItemNotification | null> {
+    const request = new PublishRequest({ requestHeader: { timeoutHint: 100000 }, subscriptionAcknowledgements: [] });
+    return await new Promise<MonitoredItemNotification | null>((resolve, reject) => {
+        (session as RawSession).publish(request, (err: Error | null, response?: PublishResponse) => {
+            if (err) return reject(err);
+            const notificationData = response!.notificationMessage.notificationData;
+            if (!notificationData || notificationData.length === 0) return resolve(null);
+            const dataChangeNotification = notificationData[0] as DataChangeNotification;
+            const monitoredItems = dataChangeNotification.monitoredItems;
+            resolve(monitoredItems && monitoredItems.length > 0 ? monitoredItems[0] : null);
+        });
+    });
+}
+
 export function t(test: TestHarness) {
     describe("SemanticChanged bit behaviour", () => {
         let client: OPCUAClient;
@@ -258,6 +276,60 @@ export function t(test: TestHarness) {
 
                 const firstNotif = await getNextDataChangeNotification(session);
                 should(firstNotif.value.statusCode.hasSemanticChangedBit).eql(true);
+
+                await writeEURange(session, analogNodeId, orgEURange);
+            });
+        });
+
+        /**
+         * A semantic change stamps one notification; it must not also manufacture a second,
+         * bit-less one for a value that never changed. The bit used to be recorded in the item's
+         * oldDataValue - the baseline the next sample is compared against - so that sample differed
+         * by StatusCode alone and was reported as a data change. CTT Data Access AnalogItemType 008
+         * and Semantic Changes 010/013/014-017 read MonitoredItems[0] of the publish that follows,
+         * and got that duplicate rather than the stamped notification.
+         */
+        it("YY6 a semantic change produces exactly one notification, not a bit-less duplicate", async () => {
+            const analogNodeId = "ns=2;s=DoubleAnalogDataItem";
+
+            await perform_operation_on_raw_subscription(client, test.endpointUrl, async (session, { subscriptionId }) => {
+                const orgEURange = await readEURange(session, analogNodeId);
+
+                const createResponse = await (session as RawSession).createMonitoredItems(
+                    new CreateMonitoredItemsRequest({
+                        subscriptionId,
+                        timestampsToReturn: TimestampsToReturn.Both,
+                        itemsToCreate: [
+                            {
+                                itemToMonitor: new ReadValueId({ attributeId: AttributeIds.Value, nodeId: analogNodeId }),
+                                monitoringMode: MonitoringMode.Reporting,
+                                requestedParameters: new MonitoringParameters({
+                                    clientHandle: 1003,
+                                    samplingInterval: 100,
+                                    // the queue size the CTT asks for: a duplicate does not merely
+                                    // follow the stamped notification, it replaces it
+                                    queueSize: 1,
+                                    discardOldest: true,
+                                    filter: null
+                                })
+                            }
+                        ]
+                    })
+                );
+                should(createResponse.results?.[0].statusCode).eql(StatusCodes.Good);
+
+                // drain the initial value, so the semantic change is the only thing left to report
+                const initial = await getNextDataChangeNotification(session);
+                should(initial.value.statusCode.hasSemanticChangedBit).eql(false);
+
+                await writeEURange(session, analogNodeId, { low: orgEURange.low + 1, high: orgEURange.high - 1 });
+
+                const stamped = await getNextDataChangeNotification(session);
+                should(stamped.value.statusCode.hasSemanticChangedBit).eql(true);
+
+                // the value itself never changed, so nothing more is due
+                const extra = await getNextDataChangeNotificationOrKeepAlive(session);
+                should(extra).eql(null, "a semantic change must not report a second data change");
 
                 await writeEURange(session, analogNodeId, orgEURange);
             });

--- a/packages/node-opcua-server/source/monitored_item.ts
+++ b/packages/node-opcua-server/source/monitored_item.ts
@@ -44,7 +44,14 @@ import {
     MonitoringParameters,
     type PseudoRange
 } from "node-opcua-service-subscription";
-import { type CallbackT, type ModifiableStatusCode, StatusCode, StatusCodes } from "node-opcua-status-code";
+import {
+    type CallbackT,
+    coerceStatusCode,
+    extraStatusCodeBits,
+    type ModifiableStatusCode,
+    StatusCode,
+    StatusCodes
+} from "node-opcua-status-code";
 import {
     EventFieldList,
     type MonitoringFilter,
@@ -1530,12 +1537,30 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
             safeGuardVerify(this);
         }
         this.oldDataValue = dataValue.clone();
+
+        // the notification is built first, and from the stamped DataValue: apply_timestamps hands
+        // back a fresh DataValue, so clearing the bit below cannot reach the queued notification.
+        const notification = this._makeDataChangeNotification(this.oldDataValue);
+
+        // The SemanticsChanged bit marks one notification (OPC 10000-4 7.39); it is not a new state
+        // of the value, which did not change at all. oldDataValue is the baseline the next sample is
+        // compared against, so leaving the bit in it makes that sample differ by StatusCode alone:
+        // the item then reports a second, bit-less data change for an unchanged value, and that is
+        // the one the client reads as MonitoredItems[0] once the stamped notification has been
+        // delivered or discarded. CTT Data Access AnalogItemType 008 and Semantic Changes
+        // 010/013/014-017 all read the bit off a publish that follows a drained queue, and all saw
+        // that second notification instead ("Expected <16384> but got <0>").
+        if (this.oldDataValue.statusCode.hasSemanticChangedBit) {
+            this.oldDataValue.statusCode = coerceStatusCode(
+                this.oldDataValue.statusCode.value & ~extraStatusCodeBits.SemanticChanged
+            );
+        }
+
         // c8 ignore next
         if (doDebug) {
             safeGuardRegister(this);
         }
 
-        const notification = this._makeDataChangeNotification(this.oldDataValue);
         this._enqueue_notification(notification);
     }
 

--- a/packages/node-opcua-server/source/monitored_item.ts
+++ b/packages/node-opcua-server/source/monitored_item.ts
@@ -1174,6 +1174,21 @@ export class MonitoredItem extends EventEmitter implements MonitoredItemBase {
         if (!this.node) {
             throw new Error("_on_semantic_changed: expecting a valid node");
         }
+        // OPC 10000-4 7.39: the *next* data change notification the client receives has to carry
+        // the bit. While notifications are still queued - the initial value of a freshly created
+        // item above all - that next notification is one of them, not a new sample, so the queue
+        // is what has to be stamped. Appending a fresh notification instead leaves the client's
+        // first notification bit-less, and since the DataItem's value did not change that extra
+        // notification repeats a value the client is about to receive anyway. CTT Data Access
+        // Semantic Changes 003/004/005/010/013 create the item, write the Property and publish
+        // once, and read the bit off MonitoredItems[0] - the queued initial value.
+        if (this.queue.length > 0) {
+            for (const notification of this.queue) {
+                setSemanticChangeBit(notification);
+            }
+            this._semantic_version = (this.node as UAVariable).semantic_version;
+            return;
+        }
         // readValue() hands out the node's own DataValue: recordValue stores what it is given, so
         // a clone is required or the queue would alias the node's live value.
         const dataValue: DataValue = (this.node as UAVariable).readValue().clone();


### PR DESCRIPTION
# FEAT-50b: the SemanticsChanged bit reaches the client the CTT is

Branch `feat-50b-semantics-changed-ctt`, five commits on top of `v2.183.1`.

## Why

PR 1674 made every DataItem *notice* a semantics change: writing EURange,
TrueState or Title bumps the owning DataItem's `semantic_version`, whatever way
that DataItem was built. That part works — `test_semantics_changed.ts` SC1-SC6
prove it, and a runtime probe against the real conformance server confirms the
write reaches `_inner_replace_dataValue`, `property.parent` resolves to the
AnalogItem, and the MonitoredItem's `semantic_changed` listener fires.

What PR 1674 missed is what happens to the notification after it is stamped.
Two defects, both invisible to the unit tests because both need a *second*
notification to be observed:

**1. The stamped notification was appended behind notifications already queued.**
`_on_semantic_changed` unconditionally built a fresh DataValue and enqueued it.
When the queue was not empty — above all when the item's initial value has not
been published yet — the client's *next* notification was the bit-less one, and
the stamped one came after it. OPC 10000-4 7.39 wants the next notification the
client receives to carry the bit, and CTT Semantic Changes 003/004/005/010/013
read it off `MonitoredItems[0]` of a single Publish without draining the queue
first.

**2. The bit was recorded as part of the item's value state.** `_enqueue_value`
stores `dataValue.clone()` as `oldDataValue`, the baseline every later sample is
compared against — and it stored it *with* the SemanticsChanged bit. The next
sample of an unchanged value therefore differed from the baseline by StatusCode
alone, was reported as a data change, and produced a second, bit-less
notification for a value that never changed.

Runtime evidence, probing the conformance server directly over OPC UA (the CTT's
own log only says the assertion failed):

```
=== queue drained first (the shape of AnalogItemType 008) ===
    initial data change consumed (1 notification)
    write EURange low=11 high=249 -> Good (0x00000000)
    notification #1: 0x00004000  <-- SEMANTIC
    notification #2: 0x00000000          <-- the duplicate, nothing changed
```

That duplicate is why fix 1 alone turned Semantic Changes 003/004/005 green and
left everything else red: those three keep a non-empty queue, so stamping it in
place never touches `oldDataValue`; every other failing script drains the queue
first and then reads the duplicate as `MonitoredItems[0]`.

**3. Two further gaps the same CTT units exposed.** The hand-built ArrayItemType
nodes of the conformance folder named their mandatory Properties in the
simulator's own namespace, so a client translating the standard browse path got
`BadNoMatch` (Semantic Changes 014-017: "Mandatory property 'EURange' missing").
And OPC 10000-5 6.4.31 has the Server report a semantics change twice — the bit
for whoever monitors the DataItem, a `SemanticChangeEventType` on the Server
object for whoever monitors the Server. Only the bit existed.

## What

| file | change |
|---|---|
| `packages/node-opcua-server/source/monitored_item.ts` | `_on_semantic_changed` stamps the notifications already queued and returns, instead of appending a fresh one; the queue-empty case keeps the old behaviour. `_enqueue_value` clears the SemanticsChanged bit from `oldDataValue` after the notification is built, so the bit never becomes part of the change-detection baseline. `apply_timestamps` returns a fresh DataValue, so the queued notification keeps it. |
| `packages/node-opcua-address-space/impl/ua_variable_impl.ts` | `handle_semantic_changed` also raises the event, from the one place every semantics change goes through. |
| `packages/node-opcua-address-space/impl/data_access/semantics_changed.ts` | new `raiseSemanticChangeEvent`: a `SemanticChangeEventType` on the Server object carrying one `SemanticChangeStructureDataType` (affected node + its TypeDefinition). Modelled on how the address space raises `GeneralModelChangeEventType`. |
| `packages/node-opcua-address-space-for-conformance-testing/src/conformance_testing/ctt_folder.ts` | the mandatory ArrayItemType Properties are named in namespace 0; the six AnalogItemType Arrays items accept a write to EngineeringUnits. |
| `packages/node-opcua-address-space/test/data_access/test_semantics_changed.ts` | SC7: exactly one `SemanticChangeEventType`, naming the affected DataItem and its type. |
| `packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_monitored_item_semantic_changed.ts` | YY5 (the bit on a still-queued initial value) and YY6 (a semantic change produces exactly one notification, at the queue size of 1 the CTT uses). |
| `packages/node-opcua-address-space-for-conformance-testing/test/test_ctt_folder.ts` | the ArrayItemType properties are namespace 0. |

## CTT replay

CTT 1.05.513, `CTT_RUN_CONTEXT=admin-signandencrypt`, three units. Before =
certification nightly 11784 (node-opcua 2.183.1). After = local replay of this
branch, same selection, same run context.

| script | before | after |
|---|---|---|
| Data Access Semantic Changes 003 | error | **ok** |
| Data Access Semantic Changes 004 | error | **ok** |
| Data Access Semantic Changes 005 | error | **ok** |
| Data Access Semantic Changes 010 | error | **ok** |
| Data Access Semantic Changes 013 | error | **ok** |
| Data Access Semantic Changes 014 | warning | **ok** |
| Data Access Semantic Changes 015 | warning | **ok** |
| Data Access Semantic Changes 016 | warning | **ok** |
| Data Access Semantic Changes 017 | warning | **ok** |
| Data Access AnalogItemType 008 | error | **ok** |
| Data Access AnalogItemType Err-002 | warning (unsupported) | **ok** |
| Base Info SemanticChange 001 | error (no event, and no bit) | error — CTT script defect, see below |
| Data Access AnalogItemType 010 | quarantined Q-007 | quarantined Q-007 |

Totals for the three units: 51 scripts, **42 ok, 1 error, 0 warnings** (before:
7 errors and 2 warnings on the two Data Access units alone).

### The one remaining failure is a CTT script defect

Base Info SemanticChange 001 now receives the event — the "No EventNotification
has been received" error is gone — and then crashes reading it:

```
ERROR: Test.Execute() encounted an unexpected error:
  message: Result of expression
  'PublishHelper.CurrentEvents[0].Events[0].EventFields[0].toExtensionObject()'
  [null] is not an object.
  lineNumber: 275
```

`001.js:275` is

```js
receivedEvents.push( PublishHelper.CurrentEvents[0].Events[0].EventFields[0].toExtensionObject().toSemanticChangeStructureDataType() );
```

Its own select clause (`001.js:140-142`) asks for the whole `Changes` property of
`SemanticChangeEventType`, which OPC 10000-5 6.4.31 defines as
`SemanticChangeStructureDataType[]` — an array. The script then calls the scalar
`toExtensionObject()` on it, which returns null. Probing the field over the wire
shows the server delivers exactly what the spec and the select clause ask for:

```
event received, 1 field(s)
  field[0]: dataType=ExtensionObject arrayType=1
            value=[{"affected":"ns=16;s=CTT/Static/DA Profile/AnalogItemType Arrays/Double",
                    "affectedType":"ns=0;i=2368"}]
```

`affected` is the DataItem whose semantics changed, `affectedType` is
AnalogItemType (`i=2368`) — the two values the script goes on to assert. Emitting
a scalar instead would contradict the nodeset, which declares `Changes` with
ValueRank 1. Candidate for `ctt/quarantine.json` alongside Q-007.

## Verification

- `npx tsc -b packages` — clean.
- `test_semantics_changed.ts` — 7 passing (SC1-SC7).
- `test_ctt_folder.ts` — 8 passing.
- e2e `SemanticChanged bit behaviour` (series C) — 6 passing, including the two
  new regression tests.
- `pnpm run lint:ci` — exit 0.
- `pnpm run check:shortcircuit` — 3299 files, no assertion behind an optional chain.
- `node tools/check-test-ports.mjs --summary` — OK, nothing unaccounted for.
- CTT replay as above; the build under test was packed from the branch head
  (the replayed tree differs from the final commit only by an import reorder).
