### PR TITLE
fix(samples): point simple_client at the script it was renamed to

### DIFF
--- a/packages/node-opcua-samples/package.json
+++ b/packages/node-opcua-samples/package.json
@@ -4,7 +4,7 @@
     "version": "2.183.1",
     "description": "pure nodejs OPCUA SDK - module samples",
     "bin": {
-        "simple_client": "./dist/simple_client_ts.js",
+        "simple_client": "./bin/client_example.cjs",
         "interactive_client": "./bin/interactive_client.cjs",
         "simple_server": "./bin/simple_server.cjs",
         "di_server": "./bin/di_server.cjs"

--- a/tools/check-package-shape/README.md
+++ b/tools/check-package-shape/README.md
@@ -44,18 +44,25 @@ node tools/check-package-shape.mjs --concurrency 8
 
 Never commit an `--update` that *adds* a package. The list only shrinks.
 
+Run it on a **fresh** build. A dist left over from before a package was flipped to ESM makes attw
+report `unexpected module syntax` for it, because the files on disk were compiled as CommonJS while
+the manifest now says `type: module`. That looks exactly like a real regression; `pnpm run
+build:all` on a cleaned tree tells the two apart.
+
 ### What is in the baseline today, and why
 
-- `node-opcua`, `node-opcua-client`, `node-opcua-modeler`, `node-opcua-secure-channel`:
-  attw's *named exports* problem. TypeScript lets an ESM consumer write
-  `import { OPCUAClient } from "node-opcua"`, but Node cannot statically detect those exports in
-  the CommonJS file, so the import crashes at run time. The ESM migration (FEAT-2) removes this by
-  making the packages real ESM; these entries should disappear as the flip reaches them.
-- `node-opcua-client-browser`: attw's *unexpected module syntax*, its second (browser) build
-  carries syntax that contradicts the module kind its extension implies.
-- `node-opcua-samples`: `bin.simple_client` names `./dist/simple_client_ts.js`, and no file of that
-  name exists anywhere in the package. Repairing it means either dropping a published command name
-  or pointing it at a different sample, which is a decision rather than a fix.
+The baseline started at six and is down to one, without anybody working on those entries:
+`node-opcua`, `node-opcua-client`, `node-opcua-modeler` and `node-opcua-secure-channel` were here
+for attw's *named exports* problem and left when FEAT-2 batches 5 and 6 made them real ESM;
+`node-opcua-client-browser` left with batch 7. That is the ratchet working as intended. One remains:
+
+- `node-opcua-samples`: attw's *resolution failed*. The package is a set of command line samples:
+  it declares `bin` entries and no `main`, `types` or `exports` at all, so importing it resolves to
+  nothing. attw is right that the `.d.ts` files in its tarball (a by-product of compiling
+  `bin/*.ts` into `dist`) are unreachable, but there is no API here for anyone to import. Compare
+  `node-opcua-local-discovery-server`, also command line only, which attw passes precisely because
+  it ships no declarations at all. Closing this means either declaring an entry point or not
+  publishing the declarations, rather than a fix to the manifest.
 
 ## Cost
 

--- a/tools/package-shape-baseline.json
+++ b/tools/package-shape-baseline.json
@@ -1,10 +1,5 @@
 {
     "failingPackages": [
-        "node-opcua",
-        "node-opcua-client",
-        "node-opcua-client-browser",
-        "node-opcua-modeler",
-        "node-opcua-samples",
-        "node-opcua-secure-channel"
+        "node-opcua-samples"
     ]
 }


### PR DESCRIPTION
## What was wrong

`node-opcua-samples` declares four commands. One of them has been installing a broken shim for
nearly three years:

```json
"simple_client": "./dist/simple_client_ts.js"
```

No file of that name exists anywhere in the package. Commit 1cba6e96e (2023-11-25, "chore:
refactore client example") renamed the example:

```
bin/simple_client.js     -> bin/client_example.js
bin/simple_client_ts.ts  -> bin/client_example_ts.ts
```

The manifest was not updated, so `npm i -g node-opcua-samples` has been creating a `simple_client`
command pointing at a missing file ever since. `check-pack` does not see this, because it verifies
`main`, `types`, `module`, `browser` and `exports`, not `bin`; publint does, which is how the new
`check:shape` gate surfaced it.

## The fix

`simple_client` now names `./bin/client_example.cjs`:

- it is the direct rename of `bin/simple_client.js`, the file this command was built on (the ESM
  flip has since given it a `.cjs` extension, since the package is now `type: module`)
- it is plain JavaScript with `#!/usr/bin/env node`, so it runs for a consumer as-is
- npm force-includes `bin` targets, so it ships even though `files` lists only `dist` (verified
  against `npm pack`)

The compiled sibling, `dist/client_example_ts.js`, was the other candidate and is the wrong one: it
inherits `#!/usr/bin/env tsx` from its TypeScript source, so it would ask a consumer to have tsx
installed. The old `simple_client_ts.ts` had the same problem with `ts-node`, which suggests this
command never worked well even before the file disappeared.

The published command name is kept. Renaming it to match the file would be a second, unrelated
break for anyone who has it in a script.

## The remaining baseline entry for this package

`node-opcua-samples` stays in `tools/package-shape-baseline.json`, now for attw alone, and the
tool's README says why in place of the old placeholder: the package declares `bin` entries and no
`main`, `types` or `exports`, so importing it resolves to nothing. attw is right that the `.d.ts`
files in its tarball (a by-product of compiling `bin/*.ts` into `dist`) are unreachable, but there
is no API here to import. `node-opcua-local-discovery-server`, also command line only, passes attw
precisely because it ships no declarations at all. Closing it means declaring an entry point or not
publishing the declarations, which is a decision about what a samples package is, not a manifest
fix.

## The ratchet tightens for the first time

While verifying this, `check:shape` reported four baselined packages as green:

```
node-opcua, node-opcua-client, node-opcua-modeler, node-opcua-secure-channel
```

These are exactly the four entries whose baseline note said "the ESM flip removes this as it
reaches each package". FEAT-2 batches 5 and 6 reached them, so `tools/package-shape-baseline.json`
drops from six entries to two: `node-opcua-client-browser` and `node-opcua-samples`.

A caution worth recording, because it nearly produced a false alarm: run this gate on a **fresh**
build. A dist left over from before those ESM flips makes 14 packages report
`🚭 Unexpected module syntax`, since the files on disk were compiled as CommonJS while their
manifest now says `type: module`. After `pnpm run build:all` on a cleaned tree, all of them pass.

## Verification

- publint on `node-opcua-samples`: clean (suggestions only), where it previously reported
  `pkg.bin.simple_client ... but the file does not exist`
- `npm pack --dry-run` lists `bin/client_example.cjs`
- `pnpm run check:shape`, `check:pack`, `check:testtypes`, `lint:ci` all green
