### PR TITLE
fix(leak-detector): report what a block leaked, not what the process accumulated

### DIFF
--- a/packages/node-opcua-leak-detector/src/resource_leak_detector.js
+++ b/packages/node-opcua-leak-detector/src/resource_leak_detector.js
@@ -66,14 +66,21 @@ ResourceLeakDetector.prototype.verify_registry_counts = (info) => {
 
     const monitoredResource = ObjectRegistry.registries;
 
+    // The registries are process-global and outlive any one block, so an absolute
+    // count answers the wrong question: it asks "has anything in this process ever
+    // leaked", and blames whichever block happens to run next. Compare against the
+    // baseline taken in start() instead, so a block is judged on what it leaked.
+    const baseline = self._registryBaseline;
+    const countOf = (res) => res.count() - (baseline ? (baseline.get(res) || 0) : 0);
+
     let totalLeak = 0;
     for (let i = 0; i < monitoredResource.length; i++) {
         const res = monitoredResource[i];
-        if (res.count() !== 0) {
+        if (countOf(res) > 0) {
             errorMessages.push(chalk.cyan(" some Resource have not been properly terminated: \n"));
             errorMessages.push(` ${res.toString()}`);
         }
-        totalLeak += res.count();
+        totalLeak += Math.max(0, countOf(res));
     }
 
     if (errorMessages.length) {
@@ -103,8 +110,8 @@ ResourceLeakDetector.prototype.verify_registry_counts = (info) => {
             }
             console.log(chalk.cyan("object leaks                     : "), totalLeak);
             for (const resource of Object.values(monitoredResource)) {
-                if (resource.count() !== 0) {
-                    console.log("   ", chalk.yellow(resource.getClassName()).padEnd(38), ":", resource.count());
+                if (countOf(resource) > 0) {
+                    console.log("   ", chalk.yellow(resource.getClassName()).padEnd(38), ":", countOf(resource));
                 }
             }
 
@@ -129,10 +136,23 @@ ResourceLeakDetector.prototype.start = (info) => {
     if (trace) {
         console.log("[LeakDetector] 🚀 starting resourceLeakDetector");
     }
-    assert(!self.setInterval_old, "resourceLeakDetector.stop hasn't been called !");
-    assert(!self.clearInterval_old, "resourceLeakDetector.stop hasn't been called !");
-    assert(!self.setTimeout_old, "resourceLeakDetector.stop hasn't been called !");
-    assert(!self.clearTimeout_old, "resourceLeakDetector.stop hasn't been called !");
+    // A block whose `before` hook fails never gets its `afterEach`, so mocha skips the
+    // stop() that would put the timer globals back. Asserting here turns that one failure
+    // into a failure of every block that follows. Restore what the previous block left
+    // behind and carry on: the block that actually failed has already been reported.
+    if (self.setInterval_old || self.clearInterval_old || self.setTimeout_old || self.clearTimeout_old) {
+        console.log(chalk.yellow("[LeakDetector] ⚠️  previous block never called stop() - restoring the timer globals"));
+        // restore in place rather than calling stop(), which would also close handles and
+        // run the leak check - neither belongs in the middle of starting a new block
+        if (self.setInterval_old) { global.setInterval = self.setInterval_old; }
+        if (self.clearInterval_old) { global.clearInterval = self.clearInterval_old; }
+        if (self.setTimeout_old) { global.setTimeout = self.setTimeout_old; }
+        if (self.clearTimeout_old) { global.clearTimeout = self.clearTimeout_old; }
+        self.setInterval_old = null;
+        self.clearInterval_old = null;
+        self.setTimeout_old = null;
+        self.clearTimeout_old = null;
+    }
 
     self.setIntervalCallCount = 0;
     self.clearIntervalCallCount = 0;
@@ -150,7 +170,13 @@ ResourceLeakDetector.prototype.start = (info) => {
     self.interval_map = {};
     self.timeout_map = {};
 
-    self.verify_registry_counts(self, info);
+    // Record what each registry already holds, so stop() can report what THIS block
+    // leaked rather than what the process has accumulated. This used to call
+    // verify_registry_counts(self, info) - one argument too many, so `info` was `self`,
+    // `info.silent` was undefined, and the check could never stay quiet: once anything
+    // anywhere in the process leaked, every later start() threw `LEAKS !!!` from a
+    // `before` hook, and every block after the first leak failed.
+    self._registryBaseline = new Map(ObjectRegistry.registries.map((res) => [res, res.count()]));
 
     // Track active timer handles for cleanup in stop().
     // This is a lightweight tracking that doesn't wrap the API (no assertions,
@@ -466,6 +492,7 @@ ResourceLeakDetector.prototype.stop = (info) => {
     } finally {
         self.interval_map = {};
         self.timeout_map = {};
+        self._registryBaseline = null;
 
         // call garbage collector
         if (typeof global.gc === "function") {

--- a/packages/node-opcua-leak-detector/test/test_leak_detector_isolation.ts
+++ b/packages/node-opcua-leak-detector/test/test_leak_detector_isolation.ts
@@ -1,0 +1,68 @@
+/**
+ * T12 - A leak in one block must not fail the blocks that follow it.
+ *
+ * ObjectRegistry.registries is process-global and outlives any one block. The check used
+ * to ask an absolute question of it ("is every registry empty?"), so the first package to
+ * leak an object made every later describeWithLeakDetector block fail, reporting the leak
+ * against an innocent test. In a per-process CI job that never showed; in a single-process
+ * whole-suite run it produced hundreds of failures from one root cause.
+ *
+ * The block below leaks on purpose and is never cleaned up. Everything after it must still
+ * pass, and must still catch a leak of its own.
+ */
+
+import assert from "node:assert";
+import { ObjectRegistry } from "node-opcua-object-registry";
+import { describeWithLeakDetector } from "../index.js";
+
+class AbandonedResource {
+    public static registry = new ObjectRegistry();
+    public name: string;
+
+    constructor(name: string) {
+        this.name = name;
+        AbandonedResource.registry.register(this);
+    }
+
+    dispose() {
+        AbandonedResource.registry.unregister(this);
+    }
+
+    toString() {
+        return `AbandonedResource(${this.name})`;
+    }
+}
+
+// Held at module scope so the WeakRef in the registry cannot be collected: the leak has to
+// still be there when the later blocks run, or the test would pass for the wrong reason.
+const leaked: AbandonedResource[] = [];
+
+describe("T12.A - a block that leaks an object and never disposes it", () => {
+    it("T12.A.1 - leaks on purpose", () => {
+        leaked.push(new AbandonedResource("abandoned"));
+        assert.strictEqual(AbandonedResource.registry.count(), 1);
+    });
+});
+
+describeWithLeakDetector("T12.B - a clean block running after the leak", () => {
+    it("T12.B.1 - is not blamed for the earlier leak", () => {
+        assert.strictEqual(AbandonedResource.registry.count(), 1, "the earlier leak is still there");
+    });
+});
+
+describeWithLeakDetector("T12.C - a second clean block running after the leak", () => {
+    it("T12.C.1 - is not blamed either", () => {
+        assert.ok(true);
+    });
+});
+
+describeWithLeakDetector("T12.D - a block that still detects its own leak", () => {
+    it("T12.D.1 - a leak made inside the block is a delta above the baseline", () => {
+        const before = AbandonedResource.registry.count();
+        const mine = new AbandonedResource("mine");
+        assert.strictEqual(AbandonedResource.registry.count(), before + 1);
+        // dispose it here: this test asserts the delta is visible, not that the block fails
+        mine.dispose();
+        assert.strictEqual(AbandonedResource.registry.count(), before);
+    });
+});


### PR DESCRIPTION
## The bug

`start()` called the registry check with one argument too many:

```js
self.verify_registry_counts(self, info);   // the signature is (info)
```

So inside the check `info` is `self`, `info.silent` is `undefined`, and the quiet path is
unreachable. Every `start()` therefore throws `LEAKS !!!` **from a `before` hook** as soon as
anything anywhere in the process has leaked, and the block that gets blamed is whichever one
happens to run next.

`ObjectRegistry.registries` is process-global and outlives any one block, so the check was
asking an absolute question of shared state: "has anything in this process ever leaked?"
rather than "did this block leak?".

## Why it cascades

One leak produces four distinct-looking failure families, all from the same origin:

1. `start()` throws `LEAKS !!!` inside a `before` hook.
2. mocha skips that suite's tests **and its `afterEach`**, so `stop()` never runs and the
   patched timer globals are never restored.
3. the next `start()` hits `assert(!self.setInterval_old, "resourceLeakDetector.stop hasn't
   been called !")`.
4. tests whose `before` died never got their server assigned:
   `Cannot read properties of undefined (reading 'shutdown')`.

Per-process CI jobs (`test:per-package`, `test:parallel`) hide this, because a leak cannot
cross a package boundary there. It is fatal to any single-process run of the whole suite.

## The fix

- `start()` records a baseline of each registry's count instead of calling the check.
- `verify_registry_counts` compares against that baseline, so a block is judged on the delta
  it caused. It also makes the reported count accurate: it no longer includes other
  packages' objects.
- `start()` restores the timer globals in place, with a warning, instead of asserting when a
  previous block never reached its `stop()`. Restoring in place rather than calling `stop()`
  avoids running the leak check and closing handles in the middle of starting a block.

## Evidence

New regression test `test_leak_detector_isolation.ts` leaks one object on purpose and then
asserts that later blocks still pass. In the leak detector's own suite:

| | passing | failing |
|---|---|---|
| before | 31 | **42** |
| after | **75** | **0** |

One abandoned object took down 42 unrelated tests.

Whole suite in a single process (`NO_BAIL=1 node run_all_mocha_tests.js`), same machine,
same commit base. Both runs stop at the same point: the discovery suite's root-level
`after all` hook fails, and a failing root-level hook aborts mocha. That is unrelated to
this change and is not fixed here.

| | baseline | with this change |
|---|---|---|
| passing | 2575 | 2510 |
| **failing** | **293** | **3** |
| `LEAKS` | 155 | **0** |
| `stop hasn't been called` | 65 | **0** |
| `reading 'shutdown'` | 53 | **0** |
| exit | `[FATAL]`, code 2 | clean summary, code 1 |

The 3 remaining failures are the discovery/mDNS tests on that machine (`DISCO3-2` and its
two hooks), which bind to the real hostname and its network interfaces.

## Trade-off

A block no longer fails for a leak an earlier block created. That is the point, but it means
the first leaker must still be caught somewhere: the per-block check now gives precise
attribution, and a whole-process check at the end of a run would still catch anything that
leaked overall. Worth adding separately if wanted.
