### PR TITLE
test: load the suites with the tsx ESM hook, and fix what that exposed (FEAT-4)

### DIFF
--- a/packages/.mocharc.js
+++ b/packages/.mocharc.js
@@ -10,11 +10,20 @@
 // tsx and should are part of the baseline because the tests are TypeScript and use
 // should-style assertions; without them a package with no config of its own cannot run
 // its own suite at all.
+//
+// tsx is registered as the ESM hook (`--import tsx/esm`), not as the CommonJS one. Every
+// package publishes ESM since FEAT-2, and `tsx/cjs` transpiles each test file to CommonJS
+// instead, so the suites exercised a CommonJS translation of the code we ship: different
+// evaluation order, different cycle behaviour, no `import.meta`, and named exports found by
+// a lexer rather than declared. It also meant `require("x")` and `await import("x")` returned
+// two different instances of the same module, so anything holding module-level state could
+// split in two without saying so, which is the failure that cost a day in FEAT-2 batch 3.
 const resolve = (id) => require.resolve(id);
 
 module.exports = {
     colors: true,
     recursive: true,
     extension: ["js", "ts"],
-    require: [resolve("source-map-support/register"), resolve("tsx/cjs"), resolve("should")]
+    require: [resolve("source-map-support/register"), resolve("should")],
+    "node-option": ["import=tsx/esm"]
 };

--- a/packages/node-opcua-address-space/api/index.ts
+++ b/packages/node-opcua-address-space/api/index.ts
@@ -98,8 +98,9 @@ export {
 } from "../impl/historical_access/read_processed_details_hook.js";
 /** @internal */
 export { isNonEmptyQualifiedName, NamespaceImpl } from "../impl/namespace_impl.js";
+export type { ConstructNodeIdOptions } from "../impl/nodeid_manager.js";
 /** How node ids are assigned within a namespace. */
-export { ConstructNodeIdOptions, NamespaceOptions, NodeIdManager } from "../impl/nodeid_manager.js";
+export { NamespaceOptions, NodeIdManager } from "../impl/nodeid_manager.js";
 /** Rewrites the server's namespace array to match the namespaces actually loaded. */
 export { adjustNamespaceArray } from "../impl/nodeset_tools/adjust_namespace_array.js";
 export * from "../impl/nodeset_tools/construct_namespace_dependency.js";

--- a/packages/node-opcua-basic-types/test/test_coerce.ts
+++ b/packages/node-opcua-basic-types/test/test_coerce.ts
@@ -1,4 +1,4 @@
-import "should";
+import should from "should";
 
 import * as ec from "../dist/index.js";
 import { coerceBoolean, coerceByteString, coerceInt32, coerceInt64, coerceUInt32, coerceUInt64 } from "../dist/index.js";
