### PR TITLE
test(address-space): stop the shelving test racing its own unshelve timer

### DIFF
--- a/packages/node-opcua-address-space/test/alarms_and_conditions/utest_alarm_condition.ts
+++ b/packages/node-opcua-address-space/test/alarms_and_conditions/utest_alarm_condition.ts
@@ -192,49 +192,63 @@ export function utest_alarm_condition(test: MochaSuiteExWithEngine): void {
 
                 // simulate a call to timeshelved
 
-                const timeShelvedDuration = 1500; // 0.5 seconds
+                const timeShelvedDuration = 1500;
+                // sample much more often than the shelved duration: the test only needs to witness
+                // unshelveTime counting down, and a sampling period close to the duration would make
+                // the number of samples depend on event loop jitter
+                const samplingInterval = 200;
                 const shelvingTime = new Variant({ dataType: DataType.Double, value: timeShelvedDuration });
 
                 const context = new SessionContext();
 
-                const values: number[] = [];
+                const samples: { dataType: DataType | undefined; value: number }[] = [];
 
                 // function calling_timedShelve(callback) {
                 const _callMethodResponse1 = await alarm.shelvingState?.timedShelve.execute(null, [shelvingTime], context);
 
-                const currentStateChangePromise = new Promise<void>((resolve) => {
+                // note: neither the listener below nor the sampling timer may assert: they run inside a
+                // timer callback, where a failing assertion escapes mocha as an uncaught exception and
+                // leaves the pending promise unresolved. Everything is verified after the await instead.
+                const currentStateChangePromise = new Promise<DataValue>((resolve) => {
                     alarm.shelvingState?.currentState.once("value_changed", (newValue: DataValue) => {
                         debugLog(" alarm.shelvingState.currentState. ", newValue.toString());
-
-                        newValue.value.value.text.should.eql("Unshelved");
-                        values.length.should.be.greaterThan(2);
-                        // c8 ignore next
-                        if (doDebug) {
-                            debugLog("                     unshelveTime value history = ", values);
-                        }
-                        resolve();
+                        resolve(newValue);
                     });
                 });
 
                 should(alarm.shelvingState?.getCurrentState()).eql("TimedShelved");
 
-                let previous = timeShelvedDuration + 1;
-
                 const _timer = setInterval(() => {
                     const variant = alarm.shelvingState?.unshelveTime.readValue().value;
-                    should(variant?.dataType).eql(DataType.Double);
+                    samples.push({ dataType: variant?.dataType, value: variant?.value || 0 });
+                }, samplingInterval);
 
-                    should((variant?.value || 0) < timeShelvedDuration).eql(true);
-                    should((variant?.value || 0) >= 0).eql(true, " unshelveTime must be greater than 0");
-                    should((variant?.value || 0) < previous).eql(true);
+                let newValue: DataValue;
+                try {
+                    newValue = await currentStateChangePromise;
+                } finally {
+                    clearInterval(_timer);
+                }
 
-                    values.push(variant?.value || 0);
-                    previous = variant?.value || 0;
-                }, 400);
+                // c8 ignore next
+                if (doDebug) {
+                    debugLog(
+                        "                     unshelveTime value history = ",
+                        samples.map((sample) => sample.value)
+                    );
+                }
 
-                await currentStateChangePromise;
+                should(newValue.value.value.text).eql("Unshelved");
+                should(samples.length).be.greaterThan(2);
 
-                clearInterval(_timer);
+                let previous = timeShelvedDuration + 1;
+                for (const sample of samples) {
+                    should(sample.dataType).eql(DataType.Double);
+                    should(sample.value < timeShelvedDuration).eql(true);
+                    should(sample.value >= 0).eql(true, " unshelveTime must be greater than 0");
+                    should(sample.value < previous).eql(true);
+                    previous = sample.value;
+                }
             });
 
             it("checking suppressedOrShelved behavior", () => {


### PR DESCRIPTION
## Problem

`AlarmConditionType > ... > checking shelving state behavior with automatic unshelving` fails intermittently on CI with:

```
AssertionError: expected 2 to be above 2
  at UAVariableImpl.<anonymous> (test/alarms_and_conditions/utest_alarm_condition.ts:210:49)
```

Two independent defects in the test:

**1. The timing margin was ~300 ms.**

`timedShelve` arms `setTimeout(_automatically_unshelve, 1500)` inside `execute()`. The test started its `setInterval(..., 400)` sampler only *after* awaiting `execute()`, so samples land at `Δ+400`, `Δ+800`, `Δ+1200` against a 1500 ms deadline. The assertion needs three of them, so it needs `Δ + interval drift < 300 ms`. On a CI box running 44 test files in parallel, any event-loop hiccup above that (contention, GC, the leak detector wrapping these timers) pushes the third tick past the unshelve and leaves exactly two samples. `setInterval` never catches up after a late tick either, it only drifts further.

The literal was even commented `// 0.5 seconds`, so the ratio was likely never revisited when the duration changed.

**2. The failure mode took the whole run down.**

The assertions ran inside a `once("value_changed")` listener, executed synchronously from `setValueFromSource` inside the unshelve timer callback. A failure there does not reach mocha: it is logged by `_inner_replace_dataValue`, the promise never resolves, the sampling interval is never cleared, and the run ends with `[FATAL] Uncaught Exception` plus `still running at exit: 4`. The sampler's own `should(...)` calls had the same problem.

## Change

- Sample every 200 ms instead of 400 ms: ~7 samples per shelve, so the third one lands around 600 ms and the margin becomes ~900 ms.
- The listener and the sampling timer now only capture; every assertion runs after the `await`, and `clearInterval` moved into a `finally`.

Test-only, no production code touched.

## Verification

- `mocha --spec test/alarms_and_conditions/test_alarms_and_conditions.ts`: 87 passing. The pre-existing `1 setTimeout handle(s) were not cleared` leak-detector warning is present on the unmodified baseline too, so it is untouched by this change.
- Observed sample history with `DEBUG=TEST`: `[1296, 1093, 878, 678, 475, 262, 60]`, strictly decreasing.
- `tsc --noEmit -p test/tsconfig.json` clean, `pnpm run lint:ci` green at the repo root.
