### PR TITLE
test(end2end): wait for the data, not for a keepalive, in the 5000-node test

### DIFF
--- a/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_monitoring_large_number_of_nodes.ts
+++ b/packages/node-opcua-end2end-test/test/end_to_end/u_test_e2e_monitoring_large_number_of_nodes.ts
@@ -223,22 +223,36 @@ export function t(test: UmbrellaTestContext) {
                         "expecting some raw notification"
                     );
 
-                    keepAlive.resetHistory();
-                    await waitUntilCondition(async () => keepAlive.callCount >= 2, 5000, "expecting a keepalive notification");
+                    // Wait for the condition the assertions below are about: data received
+                    // for every monitored item.
+                    //
+                    // This used to wait for two keepalives instead, which made the test
+                    // depend on scheduler luck. A keepalive is only sent on a publish cycle
+                    // that has nothing to report, and 5000 items on continuously changing
+                    // Scalar_Simulation_* variables rarely leave one; keepalives only appear
+                    // in the gaps between simulation ticks. Anything that slows the backlog
+                    // down - c8's instrumentation, a loaded machine - fills those gaps, and
+                    // the 5s budget expired before a second keepalive ever arrived.
+                    const dataNotifications = () =>
+                        notificationMessageSpy
+                            .getCalls()
+                            .map((call) => call.args[0] as NotificationMessage)
+                            .filter((n) => n.notificationData!.length > 0);
 
-                    //      keepAlive.resetHistory();
-                    //       await waitUntilCondition(async () => keepAlive.callCount >= 2, 5000, "expecting a keepalive notification");
+                    const countReportedItems = () =>
+                        dataNotifications().reduce((acc, n) => {
+                            const dataChangeNotification = n.notificationData?.[0] as DataChangeNotification;
+                            return acc + dataChangeNotification.monitoredItems!.length;
+                        }, 0);
 
-                    // find the first raw notification that as notification.length > 0 inside the notificationMessageSpy calls
-                    const rawNotifs = notificationMessageSpy
-                        .getCalls()
-                        .map((call) => call.args[0] as NotificationMessage)
-                        .filter((n) => n.notificationData!.length > 0);
+                    await waitUntilCondition(
+                        async () => countReportedItems() >= itemsToMonitor.length,
+                        30_000,
+                        "expecting data for all monitored items"
+                    );
 
-                    const totalItemsCreated = rawNotifs.reduce((acc, n) => {
-                        const dataChangeNotification = n.notificationData?.[0] as DataChangeNotification;
-                        return acc + dataChangeNotification.monitoredItems!.length;
-                    }, 0);
+                    const rawNotifs = dataNotifications();
+                    const totalItemsCreated = countReportedItems();
 
                     rawNotifs.length.should.be.greaterThan(0, "expecting at least one notification with some data");
                     totalItemsCreated.should.be.greaterThan(


### PR DESCRIPTION
`monitors a very large number of nodes (~5000)` fails the `coverage` job:
`waitUntilCondition: Timeout reached timeout=5000 expecting a keepalive notification`.

A keepalive is only sent on a publish cycle with nothing to report. 5000 items on
continuously changing `Scalar_Simulation_*` variables rarely leave one, so keepalives only
appear in the gaps between simulation ticks. c8 slows the backlog down enough to fill those
gaps, and 5s expires.

The three assertions that follow are all about having received data for every monitored
item, so wait for that directly instead.

| | old | new |
|---|---|---|
| without c8 | fails | passes (9.9s) |
| under c8 | fails | passes (24s) |

The test needs ~10s uninstrumented, so the 5s budget had no headroom even before c8.