@@ -144,9 +144,9 @@ describe("check coerce various types", () => {
             const randomFunc = ecByName[`random${type}`];
             //xx var isValidFunc = ecByName["isValid" + type];
 
-            ec.should.have.property(`coerce${type}`);
-            ec.should.have.property(`random${type}`);
-            ec.should.have.property(`isValid${type}`);
+            should(ec).have.property(`coerce${type}`);
+            should(ec).have.property(`random${type}`);
+            should(ec).have.property(`isValid${type}`);
 
             const random_value = randomFunc();
 
@@ -166,7 +166,7 @@ describe("check coerce various types", () => {
         it(`coerce${w(type, 8)} should preserves null or undefined values `, () => {
             const coerceFunc = ecByName[`coerce${type}`];
 
-            ec.should.have.property(`coerce${type}`);
+            should(ec).have.property(`coerce${type}`);
 
             const value1 = coerceFunc(null);
             if (Array.isArray(value1)) {

--- a/packages/node-opcua-basic-types/test/test_encode_decode.ts
+++ b/packages/node-opcua-basic-types/test/test_encode_decode.ts
@@ -537,10 +537,10 @@ describe("check isValid and random for various types", () => {
             const randomFunc = ecByName[`random${type}`];
             const isValidFunc = ecByName[`isValid${type}`];
 
-            ec.should.have.property(`encode${type}`);
-            ec.should.have.property(`decode${type}`);
-            ec.should.have.property(`random${type}`);
-            ec.should.have.property(`isValid${type}`);
+            should(ec).have.property(`encode${type}`);
+            should(ec).have.property(`decode${type}`);
+            should(ec).have.property(`random${type}`);
+            should(ec).have.property(`isValid${type}`);
 
             const random_value = randomFunc();
             isValidFunc(random_value).should.eql(true);

--- a/packages/node-opcua-client/source/client_session.ts
+++ b/packages/node-opcua-client/source/client_session.ts
@@ -66,7 +66,7 @@ import type { DataType, Variant } from "node-opcua-variant";
 export { ExtraDataTypeManager } from "node-opcua-client-dynamic-extension-object";
 
 export { ExtensionObject } from "node-opcua-extension-object";
-export { ArgumentDefinition, CallMethodRequestLike, MethodId } from "node-opcua-pseudo-session";
+export type { ArgumentDefinition, CallMethodRequestLike, MethodId } from "node-opcua-pseudo-session";
 
 import type { ClientSubscription } from "./client_subscription.js";
 

--- a/packages/node-opcua-client/source/index.ts
+++ b/packages/node-opcua-client/source/index.ts
@@ -24,7 +24,8 @@
 export * from "node-opcua-alarm-condition";
 export { assert } from "node-opcua-assert";
 export { ServerState, ServiceCounterDataType } from "node-opcua-common";
-export { ClientSecureChannelLayer, ConnectionStrategyOptions, SecurityPolicy } from "node-opcua-secure-channel";
+export type { ConnectionStrategyOptions } from "node-opcua-secure-channel";
+export { ClientSecureChannelLayer, SecurityPolicy } from "node-opcua-secure-channel";
 export * from "node-opcua-utils";
 export * from "./alarms_and_conditions/client_alarm_tools.js";
 export * from "./alarms_and_conditions/client_tools.js";
@@ -66,6 +67,7 @@ export {
     setLogLevel,
     setWarningLogger
 } from "node-opcua-debug";
+export type { NodeIdLike } from "node-opcua-nodeid";
 ///
 export {
     coerceExpandedNodeId,
@@ -74,7 +76,6 @@ export {
     makeExpandedNodeId,
     makeNodeId,
     NodeId,
-    NodeIdLike,
     resolveNodeId,
     sameNodeId
 } from "node-opcua-nodeid";
@@ -94,6 +95,7 @@ export * from "node-opcua-service-session";
 export * from "node-opcua-service-subscription";
 export * from "node-opcua-service-translate-browse-path";
 export * from "node-opcua-service-write";
-export { ErrorCallback, StatusCode, StatusCodes } from "node-opcua-status-code";
+export type { ErrorCallback } from "node-opcua-status-code";
+export { StatusCode, StatusCodes } from "node-opcua-status-code";
 export { DataTypeDefinition } from "node-opcua-types";
 export * from "node-opcua-variant";

--- a/packages/node-opcua-client/source/user_identity_info.ts
+++ b/packages/node-opcua-client/source/user_identity_info.ts
@@ -1,4 +1,4 @@
-export {
+export type {
     AnonymousIdentity,
     UserIdentityInfo,
     UserIdentityInfoUserName,

--- a/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_limited_number_of_nodes.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/test_e2e_limited_number_of_nodes.ts
@@ -3,7 +3,6 @@
 // Validates server operationLimits (read, browse, translate) enforcement and crawler behavior
 // under constrained maxNodesPer* settings. Original JS archived as test_e2e_limited_number_of_nodes-old.js
 // --------------------------------------------------------------------------------------------
-import "should"; // assertion side-effects
 import {
     AttributeIds,
     assert,
@@ -17,7 +16,11 @@ import {
 } from "node-opcua";
 import { NodeCrawler } from "node-opcua-client-crawler";
 import { describeWithLeakDetector as describe } from "node-opcua-leak-detector";
-import * as should from "should"; // explicit import to silence TS UMD global warning
+// The default export is the callable `should`, and the statics (`should.exist`) hang off it.
+// A namespace import is not the same object: `should` is CommonJS, so under ESM its namespace
+// carries only `default`, and `should.exist` silently becomes undefined. Calling it threw
+// inside a read callback, before resolve(), so the test hung until mocha timed out.
+import should from "should";
 import { perform_operation_on_client_session } from "../../test_helpers/perform_operation_on_client_session.js";
 
 assert(typeof makeBrowsePath === "function");

--- a/packages/node-opcua-modeler/source/types.ts
+++ b/packages/node-opcua-modeler/source/types.ts
@@ -1,1 +1,1 @@
-export { UANamespaceMetadata } from "node-opcua-address-space";
+export type { UANamespaceMetadata } from "node-opcua-address-space";

--- a/packages/node-opcua-secure-channel/source/common.ts
+++ b/packages/node-opcua-secure-channel/source/common.ts
@@ -46,7 +46,7 @@ export interface ServiceFaultAnnotatedError extends Error {
     diagnosticsInfo?: unknown;
 }
 
-export { ICertificateKeyPairProvider } from "node-opcua-common";
+export type { ICertificateKeyPairProvider } from "node-opcua-common";
 
 export function extractFirstCertificateInChain(certificateChain?: Buffer | Buffer[] | null): Buffer | null {
     if (!certificateChain || certificateChain.length === 0) {

--- a/packages/node-opcua-secure-channel/source/server/server_secure_channel_layer.ts
+++ b/packages/node-opcua-secure-channel/source/server/server_secure_channel_layer.ts
@@ -168,7 +168,10 @@ function isValidSecurityPolicy(securityPolicy: SecurityPolicy) {
     }
 }
 
-export { isEmptyNonce, Nonce, nonceAlreadyBeenUsed } from "./nonce_cache.js";
+// `Nonce` is a type: a transpiler that compiles one file at a time (tsx, esbuild) cannot
+// know that, so a plain re-export survives into the output and fails to link under ESM.
+export type { Nonce } from "./nonce_cache.js";
+export { isEmptyNonce, nonceAlreadyBeenUsed } from "./nonce_cache.js";
 
 import type { Nonce } from "./nonce_cache.js";
 import { nonceAlreadyBeenUsed } from "./nonce_cache.js";

--- a/packages/node-opcua-service-discovery/source/index.ts
+++ b/packages/node-opcua-service-discovery/source/index.ts
@@ -21,7 +21,7 @@ export {
     RegisterServerResponse,
     ServerOnNetwork
 } from "node-opcua-types";
-export { Announcement } from "./Announcement.js";
+export type { Announcement } from "./Announcement.js";
 export { announcementToServiceConfig } from "./announcement_to_service_config.js";
 export { BonjourHolder, multicastDNSInstanceCount } from "./bonjourHolder.js";
 export { serverCapabilities } from "./server_capabilities.js";

--- a/packages/node-opcua/source/index.ts
+++ b/packages/node-opcua/source/index.ts
@@ -74,6 +74,7 @@ export {
 } from "node-opcua-data-model";
 export { DataValue, sameDataValue } from "node-opcua-data-value";
 export * from "node-opcua-hostname";
+export type { NodeIdLike } from "node-opcua-nodeid";
 export {
     coerceExpandedNodeId,
     coerceNodeId,
@@ -81,7 +82,6 @@ export {
     makeExpandedNodeId,
     makeNodeId,
     NodeId,
-    NodeIdLike,
     NodeIdType,
     resolveNodeId,
     sameNodeId

--- a/tsconfig.common.json
+++ b/tsconfig.common.json
@@ -13,6 +13,14 @@
         "noImplicitReturns": true,
         "target": "es2022",
         "module": "NodeNext",
+        // Type-check each file as if nothing else about the program were known, which is what
+        // every single-file transpiler actually does. tsx and esbuild run the test suites and
+        // cannot tell a re-exported type from a re-exported value; tsc can, and elided those
+        // re-exports silently, so `export { SomeInterface } from "..."` survived into the
+        // transpiled output and failed to link under ESM with "does not provide an export
+        // named ...". Twelve such re-exports existed when this was turned on, five of them in
+        // entry points, where they would have broken an ESM consumer of the published package.
+        "isolatedModules": true,
         "declaration": true,
         // the .d.ts is generated, so "go to definition" lands in it and stops there. The map
         // sends an editor on to the .ts the declaration came from, which every package publishes


### PR DESCRIPTION
FEAT-4. The suites now load through the tsx **ESM** hook instead of the CommonJS one, which is a one-line change to `packages/.mocharc.js`. Getting there exposed 14 latent defects in shipped code, so most of this PR is those.

## Why the loader had to move

Every package publishes ESM since FEAT-2, but `tsx/cjs` transpiles each test file to CommonJS, so the suites exercised a CommonJS translation of the code we ship. Measured inside a real suite:

| loader | `typeof require` in a test | `require("x") === await import("x")` |
|---|---|---|
| `tsx/cjs` (before) | function | **false, two instances** |
| `tsx/esm` (after) | undefined | **true** |

Two instances of a module means two copies of anything held at module scope. That is the failure that cost a day in FEAT-2 batch 3, where the built-in type registry existed twice and `NumericRange` registered into the copy nobody read. The flip removed that hazard from production and left it in the test environment.

## What it exposed: 14 type re-exports

`export { SomeInterface } from "..."` is elided by tsc, which has the whole program, and **kept** by tsx and esbuild, which compile one file at a time. Under CommonJS the leftover was a harmless `undefined` property. Under ESM it is a link error:

```
SyntaxError: The requested module 'node-opcua-pseudo-session'
does not provide an export named 'ArgumentDefinition'
```

Fourteen of them, in seven files. **Five were in `node-opcua/source/index.ts` and `node-opcua-client/source/index.ts`**, the umbrella's own entry points, so they would fail to link for any ESM consumer of the published package. `node-opcua-client`'s suite could not start at all.

Each is split so values stay in `export { }` and types move to `export type { }`.

## And a gate, so the class cannot return

`isolatedModules: true` in `tsconfig.common.json` makes tsc answer the same question a single-file transpiler has to answer. The workspace is clean under it; it would have caught all 14 at build time.

This is the same pattern the earlier ESM work used: fix the instances, then turn the invariant into something that always runs. Worth noting that the repo already had the rule (PR 1590, "always `export type`") with nothing enforcing it.

## Also fixed

Two test files asserted through a module namespace (`ec.should.have.property(...)`). A namespace object has a **null prototype** under real ESM, so it never inherits `Object.prototype.should`. Rewritten as `should(ec).have.property(...)`, which is the repo's own assertion rule anyway.

## Evidence

- `npx tsc -b packages --force`: 0 errors with `isolatedModules` on.
- `check:consumers`: both fixtures ok. `lint:ci`: 0. `check:testtypes`: 0 (77 packages, 0 grandfathered).
- Suites: `address-space` 1388, `server` 532, `secure-channel` 274, `basic-types` 155, `client` 77. `client` previously could not start.

One caveat for review: `node-opcua-service-discovery` fails one mDNS test on my machine, identically **before and after** this change, so it is the local multicast environment rather than the loader.
